### PR TITLE
Centralize Streamlit theming and add dark-mode support

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -278,22 +278,8 @@ def render(ctx):
     st.markdown(
         f"""
         <div class="lbtable">
-          <style>
-            .lbtable {{ width: 100%; overflow-x: auto; }}
-            .lbtable table {{ width: 100%; border-collapse: collapse; }}
-            .lbtable th, .lbtable td {{
-              padding: 8px;
-              border-bottom: 1px solid rgba(0,0,0,0.08);
-              text-align: left;
-              vertical-align: middle;
-              white-space: nowrap;
-            }}
-            .lbtable th {{ font-weight: 700; }}
-            .lbtable a {{ text-decoration: underline; }}
-          </style>
           {html}
         </div>
         """,
         unsafe_allow_html=True,
     )
-

--- a/jupr_app/ui/public_links.py
+++ b/jupr_app/ui/public_links.py
@@ -34,8 +34,7 @@ def public_link_button(label: str, url: str):
         st.link_button(label, url)
     except Exception:
         st.markdown(
-            f'<a href="{url}" target="_blank" rel="noopener noreferrer">'
-            f'<button style="padding:0.5rem 1rem; font-size:1rem; border-radius:0.5rem; cursor:pointer;">'
-            f'{label}</button></a>',
+            f'<a class="jupr-link-button" href="{url}" target="_blank" rel="noopener noreferrer">'
+            f'<button class="jupr-link-button__btn">{label}</button></a>',
             unsafe_allow_html=True,
         )

--- a/jupr_app/ui/theme_clean.py
+++ b/jupr_app/ui/theme_clean.py
@@ -15,13 +15,52 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
     <style>
       :root {{
         --accent: {accent_hex};
+        --accent-contrast: #F8FAFC;
         --bg: #F6F7FB;
-        --panel: #FFFFFF;
+        --panel: #FDFDFE;
         --text: #111827;
         --muted: #6B7280;
         --border: #E5E7EB;
-        --shadow: 0 1px 2px rgba(0,0,0,0.06);
+        --border-strong: #CBD5E1;
+        --shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+        --link: #1D4ED8;
+        --link-hover: #1E40AF;
+        --focus: rgba(59, 130, 246, 0.45);
+        --table-stripe: #F3F4F6;
+        --pill-bg: #F8FAFC;
         --radius: 14px;
+      }}
+
+      html[data-theme="dark"] {{
+        --bg: #0F1218;
+        --panel: #161B24;
+        --text: #E5E7EB;
+        --muted: #9CA3AF;
+        --border: #2B3240;
+        --border-strong: #3B4557;
+        --shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+        --link: #8CB4FF;
+        --link-hover: #B3CCFF;
+        --focus: rgba(96, 165, 250, 0.55);
+        --table-stripe: #1C2230;
+        --pill-bg: #1B2230;
+      }}
+
+      @media (prefers-color-scheme: dark) {{
+        :root {{
+          --bg: #0F1218;
+          --panel: #161B24;
+          --text: #E5E7EB;
+          --muted: #9CA3AF;
+          --border: #2B3240;
+          --border-strong: #3B4557;
+          --shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+          --link: #8CB4FF;
+          --link-hover: #B3CCFF;
+          --focus: rgba(96, 165, 250, 0.55);
+          --table-stripe: #1C2230;
+          --pill-bg: #1B2230;
+        }}
       }}
 
       /* App background */
@@ -55,6 +94,12 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
       .stCaption, .stMarkdown p {{
         color: var(--muted);
       }}
+      a {{
+        color: var(--link);
+      }}
+      a:hover {{
+        color: var(--link-hover);
+      }}
 
       /* Panel look for bordered containers (Streamlit uses this wrapper for border=True) */
       [data-testid="stVerticalBlockBorderWrapper"] {{
@@ -73,20 +118,25 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         font-weight: 650;
         padding: 0.55rem 0.9rem;
         box-shadow: 0 1px 1px rgba(0,0,0,0.04);
+        transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
       }}
       .stButton > button:hover {{
-        border-color: #D1D5DB;
+        border-color: var(--border-strong);
         transform: translateY(-1px);
+      }}
+      .stButton > button:focus-visible {{
+        outline: 3px solid var(--focus);
+        outline-offset: 2px;
       }}
 
       /* Primary buttons: use accent */
       .stButton > button[kind="primary"] {{
         background: var(--accent);
-        color: #FFFFFF;
+        color: var(--accent-contrast);
         border-color: rgba(0,0,0,0.0);
       }}
       .stButton > button[kind="primary"]:hover {{
-        filter: brightness(0.97);
+        filter: brightness(0.95);
       }}
 
       /* Inputs: soft borders */
@@ -94,6 +144,9 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         border-radius: 12px !important;
       }}
       [data-baseweb="select"] > div {{
+        border-radius: 12px !important;
+      }}
+      [data-baseweb="input"] > div {{
         border-radius: 12px !important;
       }}
 
@@ -137,7 +190,7 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         font-size: 0.78rem;
         font-weight: 750;
         border: 1px solid var(--border);
-        background: #F9FAFB;
+        background: var(--pill-bg);
         color: var(--text);
         white-space: nowrap;
       }}
@@ -153,6 +206,60 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         border: 1px solid var(--border);
         box-shadow: var(--shadow);
         background: var(--panel);
+      }}
+
+      /* Leaderboard table (HTML) */
+      .lbtable {{
+        width: 100%;
+        overflow-x: auto;
+      }}
+      .lbtable table {{
+        width: 100%;
+        border-collapse: collapse;
+        background: var(--panel);
+        color: var(--text);
+      }}
+      .lbtable th, .lbtable td {{
+        padding: 8px;
+        border-bottom: 1px solid var(--border);
+        text-align: left;
+        vertical-align: middle;
+        white-space: nowrap;
+      }}
+      .lbtable th {{
+        font-weight: 700;
+        background: var(--table-stripe);
+      }}
+      .lbtable tr:nth-child(even) td {{
+        background: var(--table-stripe);
+      }}
+      .lbtable a {{
+        text-decoration: underline;
+      }}
+
+      /* Public link button fallback */
+      .jupr-link-button {{
+        text-decoration: none;
+      }}
+      .jupr-link-button__btn {{
+        padding: 0.5rem 1rem;
+        font-size: 1rem;
+        border-radius: 0.75rem;
+        cursor: pointer;
+        border: 1px solid var(--border);
+        background: var(--panel);
+        color: var(--text);
+        font-weight: 650;
+        box-shadow: 0 1px 1px rgba(0,0,0,0.04);
+        transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+      }}
+      .jupr-link-button__btn:hover {{
+        border-color: var(--border-strong);
+        transform: translateY(-1px);
+      }}
+      .jupr-link-button__btn:focus-visible {{
+        outline: 3px solid var(--focus);
+        outline-offset: 2px;
       }}
     </style>
     """

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -13,6 +13,7 @@ import pandas as pd  # kept because pages may rely on it
 from jupr_app.data.client import make_supabase
 from jupr_app.data.load import load_data
 from jupr_app.ui.context import AppContext
+from jupr_app.ui.theme_clean import apply_clean_theme
 from jupr_app.ui.url import qp_get
 
 
@@ -207,16 +208,7 @@ def main():
             page_icon="🌵",
             initial_sidebar_state="collapsed",
         )
-        # 1) streamlit_app.py (or jupr/streamlit_app.py)
-        # Add this near the top, AFTER st.set_page_config(...)
-        
-        from jupr_app.ui.theme_clean import apply_clean_theme
-        
-        def main():
-            st.set_page_config(page_title="JUPR Leagues", layout="wide")
-            apply_clean_theme(accent_hex="#2F6FED")  # pick your accent once (can later be club-specific)
-        
-            # ... rest of your app boot + routing
+        apply_clean_theme(accent_hex="#2F6FED")  # pick your accent once (can later be club-specific)
                                 
         # ---- Public mode ----
         PUBLIC_MODE = qp_get("public", "0").lower() in ("1", "true", "yes", "y")


### PR DESCRIPTION
### Motivation
- Ensure a single, reliable styling entrypoint so PUBLIC pages and admin pages share consistent branding and layout. 
- Improve appearance and contrast in dark mode so text, tables, buttons, links, and borders remain visible and accessible. 
- Remove duplicated page-level CSS and provide a minimal, theme-aware shared stylesheet to simplify maintenance.

### Description
- Apply the shared theme once at app startup by importing and calling `apply_clean_theme` from `streamlit_app.py` immediately after `st.set_page_config` so styling is applied before any page renders. 
- Expand `jupr_app/ui/theme_clean.py` with mode-aware CSS variables and rules (added `html[data-theme="dark"]` and `@media (prefers-color-scheme: dark)` fallbacks), safer color tokens for links, borders, focus outlines, table stripes, pills, and button hover/focus states, and avoid pure white/black backgrounds. 
- Consolidate per-page styling by removing the inline leaderboard `<style>` from `jupr_app/ui/pages/leaderboards.py` and move that markup responsibility to the shared theme, and update the public link fallback in `jupr_app/ui/public_links.py` to use theme classes (`jupr-link-button*`). 
- Styling-only changes; no business logic or data logic was modified and existing indentation conventions were preserved.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a3e30c188326ad6f4ccc5bd11532)