### PR TITLE
Fix bench name f-string syntax

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -626,8 +626,8 @@ def render(ctx):
                     st.caption(str(st.session_state.ladder_roster_change_note))
                 bench_ids = st.session_state.get("ladder_roster_bench_ids") or []
                 if bench_ids:
-                    bench_names = [id_to_name.get(int(pid), f\"#{pid}\") for pid in bench_ids]
-                    st.warning(f\"Sit-out this round: {', '.join(bench_names)}\")
+                    bench_names = [id_to_name.get(int(pid), f"#{pid}") for pid in bench_ids]
+                    st.warning(f"Sit-out this round: {', '.join(bench_names)}")
 
             st.markdown("#### Roster Changes (Between Rounds)")
             st.caption("Roster changes apply to the next round only. Completed rounds stay unchanged.")


### PR DESCRIPTION
### Motivation
- Fix a SyntaxError in `jupr_app/ui/pages/league_manager.py` that prevented the Streamlit app from importing by correcting an improperly escaped f-string used to render bench player names.

### Description
- Replace escaped f-string quotes with regular quotes in the bench name list comprehension and the warning message in `jupr_app/ui/pages/league_manager.py` to produce `bench_names = [id_to_name.get(int(pid), f"#{pid}") for pid in bench_ids]` and `st.warning(f"Sit-out this round: {', '.join(bench_names)}")`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697667cdc26883268f8355931b4bd1ab)