### PR TITLE
Do not filter full league standings by min games; remove "Qualified only" checkbox

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -216,15 +216,8 @@ def render(ctx):
 
     st.text_input("Find yourself", key="lb_search")
 
-    qualified_default = True if PUBLIC_MODE else False
-    show_qualified_only = False
     show_inactive = False
     if target_league != "OVERALL":
-        show_qualified_only = st.checkbox(
-            "Qualified only",
-            key="lb_qualified_only",
-            value=qualified_default,
-        )
         if not PUBLIC_MODE:
             show_inactive = st.checkbox(
                 "Show inactive",
@@ -573,8 +566,6 @@ def render(ctx):
     if target_league != "OVERALL":
         if "Qualified" not in standings.columns:
             standings["Qualified"] = False
-        if show_qualified_only and "Qualified" in standings.columns:
-            standings = standings[standings["Qualified"] == True].copy()
 
     standings["Player"] = standings["name"].astype(str)
     if "Qualified" in standings.columns:


### PR DESCRIPTION
### Motivation
- Full standings should list all active players for a league regardless of `min_games_req`, while the Top Performers should remain subject to the min-games requirement.
- The existing "Qualified only" checkbox was filtering the standings and causing confusion; remove that behavior so the checkbox no longer affects the standings rows.

### Description
- Removed the `Qualified only` checkbox UI and the `show_qualified_only` variable so the league view no longer exposes a control that filters the standings.
- Deleted the code path that filtered `standings` by the `Qualified` flag, ensuring `standings` is always built from `final_view` (which is sorted `display_df`) and shows all active players for non-OVERALL leagues.
- Left the `Qualified` column calculation intact (computed from `matches_played >= min_games_req`) and render it as a display-only badge (`✓`/blank) in the standings.
- Preserved the Top Performers logic unchanged: `qualified_df = display_df[display_df["matches_played"] >= min_games_req]` and `render_top_performers_cards(qualified_df=qualified_df, ...)` still enforces the min-games requirement.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972f3890fbc83269cdf1e7111bb56c4)