### PR TITLE
Leaderboards Story View: emphasize player name + add badge hover tooltips

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -402,15 +402,32 @@ def render(ctx):
             font-weight: 700;
             font-size: 16px;
             min-width: 38px;
+            flex: 0 0 42px;
         }
         .lb-standings-name {
-            font-size: 15px;
-            font-weight: 600;
+            font-size: 18px;
+            font-weight: 650;
+            color: var(--accent);
+            letter-spacing: 0.2px;
+            flex: 1 1 240px;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .lb-standings-name a {
+            color: inherit;
+            text-decoration: none;
+        }
+        .lb-standings-name a:hover {
+            text-decoration: underline;
+            opacity: 0.95;
         }
         .lb-standings-rating {
             font-size: 16px;
             font-weight: 700;
             text-align: right;
+            flex: 0 0 72px;
         }
         .lb-standings-stats {
             font-size: 12px;
@@ -468,6 +485,12 @@ def render(ctx):
             }
             .lb-kpi {
                 min-width: 0;
+            }
+            .lb-standings-name {
+                white-space: normal;
+                display: -webkit-box;
+                -webkit-line-clamp: 2;
+                -webkit-box-orient: vertical;
             }
             .stButton > button,
             .stLinkButton > a {
@@ -1080,11 +1103,13 @@ def render(ctx):
                     )
                     name = badge.get("name", "Badge")
                     prestige = badge.get("prestige", 0)
-                    title = (
-                        f"{name} (Prestige {prestige})"
-                        if prestige and int(prestige) > 0
-                        else str(name)
-                    )
+                    category = badge.get("category")
+                    title_parts = [str(name)]
+                    if category:
+                        title_parts.append(str(category))
+                    if prestige and int(prestige) > 0:
+                        title_parts.append(f"Prestige {int(prestige)}")
+                    title = " • ".join(title_parts)
                     badge_parts.append(
                         f'<span class="lb-story-badge" title="{html.escape(title)}">'
                         f"{html.escape(str(icon))}</span>"


### PR DESCRIPTION
### Motivation
- Improve the visual hierarchy of Story View cards so the player name reads as the focal point without overpowering the clean/dark theme. 
- Surface badge metadata on hover so users can see badge names (and optional category/prestige) without adding visible labels or extra Streamlit controls.

### Description
- Increased prominence of the player name by updating Story View CSS in `jupr_app/ui/pages/leaderboards.py` — larger font size, heavier weight, accent color via `var(--accent)`, added letter-spacing, and a flex-based center column with `overflow: hidden` + `text-overflow: ellipsis` to gracefully truncate long names. 
- Improved layout sizing so rank and rating reserve fixed space (`flex: 0 0 ...`) and the name area takes more horizontal room (`flex: 1 1 240px`), with mobile-friendly wrapping that allows up to two lines using `-webkit-line-clamp`. 
- Added anchor styling to keep player links inheriting the new name color and to provide an understated hover state. 
- Added richer badge tooltip content by joining badge `name`, optional `category`, and optional `Prestige N` with separators and emitting it as the `title` attribute on the existing badge icon span so native hover tooltips appear without extra UI elements.

### Testing
- Launched the Streamlit app and captured a full-page screenshot via Playwright to visually verify the Story View cards and badge tooltips, which completed successfully. 
- No automated unit tests were required for this UI-only change and none were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974f4b52ed083269d42c9fac9a666db)