### PR TITLE
Add shared page_shell and surface clean-theme primitives across pages

### DIFF
--- a/jupr_app/ui/layout.py
+++ b/jupr_app/ui/layout.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import html
+
+import streamlit as st
+
+from jupr_app.ui.theme_clean import topbar, divider, callout
+
+
+def page_shell(
+    title: str,
+    subtitle: str = "",
+    *,
+    mode_label: str = "",
+    right_html: str = "",
+) -> None:
+    """
+    Render a consistent page chrome wrapper (topbar + spacing).
+    """
+    resolved_right_html = right_html
+    if not resolved_right_html and mode_label:
+        resolved_right_html = f'<span class="jupr-pill neutral">{html.escape(mode_label)}</span>'
+
+    topbar(title, subtitle, right_html=resolved_right_html)
+    st.markdown("<div style='height:6px'></div>", unsafe_allow_html=True)
+
+
+def theme_sanity_block() -> None:
+    """
+    Temporary helper to confirm theme primitives are active.
+    TODO: Remove after visual verification.
+    """
+    callout("info", "New", "This page uses the updated clean theme primitives.")
+    st.markdown("<div style='height:8px'></div>", unsafe_allow_html=True)
+    st.markdown(
+        """
+        <div class="jupr-card jupr-card--hover">
+          <div class="jupr-section-title">Theme primitives active</div>
+          <div class="jupr-topbar__subtitle">
+            Cards, callouts, and dividers are now available for reuse across pages.
+          </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+    divider()

--- a/jupr_app/ui/pages/admin_guide.py
+++ b/jupr_app/ui/pages/admin_guide.py
@@ -1,7 +1,10 @@
 import streamlit as st
 
+from jupr_app.ui.layout import page_shell
+
 def render(ctx):
-    st.header("📘 Admin Guide")
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("📘 Admin Guide", "Operational playbook for admins.", mode_label=mode_label)
 
     if not bool(getattr(ctx, "admin_logged_in", False)):
         st.error("Admin login required.")

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -5,9 +5,11 @@ from datetime import datetime, timezone
 
 from jupr_app.domain.ratings import calculate_hybrid_elo
 from jupr_app.domain.constants import DEFAULT_K_FACTOR
+from jupr_app.ui.layout import page_shell
 
 def render(ctx):
-    st.header("⚙️ Admin Tools")
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("⚙️ Admin Tools", "Diagnostics, replays, and system maintenance.", mode_label=mode_label)
 
     if not bool(getattr(ctx, "admin_logged_in", False)):
         st.error("Admin login required.")

--- a/jupr_app/ui/pages/challenge_ladder.py
+++ b/jupr_app/ui/pages/challenge_ladder.py
@@ -14,6 +14,7 @@ from jupr_app.domain.challenge_ladder import (
     ladder_bucket_challenge,
     ladder_compute_status_map,
 )
+from jupr_app.ui.layout import page_shell
 
 # -------------------------
 # Supabase retry (page-local)
@@ -130,7 +131,8 @@ def ladder_load_core(supabase, club_id: str) -> Tuple[pd.DataFrame, pd.DataFrame
 # Page render
 # -------------------------
 def render(ctx):
-    st.header("🪜 Challenge Ladder")
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("🪜 Challenge Ladder", "Current ladder standings and active challenges.", mode_label=mode_label)
 
     settings = ladder_fetch_settings(ctx.supabase, ctx.club_id)
     df_roster, df_flags, df_ch, df_pass = ladder_load_core(ctx.supabase, ctx.club_id)

--- a/jupr_app/ui/pages/challenge_ladder_admin.py
+++ b/jupr_app/ui/pages/challenge_ladder_admin.py
@@ -27,6 +27,7 @@ from jupr_app.domain.challenge_ladder import (
 from jupr_app.domain.build_challenge_notice_message import build_challenge_notice_message
 
   # adjust if needed
+from jupr_app.ui.layout import page_shell
 
 
 # -------------------------
@@ -156,7 +157,8 @@ def ladder_audit(supabase, club_id: str, action_type: str, entity_type: str, ent
 # Page render
 # -------------------------
 def render(ctx):
-    st.header("🛠️ Challenge Ladder Admin")
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("🛠️ Challenge Ladder Admin", "Manage ladder ops, roster, and challenges.", mode_label=mode_label)
 
     if bool(ctx.public_mode):
         st.error("Admin page is not available in public mode.")

--- a/jupr_app/ui/pages/faqs.py
+++ b/jupr_app/ui/pages/faqs.py
@@ -1,7 +1,11 @@
 import streamlit as st
 
+from jupr_app.ui.layout import page_shell
+
+
 def render(ctx):
-    st.header("❓ JUPR Rating FAQs")
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("❓ JUPR Rating FAQs", "Answers about JUPR ratings and recorded play.", mode_label=mode_label)
     st.markdown(
         """
 JUPR (Joe’s Unique Pickleball Ratings) is Tres Palapas’ **in-house rating system** used to create better matchups, seed events, and keep leveled play fair.

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -4,6 +4,7 @@ import pandas as pd
 from jupr_app.ui.url import qp_get
 from jupr_app.ui.helpers import build_player_profile_link
 from jupr_app.ui.public_links import build_public_url, public_link_button
+from jupr_app.ui.layout import page_shell, theme_sanity_block
 
 
 def render(ctx):
@@ -21,7 +22,9 @@ def render(ctx):
         getattr(ctx, "admin_logged_in", st.session_state.get("admin_logged_in", False))
     )
 
-    st.header("🏆 Leaderboards")
+    mode_label = "Public" if PUBLIC_MODE else "Admin"
+    page_shell("🏆 Leaderboards", "Standings and top performers by league.", mode_label=mode_label)
+    theme_sanity_block()
 
     # -------------------------
     # Available leagues

--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -23,6 +23,7 @@ from jupr_app.domain.roster import (
     swap_players,
 )
 from jupr_app.domain.schedule import get_match_schedule
+from jupr_app.ui.layout import page_shell
 
 
 def _utc_iso_now() -> str:
@@ -96,7 +97,8 @@ def _suggest_court_sizes(total_players: int) -> dict:
 
 
 def render(ctx):
-    st.header("🏟️ League Manager")
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("🏟️ League Manager", "Run live events and manage ladders.", mode_label=mode_label)
 
     if not bool(getattr(ctx, "admin_logged_in", False)):
         st.error("Admin login required.")

--- a/jupr_app/ui/pages/match_explorer.py
+++ b/jupr_app/ui/pages/match_explorer.py
@@ -6,6 +6,7 @@ import altair as alt
 from jupr_app.ui.helpers import qp_get
 from jupr_app.domain.ratings import calculate_hybrid_elo
 from jupr_app.domain.constants import DEFAULT_K_FACTOR, MIN_WIN_DELTA_ELO, CAP_LOSER_GAIN_ELO
+from jupr_app.ui.layout import page_shell
 
 
 def render(ctx):
@@ -16,8 +17,12 @@ def render(ctx):
     id_to_name = ctx.id_to_name
     PUBLIC_MODE = bool(ctx.public_mode)
 
-    st.header("🎯 Match Explorer")
-    st.caption("Preview win odds, expectation, and projected JUPR movement — from your perspective. Preview only; ratings do not change.")
+    mode_label = "Public" if PUBLIC_MODE else "Admin"
+    page_shell(
+        "🎯 Match Explorer",
+        "Preview win odds and projected JUPR movement.",
+        mode_label=mode_label,
+    )
 
     # -------- Helpers --------
     def win_label(p: float) -> str:

--- a/jupr_app/ui/pages/match_log.py
+++ b/jupr_app/ui/pages/match_log.py
@@ -2,9 +2,11 @@ import streamlit as st
 import pandas as pd
 
 from jupr_app.domain.dupes import canonical_dup_key
+from jupr_app.ui.layout import page_shell
 
 def render(ctx):
-    st.header("📝 Match Log")
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("📝 Match Log", "Review and filter recorded matches.", mode_label=mode_label)
 
     if not bool(getattr(ctx, "admin_logged_in", False)):
         st.error("Admin login required.")

--- a/jupr_app/ui/pages/match_uploader.py
+++ b/jupr_app/ui/pages/match_uploader.py
@@ -8,10 +8,12 @@ import streamlit as st
 
 from jupr_app.domain.schedule import get_match_schedule
 from jupr_app.domain.match_processing import process_matches
+from jupr_app.ui.layout import page_shell
 
 
 def render(ctx):
-    st.header("📝 Match Uploader (Quick/Pop-Up)")
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("📝 Match Uploader", "Quick entry for pop-up or league matches.", mode_label=mode_label)
     if not bool(getattr(ctx, "admin_logged_in", False)):
         st.error("Admin only.")
         return

--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -3,8 +3,11 @@ import pandas as pd
 import time
 from datetime import datetime, timezone
 
+from jupr_app.ui.layout import page_shell
+
 def render(ctx):
-    st.header("👥 Player Editor")
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("👥 Player Editor", "Edit player records and league ratings.", mode_label=mode_label)
 
     if not bool(getattr(ctx, "admin_logged_in", False)):
         st.error("Admin login required.")

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 
 from jupr_app.ui.helpers import qp_get, build_match_explorer_link
+from jupr_app.ui.layout import page_shell
 
 try:
     import altair as alt
@@ -219,7 +220,9 @@ def build_league_snapshot_map(_supabase, club_id: str, league_name: str, df_meta
 
 
 def render(ctx):
-    st.header("🔍 Player Search")
+    PUBLIC_MODE = bool(getattr(ctx, "public_mode", False))
+    mode_label = "Public" if PUBLIC_MODE else "Admin"
+    page_shell("🔍 Player Search", "Find players and view ratings.", mode_label=mode_label)
 
     df_players_all = ctx.df_players_all
     df_leagues = getattr(ctx, "df_leagues", None)
@@ -636,4 +639,3 @@ def render(ctx):
             df_lg = df[df["League"].astype(str).str.strip() == lg].copy()
             # Show league replay trend if available; otherwise overall trend filtered to that league’s matches.
             render_chart_and_table(df_lg, f"League: {lg}", league_trend=True, league_name=lg)
-

--- a/jupr_app/ui/theme_clean.py
+++ b/jupr_app/ui/theme_clean.py
@@ -301,6 +301,31 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         display: none;
       }}
 
+      /* Radio navigation (public top nav) */
+      div[data-testid="stRadio"] div[role="radiogroup"] {{
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+      }}
+      div[data-testid="stRadio"] label[data-baseweb="radio"] {{
+        margin: 0 !important;
+      }}
+      div[data-testid="stRadio"] label[data-baseweb="radio"] > div {{
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        padding: 0.35rem 0.85rem;
+        background: var(--panel);
+        color: var(--muted);
+        font-weight: 650;
+        transition: border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+      }}
+      div[data-testid="stRadio"] label[data-baseweb="radio"] input:checked + div {{
+        border-color: var(--accent-border);
+        color: var(--text);
+        background: var(--accent-soft);
+        box-shadow: 0 0 0 1px var(--accent-soft);
+      }}
+
       /* Expanders */
       details[data-testid="stExpander"] {{
         border: 1px solid var(--border);


### PR DESCRIPTION
### Motivation
- Provide a durable, consistent page chrome (sticky topbar + spacing) so pages use the new product-grade primitives from the clean theme. 
- Make the updated primitives immediately visible with a minimal, low-risk change set that does not touch routing, URLs, or business logic. 
- Keep changes minimal and reversible while enabling future UI polish across pages. 

### Description
- Add a shared layout helper `jupr_app/ui/layout.py` with `page_shell(title, subtitle, *, mode_label, right_html)` and a temporary `theme_sanity_block()` used only on Leaderboards. 
- Apply the `page_shell(...)` call at the top of the updated pages to render the topbar and small spacer; pages updated: `leaderboards`, `match_explorer`, `players` (Player Search), `challenge_ladder`, `faqs`, `admin_tools`, `match_log`, `challenge_ladder_admin`, `match_uploader`, `player_editor`, `league_manager`, and `admin_guide`. 
- Surface primitives on Leaderboards by calling `theme_sanity_block()` (temporary) which renders a `callout` and small hover `jupr-card` to verify the new look. 
- Style the public top navigation (horizontal `st.radio`) in `jupr_app/ui/theme_clean.py` by targeting `div[data-testid="stRadio"]` and `label[data-baseweb="radio"]` selectors to give the radio options a pill look and selected state. 
- Confirm production entrypoint is `streamlit_app.py`, and `apply_clean_theme(...)` is already called unconditionally right after `st.set_page_config(...)` in `main()`. 

### Testing
- No automated tests were executed because these are UI-only, non-functional changes; manual visual verification is expected after deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972dfbd1fc083269d3eda445281cdb7)