### PR TITLE
Add Substitute / Add Player workflow for League Night (between rounds)

### DIFF
--- a/jupr_app/domain/league_night_roster.py
+++ b/jupr_app/domain/league_night_roster.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import pandas as pd
+
+
+class RosterChangeError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class RosterChangeResult:
+    roster_df: pd.DataFrame
+    court_sizes: list[int]
+    bench_ids: list[int]
+    note: str | None = None
+
+
+def suggest_court_sizes(total_players: int) -> dict:
+    """
+    Courts may be size 4 or 5 only.
+    Prefer exact fit (bench=0), then fewer 5s, then fewer courts.
+    """
+    n = int(total_players or 0)
+    if n <= 0:
+        return {"ok": False, "sizes": [], "bench": 0, "note": "No players."}
+
+    if n in (20, 40) and n % 4 == 0:
+        sizes = [4] * (n // 4)
+        return {"ok": True, "sizes": sizes, "bench": 0, "note": f"Preferred all-4s for total {n}."}
+
+    candidates = []
+    min_courts = (n + 5 - 1) // 5
+    max_courts = max(1, n // 4)
+
+    for courts in range(max(1, min_courts - 2), max_courts + 3):
+        for fives in range(0, courts + 1):
+            fours = courts - fives
+            capacity = 4 * fours + 5 * fives
+            if capacity > n:
+                continue
+            bench = n - capacity
+            score = (bench, fives, courts)
+            candidates.append((score, fours, fives, bench))
+
+    if not candidates:
+        return {"ok": False, "sizes": [], "bench": n, "note": "No feasible setup with 4/5 courts."}
+
+    candidates.sort(key=lambda x: x[0])
+    _, fours, fives, bench = candidates[0]
+    sizes = ([4] * int(fours)) + ([5] * int(fives))
+
+    if bench == 0:
+        note = f"Exact fit: {fours} court(s) of 4 and {fives} court(s) of 5."
+    else:
+        note = f"Closest fit: {fours} court(s) of 4 and {fives} court(s) of 5, with {bench} bench."
+
+    return {"ok": True, "sizes": sizes, "bench": int(bench), "note": note}
+
+
+def roster_change_availability(
+    ladder_state: str,
+    current_round: int,
+    total_rounds: int,
+    is_admin: bool = True,
+) -> tuple[bool, str]:
+    if not is_admin:
+        return False, "Admin login required."
+    if str(ladder_state or "").strip().upper() != "CONFIRM_MOVEMENT":
+        return False, "Roster changes are available between rounds only."
+    if int(current_round) >= int(total_rounds):
+        return False, "Roster changes are unavailable because the league night is complete."
+    return True, ""
+
+
+def _ordered_roster(roster_df: pd.DataFrame) -> pd.DataFrame:
+    df = roster_df.copy()
+    if df.empty:
+        return df
+
+    order_cols = []
+    if "court" in df.columns:
+        order_cols.append("court")
+    if "slot" in df.columns:
+        order_cols.append("slot")
+
+    if order_cols:
+        return df.sort_values(order_cols).reset_index(drop=True)
+
+    if "rating" in df.columns:
+        return df.sort_values("rating", ascending=False).reset_index(drop=True)
+
+    return df.reset_index(drop=True)
+
+
+def _apply_court_sizes(roster_df: pd.DataFrame, court_sizes: Iterable[int]) -> pd.DataFrame:
+    df = _ordered_roster(roster_df)
+    sizes = [int(x) for x in court_sizes]
+    total = int(sum(sizes))
+    if len(df) != total:
+        raise RosterChangeError("Court sizes must match roster size.")
+
+    assignments = []
+    idx = 0
+    for c_idx, size in enumerate(sizes, start=1):
+        for slot in range(1, int(size) + 1):
+            row = df.iloc[idx].copy()
+            row["court"] = int(c_idx)
+            row["slot"] = int(slot)
+            assignments.append(row)
+            idx += 1
+
+    return pd.DataFrame(assignments)
+
+
+def _select_bench_ids(
+    roster_df: pd.DataFrame,
+    bench_count: int,
+    prefer_keep_ids: set[int] | None = None,
+) -> list[int]:
+    if bench_count <= 0:
+        return []
+
+    prefer_keep_ids = prefer_keep_ids or set()
+    df = roster_df.copy()
+    df["rating"] = pd.to_numeric(df.get("rating", 1200.0), errors="coerce").fillna(1200.0)
+    df["player_id"] = pd.to_numeric(df["player_id"], errors="coerce").fillna(-1).astype(int)
+
+    sorted_df = df.sort_values("rating", ascending=True).reset_index(drop=True)
+    bench_ids: list[int] = []
+
+    for _, row in sorted_df.iterrows():
+        pid = int(row["player_id"])
+        if pid in prefer_keep_ids:
+            continue
+        bench_ids.append(pid)
+        if len(bench_ids) >= bench_count:
+            break
+
+    if len(bench_ids) < bench_count:
+        for _, row in sorted_df.iterrows():
+            pid = int(row["player_id"])
+            if pid in bench_ids:
+                continue
+            bench_ids.append(pid)
+            if len(bench_ids) >= bench_count:
+                break
+
+    return bench_ids
+
+
+def rebalance_roster(
+    roster_df: pd.DataFrame,
+    court_sizes: list[int] | None = None,
+    prefer_keep_ids: set[int] | None = None,
+) -> tuple[pd.DataFrame, list[int], list[int], str | None]:
+    df = roster_df.copy()
+    total = len(df)
+    sizes = [int(x) for x in (court_sizes or []) if int(x) > 0]
+
+    note = None
+    bench_ids: list[int] = []
+
+    if not sizes or sum(sizes) != total:
+        suggestion = suggest_court_sizes(total)
+        sizes = [int(x) for x in suggestion.get("sizes", [])]
+        bench_count = int(suggestion.get("bench", 0) or 0)
+        note = suggestion.get("note")
+        if bench_count > 0:
+            bench_ids = _select_bench_ids(df, bench_count, prefer_keep_ids=prefer_keep_ids)
+            df = df[~df["player_id"].astype(int).isin(bench_ids)].copy()
+            total = len(df)
+            suggestion = suggest_court_sizes(total)
+            sizes = [int(x) for x in suggestion.get("sizes", [])]
+            note = suggestion.get("note")
+
+    if sum(sizes) != len(df):
+        raise RosterChangeError("Unable to rebalance courts with current roster size.")
+
+    df = _apply_court_sizes(df, sizes)
+    return df, sizes, bench_ids, note
+
+
+def apply_roster_change(
+    roster_df: pd.DataFrame,
+    change_type: str,
+    new_player: dict,
+    replaced_player_id: int | None = None,
+    court_sizes: list[int] | None = None,
+    roster_locked: bool = False,
+) -> RosterChangeResult:
+    if roster_locked:
+        raise RosterChangeError("Round in progress; roster changes are locked.")
+
+    if roster_df is None or roster_df.empty:
+        raise RosterChangeError("Roster is empty.")
+
+    df = roster_df.copy()
+    df["player_id"] = pd.to_numeric(df["player_id"], errors="coerce").fillna(-1).astype(int)
+
+    change_type = str(change_type or "").strip().lower()
+    if change_type not in {"substitute", "add"}:
+        raise RosterChangeError("Invalid roster change type.")
+
+    new_pid = int(new_player.get("id", -1))
+    if new_pid <= 0:
+        raise RosterChangeError("New player is invalid.")
+
+    if change_type == "substitute":
+        if replaced_player_id is None:
+            raise RosterChangeError("Replacement player is required.")
+        replaced_player_id = int(replaced_player_id)
+        if replaced_player_id == new_pid:
+            raise RosterChangeError("Cannot substitute with the same player.")
+        if new_pid in df["player_id"].tolist():
+            raise RosterChangeError("Player already active.")
+        if replaced_player_id not in df["player_id"].tolist():
+            raise RosterChangeError("Replacement player is not active.")
+
+        df.loc[df["player_id"] == replaced_player_id, "player_id"] = new_pid
+        df.loc[df["player_id"] == new_pid, "name"] = str(new_player.get("name", ""))
+        df.loc[df["player_id"] == new_pid, "rating"] = float(new_player.get("rating", 1200.0))
+
+        new_df, new_sizes, bench_ids, note = rebalance_roster(df, court_sizes=court_sizes)
+        return RosterChangeResult(roster_df=new_df, court_sizes=new_sizes, bench_ids=bench_ids, note=note)
+
+    if new_pid in df["player_id"].tolist():
+        raise RosterChangeError("Player already active.")
+
+    new_row = {
+        "player_id": new_pid,
+        "name": str(new_player.get("name", "")),
+        "rating": float(new_player.get("rating", 1200.0)),
+        "court": int(new_player.get("court", 0) or 0),
+        "slot": int(new_player.get("slot", 0) or 0),
+    }
+
+    df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
+    prefer_keep_ids = {new_pid}
+    new_df, new_sizes, bench_ids, note = rebalance_roster(df, court_sizes=court_sizes, prefer_keep_ids=prefer_keep_ids)
+    return RosterChangeResult(roster_df=new_df, court_sizes=new_sizes, bench_ids=bench_ids, note=note)

--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -12,6 +12,12 @@ from jupr_court_board import court_board
 
 from jupr_app.domain.constants import DEFAULT_K_FACTOR
 from jupr_app.domain.live_ladder import build_movement_preview, compute_round_stats, validate_courts
+from jupr_app.domain.league_night_roster import (
+    RosterChangeError,
+    apply_roster_change,
+    roster_change_availability,
+    suggest_court_sizes,
+)
 from jupr_app.domain.match_processing import process_matches
 from jupr_app.domain.roster import (
     compress_courts,
@@ -54,46 +60,14 @@ def _seed_rating_for_player(pid: int, league_name: str, df_players_all: pd.DataF
     return 1200.0
 
 
-def _suggest_court_sizes(total_players: int) -> dict:
-    """
-    Courts may be size 4 or 5 only.
-    Prefer exact fit (bench=0), then fewer 5s, then fewer courts.
-    """
-    n = int(total_players or 0)
-    if n <= 0:
-        return {"ok": False, "sizes": [], "bench": 0, "note": "No players."}
-
-    if n in (20, 40) and n % 4 == 0:
-        sizes = [4] * (n // 4)
-        return {"ok": True, "sizes": sizes, "bench": 0, "note": f"Preferred all-4s for total {n}."}
-
-    candidates = []
-    min_courts = (n + 5 - 1) // 5
-    max_courts = max(1, n // 4)
-
-    for courts in range(max(1, min_courts - 2), max_courts + 3):
-        for fives in range(0, courts + 1):
-            fours = courts - fives
-            capacity = 4 * fours + 5 * fives
-            if capacity > n:
-                continue
-            bench = n - capacity
-            score = (bench, fives, courts)
-            candidates.append((score, fours, fives, bench))
-
-    if not candidates:
-        return {"ok": False, "sizes": [], "bench": n, "note": "No feasible setup with 4/5 courts."}
-
-    candidates.sort(key=lambda x: x[0])
-    _, fours, fives, bench = candidates[0]
-    sizes = ([4] * int(fours)) + ([5] * int(fives))
-
-    if bench == 0:
-        note = f"Exact fit: {fours} court(s) of 4 and {fives} court(s) of 5."
-    else:
-        note = f"Closest fit: {fours} court(s) of 4 and {fives} court(s) of 5, with {bench} bench."
-
-    return {"ok": True, "sizes": sizes, "bench": int(bench), "note": note}
+def _summarize_roster(roster_df: pd.DataFrame) -> pd.DataFrame:
+    if roster_df is None or roster_df.empty:
+        return pd.DataFrame()
+    cols = [c for c in ["court", "slot", "name", "player_id", "rating"] if c in roster_df.columns]
+    df = roster_df[cols].copy()
+    df["court"] = pd.to_numeric(df.get("court"), errors="coerce").fillna(0).astype(int)
+    df["slot"] = pd.to_numeric(df.get("slot"), errors="coerce").fillna(0).astype(int)
+    return df.sort_values(["court", "slot"]).reset_index(drop=True)
 
 
 def render(ctx):
@@ -340,7 +314,7 @@ def render(ctx):
             total_p = len(st.session_state.ladder_roster)
             st.info(f"Total Players: {total_p}")
 
-            auto = _suggest_court_sizes(total_p)
+            auto = suggest_court_sizes(total_p)
             use_auto = st.checkbox("Use suggested setup (4s/5s only)", value=True, key="ladder_use_auto_courts")
 
             if use_auto and auto["ok"]:
@@ -635,6 +609,230 @@ def render(ctx):
             total_r = int(st.session_state.get("ladder_total_rounds", 1))
             btn_label = "Start Next Round" if current_r < total_r else "🏁 Finish League Night"
 
+            base_next_roster = editor_df.copy()
+            base_next_roster["court"] = base_next_roster["Proposed Court"].astype(int)
+            base_next_roster = base_next_roster.sort_values(["court", "rating"], ascending=[True, False]).copy()
+            base_next_roster["slot"] = base_next_roster.groupby("court").cumcount() + 1
+            base_next_roster = base_next_roster[["player_id", "name", "rating", "court", "slot"]].copy()
+
+            if st.session_state.get("ladder_next_roster_override") is not None:
+                st.info("Roster changes queued for the next round.")
+                st.dataframe(
+                    _summarize_roster(st.session_state.ladder_next_roster_override),
+                    use_container_width=True,
+                    hide_index=True,
+                )
+                if st.session_state.get("ladder_roster_change_note"):
+                    st.caption(str(st.session_state.ladder_roster_change_note))
+                bench_ids = st.session_state.get("ladder_roster_bench_ids") or []
+                if bench_ids:
+                    bench_names = [id_to_name.get(int(pid), f\"#{pid}\") for pid in bench_ids]
+                    st.warning(f\"Sit-out this round: {', '.join(bench_names)}\")
+
+            st.markdown("#### Roster Changes (Between Rounds)")
+            st.caption("Roster changes apply to the next round only. Completed rounds stay unchanged.")
+
+            roster_change_enabled, roster_change_msg = roster_change_availability(
+                ladder_state=st.session_state.get("ladder_state"),
+                current_round=current_r,
+                total_rounds=total_r,
+                is_admin=bool(ctx.admin_logged_in),
+            )
+            if st.button(
+                "Substitute / Add Player",
+                key="ladder_roster_change_btn",
+                disabled=not roster_change_enabled,
+            ):
+                st.session_state.ladder_show_roster_change_dialog = True
+            if not roster_change_enabled and roster_change_msg:
+                st.caption(roster_change_msg)
+
+            if st.session_state.get("ladder_show_roster_change_dialog", False):
+                with st.dialog("Roster Changes (Next Round)"):
+                    next_round = int(current_r + 1)
+                    final_round = int(total_r)
+                    tabs_rc = st.tabs(["Substitute", "Add Player"])
+
+                    def _player_options() -> tuple[list[str], dict[str, dict]]:
+                        rows = ctx.df_players_all if ctx.df_players_all is not None else pd.DataFrame()
+                        options = []
+                        mapping = {}
+                        if rows is None or rows.empty:
+                            return options, mapping
+                        for _, row in rows.iterrows():
+                            pid = int(row.get("id"))
+                            nm = str(row.get("name", "")).strip()
+                            if not nm:
+                                continue
+                            label = f"{nm} (#{pid})"
+                            options.append(label)
+                            mapping[label] = {
+                                "id": pid,
+                                "name": nm,
+                                "rating": float(row.get("rating", 1200.0) or 1200.0),
+                            }
+                        return options, mapping
+
+                    options, option_map = _player_options()
+
+                    with tabs_rc[0]:
+                        st.markdown("Replace player (active roster):")
+                        active_names = preview_df["name"].astype(str).tolist()
+                        active_map = {
+                            str(r["name"]): {
+                                "id": int(r["player_id"]),
+                                "name": str(r["name"]),
+                                "rating": float(r.get("rating", 1200.0)),
+                            }
+                            for _, r in preview_df.iterrows()
+                        }
+                        replaced_name = st.selectbox("Replace player", active_names, key="ladder_sub_out")
+                        replace_info = active_map.get(replaced_name, {})
+
+                        st.markdown("Substitute with:")
+                        use_guest_sub = st.checkbox("Create guest substitute", value=False, key="ladder_sub_guest")
+                        if use_guest_sub:
+                            guest_name = st.text_input("Guest name", key="ladder_sub_guest_name")
+                            guest_rating = st.number_input(
+                                "Guest starting JUPR", min_value=1.0, max_value=7.0, step=0.1, value=3.5, key="ladder_sub_guest_rating"
+                            )
+                            sub_player = {"name": guest_name.strip(), "rating": float(guest_rating)}
+                        else:
+                            sub_label = st.selectbox("Select substitute", options, key="ladder_sub_in")
+                            sub_player = option_map.get(sub_label, {})
+
+                        st.text(f"Effective round: {next_round}")
+                        st.warning(
+                            f\"This will regenerate matchups for rounds {next_round}–{final_round}. Completed rounds will not change.\"
+                        )
+                        confirm_sub = st.checkbox("I understand and want to apply this substitute.", key="ladder_sub_confirm")
+
+                        if st.button("Apply Substitute", type="primary", key="ladder_sub_apply"):
+                            if not confirm_sub:
+                                st.error("Please confirm the roster change before applying.")
+                                st.stop()
+                            try:
+                                if use_guest_sub:
+                                    if not sub_player.get("name"):
+                                        raise RosterChangeError("Guest name is required.")
+                                    ok, err = safe_add_player(
+                                        supabase=ctx.supabase,
+                                        club_id=str(ctx.club_id),
+                                        name=sub_player["name"],
+                                        rating_jupr=float(sub_player.get("rating", 3.5)),
+                                    )
+                                    if not ok:
+                                        raise RosterChangeError(f"Could not add guest: {err}")
+
+                                    fetch = (
+                                        ctx.supabase.table("players")
+                                        .select("id,name,rating")
+                                        .eq("club_id", str(ctx.club_id))
+                                        .eq("name", sub_player["name"])
+                                        .execute()
+                                    )
+                                    rows = fetch.data or []
+                                    if not rows:
+                                        raise RosterChangeError("Guest player was created but could not be loaded.")
+                                    row = rows[0]
+                                    sub_player = {
+                                        "id": int(row["id"]),
+                                        "name": str(row["name"]),
+                                        "rating": float(row.get("rating", 1200.0) or 1200.0),
+                                    }
+                                    id_to_name[int(row["id"])] = str(row["name"])
+                                    name_to_id[str(row["name"])] = int(row["id"])
+
+                                result = apply_roster_change(
+                                    roster_df=base_next_roster,
+                                    change_type="substitute",
+                                    replaced_player_id=int(replace_info.get("id")),
+                                    new_player=sub_player,
+                                    court_sizes=st.session_state.get("ladder_court_sizes"),
+                                    roster_locked=False,
+                                )
+                                st.session_state.ladder_next_roster_override = result.roster_df
+                                st.session_state.ladder_next_court_sizes = result.court_sizes
+                                st.session_state.ladder_roster_change_note = result.note
+                                st.session_state.ladder_roster_bench_ids = result.bench_ids
+                                st.session_state.ladder_show_roster_change_dialog = False
+                                st.success("Substitution queued for next round.")
+                                st.rerun()
+                            except RosterChangeError as exc:
+                                st.error(str(exc))
+
+                    with tabs_rc[1]:
+                        st.markdown("Add player (late arrival):")
+                        use_guest_add = st.checkbox("Create guest player", value=False, key="ladder_add_guest")
+                        if use_guest_add:
+                            guest_name = st.text_input("Guest name", key="ladder_add_guest_name")
+                            guest_rating = st.number_input(
+                                "Guest starting JUPR", min_value=1.0, max_value=7.0, step=0.1, value=3.5, key="ladder_add_guest_rating"
+                            )
+                            add_player = {"name": guest_name.strip(), "rating": float(guest_rating)}
+                        else:
+                            add_label = st.selectbox("Select player", options, key="ladder_add_player")
+                            add_player = option_map.get(add_label, {})
+
+                        st.text(f"Effective round: {next_round}")
+                        st.warning(
+                            f\"This will regenerate matchups for rounds {next_round}–{final_round}. Completed rounds will not change.\"
+                        )
+                        confirm_add = st.checkbox("I understand and want to add this player.", key="ladder_add_confirm")
+
+                        if st.button("Apply Add Player", type="primary", key="ladder_add_apply"):
+                            if not confirm_add:
+                                st.error("Please confirm the roster change before applying.")
+                                st.stop()
+                            try:
+                                if use_guest_add:
+                                    if not add_player.get("name"):
+                                        raise RosterChangeError("Guest name is required.")
+                                    ok, err = safe_add_player(
+                                        supabase=ctx.supabase,
+                                        club_id=str(ctx.club_id),
+                                        name=add_player["name"],
+                                        rating_jupr=float(add_player.get("rating", 3.5)),
+                                    )
+                                    if not ok:
+                                        raise RosterChangeError(f"Could not add guest: {err}")
+
+                                    fetch = (
+                                        ctx.supabase.table("players")
+                                        .select("id,name,rating")
+                                        .eq("club_id", str(ctx.club_id))
+                                        .eq("name", add_player["name"])
+                                        .execute()
+                                    )
+                                    rows = fetch.data or []
+                                    if not rows:
+                                        raise RosterChangeError("Guest player was created but could not be loaded.")
+                                    row = rows[0]
+                                    add_player = {
+                                        "id": int(row["id"]),
+                                        "name": str(row["name"]),
+                                        "rating": float(row.get("rating", 1200.0) or 1200.0),
+                                    }
+                                    id_to_name[int(row["id"])] = str(row["name"])
+                                    name_to_id[str(row["name"])] = int(row["id"])
+
+                                result = apply_roster_change(
+                                    roster_df=base_next_roster,
+                                    change_type="add",
+                                    new_player=add_player,
+                                    court_sizes=st.session_state.get("ladder_court_sizes"),
+                                    roster_locked=False,
+                                )
+                                st.session_state.ladder_next_roster_override = result.roster_df
+                                st.session_state.ladder_next_court_sizes = result.court_sizes
+                                st.session_state.ladder_roster_change_note = result.note
+                                st.session_state.ladder_roster_bench_ids = result.bench_ids
+                                st.session_state.ladder_show_roster_change_dialog = False
+                                st.success("Player added for next round.")
+                                st.rerun()
+                            except RosterChangeError as exc:
+                                st.error(str(exc))
+
             if st.button(btn_label):
                 if current_r >= total_r:
                     st.success("League Night Complete! All matches saved.")
@@ -654,14 +852,17 @@ def render(ctx):
                     st.session_state.ladder_state = "SETUP"
                     st.rerun()
 
-                # Next round roster
-                new_roster = editor_df.copy()
-                new_roster["court"] = new_roster["Proposed Court"].astype(int)
-                new_roster = new_roster.sort_values(["court", "rating"], ascending=[True, False]).copy()
-                new_roster["slot"] = new_roster.groupby("court").cumcount() + 1
+                new_roster = st.session_state.get("ladder_next_roster_override") or base_next_roster
+                new_court_sizes = st.session_state.get("ladder_next_court_sizes") or [
+                    int(x) for x in new_roster["court"].value_counts().sort_index().tolist()
+                ]
 
-                st.session_state.ladder_live_roster = new_roster[["player_id", "name", "rating", "court", "slot"]].copy()
-                st.session_state.ladder_court_sizes = [int(x) for x in new_roster["court"].value_counts().sort_index().tolist()]
+                st.session_state.ladder_live_roster = new_roster.copy()
+                st.session_state.ladder_court_sizes = new_court_sizes
+                st.session_state.pop("ladder_next_roster_override", None)
+                st.session_state.pop("ladder_next_court_sizes", None)
+                st.session_state.pop("ladder_roster_change_note", None)
+                st.session_state.pop("ladder_roster_bench_ids", None)
 
                 st.session_state.ladder_round_num = current_r + 1
                 st.session_state.ladder_state = "CONFIRM_START"

--- a/tests/test_league_night_roster.py
+++ b/tests/test_league_night_roster.py
@@ -1,0 +1,117 @@
+import pandas as pd
+import pytest
+
+from jupr_app.domain.league_night_roster import (
+    RosterChangeError,
+    apply_roster_change,
+    roster_change_availability,
+)
+
+
+def _make_roster(player_ids, ratings=None):
+    ratings = ratings or [1200.0] * len(player_ids)
+    rows = []
+    court = 1
+    slot = 1
+    for idx, pid in enumerate(player_ids):
+        rows.append(
+            {
+                "player_id": int(pid),
+                "name": f"Player {pid}",
+                "rating": float(ratings[idx]),
+                "court": int(court),
+                "slot": int(slot),
+            }
+        )
+        slot += 1
+        if slot > 4:
+            court += 1
+            slot = 1
+    return pd.DataFrame(rows)
+
+
+def test_roster_change_availability_between_rounds():
+    ok, msg = roster_change_availability("CONFIRM_MOVEMENT", current_round=2, total_rounds=5, is_admin=True)
+    assert ok is True
+    assert msg == ""
+
+    ok, msg = roster_change_availability("PLAY_ROUND", current_round=2, total_rounds=5, is_admin=True)
+    assert ok is False
+    assert "between rounds" in msg
+
+    ok, msg = roster_change_availability("CONFIRM_MOVEMENT", current_round=5, total_rounds=5, is_admin=True)
+    assert ok is False
+    assert "complete" in msg
+
+
+def test_apply_roster_change_rejects_locked_round():
+    roster = _make_roster([1, 2, 3, 4])
+    with pytest.raises(RosterChangeError, match="locked"):
+        apply_roster_change(
+            roster_df=roster,
+            change_type="add",
+            new_player={"id": 5, "name": "Player 5", "rating": 1200.0},
+            roster_locked=True,
+        )
+
+
+def test_apply_roster_change_validation():
+    roster = _make_roster([1, 2, 3, 4])
+    with pytest.raises(RosterChangeError, match="already active"):
+        apply_roster_change(
+            roster_df=roster,
+            change_type="add",
+            new_player={"id": 2, "name": "Player 2", "rating": 1200.0},
+        )
+
+    with pytest.raises(RosterChangeError, match="same player"):
+        apply_roster_change(
+            roster_df=roster,
+            change_type="substitute",
+            replaced_player_id=2,
+            new_player={"id": 2, "name": "Player 2", "rating": 1200.0},
+        )
+
+
+def test_substitute_updates_future_roster():
+    roster = _make_roster([1, 2, 3, 4, 5, 6, 7, 8])
+    result = apply_roster_change(
+        roster_df=roster,
+        change_type="substitute",
+        replaced_player_id=3,
+        new_player={"id": 99, "name": "Sub", "rating": 1300.0},
+        court_sizes=[4, 4],
+    )
+
+    updated_ids = result.roster_df["player_id"].astype(int).tolist()
+    assert 3 not in updated_ids
+    assert 99 in updated_ids
+    assert result.court_sizes == [4, 4]
+
+
+def test_add_player_rebalances_courts():
+    roster = _make_roster([1, 2, 3, 4, 5, 6, 7, 8])
+    result = apply_roster_change(
+        roster_df=roster,
+        change_type="add",
+        new_player={"id": 99, "name": "Late", "rating": 1150.0},
+        court_sizes=[4, 4],
+    )
+
+    updated_ids = result.roster_df["player_id"].astype(int).tolist()
+    assert 99 in updated_ids
+    assert sum(result.court_sizes) == len(result.roster_df)
+    assert len(result.roster_df) == 9
+
+
+def test_add_player_benches_lowest_rating_first():
+    roster = _make_roster([1, 2, 3, 4, 5, 6])
+    result = apply_roster_change(
+        roster_df=roster,
+        change_type="add",
+        new_player={"id": 99, "name": "Late", "rating": 1300.0},
+    )
+
+    assert 99 in result.roster_df["player_id"].astype(int).tolist()
+    assert len(result.bench_ids) == 2
+    assert 99 not in result.bench_ids


### PR DESCRIPTION
### Motivation
- Real-world league nights require admins to substitute or add players after a round finishes and before the next round starts, without altering completed rounds.
- Provide a single UI entrypoint and a backend-safe way to apply roster changes effective from the next round and regenerate future matchups.

### Description
- Added a new domain module `jupr_app/domain/league_night_roster.py` implementing `apply_roster_change`, `rebalance_roster`, `suggest_court_sizes`, bench selection logic, `roster_change_availability`, and typed `RosterChangeResult` and `RosterChangeError` to encapsulate roster-change rules and validation.
- Wired a between-rounds UI in `jupr_app/ui/pages/league_manager.py` that adds a `Substitute / Add Player` button and a modal titled `Roster Changes (Next Round)` with two tabs `Substitute` and `Add Player`, guest creation paths, confirmation text, and messaging about queued overrides and sit-outs; overrides are stored in session state (`ladder_next_roster_override`, `ladder_next_court_sizes`, etc.).
- Integrated roster changes with the existing round transition flow so that when `Start Next Round` is clicked the queued override (if any) is applied only to future rounds and completed rounds remain unchanged.
- Kept existing scheduler usage (`get_match_schedule`) and UI refresh/invalidation patterns; updated player lookup state (`id_to_name`, `name_to_id`) when guests are created so the UI resolves names immediately.
- Added tests `tests/test_league_night_roster.py` covering availability checks, validation errors, substitution behavior, add-player rebalancing, and bench selection.

### Testing
- Ran the test suite with `pytest -q`; all tests passed: `16 passed in 1.05s`.
- New unit tests in `tests/test_league_night_roster.py` exercise `roster_change_availability` and `apply_roster_change` validation and scheduling outcomes and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697662fbcb4c8326a743e51923579243)