### PR TITLE
Add styled top performer cards to leaderboards

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -1,3 +1,4 @@
+import html
 import streamlit as st
 import pandas as pd
 
@@ -7,6 +8,144 @@ from jupr_app.ui.public_links import build_public_url, public_link_button
 from jupr_app.ui.layout import page_shell
 from jupr_app.ui.theme_clean import callout
 from jupr_app.ui.theme import color_for_delta
+
+
+def render_top_performers_cards(
+    top_perf_dict=None,
+    qualified_df=None,
+    title="Top Performers (Min 6 Games)",
+):
+    if top_perf_dict is None:
+        if qualified_df is None or qualified_df.empty:
+            return
+
+        def _build_entries(df, sort_key, value_fn):
+            top = df.sort_values(sort_key, ascending=False).head(5)
+            entries = []
+            for _, r in top.iterrows():
+                entries.append(
+                    {
+                        "value": value_fn(r),
+                        "name": str(r.get("name", "")),
+                    }
+                )
+            return entries
+
+        top_perf_dict = [
+            {
+                "label": "Highest Rating",
+                "entries": _build_entries(
+                    qualified_df,
+                    "rating",
+                    lambda r: f"{float(r['JUPR']):.3f}",
+                ),
+            },
+            {
+                "label": "Most Improved",
+                "entries": _build_entries(
+                    qualified_df,
+                    "rating_gain",
+                    lambda r: f"{(float(r['rating_gain'])/400.0):+.3f}",
+                ),
+            },
+            {
+                "label": "Best Win %",
+                "entries": _build_entries(
+                    qualified_df,
+                    "Win %",
+                    lambda r: f"{float(r['Win %']):.1f}%",
+                ),
+            },
+            {
+                "label": "Most Wins",
+                "entries": _build_entries(
+                    qualified_df,
+                    "wins",
+                    lambda r: f"{int(r['wins'])}",
+                ),
+            },
+        ]
+
+    if not top_perf_dict:
+        return
+
+    accent = st.get_option("theme.primaryColor") or "#4C78A8"
+
+    st.markdown(f"### 🏅 {title}")
+    st.markdown(
+        """
+        <style>
+        .tp-cards .tp-card {
+            background: rgba(255,255,255,0.02);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 14px;
+            padding: 14px 16px;
+            box-shadow: 0 6px 18px rgba(0,0,0,0.18);
+            border-top: 3px solid var(--tp-accent);
+        }
+        .tp-cards .tp-label {
+            font-size: 12px;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: rgba(255,255,255,0.55);
+            margin-bottom: 6px;
+        }
+        .tp-cards .tp-value {
+            font-size: 26px;
+            font-weight: 700;
+            color: var(--tp-accent);
+            margin-bottom: 2px;
+        }
+        .tp-cards .tp-name {
+            font-size: 14px;
+            color: rgba(255,255,255,0.8);
+            margin-bottom: 8px;
+        }
+        .tp-cards .tp-list {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+        .tp-cards .tp-list-item {
+            display: flex;
+            justify-content: space-between;
+            font-size: 12px;
+            color: rgba(255,255,255,0.55);
+        }
+        .tp-cards .tp-list-value {
+            font-weight: 600;
+            color: rgba(255,255,255,0.65);
+            margin-right: 8px;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    st.markdown(f'<div class="tp-cards" style="--tp-accent: {accent};">', unsafe_allow_html=True)
+    cols = st.columns(4)
+    for col, card in zip(cols, top_perf_dict):
+        entries = card.get("entries", [])
+        if not entries:
+            continue
+        primary = entries[0]
+        secondary = entries[1:5]
+        list_items = "".join(
+            f'<div class="tp-list-item"><span class="tp-list-value">{html.escape(entry["value"])}</span>'
+            f'<span class="tp-list-name">{html.escape(entry["name"])}</span></div>'
+            for entry in secondary
+        )
+        card_html = f"""
+        <div class="tp-card">
+            <div class="tp-label">{html.escape(str(card.get("label", "")))}</div>
+            <div class="tp-value">{html.escape(primary["value"])}</div>
+            <div class="tp-name">{html.escape(primary["name"])}</div>
+            <div class="tp-list">{list_items}</div>
+        </div>
+        """
+        with col:
+            st.markdown(card_html, unsafe_allow_html=True)
+    st.markdown("</div>", unsafe_allow_html=True)
 
 
 def render(ctx):
@@ -205,34 +344,10 @@ def render(ctx):
         qualified_df = display_df[display_df["matches_played"].astype(int) >= int(min_games_req)].copy()
 
         if not qualified_df.empty:
-            st.markdown(f"### 🏅 Top Performers (Min {min_games_req} Games)")
-            with st.container(border=True):
-                c1, c2, c3, c4 = st.columns(4)
-
-                with c1:
-                    st.markdown("**👑 Highest Rating**")
-                    top = qualified_df.sort_values("rating", ascending=False).head(5)
-                    for _, r in top.iterrows():
-                        st.markdown(f"**{float(r['JUPR']):.3f}** - {r['name']}")
-
-                with c2:
-                    st.markdown("**🔥 Most Improved**")
-                    top = qualified_df.sort_values("rating_gain", ascending=False).head(5)
-                    for _, r in top.iterrows():
-                        st.markdown(f"**{(float(r['rating_gain'])/400.0):+.3f}** - {r['name']}")
-
-                with c3:
-                    st.markdown("**🎯 Best Win %**")
-                    top = qualified_df.sort_values("Win %", ascending=False).head(5)
-                    for _, r in top.iterrows():
-                        st.markdown(f"**{float(r['Win %']):.1f}%** - {r['name']}")
-
-                with c4:
-                    st.markdown("**🚜 Most Wins**")
-                    top = qualified_df.sort_values("wins", ascending=False).head(5)
-                    for _, r in top.iterrows():
-                        st.markdown(f"**{int(r['wins'])} Wins** - {r['name']}")
-
+            render_top_performers_cards(
+                qualified_df=qualified_df,
+                title=f"Top Performers (Min {min_games_req} Games)",
+            )
             st.divider()
 
     # -------------------------


### PR DESCRIPTION
### Motivation
- Improve the visual presentation of the Top Performers (Min N Games) section to match the app's clean dark theme while keeping styling subtle and theme-aware. 
- Replace the current plain 4-column lists with compact stat-style cards to make key metrics easier to scan. 

### Description
- Added a reusable helper `render_top_performers_cards(top_perf_dict=None, qualified_df=None, title=...)` that builds four stat cards (Highest Rating, Most Improved, Best Win %, Most Wins) from an already-prepared dataframe or a supplied data structure. 
- Injected minimal, scoped CSS inside a `.tp-cards` wrapper and use `st.columns(4)` with `st.markdown(..., unsafe_allow_html=True)` to render HTML cards, using `st.get_option("theme.primaryColor")` (with fallback) for the accent color. 
- Kept template semantics: each card shows a muted label header, large primary value, player name, and a compact muted list of the next four entries; also added `import html` and HTML-escaping for safety. 
- Replaced the previous inline markdown lists in the leaderboards flow with a call to `render_top_performers_cards(...)` so the rest of the page and standings remain unchanged. 

### Testing
- Launched the app with `streamlit run streamlit_app.py` and captured a full-page screenshot via a Playwright script, which completed successfully and produced `artifacts/leaderboards-top-performers.png`. 
- Verified the new helper renders when a non-empty `qualified_df` is present and that the page still renders the Standings table as before. 
- No automated unit tests were run as part of this change; there were no runtime errors observed during the manual automated run described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972ebaa327083269a0f26e47a3e2eff)