### PR TITLE
Remove theme sanity demo UI

### DIFF
--- a/jupr_app/ui/layout.py
+++ b/jupr_app/ui/layout.py
@@ -4,7 +4,7 @@ import html
 
 import streamlit as st
 
-from jupr_app.ui.theme_clean import topbar, divider, callout
+from jupr_app.ui.theme_clean import topbar
 
 
 def page_shell(
@@ -23,24 +23,3 @@ def page_shell(
 
     topbar(title, subtitle, right_html=resolved_right_html)
     st.markdown("<div style='height:6px'></div>", unsafe_allow_html=True)
-
-
-def theme_sanity_block() -> None:
-    """
-    Temporary helper to confirm theme primitives are active.
-    TODO: Remove after visual verification.
-    """
-    callout("info", "New", "This page uses the updated clean theme primitives.")
-    st.markdown("<div style='height:8px'></div>", unsafe_allow_html=True)
-    st.markdown(
-        """
-        <div class="jupr-card jupr-card--hover">
-          <div class="jupr-section-title">Theme primitives active</div>
-          <div class="jupr-topbar__subtitle">
-            Cards, callouts, and dividers are now available for reuse across pages.
-          </div>
-        </div>
-        """,
-        unsafe_allow_html=True,
-    )
-    divider()

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -4,7 +4,7 @@ import pandas as pd
 from jupr_app.ui.url import qp_get
 from jupr_app.ui.helpers import build_player_profile_link
 from jupr_app.ui.public_links import build_public_url, public_link_button
-from jupr_app.ui.layout import page_shell, theme_sanity_block
+from jupr_app.ui.layout import page_shell
 
 
 def render(ctx):
@@ -24,7 +24,6 @@ def render(ctx):
 
     mode_label = "Public" if PUBLIC_MODE else "Admin"
     page_shell("🏆 Leaderboards", "Standings and top performers by league.", mode_label=mode_label)
-    theme_sanity_block()
 
     # -------------------------
     # Available leagues


### PR DESCRIPTION
### Motivation
- Remove a temporary visual "theme sanity"/demo block that was intended for local verification but was leaking into production pages so only the real page chrome remains.

### Description
- Deleted the `theme_sanity_block()` helper and removed its usages so `page_shell()` only renders the `topbar` and minimal spacing; changes made in `jupr_app/ui/layout.py` and `jupr_app/ui/pages/leaderboards.py` (removed the `callout`/card HTML, the `divider()` call, the helper import, and the helper invocation).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972e1ff6a948326860ba2383c6bdc58)