### PR TITLE
Hide extra radio control pills in nav

### DIFF
--- a/jupr_app/ui/theme_clean.py
+++ b/jupr_app/ui/theme_clean.py
@@ -306,9 +306,12 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         display: flex;
         flex-wrap: wrap;
         gap: 0.35rem;
+        align-items: center;
       }}
       div[data-testid="stRadio"] label[data-baseweb="radio"] {{
         margin: 0 !important;
+        gap: 0 !important;
+        padding-left: 0 !important;
       }}
       div[data-testid="stRadio"] label[data-baseweb="radio"] > div {{
         border-radius: 999px;
@@ -318,6 +321,9 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         color: var(--muted);
         font-weight: 650;
         transition: border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+      }}
+      div[data-testid="stRadio"] div[role="radiogroup"] label > div:first-child {{
+        display: none !important;
       }}
       div[data-testid="stRadio"] label[data-baseweb="radio"] input:checked + div {{
         border-color: var(--accent-border);


### PR DESCRIPTION
### Motivation
- Remove the extra empty rounded radio control elements that appear next to the navigation label pills in both the sidebar and the public horizontal nav caused by Streamlit `st.radio`/`st.sidebar.radio`, so only the intended label pills are visible.

### Description
- Update CSS in `jupr_app/ui/theme_clean.py` to hide the radio indicator using the selector `div[data-testid="stRadio"] div[role="radiogroup"] label > div:first-child { display: none !important; }` and tighten spacing/alignment via `align-items`, `gap`, and `padding-left` adjustments so the label pills remain styled and aligned.

### Testing
- No automated tests were executed for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972e6a5c50c8326ac739f79ac8e060c)