### PR TITLE
Add badge story narratives to Leaderboards Story View

### DIFF
--- a/jupr_app/ui/helpers.py
+++ b/jupr_app/ui/helpers.py
@@ -1,5 +1,9 @@
-import streamlit as st
+from __future__ import annotations
+
 import urllib.parse
+
+import pandas as pd
+import streamlit as st
 
 
 def qp_get(key: str, default: str = "") -> str:
@@ -91,3 +95,186 @@ def build_match_explorer_link(
         params["public"] = "1"
     q = urllib.parse.urlencode(params, quote_via=urllib.parse.quote_plus)
     return f"{base}/?{q}"
+
+
+def build_badge_story(player_row: dict | pd.Series, earned_badges: list[dict]) -> str:
+    name = _coerce_text(_row_value(player_row, ["name", "player", "player_name"]), "Player")
+    games = _coerce_int(_row_value(player_row, ["games", "matches_played", "matches", "games_played"]), 0)
+    win_ratio = _normalize_win_pct(_row_value(player_row, ["win_pct", "Win %", "win_pct_pct"]))
+    delta = _coerce_float(_row_value(player_row, ["delta", "Gain", "rating_gain", "rating_delta"]))
+
+    badges = _dedupe_badges(earned_badges or [])
+    headline_badges = _select_headline_badges(badges)
+
+    if not headline_badges:
+        if games <= 0:
+            return "New to the standings—play your first matches to begin earning badges."
+        if games <= 5:
+            return "New to the leaderboard—log a few matches to start earning badges."
+        return (
+            f"Active this season with {games} games logged—"
+            "badges will start appearing as milestones unlock."
+        )
+
+    badge_sentence = _build_badge_sentence(name, headline_badges)
+    stats_sentence = _build_stats_sentence(games, win_ratio, delta)
+    category_hook = _category_hook(headline_badges[0].get("category"))
+    if category_hook:
+        stats_sentence = f"{category_hook} {stats_sentence[0].lower()}{stats_sentence[1:]}"
+
+    story = f"{badge_sentence} {stats_sentence}".strip()
+    if len(story) > 180:
+        story = badge_sentence
+    if len(story) > 180 and len(headline_badges) > 1:
+        short_badge_sentence = _build_badge_sentence(name, headline_badges[:1])
+        story = short_badge_sentence
+    return story
+
+
+def _row_value(row: dict | pd.Series, keys: list[str]):
+    if row is None:
+        return None
+    for key in keys:
+        if hasattr(row, "get"):
+            value = row.get(key)
+        else:
+            try:
+                value = row[key]
+            except Exception:
+                value = None
+        if not _is_missing(value):
+            return value
+    return None
+
+
+def _is_missing(value) -> bool:
+    try:
+        return value is None or pd.isna(value)
+    except Exception:
+        return value is None
+
+
+def _coerce_float(value) -> float | None:
+    if _is_missing(value):
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def _coerce_int(value, default: int = 0) -> int:
+    if _is_missing(value):
+        return default
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _coerce_text(value, default: str) -> str:
+    if _is_missing(value):
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _normalize_win_pct(value) -> float | None:
+    val = _coerce_float(value)
+    if val is None:
+        return None
+    if val > 1.0:
+        return val / 100.0
+    return val
+
+
+def _dedupe_badges(badges: list[dict]) -> list[dict]:
+    seen: set[str] = set()
+    unique: list[dict] = []
+    for badge in badges:
+        badge_id = badge.get("badge_id") or badge.get("id") or badge.get("code") or badge.get("name")
+        key = str(badge_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(badge)
+    return unique
+
+
+def _badge_sort_key(badge: dict) -> tuple:
+    prestige = _coerce_int(badge.get("prestige"), 0)
+    earned_at = badge.get("earned_at_dt") or badge.get("earned_at")
+    earned_dt = pd.to_datetime(earned_at, utc=True, errors="coerce")
+    earned_ts = earned_dt.timestamp() if pd.notna(earned_dt) else 0.0
+    return (-prestige, -earned_ts)
+
+
+def _select_headline_badges(badges: list[dict]) -> list[dict]:
+    if not badges:
+        return []
+    ordered = sorted(badges, key=_badge_sort_key)
+    return ordered[:2]
+
+
+def _build_badge_sentence(name: str, badges: list[dict]) -> str:
+    badge_names = [str(b.get("name", "Badge")) for b in badges if b.get("name")]
+    if not badge_names:
+        return f"{name} has earned a badge this season."
+    if len(badge_names) == 1:
+        return f"{name} has earned {badge_names[0]} this season."
+    return f"{name} has earned {badge_names[0]} and {badge_names[1]} this season."
+
+
+def _build_stats_sentence(games: int, win_ratio: float | None, delta: float | None) -> str:
+    if games <= 0:
+        return "No games logged yet."
+
+    games_str = f"{games} game" + ("s" if games != 1 else "")
+    win_pct = f"{win_ratio * 100:.0f}%" if win_ratio is not None else None
+
+    if delta is not None and win_pct is not None:
+        if delta >= 0.10:
+            return (
+                f"They're climbing with a {delta:+.3f} rating change and a {win_pct} "
+                f"win rate over {games_str}."
+            )
+        if delta <= -0.10:
+            return f"Despite a small dip lately, they've logged {games_str} with a {win_pct} win rate."
+        return (
+            f"Steady with a {delta:+.3f} rating change and a {win_pct} win rate over {games_str}."
+        )
+
+    if delta is not None:
+        if delta >= 0.10:
+            return f"They're climbing with a {delta:+.3f} rating change over {games_str}."
+        if delta <= -0.10:
+            return (
+                f"Despite a small dip lately, they've logged {games_str} with a "
+                f"{delta:+.3f} rating change."
+            )
+        return f"Steady with a {delta:+.3f} rating change over {games_str}."
+
+    if win_pct is not None:
+        if win_ratio is not None and win_ratio >= 0.70:
+            form = "Hot form"
+        elif win_ratio is not None and win_ratio >= 0.55:
+            form = "Solid form"
+        else:
+            form = "Grinding"
+        return f"{form} with a {win_pct} win rate over {games_str}."
+
+    return f"Active with {games_str} logged."
+
+
+def _category_hook(category: str | None) -> str:
+    if not category:
+        return ""
+    category = str(category).strip()
+    hooks = {
+        "Prestige / Rarity": "A marquee badge highlight,",
+        "Momentum & Progress": "Momentum is building,",
+        "Dominance & Quality": "Strong results back it up,",
+        "Participation": "Plenty of activity to build on,",
+        "Performance vs Expectation": "A standout result to build on,",
+    }
+    return hooks.get(category, "")

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -10,6 +10,7 @@ from jupr_app.ui.public_links import build_public_url, public_link_button
 from jupr_app.ui.layout import page_shell
 from jupr_app.ui.theme_clean import callout
 from jupr_app.ui.pages.players import badge_icon
+from jupr_app.ui.helpers import build_badge_story
 
 
 logger = logging.getLogger(__name__)
@@ -149,6 +150,7 @@ def _build_story_badge_map(badges_df: pd.DataFrame) -> dict[int, list[dict]]:
                 "name": row.get("name", "Badge"),
                 "prestige": int(row.get("prestige", 0) or 0),
                 "category": row.get("category"),
+                "code": row.get("code"),
                 "icon": row.get("icon"),
                 "earned_at_dt": row.get("earned_at_dt"),
             }
@@ -417,6 +419,11 @@ def render(ctx):
             flex-wrap: wrap;
             gap: 8px;
         }
+        .lb-story-text {
+            font-size: 12px;
+            color: rgba(255,255,255,0.65);
+            margin-top: 6px;
+        }
         .lb-badge {
             font-size: 11px;
             padding: 2px 8px;
@@ -508,6 +515,7 @@ def render(ctx):
     st.session_state.setdefault("lb_league", available_leagues[default_idx])
     st.session_state.setdefault("lb_view_mode", "Story View")
     st.session_state.setdefault("lb_show_inactive", False)
+    st.session_state.setdefault("lb_show_stories", True)
     target_league = st.session_state.get("lb_league", available_leagues[default_idx])
     if target_league not in available_leagues:
         target_league = available_leagues[default_idx]
@@ -742,6 +750,8 @@ def render(ctx):
             )
     with control_cols[2]:
         st.text_input("Find player", key="lb_search")
+        if view_mode == "Story View":
+            st.checkbox("Show stories", key="lb_show_stories", value=True)
     if target_league != "OVERALL" and not PUBLIC_MODE:
         st.checkbox("Show inactive", key="lb_show_inactive", value=False)
 
@@ -1039,6 +1049,7 @@ def render(ctx):
             )
 
             story_badges_html = ""
+            story_text_html = ""
             player_id = row.get("_pid")
             story_badges = []
             if pd.notna(player_id):
@@ -1068,6 +1079,10 @@ def render(ctx):
                 story_badges_html = (
                     '<div class="lb-badge-strip"><span class="lb-badge">New</span></div>'
                 )
+            if st.session_state.get("lb_show_stories", True):
+                story_text = build_badge_story(row, story_badges)
+                if story_text:
+                    story_text_html = f'<div class="lb-story-text">{html.escape(story_text)}</div>'
             st.markdown(
                 f"""
                 <div class="lb-standings-card">
@@ -1082,6 +1097,7 @@ def render(ctx):
                         <span style="color:{gain_color};">{gain_val:+.3f} Δ</span>
                     </div>
                     {story_badges_html}
+                    {story_text_html}
                     <div class="lb-row" style="gap:6px;">{badge_html}</div>
                 </div>
                 """,

--- a/tests/test_badge_story.py
+++ b/tests/test_badge_story.py
@@ -1,0 +1,47 @@
+import pandas as pd
+
+from jupr_app.ui.helpers import build_badge_story
+
+
+def test_build_badge_story_with_badges_and_stats():
+    row = {
+        "name": "Ava",
+        "matches_played": 25,
+        "Win %": 80,
+        "Gain": 0.234,
+    }
+    badges = [
+        {
+            "badge_id": "upset_champion",
+            "name": "Upset Champion",
+            "prestige": 90,
+            "category": "Prestige / Rarity",
+            "earned_at_dt": pd.Timestamp("2024-05-01", tz="UTC"),
+        }
+    ]
+    story = build_badge_story(row, badges)
+    assert "Ava has earned Upset Champion" in story
+    assert "+0.234" in story
+    assert "80%" in story
+    assert "25 games" in story
+
+
+def test_build_badge_story_no_badges_zero_games():
+    row = {"name": "Kai", "matches_played": 0}
+    story = build_badge_story(row, [])
+    assert story == "New to the standings—play your first matches to begin earning badges."
+
+
+def test_build_badge_story_no_badges_low_games():
+    row = {"name": "Kai", "matches_played": 3}
+    story = build_badge_story(row, [])
+    assert story == "New to the leaderboard—log a few matches to start earning badges."
+
+
+def test_build_badge_story_no_badges_active():
+    row = {"name": "Kai", "matches_played": 12}
+    story = build_badge_story(row, [])
+    assert (
+        story
+        == "Active this season with 12 games logged—badges will start appearing as milestones unlock."
+    )


### PR DESCRIPTION
### Motivation
- Provide a short, grounded, deterministic “Badge Story” recap for each player derived only from earned badges and leaderboard stats so viewers get a compact, factual summary under the player name. 
- Avoid LLMs or invented details by using rule-based templates that map badges and stat signals to human-friendly sentences.

### Description
- Added a deterministic story builder `build_badge_story(player_row: dict|pd.Series, earned_badges: list[dict]) -> str` in `jupr_app/ui/helpers.py` that extracts name, games, win_pct, and rating delta, dedupes badges by `badge_id`, selects up to two headline badges by `prestige` then `earned_at`, and composes 1–2 sentence stories using rule-based templates and category-based hooks.  
- Implemented stat signal logic and thresholds consistent with the spec (games buckets, win_pct buckets, and delta momentum thresholds) and ensured output is concise (falls back to badge-only sentence if >180 chars).
- Integrated rendering into `Leaderboards` Story View (`jupr_app/ui/pages/leaderboards.py`) to show the story line under the badge strip using the already-built `story_badges_by_player` map (no per-row Supabase calls), added subtle `.lb-story-text` styling, and a `Show stories` checkbox toggle (default ON) to hide stories if desired.
- Ensured badges are deduped by `badge_id` and preserved existing badge icon rendering; added `code` to the in-memory badge map to support identification.
- Added unit-style tests `tests/test_badge_story.py` covering badge/no-badge scenarios and expected outputs.

### Testing
- Ran the test suite with `pytest -q`; all tests passed (`10 passed` in CI run locally).
- Added `tests/test_badge_story.py` to validate story templates for players with badges, zero games, low activity, and active players without badges.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974ef1cf84883269a765dfd288ba347)