### PR TITLE
Harden Streamlit app bootstrap diagnostics

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,69 @@
 # jupr/app.py
-from pathlib import Path
+from __future__ import annotations
+
+import os
+import re
 import sys
+from pathlib import Path
 
-THIS_DIR = Path(__file__).parent
-sys.path.insert(0, str(THIS_DIR))
 
-import streamlit_app
-streamlit_app.main()
+def _sanitize_message(message: str) -> str:
+    if not message:
+        return ""
+
+    redacted = message
+    secret_patterns = [
+        r"(?i)(api|anon|service|secret|token|password|key)[^\s'\"]{0,32}",
+        r"[A-Za-z0-9_\-]{16,}",  # long tokens/keys
+    ]
+    for pattern in secret_patterns:
+        redacted = re.sub(pattern, "[REDACTED]", redacted)
+    return redacted
+
+
+def _render_boot_error(exc: Exception) -> None:
+    try:
+        import streamlit as st
+
+        st.set_page_config(page_title="JUPR Leagues – Boot Error", layout="wide")
+        st.error("JUPR Leagues failed to start.")
+        st.write("This is a startup error report with safe diagnostics.")
+
+        st.markdown("**Exception type**")
+        st.code(exc.__class__.__name__)
+
+        st.markdown("**Exception message (sanitized)**")
+        st.code(_sanitize_message(str(exc)))
+
+        st.markdown("**Runtime diagnostics**")
+        st.code(
+            "\n".join(
+                [
+                    f"python_version: {sys.version.splitlines()[0]}",
+                    f"cwd: {os.getcwd()}",
+                    f"sys.path[:3]: {sys.path[:3]}",
+                    f"listdir(cwd): {os.listdir(os.getcwd())[:30]}",
+                ]
+            )
+        )
+    except Exception:
+        print("Failed to render Streamlit error page.")
+        print(f"{exc.__class__.__name__}: {_sanitize_message(str(exc))}")
+
+
+def _import_streamlit_app():
+    this_dir = Path(__file__).resolve().parent
+    if str(this_dir) not in sys.path:
+        sys.path.insert(0, str(this_dir))
+
+    import importlib
+
+    return importlib.import_module("streamlit_app")
+
+
+try:
+    streamlit_app = _import_streamlit_app()
+    streamlit_app.main()
+except Exception as e:
+    _render_boot_error(e)
+    raise


### PR DESCRIPTION
### Motivation
- The app was crashing at import time with a redacted KeyError; imports must be robust across environments (local Codespaces and Streamlit Cloud) and the real cause should be visible without leaking secrets. 
- Provide a safe, visible startup error page that surfaces the exception type and a sanitized message plus minimal diagnostics, and ensure import failures still produce full logs.

### Description
- Rewrote `app.py` to deterministically insert its directory into `sys.path` and import the main module via `importlib.import_module("streamlit_app")` so imports work regardless of CWD or deployment mounting. 
- Added a boot error renderer that uses Streamlit to show the exception type and a sanitized exception message and safe runtime diagnostics (`sys.version`, `sys.path[:3]`, `cwd`, limited `os.listdir`), falling back to console printing if Streamlit rendering fails. 
- Implemented a sanitizer (`_sanitize_message`) to redact likely secret-like substrings and long tokens from the displayed exception message. 
- On import failure, the code now renders the safe diagnostics and then re-raises the exception so platform logs continue to capture the full stack trace. 

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972fcac14f0832687f9d24565421b66)