### PR TITLE
Challenge Ladder: show Premier-first tier order and add Emerging tier

### DIFF
--- a/jupr_app/domain/challenge_ladder.py
+++ b/jupr_app/domain/challenge_ladder.py
@@ -54,13 +54,14 @@ def ladder_nm(pid: int, id_to_name: Dict[int, str]) -> str:
 # -------------------------
 # Tier definitions (Option A, range-labeled)
 # -------------------------
-TIER_ORDER = ["DEV", "INT", "ADV", "PREM"]
+TIER_ORDER = ["PREM", "ADV", "INT", "DEV", "EMER"]
 
 TIER_DEFS = {
-    "DEV":  {"label": "Developing",    "min": None,  "max": 3.25, "range": "< 3.25"},
-    "INT":  {"label": "Intermediate",  "min": 3.25,  "max": 3.75, "range": "3.25–3.75"},
-    "ADV":  {"label": "Advanced",      "min": 3.75,  "max": 4.25, "range": "3.75–4.25"},
-    "PREM": {"label": "Premier",       "min": 4.25,  "max": None, "range": "4.25+"},
+    "PREM": {"label": "Premier",       "min": 4.25, "max": None, "range": "4.25+"},
+    "ADV":  {"label": "Advanced",      "min": 3.75, "max": 4.25, "range": "3.75–4.25"},
+    "INT":  {"label": "Intermediate",  "min": 3.25, "max": 3.75, "range": "3.25–3.75"},
+    "DEV":  {"label": "Developing",    "min": 3.0,  "max": 3.25, "range": "3.0–3.25"},
+    "EMER": {"label": "Emerging",      "min": None, "max": 3.0,  "range": "< 3.0"},
 }
 
 
@@ -69,6 +70,8 @@ def tier_for_jupr(jupr: float) -> str:
         x = float(jupr)
     except Exception:
         return "INT"
+    if x < 3.0:
+        return "EMER"
     if x < 3.25:
         return "DEV"
     if x < 3.75:
@@ -90,11 +93,24 @@ def tier_idx(tier_id: str) -> int:
 
 
 def is_promotion(from_tier: str, to_tier: str) -> bool:
-    return tier_idx(to_tier) > tier_idx(from_tier)
+    return tier_idx(to_tier) < tier_idx(from_tier)
 
 
 def is_demotion(from_tier: str, to_tier: str) -> bool:
-    return tier_idx(to_tier) < tier_idx(from_tier)
+    return tier_idx(to_tier) > tier_idx(from_tier)
+
+
+def sorted_tiers(tiers: list[str]) -> list[str]:
+    """Return tiers sorted by TIER_ORDER (highest -> lowest).
+
+    >>> sorted_tiers(["DEV", "PREM", "EMER"])
+    ['PREM', 'DEV', 'EMER']
+    """
+    seen = set()
+    input_set = {str(t) for t in tiers}
+    ordered = [tid for tid in TIER_ORDER if tid in input_set and not (tid in seen or seen.add(tid))]
+    extras = [str(t) for t in tiers if str(t) not in TIER_ORDER and str(t) not in seen and not seen.add(str(t))]
+    return ordered + extras
 
 
 # -------------------------

--- a/jupr_app/ui/pages/challenge_ladder_admin.py
+++ b/jupr_app/ui/pages/challenge_ladder_admin.py
@@ -13,6 +13,7 @@ from jupr_app.domain.challenge_ladder import (
     TIER_ORDER,
     tier_title,
     tier_for_jupr,
+    tier_idx,
     ladder_nm,
     ladder_parse_dt,
     dt_utc_now,
@@ -630,7 +631,10 @@ def render(ctx):
         )
 
         active_all = r0[r0["is_active"] == True].copy()
-        active_all = active_all.sort_values(["tier_id", "rank"])
+        active_all = active_all.sort_values(
+            ["tier_id", "rank"],
+            key=lambda s: s.map(tier_idx) if s.name == "tier_id" else s,
+        )
 
         # Build label -> pid map for active roster
         active_all["label"] = active_all.apply(

--- a/tests/test_challenge_ladder_tiers.py
+++ b/tests/test_challenge_ladder_tiers.py
@@ -1,0 +1,5 @@
+from jupr_app.domain.challenge_ladder import sorted_tiers
+
+
+def test_sorted_tiers_orders_high_to_low():
+    assert sorted_tiers(["DEV", "PREM", "EMER", "ADV"]) == ["PREM", "ADV", "DEV", "EMER"]


### PR DESCRIPTION
### Motivation
- Update the Challenge Ladder UX so tiers display highest→lowest with Premier first and Emerging added. 
- Centralize tier ordering so all selectors, tabs, and roster views use a single source of truth and avoid alphabetical sorting.

### Description
- Replaced the previous tier ordering with `TIER_ORDER = ["PREM", "ADV", "INT", "DEV", "EMER"]` and expanded `TIER_DEFS` in `jupr_app/domain/challenge_ladder.py` (this file now holds the ordering constant). 
- Adjusted `tier_for_jupr` thresholds to include the Emerging tier and flipped `is_promotion` / `is_demotion` comparisons to match the new index-based ordering. 
- Added a deterministic helper `sorted_tiers(tiers)` with a doctest-style example and added `tests/test_challenge_ladder_tiers.py` to guard ordering behavior. 
- Ensured admin roster sorting respects the new tier order by mapping `tier_id` through `tier_idx` in `jupr_app/ui/pages/challenge_ladder_admin.py` so selectboxes/tabs built from `TIER_ORDER` show Premier first.

### Testing
- Ran the new unit test `tests/test_challenge_ladder_tiers.py` with `pytest`, and it passed. 
- No other automated test failures were observed while making this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ede715608326bff835e49fad8feb)