### PR TITLE
Fix escaped f-strings in league_manager warnings

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -703,7 +703,7 @@ def render(ctx):
 
                         st.text(f"Effective round: {next_round}")
                         st.warning(
-                            f\"This will regenerate matchups for rounds {next_round}–{final_round}. Completed rounds will not change.\"
+                            f"This will regenerate matchups for rounds {next_round}–{final_round}. Completed rounds will not change."
                         )
                         confirm_sub = st.checkbox("I understand and want to apply this substitute.", key="ladder_sub_confirm")
 
@@ -776,7 +776,7 @@ def render(ctx):
 
                         st.text(f"Effective round: {next_round}")
                         st.warning(
-                            f\"This will regenerate matchups for rounds {next_round}–{final_round}. Completed rounds will not change.\"
+                            f"This will regenerate matchups for rounds {next_round}–{final_round}. Completed rounds will not change."
                         )
                         confirm_add = st.checkbox("I understand and want to add this player.", key="ladder_add_confirm")
 


### PR DESCRIPTION
### Motivation
- Resolve a `SyntaxError` on import caused by invalid escaped f-strings in `jupr_app/ui/pages/league_manager.py` so the Streamlit app can be imported.

### Description
- Replace escaped f-strings `f\"...\"` with valid `f"..."` (i.e. `f"` → `f"`) in two roster-change `st.warning` calls in `jupr_app/ui/pages/league_manager.py`, preserving the original UI text (including the en dash), and search the repo with `rg` to ensure no other offending occurrences remain.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/league_manager.py` and `python -c "import jupr_app.ui.pages.league_manager as m; print('ok')"`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976691ec28083269042f86b6c7a9975)