### PR TITLE
Add badges/player_badges schema, RLS policies, indexes, and seed v1 badge list

### DIFF
--- a/migrations/20250220_badges_v1.sql
+++ b/migrations/20250220_badges_v1.sql
@@ -6,41 +6,119 @@ create table if not exists badges (
     prestige integer not null,
     category text not null,
     is_stackable boolean not null default false,
-    is_active boolean not null default true
+    is_active boolean not null default true,
+    created_at timestamptz not null default now()
 );
+
+alter table badges
+    add column if not exists created_at timestamptz not null default now();
+
+alter table badges
+    alter column is_stackable set default false,
+    alter column is_active set default true;
 
 create table if not exists player_badges (
     id uuid primary key default gen_random_uuid(),
     club_id text not null,
     player_id bigint not null,
-    badge_id text not null references badges(badge_id),
+    badge_id text not null references badges(badge_id) on update cascade on delete restrict,
     earned_at timestamptz not null default now(),
-    context_type text not null,
+    context_type text not null default 'overall',
     context_id text,
     match_id text,
     value_num numeric,
-    value_json jsonb,
-    unique (club_id, player_id, badge_id, context_id)
+    value_json jsonb
 );
 
+alter table player_badges
+    alter column context_type set default 'overall';
+
+alter table player_badges
+    drop constraint if exists player_badges_club_id_player_id_badge_id_context_id_key,
+    add constraint player_badges_unique_context unique (club_id, player_id, badge_id, context_type, context_id);
+
+alter table player_badges
+    drop constraint if exists player_badges_badge_id_fkey,
+    add constraint player_badges_badge_id_fkey
+        foreign key (badge_id) references badges(badge_id) on update cascade on delete restrict;
+
 create index if not exists player_badges_club_player_idx on player_badges (club_id, player_id);
-create index if not exists player_badges_badge_idx on player_badges (badge_id);
+create index if not exists player_badges_club_badge_idx on player_badges (club_id, badge_id);
+create index if not exists player_badges_club_earned_at_idx on player_badges (club_id, earned_at desc);
+
+alter table badges enable row level security;
+alter table player_badges enable row level security;
+
+revoke all on badges from anon, authenticated;
+revoke all on player_badges from anon, authenticated;
+
+grant select on badges to anon, authenticated;
+
+grant select (
+    badge_id,
+    player_id,
+    earned_at,
+    context_type,
+    context_id,
+    match_id,
+    value_num,
+    value_json
+) on player_badges to anon, authenticated;
+
+grant insert, update on player_badges to authenticated;
+
+drop policy if exists public_select_badges on badges;
+create policy public_select_badges
+    on badges
+    for select
+    to public
+    using (true);
+
+drop policy if exists public_select_player_badges on player_badges;
+create policy public_select_player_badges
+    on player_badges
+    for select
+    to public
+    using (
+        club_id = coalesce(current_setting('request.jwt.claims', true)::jsonb ->> 'club_id', '')
+    );
+
+drop policy if exists club_insert_player_badges on player_badges;
+create policy club_insert_player_badges
+    on player_badges
+    for insert
+    to authenticated
+    with check (
+        club_id = coalesce(current_setting('request.jwt.claims', true)::jsonb ->> 'club_id', '')
+    );
+
+drop policy if exists club_update_player_badges on player_badges;
+create policy club_update_player_badges
+    on player_badges
+    for update
+    to authenticated
+    using (
+        club_id = coalesce(current_setting('request.jwt.claims', true)::jsonb ->> 'club_id', '')
+    )
+    with check (
+        club_id = coalesce(current_setting('request.jwt.claims', true)::jsonb ->> 'club_id', '')
+    );
 
 insert into badges (badge_id, name, prestige, category, is_stackable, is_active)
 values
-    ('participant', 'Participant', 10, 'Participation', false, true),
-    ('dedicated_participant', 'Dedicated Participant', 25, 'Participation', false, true),
-    ('lifetime_participant', 'Lifetime Participant', 50, 'Participation', false, true),
-    ('mountain_climber', 'Mountain Climber', 45, 'Momentum & Progress', true, true),
-    ('breakthrough', 'Breakthrough', 55, 'Momentum & Progress', false, true),
-    ('above_expectations', 'Above Expectations', 50, 'Performance vs Expectation', false, true),
-    ('clutch_performer', 'Clutch Performer', 60, 'Performance vs Expectation', false, true),
-    ('dominant_run', 'Dominant Run', 45, 'Dominance & Quality', false, true),
-    ('high_output', 'High Output', 40, 'Dominance & Quality', false, true),
-    ('battle_tested', 'Battle Tested', 50, 'Dominance & Quality', false, true),
-    ('consistency', 'Consistency', 60, 'Dominance & Quality', false, true),
-    ('giant_slayer', 'Giant Slayer', 75, 'Prestige / Rarity', true, true),
-    ('upset_champion', 'Upset Champion', 90, 'Prestige / Rarity', true, true)
+    ('participant', 'Participant', 10, 'participation', false, true),
+    ('dedicated_participant_50', 'Dedicated Participant', 25, 'participation', false, true),
+    ('lifetime_participant_200', 'Lifetime Participant', 50, 'participation', false, true),
+    ('mountain_climber', 'Mountain Climber', 45, 'momentum', true, true),
+    ('breakthrough', 'Breakthrough', 55, 'momentum', false, true),
+    ('above_expectations', 'Above Expectations', 50, 'performance', true, true),
+    ('clutch_performer', 'Clutch Performer', 60, 'performance', true, true),
+    ('dominant_run', 'Dominant Run', 45, 'dominance', true, true),
+    ('high_output', 'High Output', 40, 'dominance', true, true),
+    ('battle_tested', 'Battle Tested', 50, 'quality', true, true),
+    ('consistency', 'Consistency', 60, 'quality', true, true),
+    ('giant_slayer', 'Giant Slayer', 75, 'rarity', true, true),
+    ('upset_champion', 'Upset Champion', 90, 'rarity', true, true)
 on conflict (badge_id) do update set
     name = excluded.name,
     prestige = excluded.prestige,


### PR DESCRIPTION
### Motivation
- The app attempted to query `badges` but the relation did not exist, so a migration is required to add the canonical badge schema and seed data. 
- Player-facing code expects `player_badges` to exist and be club-scoped, so RLS policies must follow repo patterns and scope access by `club_id` claims. 
- The canonical v1 badge definitions must be inserted idempotently so the application logic in `jupr_app/domain/badges.py` can rely on consistent IDs and metadata.

### Description
- Added SQL migration at `migrations/20250220_badges_v1.sql` that creates the `badges` table (with `created_at` and defaults) and the `player_badges` table with `id uuid default gen_random_uuid()`, `club_id`, `player_id bigint`, `badge_id` (FK to `badges` with `ON UPDATE CASCADE ON DELETE RESTRICT`), `earned_at`, `context_type` default `'overall'`, `context_id`, `match_id`, `value_num`, and `value_json`.
- Enforced uniqueness with a constraint `player_badges_unique_context` on `(club_id, player_id, badge_id, context_type, context_id)` to prevent duplicates.
- Added helpful indexes: `player_badges_club_player_idx (club_id, player_id)`, `player_badges_club_badge_idx (club_id, badge_id)`, and `player_badges_club_earned_at_idx (club_id, earned_at desc)`.
- Enabled Row Level Security and added policies that allow public `SELECT` on `badges`, club-scoped `SELECT` on `player_badges` using `current_setting('request.jwt.claims', true)::jsonb ->> 'club_id'`, and allow `INSERT`/`UPDATE` for authenticated users when `club_id` matches the JWT claim; grants were applied to match these policies.
- Seeded the canonical v1 badge list using an idempotent `INSERT ... ON CONFLICT (badge_id) DO UPDATE` statement with the specified badge IDs, names, prestige, categories, `is_stackable`, and `is_active` values.

### Testing
- No automated tests were executed for this change since it is a SQL migration file only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973fa8f26f883269e6e1dfcb4dfd77d)