### PR TITLE
Render badge stories in Story View under each player; resilient defaults; uses existing badge map

### DIFF
--- a/jupr_app/ui/helpers.py
+++ b/jupr_app/ui/helpers.py
@@ -128,6 +128,11 @@ def build_badge_story(player_row: dict | pd.Series, earned_badges: list[dict]) -
     if len(story) > 180 and len(headline_badges) > 1:
         short_badge_sentence = _build_badge_sentence(name, headline_badges[:1])
         story = short_badge_sentence
+    if not story:
+        if games <= 0:
+            return "New to the standings—play your first matches to begin earning badges."
+        games_str = f"{games} game" + ("s" if games != 1 else "")
+        return f"Active this season with {games_str} logged."
     return story
 
 

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -420,8 +420,8 @@ def render(ctx):
             gap: 8px;
         }
         .lb-story-text {
-            font-size: 12px;
-            color: rgba(255,255,255,0.65);
+            font-size: 0.9rem;
+            color: rgba(255,255,255,0.70);
             margin-top: 6px;
         }
         .lb-badge {
@@ -1032,6 +1032,21 @@ def render(ctx):
             story_badges_df,
             admin_logged_in,
         )
+        if admin_logged_in and story_badges_by_player:
+            if not st.session_state.get("lb_story_sanity_logged"):
+                sanity_story = ""
+                for _, row in standings.head(limit).iterrows():
+                    pid = row.get("_pid")
+                    if pd.notna(pid) and story_badges_by_player.get(int(pid)):
+                        sanity_story = build_badge_story(
+                            row, story_badges_by_player.get(int(pid), [])
+                        )
+                        break
+                if not sanity_story:
+                    logger.warning(
+                        "Story View sanity check failed: no story generated for badges."
+                    )
+                st.session_state["lb_story_sanity_logged"] = True
 
         for _, row in standings.head(limit).iterrows():
             gain_val = float(row["Gain"]) if pd.notna(row["Gain"]) else 0.0
@@ -1081,8 +1096,9 @@ def render(ctx):
                 )
             if st.session_state.get("lb_show_stories", True):
                 story_text = build_badge_story(row, story_badges)
-                if story_text:
-                    story_text_html = f'<div class="lb-story-text">{html.escape(story_text)}</div>'
+                if not story_text:
+                    story_text = build_badge_story(row, [])
+                story_text_html = f'<div class="lb-story-text">{html.escape(story_text)}</div>'
             st.markdown(
                 f"""
                 <div class="lb-standings-card">


### PR DESCRIPTION
### Motivation
- Story View showed badge icons but no visible story text for players, leaving the UI missing the intended narrative line. 
- The story builder could produce empty output in some edge cases or be suppressed by rendering logic, so we need resilient defaults and guaranteed rendering. 
- Keep performance and data access unchanged by reusing the existing badge map and avoiding per-row network calls.  

### Description
- Ensure `build_badge_story` in `jupr_app/ui/helpers.py` never returns an empty string by adding a final fallback that emits a sensible message based on `games` when no headline badges produce text. 
- Always compute a per-row story using the existing `story_badges_by_player` map in `jupr_app/ui/pages/leaderboards.py` and render it into the card HTML as an escaped `div` with class `lb-story-text` so raw HTML never appears. 
- Update the `.lb-story-text` CSS to `font-size: 0.9rem` and `color: rgba(255,255,255,0.70)` to improve visibility. 
- Add a one-time admin-only sanity check (logged to server logs and gated by `st.session_state`) that verifies at least one player with badges produces a non-empty story, without exposing debug output to users. 

### Testing
- Launched the app with `streamlit run streamlit_app.py` and ran a Playwright smoke script that loaded the leaderboards page and saved a screenshot at `artifacts/leaderboards-story-view.png`, confirming stories render in the Story View. 
- No automated unit tests were added or failed during this change and the change set was committed with the message `Render badge stories in Story View under each player; resilient defaults; uses existing badge map`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974f16ec4008326827f33ee51d7c9e1)