### PR TITLE
Add centralized match color theme and apply to leaderboards and player match history

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -6,6 +6,7 @@ from jupr_app.ui.helpers import build_player_profile_link
 from jupr_app.ui.public_links import build_public_url, public_link_button
 from jupr_app.ui.layout import page_shell
 from jupr_app.ui.theme_clean import callout
+from jupr_app.ui.theme import color_for_delta
 
 
 def render(ctx):
@@ -259,7 +260,7 @@ def render(ctx):
         return str(r)
 
     final_view["Rank"] = final_view["RankNum"].apply(_rank_badge)
-    final_view["Gain"] = (final_view["rating_gain"].astype(float) / 400.0).map("{:+.3f}".format)
+    final_view["Gain"] = final_view["rating_gain"].astype(float) / 400.0
 
     def _name_link(row):
         nm = str(row.get("name", "—") or "—")
@@ -278,6 +279,13 @@ def render(ctx):
 
     tbl = final_view[["Rank", "Player", "JUPR", "Gain", "matches_played", "wins", "losses", "Win %"]].copy()
     tbl["JUPR"] = tbl["JUPR"].map(lambda x: f"{float(x):.3f}")
+    tbl["Gain"] = tbl["Gain"].map(
+        lambda x: (
+            f"<span style='color: {color_for_delta(x)};'>{float(x):+.3f}</span>"
+            if pd.notna(x)
+            else ""
+        )
+    )
     tbl["Win %"] = tbl["Win %"].map(lambda x: f"{float(x):.1f}%")
     tbl = tbl.rename(columns={"matches_played": "MP", "wins": "W", "losses": "L"})
 

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 from jupr_app.ui.helpers import qp_get, build_match_explorer_link
 from jupr_app.ui.layout import page_shell
+from jupr_app.ui.theme import MATCH_COLORS, color_for_delta, color_for_result
 
 try:
     import altair as alt
@@ -385,6 +386,23 @@ def render(ctx):
             return f"{s1}-{s2}"
         return f"{s2}-{s1}"
 
+    def result_for_player(r):
+        try:
+            t1p1 = _safe_int(r.get("t1_p1"))
+            t1p2 = _safe_int(r.get("t1_p2"))
+            s1 = _safe_int(r.get("score_t1"), 0) or 0
+            s2 = _safe_int(r.get("score_t2"), 0) or 0
+        except Exception:
+            return ""
+
+        if s1 == s2:
+            return "DRAW"
+        on_t1 = pid in {t1p1, t1p2}
+        winner = "WIN" if s1 > s2 else "LOSS"
+        if not on_t1:
+            winner = "WIN" if s2 > s1 else "LOSS"
+        return winner
+
     def explain_link(r):
         try:
             t1p1 = _safe_int(r.get("t1_p1"))
@@ -491,6 +509,7 @@ def render(ctx):
                 "League": str(r.get("league", "") or "").strip(),
                 "match_type": str(r.get("match_type", "") or "").strip(),
                 "Score": score_for_player(r),
+                "Result": result_for_player(r),
                 "Overall Δ": delta_jupr,
                 "Overall After": after_jupr,
                 "Explain": explain_link(r),
@@ -619,16 +638,47 @@ def render(ctx):
 
         show = view_df.sort_values(["Date", "id"], ascending=[False, False]).copy()
         show["date"] = pd.to_datetime(show["Date"], utc=True, errors="coerce").dt.strftime("%Y-%m-%d")
-        show["Overall Δ"] = show["Overall Δ"].map(lambda x: f"{float(x):+.4f}" if pd.notna(x) else "")
+        show["delta_raw"] = pd.to_numeric(show["Overall Δ"], errors="coerce")
+        show["Overall Δ"] = show["delta_raw"].map(lambda x: f"{float(x):+.4f}" if pd.notna(x) else "")
         show["Overall After"] = show["Overall After"].map(lambda x: f"{float(x):.3f}" if pd.notna(x) else "")
 
-        show = show[["date", "League", "Score", "match_type", "Overall Δ", "Overall After", "Explain"]]
+        def result_badge(result: str) -> str:
+            color = color_for_result(result) or MATCH_COLORS["draw"]
+            text_color = (
+                MATCH_COLORS["text_light"]
+                if str(result).strip().upper() in {"DRAW", "PUSH", "EVEN", "TIE"}
+                else "#FFFFFF"
+            )
+            label = str(result or "").strip().upper() or "—"
+            return (
+                f"<span style='background: {color}; color: {text_color}; padding: 2px 8px; "
+                "border-radius: 999px; font-size: 0.75rem; font-weight: 600; letter-spacing: 0.02em;'>"
+                f"{label}</span>"
+            )
 
-        st.dataframe(
-            show,
-            use_container_width=True,
-            hide_index=True,
-            column_config={"Explain": st.column_config.LinkColumn("Explain", display_text="Explain")},
+        def delta_span(delta_str: str, delta_raw: float | None) -> str:
+            color = color_for_delta(delta_raw) or MATCH_COLORS["text_light"]
+            if not delta_str:
+                return ""
+            return f"<span style='color: {color}; font-weight: 600;'>{delta_str}</span>"
+
+        show["Result"] = show["Result"].map(result_badge)
+        show["Overall Δ"] = show.apply(lambda row: delta_span(row["Overall Δ"], row["delta_raw"]), axis=1)
+        show["Explain"] = show["Explain"].map(
+            lambda url: f"<a href='{url}' target='_self'>Explain</a>" if url else ""
+        )
+
+        show = show[["date", "League", "Score", "Result", "match_type", "Overall Δ", "Overall After", "Explain"]]
+
+        html_table = show.to_html(index=False, escape=False)
+
+        st.markdown(
+            f"""
+            <div class="match-history-table">
+              {html_table}
+            </div>
+            """,
+            unsafe_allow_html=True,
         )
 
     with tabs[0]:

--- a/jupr_app/ui/theme.py
+++ b/jupr_app/ui/theme.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+MATCH_COLORS = {
+    "win": "#1F7A6D",
+    "loss": "#5E6F82",
+    "draw": "#B9A874",
+    "delta_pos": "#2FAE9A",
+    "delta_neg": "#7D8A97",
+    "delta_zero": "#B9A874",
+    "text_light": "#1E2933",
+    "text_dark": "#E6EEF3",
+    "hover_light": "#F3F7F9",
+    "hover_dark": "#1C232A",
+    "border": "#D5DEE5",
+}
+
+
+def _normalize_result(result_str: str | None) -> str:
+    if result_str is None:
+        return ""
+    return str(result_str).strip().upper()
+
+
+def color_for_result(result_str: str | None) -> str | None:
+    result = _normalize_result(result_str)
+    if result in {"W", "WIN", "WON"}:
+        return MATCH_COLORS["win"]
+    if result in {"L", "LOSS", "LOST"}:
+        return MATCH_COLORS["loss"]
+    if result in {"D", "DRAW", "PUSH", "EVEN", "TIE"}:
+        return MATCH_COLORS["draw"]
+    return None
+
+
+def color_for_delta(delta_float: float | int | None) -> str | None:
+    if delta_float is None:
+        return None
+    try:
+        delta_val = float(delta_float)
+    except (TypeError, ValueError):
+        return None
+    if delta_val > 0:
+        return MATCH_COLORS["delta_pos"]
+    if delta_val < 0:
+        return MATCH_COLORS["delta_neg"]
+    return MATCH_COLORS["delta_zero"]
+
+
+def delta_sign_label(delta_float: float | int | None) -> str:
+    if delta_float is None:
+        return ""
+    try:
+        delta_val = float(delta_float)
+    except (TypeError, ValueError):
+        return ""
+    if delta_val > 0:
+        return "+"
+    if delta_val < 0:
+        return "-"
+    return ""


### PR DESCRIPTION
### Motivation

- Create a single source of truth for match/result and rating-delta colors so the UI is consistent and avoids red for negatives.
- Apply the palette to leaderboards and player match history so result badges and numeric deltas use the same colors and styling.

### Description

- Add `jupr_app/ui/theme.py` exporting `MATCH_COLORS` and helper functions `color_for_result`, `color_for_delta`, and `delta_sign_label` to normalize inputs and return hex values.
- Update `jupr_app/ui/pages/leaderboards.py` to color only the rating gain cell using `color_for_delta` (no row-level coloring) by rendering the `Gain` column as an inline-colored span in the HTML table.
- Update `jupr_app/ui/pages/players.py` to: render a small pill badge for match `Result` using `color_for_result`, color the `Overall Δ` numeric text using `color_for_delta`, and preserve the `Explain` link; the match history is output as an HTML table with inline styles so only badges and numeric spans are colored.
- Keep styling minimal and tolerant of missing values; negative deltas use the slate blue `delta_neg` color instead of red.

### Testing

- Launched the app with `streamlit run streamlit_app.py` and captured a browser screenshot via Playwright to verify the leaderboard gain colors and player match badges rendered (screenshot artifact produced); the run completed and the screenshot was generated successfully.
- No automated unit tests were added or run as part of this change; commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972e7e5c534832684f3a1894e7532f1)