### PR TITLE
Add participation badge awarding and player profile badges (v1)

### DIFF
--- a/jupr_app/data/load.py
+++ b/jupr_app/data/load.py
@@ -5,7 +5,8 @@ import pandas as pd
 def load_data(supabase, club_id: str, match_limit: int = 5000):
     """
     Loads club-scoped tables and returns:
-      df_players_all, df_players_active, df_leagues, df_matches, df_meta, name_to_id, id_to_name
+      df_players_all, df_players_active, df_leagues, df_matches, df_meta, df_badges,
+      df_player_badges, name_to_id, id_to_name
 
     No Streamlit calls here. Raise exceptions to be handled by UI.
     """
@@ -61,6 +62,19 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
             )
             df_meta = pd.DataFrame(meta_resp.data or [])
 
+            # Badges (global definitions)
+            badges_resp = supabase.table("badges").select("*").execute()
+            df_badges = pd.DataFrame(badges_resp.data or [])
+
+            # Player badges (club-scoped)
+            pb_resp = (
+                supabase.table("player_badges")
+                .select("*")
+                .eq("club_id", club_id)
+                .execute()
+            )
+            df_player_badges = pd.DataFrame(pb_resp.data or [])
+
             # Mappings
             if (
                 not df_players_all.empty
@@ -98,6 +112,8 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
                 df_leagues,
                 df_matches,
                 df_meta,
+                df_badges,
+                df_player_badges,
                 name_to_id,
                 id_to_name,
             )

--- a/jupr_app/domain/badges.py
+++ b/jupr_app/domain/badges.py
@@ -24,8 +24,8 @@ class BadgeDefinition:
 
 BADGE_DEFINITIONS: list[BadgeDefinition] = [
     BadgeDefinition("participant", "Participant", 10, "Participation", False),
-    BadgeDefinition("dedicated_participant", "Dedicated Participant", 25, "Participation", False),
-    BadgeDefinition("lifetime_participant", "Lifetime Participant", 50, "Participation", False),
+    BadgeDefinition("dedicated_participant_50", "Dedicated Participant", 25, "Participation", False),
+    BadgeDefinition("lifetime_participant_200", "Lifetime Participant", 50, "Participation", False),
     BadgeDefinition("mountain_climber", "Mountain Climber", 45, "Momentum & Progress", True),
     BadgeDefinition("breakthrough", "Breakthrough", 55, "Momentum & Progress", False),
     BadgeDefinition("above_expectations", "Above Expectations", 50, "Performance vs Expectation", False),
@@ -39,8 +39,6 @@ BADGE_DEFINITIONS: list[BadgeDefinition] = [
 ]
 
 
-PARTICIPATION_DEDICATED_GAMES = 50
-PARTICIPATION_LIFETIME_GAMES = 200
 BREAKTHROUGH_TOP_N = 5
 BREAKTHROUGH_RATING = 1600.0
 EXPECTED_WIN_DELTA = 2.0
@@ -154,39 +152,6 @@ def _compute_badges(ctx, existing: set[tuple[str, str, str | None]]) -> list[dic
                 "value_json": value_json,
             }
         )
-
-    df_players = getattr(ctx, "df_players_all", None)
-    if df_players is None or df_players.empty:
-        return awards
-
-    df_players = df_players.copy()
-    if "matches_played" not in df_players.columns:
-        df_players["matches_played"] = 0
-
-    for _, row in df_players.iterrows():
-        try:
-            player_id = int(row.get("id"))
-        except Exception:
-            continue
-        games = int(row.get("matches_played") or 0)
-        if games >= 1:
-            add_badge(player_id, "participant", context_type="overall", context_id="overall", value_num=games)
-        if games >= PARTICIPATION_DEDICATED_GAMES:
-            add_badge(
-                player_id,
-                "dedicated_participant",
-                context_type="overall",
-                context_id="overall",
-                value_num=games,
-            )
-        if games >= PARTICIPATION_LIFETIME_GAMES:
-            add_badge(
-                player_id,
-                "lifetime_participant",
-                context_type="overall",
-                context_id="overall",
-                value_num=games,
-            )
 
     _award_league_badges(ctx, add_badge)
     _award_match_badges(ctx, add_badge)

--- a/jupr_app/domain/badges_participation.py
+++ b/jupr_app/domain/badges_participation.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+from typing import Any
+from uuid import uuid4
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+PARTICIPATION_BADGES = (
+    ("participant", 1),
+    ("dedicated_participant_50", 50),
+    ("lifetime_participant_200", 200),
+)
+
+
+def compute_lifetime_games(ctx) -> dict[int, int]:
+    df_matches = getattr(ctx, "df_matches", None)
+    if df_matches is None or df_matches.empty:
+        return {}
+
+    df = df_matches.copy()
+    club_id = str(getattr(ctx, "club_id", "") or "")
+    if club_id and "club_id" in df.columns:
+        df = df[df["club_id"].astype(str) == club_id]
+
+    if df.empty:
+        return {}
+
+    score_cols = _score_columns(df)
+    if "player_id" in df.columns:
+        pid = pd.to_numeric(df["player_id"], errors="coerce")
+        valid = pid.notna()
+        if score_cols:
+            score_total = pd.to_numeric(df[score_cols[0]], errors="coerce").fillna(0) + pd.to_numeric(
+                df[score_cols[1]], errors="coerce"
+            ).fillna(0)
+            valid &= score_total > 0
+        pid = pid[valid].astype(int)
+        if pid.empty:
+            return {}
+        return pid.value_counts().to_dict()
+
+    player_cols = [c for c in ("t1_p1", "t1_p2", "t2_p1", "t2_p2") if c in df.columns]
+    if len(player_cols) < 1:
+        return {}
+
+    players = df[player_cols].apply(pd.to_numeric, errors="coerce")
+    valid = players.notna().all(axis=1)
+    if score_cols:
+        score_total = pd.to_numeric(df[score_cols[0]], errors="coerce").fillna(0) + pd.to_numeric(
+            df[score_cols[1]], errors="coerce"
+        ).fillna(0)
+        valid &= score_total > 0
+
+    players = players[valid]
+    counts: dict[int, int] = {}
+    for _, row in players.iterrows():
+        ids = {int(pid) for pid in row.tolist() if pd.notna(pid)}
+        for pid in ids:
+            counts[pid] = counts.get(pid, 0) + 1
+    return counts
+
+
+def ensure_participation_badges(ctx) -> None:
+    if bool(getattr(ctx, "public_mode", False)):
+        return
+
+    supabase = getattr(ctx, "supabase", None)
+    club_id = str(getattr(ctx, "club_id", "") or "")
+    if supabase is None or not club_id:
+        return
+
+    try:
+        lifetime_games = compute_lifetime_games(ctx)
+        if not lifetime_games:
+            return
+
+        badge_ids = [badge_id for badge_id, _ in PARTICIPATION_BADGES]
+        existing = _fetch_existing_badges(supabase, club_id, badge_ids)
+
+        now = datetime.now(timezone.utc).isoformat()
+        rows: list[dict[str, Any]] = []
+        for player_id, games in lifetime_games.items():
+            for badge_id, threshold in PARTICIPATION_BADGES:
+                if games < threshold:
+                    continue
+                key = (int(player_id), badge_id)
+                if key in existing:
+                    continue
+                existing.add(key)
+                rows.append(
+                    {
+                        "id": str(uuid4()),
+                        "club_id": club_id,
+                        "player_id": int(player_id),
+                        "badge_id": badge_id,
+                        "earned_at": now,
+                        "context_type": "overall",
+                        "context_id": None,
+                        "value_num": float(games),
+                    }
+                )
+
+        if rows:
+            _insert_badges(supabase, rows)
+    except Exception:
+        logger.exception("ensure_participation_badges failed")
+
+
+def _score_columns(df: pd.DataFrame) -> tuple[str, str] | None:
+    if "score_t1" in df.columns and "score_t2" in df.columns:
+        return "score_t1", "score_t2"
+    if "s1" in df.columns and "s2" in df.columns:
+        return "s1", "s2"
+    return None
+
+
+def _fetch_existing_badges(supabase, club_id: str, badge_ids: list[str]) -> set[tuple[int, str]]:
+    try:
+        resp = (
+            supabase.table("player_badges")
+            .select("player_id,badge_id")
+            .eq("club_id", club_id)
+            .in_("badge_id", badge_ids)
+            .execute()
+        )
+    except Exception:
+        logger.exception("Failed to fetch participation badges")
+        return set()
+
+    existing = set()
+    for row in resp.data or []:
+        try:
+            player_id = int(row.get("player_id"))
+        except Exception:
+            continue
+        badge_id = str(row.get("badge_id"))
+        existing.add((player_id, badge_id))
+    return existing
+
+
+def _insert_badges(supabase, rows: list[dict[str, Any]]) -> None:
+    chunk = 200
+    for i in range(0, len(rows), chunk):
+        supabase.table("player_badges").insert(rows[i : i + chunk]).execute()

--- a/jupr_app/domain/types.py
+++ b/jupr_app/domain/types.py
@@ -11,6 +11,8 @@ class AppContext:
     df_leagues: pd.DataFrame
     df_matches: pd.DataFrame
     df_meta: pd.DataFrame
+    df_badges: pd.DataFrame
+    df_player_badges: pd.DataFrame
     name_to_id: dict
     id_to_name: dict
     public_mode: bool

--- a/jupr_app/ui/context.py
+++ b/jupr_app/ui/context.py
@@ -14,6 +14,8 @@ class AppContext:
     df_leagues: pd.DataFrame
     df_matches: pd.DataFrame
     df_meta: pd.DataFrame
+    df_badges: pd.DataFrame
+    df_player_badges: pd.DataFrame
     name_to_id: dict
     id_to_name: dict
     public_mode: bool

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -105,8 +105,8 @@ def fetch_player_badges(_supabase, club_id: str, pid: int) -> pd.DataFrame:
 
 BADGE_ICONS = {
     "participant": "🎟️",
-    "dedicated_participant": "🧭",
-    "lifetime_participant": "🏅",
+    "dedicated_participant_50": "🧭",
+    "lifetime_participant_200": "🏅",
     "mountain_climber": "🧗",
     "breakthrough": "🚀",
     "above_expectations": "⭐",
@@ -414,11 +414,21 @@ def render(ctx):
         st.caption("No league ratings table entries found for this player yet.")
 
     st.markdown("### Badges")
-    try:
-        badges_df = fetch_player_badges(_supabase, club_id, pid)
-    except Exception:
-        logger.exception("Failed to fetch badges for player view")
-        badges_df = pd.DataFrame()
+    badges_df = pd.DataFrame()
+    if getattr(ctx, "df_player_badges", None) is not None and getattr(ctx, "df_badges", None) is not None:
+        pb_df = ctx.df_player_badges
+        b_df = ctx.df_badges
+        if isinstance(pb_df, pd.DataFrame) and isinstance(b_df, pd.DataFrame) and not pb_df.empty:
+            pb_df = pb_df[pb_df.get("player_id") == int(pid)].copy()
+            if not pb_df.empty and "badge_id" in pb_df.columns:
+                badges_df = pb_df.merge(b_df, on="badge_id", how="left")
+
+    if badges_df.empty:
+        try:
+            badges_df = fetch_player_badges(_supabase, club_id, pid)
+        except Exception:
+            logger.exception("Failed to fetch badges for player view")
+            badges_df = pd.DataFrame()
 
     if badges_df.empty:
         st.caption("No badges earned yet.")
@@ -427,6 +437,25 @@ def render(ctx):
         badges_df["prestige"] = pd.to_numeric(badges_df.get("prestige", 0), errors="coerce").fillna(0)
         badges_df = badges_df.sort_values(["prestige", "earned_at_dt"], ascending=[False, False])
 
+        participation_order = ["lifetime_participant_200", "dedicated_participant_50", "participant"]
+        participation_df = badges_df[badges_df["badge_id"].isin(participation_order)].copy()
+        participation_badge = None
+        if not participation_df.empty:
+            participation_df["tier_rank"] = participation_df["badge_id"].map(
+                {badge_id: idx for idx, badge_id in enumerate(participation_order)}
+            )
+            participation_df = participation_df.sort_values(["tier_rank", "earned_at_dt"])
+            participation_badge = participation_df.iloc[0]
+
+        st.subheader("Participation")
+        if participation_badge is None:
+            st.caption("No participation badge earned yet.")
+        else:
+            icon = badge_icon(participation_badge.get("badge_id"), participation_badge.get("category"))
+            st.markdown(f"**{icon} {participation_badge.get('name', 'Badge')}**")
+            st.caption(f"Prestige {int(participation_badge.get('prestige', 0) or 0)}")
+
+        st.subheader("All badges")
         top_badges = badges_df.head(3).copy()
         cols = st.columns(len(top_badges))
         for idx, (_, row) in enumerate(top_badges.iterrows()):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -13,6 +13,7 @@ import pandas as pd  # kept because pages may rely on it
 from jupr_app.data.client import make_supabase
 from jupr_app.data.load import load_data
 from jupr_app.domain.badges import ensure_badges
+from jupr_app.domain.badges_participation import ensure_participation_badges
 from jupr_app.ui.context import AppContext
 from jupr_app.ui.theme_clean import apply_clean_theme
 from jupr_app.ui.url import qp_get
@@ -269,6 +270,8 @@ def main():
             df_leagues,
             df_matches,
             df_meta,
+            df_badges,
+            df_player_badges,
             name_to_id,
             id_to_name,
         ) = get_data(CLUB_ID)
@@ -281,6 +284,8 @@ def main():
             df_leagues=df_leagues,
             df_matches=df_matches,
             df_meta=df_meta,
+            df_badges=df_badges,
+            df_player_badges=df_player_badges,
             name_to_id=name_to_id,
             id_to_name=id_to_name,
             public_mode=PUBLIC_MODE,
@@ -288,6 +293,14 @@ def main():
         )
 
         ensure_badges(ctx)
+        data_sig = (
+            str(CLUB_ID),
+            int(len(df_players_all) if df_players_all is not None else 0),
+            int(len(df_matches) if df_matches is not None else 0),
+        )
+        if st.session_state.get("participation_badges_sig") != data_sig:
+            ensure_participation_badges(ctx)
+            st.session_state["participation_badges_sig"] = data_sig
 
         # -------------------------
         # LAZY IMPORT PAGES (prevents import-time KeyError crashes)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_badges_participation.py
+++ b/tests/test_badges_participation.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from jupr_app.domain.badges_participation import compute_lifetime_games, ensure_participation_badges
+
+
+class FakeTable:
+    def __init__(self, storage, name):
+        self.storage = storage
+        self.name = name
+        self.filters = []
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, column, value):
+        self.filters.append(("eq", column, value))
+        return self
+
+    def in_(self, column, values):
+        self.filters.append(("in", column, set(values)))
+        return self
+
+    def insert(self, rows):
+        self.storage.setdefault(self.name, []).extend(rows)
+        return self
+
+    def execute(self):
+        data = list(self.storage.get(self.name, []))
+        for op, column, value in self.filters:
+            if op == "eq":
+                data = [row for row in data if str(row.get(column)) == str(value)]
+            elif op == "in":
+                data = [row for row in data if row.get(column) in value]
+        return SimpleNamespace(data=data)
+
+
+class FakeSupabase:
+    def __init__(self, storage=None):
+        self.storage = storage or {}
+
+    def table(self, name):
+        return FakeTable(self.storage, name)
+
+
+def test_compute_lifetime_games_counts_team_rows():
+    df_matches = pd.DataFrame(
+        [
+            {"t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 8},
+            {"t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 9},
+            {"t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": None, "score_t1": 11, "score_t2": 9},
+            {"t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 0, "score_t2": 0},
+        ]
+    )
+    ctx = SimpleNamespace(df_matches=df_matches, club_id="club")
+    counts = compute_lifetime_games(ctx)
+    assert counts == {1: 2, 2: 2, 3: 2, 4: 2}
+
+
+def test_compute_lifetime_games_counts_player_rows():
+    df_matches = pd.DataFrame(
+        [
+            {"player_id": 10, "score_t1": 11, "score_t2": 6},
+            {"player_id": 10, "score_t1": 11, "score_t2": 9},
+            {"player_id": 11, "score_t1": 0, "score_t2": 0},
+        ]
+    )
+    ctx = SimpleNamespace(df_matches=df_matches, club_id="club")
+    counts = compute_lifetime_games(ctx)
+    assert counts == {10: 2}
+
+
+def test_ensure_participation_badges_is_idempotent():
+    rows = [{"player_id": 1, "score_t1": 11, "score_t2": 9, "club_id": "club"} for _ in range(210)]
+    rows.append({"player_id": 2, "score_t1": 11, "score_t2": 9, "club_id": "club"})
+    df_matches = pd.DataFrame(rows)
+
+    storage = {"player_badges": []}
+    supabase = FakeSupabase(storage)
+    ctx = SimpleNamespace(
+        df_matches=df_matches,
+        club_id="club",
+        supabase=supabase,
+        public_mode=False,
+    )
+
+    ensure_participation_badges(ctx)
+    ensure_participation_badges(ctx)
+
+    inserted = storage["player_badges"]
+    badge_map = {(row["player_id"], row["badge_id"]) for row in inserted}
+    assert len(inserted) == 4
+    assert badge_map == {
+        (1, "participant"),
+        (1, "dedicated_participant_50"),
+        (1, "lifetime_participant_200"),
+        (2, "participant"),
+    }


### PR DESCRIPTION
### Motivation
- Provide automatic, idempotent awarding of participation-tier badges based on lifetime games played across a club's matches so players earn `participant`, `dedicated_participant_50`, and `lifetime_participant_200` tiers. 
- Surface badge data in the Player Profile UI and preload badge tables into app context for faster page rendering. 
- Keep awarding safe in public deployments and avoid duplicate awards.

### Description
- Added a new domain module `jupr_app/domain/badges_participation.py` implementing `compute_lifetime_games(ctx)` to count a player’s lifetime games (handles both per-player rows and 4-player match rows, filters by `club_id`, ignores empty/deleted matches) and `ensure_participation_badges(ctx)` to idempotently insert missing participation badges in bulk to `player_badges` via the Supabase client. 
- Updated canonical badge definitions to use `dedicated_participant_50` and `lifetime_participant_200` in `jupr_app/domain/badges.py`. 
- Loaded badge tables in `jupr_app/data/load.py` so the app context now includes `df_badges` and `df_player_badges`. 
- Extended `AppContext` dataclasses (`jupr_app/ui/context.py`, `jupr_app/domain/types.py`) to include `df_badges` and `df_player_badges`. 
- Wire-up: call `ensure_participation_badges(ctx)` during app load in `streamlit_app.py` after data is fetched, guarded to run at most once per data-sig using `st.session_state['participation_badges_sig']`. 
- Player Profile UI (`jupr_app/ui/pages/players.py`) now uses cached `ctx.df_player_badges` / `ctx.df_badges` when available and displays the highest participation tier earned (priority: `lifetime_participant_200` > `dedicated_participant_50` > `participant`) with icon and prestige; also still shows all earned badges in an expander. 
- Awarding behavior: only inserts missing rows (checks existing `player_badges` for club + badge_ids), uses bulk inserts in chunks, sets `context_type='overall'`, `context_id=None`, `value_num` to current lifetime game count, never deletes or overwrites `earned_at`, and returns silently in `public_mode`. 
- Added tests and small test harness: `tests/test_badges_participation.py` and `tests/conftest.py` to validate counting and idempotency logic.

### Testing
- Ran the automated test suite with `pytest -q`; all tests passed: `6 passed`.
- Added unit tests `tests/test_badges_participation.py` that assert `compute_lifetime_games` counts for team-style and per-player rows and that `ensure_participation_badges` is idempotent; these tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974043ac6cc832698e5e83e45b0b247)