### PR TITLE
Move theme init to production Streamlit entrypoint and add deployment marker

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -209,6 +209,10 @@ def main():
             initial_sidebar_state="collapsed",
         )
         apply_clean_theme(accent_hex="#2F6FED")  # pick your accent once (can later be club-specific)
+        st.markdown(
+            "<!-- JUPR_THEME_ACTIVE_2026_01_22 -->",  # TODO: remove after deployment verification
+            unsafe_allow_html=True,
+        )
                                 
         # ---- Public mode ----
         PUBLIC_MODE = qp_get("public", "0").lower() in ("1", "true", "yes", "y")


### PR DESCRIPTION
### Motivation
- Ensure the global theme and app chrome load in the real production Streamlit entrypoint so Streamlit Cloud picks up the styling for both public and admin modes instead of relying on test-only wiring.

### Description
- Add a small HTML fingerprint immediately after the global theme initialization in `streamlit_app.py` so the deployed app can be verified; the marker is `<!-- JUPR_THEME_ACTIVE_2026_01_22 -->` and is marked TODO for later removal.
- The production entrypoint is `streamlit_app.py`, with `st.set_page_config(...)` at lines `205-210`, `apply_clean_theme(accent_hex="#2F6FED")` at line `211`, and the debug marker rendered at lines `212-215`.
- No test-only theme wiring was found or removed (searches for `apply_clean_theme|theme_clean|topbar|callout` in `tests`/`jupr_app` returned nothing that applied the theme as a main-app init).

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972dd20cfe08326a1633aa61f74b15b)