### PR TITLE
Improve contrast: standardize text tokens, refactor UI to use tokens, add Theme QA and regression test

### DIFF
--- a/jupr_app/ui/pages/__init__.py
+++ b/jupr_app/ui/pages/__init__.py
@@ -16,6 +16,7 @@ from . import admin_tools
 from . import admin_guide
 from . import moneyball
 from . import league_results
+from . import theme_gallery
 
 __all__ = [
     "leaderboards",
@@ -32,4 +33,5 @@ __all__ = [
     "admin_guide",
     "moneyball",
     "league_results",
+    "theme_gallery",
 ]

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -236,25 +236,25 @@ def render_top_performers_cards(
     if not top_perf_dict:
         return
 
-    accent = st.get_option("theme.primaryColor") or "#4C78A8"
+    accent = st.get_option("theme.primaryColor") or "var(--accent)"
 
     st.markdown(f"### {title}")
     st.markdown(
         """
         <style>
         .tp-card {
-            background: rgba(255,255,255,0.03);
-            border: 1px solid rgba(255,255,255,0.08);
+            background: var(--panel);
+            border: 1px solid var(--border);
             border-radius: 16px;
             padding: 16px 18px;
-            box-shadow: 0 6px 16px rgba(0,0,0,0.16);
+            box-shadow: var(--shadow);
             border-top: 3px solid var(--tp-accent);
         }
         .tp-label {
             font-size: 12px;
             letter-spacing: 0.04em;
             text-transform: uppercase;
-            color: rgba(255,255,255,0.55);
+            color: var(--text-muted);
             margin-bottom: 6px;
         }
         .tp-value {
@@ -265,7 +265,7 @@ def render_top_performers_cards(
         }
         .tp-name {
             font-size: 14px;
-            color: rgba(255,255,255,0.8);
+            color: var(--text-primary);
             margin-bottom: 8px;
         }
         .tp-list {
@@ -277,11 +277,11 @@ def render_top_performers_cards(
             display: flex;
             justify-content: space-between;
             font-size: 12px;
-            color: rgba(255,255,255,0.55);
+            color: var(--text-muted);
         }
         .tp-list-value {
             font-weight: 600;
-            color: rgba(255,255,255,0.65);
+            color: var(--text-secondary);
             margin-right: 8px;
         }
         </style>
@@ -341,11 +341,11 @@ def render(ctx):
             padding-bottom: 24px;
         }
         .lb-card {
-            background: rgba(255,255,255,0.02);
-            border: 1px solid rgba(255,255,255,0.08);
+            background: var(--panel);
+            border: 1px solid var(--border);
             border-radius: 18px;
             padding: 18px 20px;
-            box-shadow: 0 8px 20px rgba(0,0,0,0.16);
+            box-shadow: var(--shadow);
         }
         .lb-link {
             color: inherit;
@@ -363,8 +363,8 @@ def render(ctx):
         .lb-kpi {
             flex: 1 1 140px;
             min-width: 120px;
-            background: rgba(255,255,255,0.03);
-            border: 1px solid rgba(255,255,255,0.08);
+            background: var(--panel);
+            border: 1px solid var(--border);
             border-radius: 12px;
             padding: 10px 12px;
         }
@@ -372,7 +372,7 @@ def render(ctx):
             font-size: 11px;
             letter-spacing: 0.04em;
             text-transform: uppercase;
-            color: rgba(255,255,255,0.6);
+            color: var(--text-muted);
             margin-bottom: 4px;
         }
         .lb-kpi .lb-kpi-value {
@@ -386,14 +386,14 @@ def render(ctx):
         }
         .lb-subtitle {
             font-size: 13px;
-            color: rgba(255,255,255,0.65);
+            color: var(--text-muted);
         }
         .lb-muted {
-            color: rgba(255,255,255,0.6);
+            color: var(--text-muted);
         }
         .lb-standings-card {
-            background: rgba(255,255,255,0.02);
-            border: 1px solid rgba(255,255,255,0.08);
+            background: var(--panel);
+            border: 1px solid var(--border);
             border-radius: 16px;
             padding: 14px 16px;
             display: flex;
@@ -434,22 +434,23 @@ def render(ctx):
         }
         .lb-standings-stats {
             font-size: 12px;
-            color: rgba(255,255,255,0.6);
+            color: var(--text-muted);
             display: flex;
             flex-wrap: wrap;
             gap: 8px;
         }
         .lb-story-text {
             font-size: 0.9rem;
-            color: rgba(255,255,255,0.70);
+            color: var(--text-secondary);
             margin-top: 6px;
         }
         .lb-badge {
             font-size: 11px;
             padding: 2px 8px;
             border-radius: 999px;
-            border: 1px solid rgba(255,255,255,0.18);
-            color: rgba(255,255,255,0.65);
+            border: 1px solid var(--border-strong);
+            color: var(--text-muted);
+            background: var(--pill-bg);
         }
         .lb-badge-strip {
             display: flex;
@@ -462,20 +463,20 @@ def render(ctx):
             line-height: 1;
             padding: 2px 6px;
             border-radius: 8px;
-            background: rgba(255,255,255,0.06);
-            border: 1px solid rgba(255,255,255,0.12);
+            background: var(--pill-bg);
+            border: 1px solid var(--border);
         }
         .lb-controls {
-            background: rgba(255,255,255,0.02);
-            border: 1px solid rgba(255,255,255,0.08);
+            background: var(--panel);
+            border: 1px solid var(--border);
             border-radius: 16px;
             padding: 16px;
         }
         .lb-table-wrap {
             overflow-x: auto;
             border-radius: 14px;
-            border: 1px solid rgba(255,255,255,0.08);
-            background: rgba(255,255,255,0.02);
+            border: 1px solid var(--border);
+            background: var(--panel);
         }
         .lb-table {
             width: 100%;
@@ -486,20 +487,20 @@ def render(ctx):
         .lb-table td {
             padding: 10px 12px;
             text-align: left;
-            border-bottom: 1px solid rgba(255,255,255,0.08);
+            border-bottom: 1px solid var(--border);
             font-size: 13px;
         }
         .lb-table th {
             font-size: 12px;
             text-transform: uppercase;
             letter-spacing: 0.05em;
-            color: rgba(255,255,255,0.65);
-            background: rgba(255,255,255,0.03);
+            color: var(--text-muted);
+            background: var(--table-stripe);
             position: sticky;
             top: 0;
         }
         .lb-table tbody tr:hover {
-            background: rgba(255,255,255,0.04);
+            background: var(--accent-soft);
         }
         .lb-actions a,
         .lb-actions button {
@@ -534,9 +535,9 @@ def render(ctx):
         """,
         unsafe_allow_html=True,
     )
-    delta_up = "#6DBE7C"
-    delta_flat = "#8D94A3"
-    delta_down = "#C08A3C"
+    delta_up = "var(--delta-pos)"
+    delta_flat = "var(--delta-zero)"
+    delta_down = "var(--delta-neg)"
 
     # -------------------------
     # Available leagues

--- a/jupr_app/ui/pages/league_results.py
+++ b/jupr_app/ui/pages/league_results.py
@@ -364,8 +364,8 @@ def render(ctx):
         .lb-table-wrap {
             overflow-x: auto;
             border-radius: 14px;
-            border: 1px solid rgba(255,255,255,0.08);
-            background: rgba(255,255,255,0.02);
+            border: 1px solid var(--border);
+            background: var(--panel);
         }
         .lb-table {
             width: 100%;
@@ -376,20 +376,20 @@ def render(ctx):
         .lb-table td {
             padding: 10px 12px;
             text-align: left;
-            border-bottom: 1px solid rgba(255,255,255,0.08);
+            border-bottom: 1px solid var(--border);
             font-size: 13px;
         }
         .lb-table th {
             font-size: 12px;
             text-transform: uppercase;
             letter-spacing: 0.05em;
-            color: rgba(255,255,255,0.65);
-            background: rgba(255,255,255,0.03);
+            color: var(--text-muted);
+            background: var(--table-stripe);
             position: sticky;
             top: 0;
         }
         .lb-table tbody tr:hover {
-            background: rgba(255,255,255,0.04);
+            background: var(--accent-soft);
         }
         </style>
         """,

--- a/jupr_app/ui/pages/moneyball.py
+++ b/jupr_app/ui/pages/moneyball.py
@@ -551,10 +551,13 @@ def render(ctx):
     table_html = summary_df.to_html(index=False, float_format="%.2f", border=0)
     html_body = (
         "<html><head><style>"
-        "body{font-family:Arial, sans-serif;}"
-        "table{border-collapse:collapse;width:100%;}"
-        "th,td{border:1px solid #ddd;padding:6px;text-align:center;}"
-        "th{background:#f2f2f2;}"
+        "body{font-family:Arial, sans-serif;"
+        "color:var(--text-primary);"
+        "background:var(--bg);}"
+        "table{border-collapse:collapse;width:100%;"
+        "background:var(--panel);color:var(--text-primary);}"
+        "th,td{border:1px solid var(--border);padding:6px;text-align:center;}"
+        "th{background:var(--table-stripe);color:var(--text-muted);}"
         "</style></head><body>"
         f"{header_html}{table_html}"
         "</body></html>"

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -5,7 +5,6 @@ import pandas as pd
 
 from jupr_app.ui.helpers import qp_get, build_match_explorer_link
 from jupr_app.ui.layout import page_shell
-from jupr_app.ui.theme import MATCH_COLORS, color_for_delta, color_for_result
 
 logger = logging.getLogger(__name__)
 
@@ -779,24 +778,29 @@ def render(ctx):
         show["Overall After"] = show["Overall After"].map(lambda x: f"{float(x):.3f}" if pd.notna(x) else "")
 
         def result_badge(result: str) -> str:
-            color = color_for_result(result) or MATCH_COLORS["draw"]
-            text_color = (
-                MATCH_COLORS["text_light"]
-                if str(result).strip().upper() in {"DRAW", "PUSH", "EVEN", "TIE"}
-                else "#FFFFFF"
-            )
             label = str(result or "").strip().upper() or "—"
-            return (
-                f"<span style='background: {color}; color: {text_color}; padding: 2px 8px; "
-                "border-radius: 999px; font-size: 0.75rem; font-weight: 600; letter-spacing: 0.02em;'>"
-                f"{label}</span>"
-            )
+            normalized = label.upper()
+            if normalized in {"W", "WIN", "WON"}:
+                variant = "win"
+            elif normalized in {"L", "LOSS", "LOST"}:
+                variant = "loss"
+            else:
+                variant = "draw"
+            return f"<span class='jupr-result-badge {variant}'>{label}</span>"
 
         def delta_span(delta_str: str, delta_raw: float | None) -> str:
-            color = color_for_delta(delta_raw) or MATCH_COLORS["text_light"]
             if not delta_str:
                 return ""
-            return f"<span style='color: {color}; font-weight: 600;'>{delta_str}</span>"
+            kind = "zero"
+            try:
+                delta_val = float(delta_raw)
+            except (TypeError, ValueError):
+                delta_val = 0.0
+            if delta_val > 0:
+                kind = "pos"
+            elif delta_val < 0:
+                kind = "neg"
+            return f"<span class='jupr-delta {kind}'>{delta_str}</span>"
 
         show["Result"] = show["Result"].map(result_badge)
         show["Overall Δ"] = show.apply(lambda row: delta_span(row["Overall Δ"], row["delta_raw"]), axis=1)

--- a/jupr_app/ui/pages/theme_gallery.py
+++ b/jupr_app/ui/pages/theme_gallery.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import html
+
+import streamlit as st
+
+from jupr_app.ui.layout import page_shell
+from jupr_app.ui.theme_clean import card, callout, divider, kpi_card, pill, theme_override_css
+
+
+def _apply_theme_override(mode: str) -> None:
+    if mode == "Force Light":
+        css = theme_override_css("light")
+    elif mode == "Force Dark":
+        css = theme_override_css("dark")
+    else:
+        css = ""
+
+    if css:
+        st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
+
+
+def render(ctx):
+    PUBLIC_MODE = bool(getattr(ctx, "public_mode", False))
+    mode_label = "Public" if PUBLIC_MODE else "Admin"
+    page_shell("🎨 Theme QA", "Style gallery for contrast checks across tokens.", mode_label=mode_label)
+
+    theme_mode = st.selectbox(
+        "Theme override",
+        ["System", "Force Light", "Force Dark"],
+        help="Use this to quickly preview light/dark theme tokens without changing OS settings.",
+        index=0,
+    )
+    _apply_theme_override(theme_mode)
+
+    st.markdown(
+        """
+        <style>
+        .qa-section {
+            margin-top: 1rem;
+        }
+        .qa-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 12px;
+        }
+        .qa-card {
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            background: var(--panel);
+            padding: 12px;
+            box-shadow: var(--shadow);
+        }
+        .qa-tone {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 0.9rem;
+        }
+        .qa-tone .value {
+            font-weight: 650;
+        }
+        .qa-table {
+            width: 100%;
+            border-collapse: collapse;
+            background: var(--panel);
+            color: var(--text-primary);
+        }
+        .qa-table th,
+        .qa-table td {
+            padding: 8px 10px;
+            border-bottom: 1px solid var(--border);
+            text-align: left;
+            font-size: 0.85rem;
+        }
+        .qa-table th {
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.04em;
+            color: var(--text-muted);
+            background: var(--table-stripe);
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    st.markdown("### Typography")
+    st.markdown(
+        "This is **primary body text** with a [link](https://example.com) and some `inline code`."
+    )
+    st.caption("Caption text uses the muted token for secondary emphasis.")
+
+    divider()
+    st.markdown("### Status & text tokens")
+    st.markdown(
+        """
+        <div class="qa-grid">
+          <div class="qa-card qa-tone"><span>Primary text</span><span class="value">Readable</span></div>
+          <div class="qa-card qa-tone"><span>Secondary text</span><span class="value" style="color:var(--text-secondary);">Readable</span></div>
+          <div class="qa-card qa-tone"><span>Muted text</span><span class="value" style="color:var(--text-muted);">Muted</span></div>
+          <div class="qa-card qa-tone"><span>Success</span><span class="value" style="color:var(--status-success);">+12%</span></div>
+          <div class="qa-card qa-tone"><span>Warning</span><span class="value" style="color:var(--status-warning);">Needs attention</span></div>
+          <div class="qa-card qa-tone"><span>Danger</span><span class="value" style="color:var(--status-danger);">Decline</span></div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    divider()
+    st.markdown("### Cards, callouts, KPIs, and badges")
+    card("<strong>Card title</strong><br/>Card body text uses primary text tokens.")
+    callout("info", "Info callout", "This callout uses theme-aware text colors.")
+
+    kpi_cols = st.columns(3)
+    with kpi_cols[0]:
+        kpi_card("Active Players", "128", delta="▲ +12 vs last week", icon="👥")
+    with kpi_cols[1]:
+        kpi_card("Matches", "52", delta="▼ -3 vs last week", icon="🏆")
+    with kpi_cols[2]:
+        kpi_card("New Badges", "9", delta="• steady", icon="✨")
+
+    badge_html = " ".join(
+        [
+            pill("Elite", "good"),
+            pill("Rising", "neutral"),
+            pill("Warning", "warn"),
+            pill("At Risk", "bad"),
+        ]
+    )
+    st.markdown(f"<div class='qa-section'>{badge_html}</div>", unsafe_allow_html=True)
+
+    divider()
+    st.markdown("### Buttons & form controls")
+    button_cols = st.columns(3)
+    with button_cols[0]:
+        st.button("Primary Action", type="primary")
+    with button_cols[1]:
+        st.button("Secondary Action")
+    with button_cols[2]:
+        st.button("Disabled", disabled=True)
+
+    input_cols = st.columns(3)
+    with input_cols[0]:
+        st.text_input("Text input", placeholder="Placeholder text")
+    with input_cols[1]:
+        st.selectbox("Selectbox", ["Option A", "Option B", "Option C"])
+    with input_cols[2]:
+        st.number_input("Number input", value=3, min_value=0, max_value=10)
+
+    st.text_area("Text area", placeholder="Longer description", height=80)
+
+    divider()
+    st.markdown("### Tables & deltas")
+    table_html = """
+    <table class="qa-table">
+      <thead>
+        <tr>
+          <th>Player</th>
+          <th>Rating</th>
+          <th>Delta</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Jamie</td>
+          <td>4.021</td>
+          <td><span class="jupr-delta pos">+0.012</span></td>
+          <td><span class="jupr-result-badge win">WIN</span></td>
+        </tr>
+        <tr>
+          <td>Morgan</td>
+          <td>3.842</td>
+          <td><span class="jupr-delta neg">-0.018</span></td>
+          <td><span class="jupr-result-badge loss">LOSS</span></td>
+        </tr>
+        <tr>
+          <td>Taylor</td>
+          <td>3.910</td>
+          <td><span class="jupr-delta zero">+0.000</span></td>
+          <td><span class="jupr-result-badge draw">DRAW</span></td>
+        </tr>
+      </tbody>
+    </table>
+    """
+    st.markdown(table_html, unsafe_allow_html=True)
+
+    divider()
+    st.markdown("### Links and helper text")
+    st.markdown(
+        "Need help? Visit the "
+        f"<a href='https://example.com' target='_blank'>{html.escape('support page')}</a>."
+        "",
+        unsafe_allow_html=True,
+    )

--- a/jupr_app/ui/theme.py
+++ b/jupr_app/ui/theme.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 MATCH_COLORS = {
-    "win": "#1F7A6D",
-    "loss": "#5E6F82",
-    "draw": "#B9A874",
-    "delta_pos": "#2FAE9A",
-    "delta_neg": "#7D8A97",
-    "delta_zero": "#B9A874",
-    "text_light": "#1E2933",
-    "text_dark": "#E6EEF3",
-    "hover_light": "#F3F7F9",
-    "hover_dark": "#1C232A",
-    "border": "#D5DEE5",
+    "win": "var(--result-win-bg)",
+    "loss": "var(--result-loss-bg)",
+    "draw": "var(--result-draw-bg)",
+    "delta_pos": "var(--delta-pos)",
+    "delta_neg": "var(--delta-neg)",
+    "delta_zero": "var(--delta-zero)",
+    "text_primary": "var(--text-primary)",
+    "text_inverse": "var(--text-inverse)",
+    "text_muted": "var(--text-muted)",
+    "hover": "var(--accent-soft)",
+    "border": "var(--border)",
 }
 
 

--- a/jupr_app/ui/theme_clean.py
+++ b/jupr_app/ui/theme_clean.py
@@ -22,6 +22,11 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         --panel: #FDFDFE;
         --text: #111827;
         --muted: #6B7280;
+        --text-primary: var(--text);
+        --text-secondary: #475569;
+        --text-muted: var(--muted);
+        --text-inverse: #FFFFFF;
+        --text-disabled: #9CA3AF;
         --border: #E5E7EB;
         --border-strong: #CBD5E1;
         --shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
@@ -35,6 +40,19 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         --font-sm: 0.86rem;
         --font-base: 1rem;
         --font-lg: 1.2rem;
+        --status-success: #16A34A;
+        --status-warning: #D97706;
+        --status-danger: #DC2626;
+        --status-info: #2563EB;
+        --delta-pos: var(--status-success);
+        --delta-neg: var(--status-danger);
+        --delta-zero: var(--text-muted);
+        --result-win-bg: #1F7A6D;
+        --result-loss-bg: #5E6F82;
+        --result-draw-bg: #B9A874;
+        --result-win-text: var(--text-inverse);
+        --result-loss-text: var(--text-inverse);
+        --result-draw-text: var(--text-primary);
       }}
 
       html[data-theme="dark"] {{
@@ -42,6 +60,11 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         --panel: #161B24;
         --text: #E5E7EB;
         --muted: #9CA3AF;
+        --text-primary: var(--text);
+        --text-secondary: #CBD5E1;
+        --text-muted: var(--muted);
+        --text-inverse: #0B0F14;
+        --text-disabled: #6B7280;
         --border: #2B3240;
         --border-strong: #3B4557;
         --shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
@@ -53,6 +76,19 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         --pill-bg: #1B2230;
         --accent-soft: rgba(140, 180, 255, 0.16);
         --accent-border: rgba(140, 180, 255, 0.35);
+        --status-success: #34D399;
+        --status-warning: #FBBF24;
+        --status-danger: #F87171;
+        --status-info: #93C5FD;
+        --delta-pos: var(--status-success);
+        --delta-neg: var(--status-danger);
+        --delta-zero: var(--text-muted);
+        --result-win-bg: #1F9E8F;
+        --result-loss-bg: #74839B;
+        --result-draw-bg: #CDBE84;
+        --result-win-text: var(--text-inverse);
+        --result-loss-text: var(--text-inverse);
+        --result-draw-text: #1A1D23;
       }}
 
       @media (prefers-color-scheme: dark) {{
@@ -61,6 +97,11 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
           --panel: #161B24;
           --text: #E5E7EB;
           --muted: #9CA3AF;
+          --text-primary: var(--text);
+          --text-secondary: #CBD5E1;
+          --text-muted: var(--muted);
+          --text-inverse: #0B0F14;
+          --text-disabled: #6B7280;
           --border: #2B3240;
           --border-strong: #3B4557;
           --shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
@@ -72,6 +113,19 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
           --pill-bg: #1B2230;
           --accent-soft: rgba(140, 180, 255, 0.16);
           --accent-border: rgba(140, 180, 255, 0.35);
+          --status-success: #34D399;
+          --status-warning: #FBBF24;
+          --status-danger: #F87171;
+          --status-info: #93C5FD;
+          --delta-pos: var(--status-success);
+          --delta-neg: var(--status-danger);
+          --delta-zero: var(--text-muted);
+          --result-win-bg: #1F9E8F;
+          --result-loss-bg: #74839B;
+          --result-draw-bg: #CDBE84;
+          --result-win-text: var(--text-inverse);
+          --result-loss-text: var(--text-inverse);
+          --result-draw-text: #1A1D23;
         }}
       }}
 
@@ -103,8 +157,15 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         font-weight: 700;
         letter-spacing: -0.01em;
       }}
-      .stCaption, .stMarkdown p {{
-        color: var(--muted);
+      .stCaption {{
+        color: var(--text-muted);
+      }}
+      .stMarkdown p,
+      .stMarkdown li {{
+        color: var(--text-primary);
+      }}
+      .stMarkdown small {{
+        color: var(--text-muted);
       }}
       a {{
         color: var(--link);
@@ -238,6 +299,11 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         outline: 3px solid var(--focus);
         outline-offset: 2px;
       }}
+      .stButton > button:disabled {{
+        color: var(--text-disabled);
+        border-color: var(--border);
+        opacity: 0.7;
+      }}
 
       /* Primary buttons: use accent */
       .stButton > button[kind="primary"] {{
@@ -252,6 +318,11 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
       /* Inputs: soft borders */
       input, textarea {{
         border-radius: 12px !important;
+      }}
+      input::placeholder,
+      textarea::placeholder {{
+        color: var(--text-muted);
+        opacity: 1;
       }}
       [data-baseweb="select"] > div {{
         border-radius: 12px !important;
@@ -387,13 +458,39 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         font-weight: 750;
         border: 1px solid var(--border);
         background: var(--pill-bg);
-        color: var(--text);
+        color: var(--text-primary);
         white-space: nowrap;
       }}
       .jupr-pill.good {{ border-color: rgba(16,185,129,0.30); background: rgba(16,185,129,0.10); }}
       .jupr-pill.warn {{ border-color: rgba(245,158,11,0.35); background: rgba(245,158,11,0.10); }}
       .jupr-pill.bad  {{ border-color: rgba(239,68,68,0.30); background: rgba(239,68,68,0.10); }}
       .jupr-pill.neutral {{ border-color: rgba(59,130,246,0.25); background: rgba(59,130,246,0.08); }}
+
+      /* Result badges + deltas */
+      .jupr-result-badge {{
+        display: inline-flex;
+        align-items: center;
+        padding: 2px 8px;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 650;
+        letter-spacing: 0.02em;
+      }}
+      .jupr-result-badge.win {{
+        background: var(--result-win-bg);
+        color: var(--result-win-text);
+      }}
+      .jupr-result-badge.loss {{
+        background: var(--result-loss-bg);
+        color: var(--result-loss-text);
+      }}
+      .jupr-result-badge.draw {{
+        background: var(--result-draw-bg);
+        color: var(--result-draw-text);
+      }}
+      .jupr-delta.pos {{ color: var(--delta-pos); font-weight: 600; }}
+      .jupr-delta.neg {{ color: var(--delta-neg); font-weight: 600; }}
+      .jupr-delta.zero {{ color: var(--delta-zero); font-weight: 600; }}
 
       /* Dataframe container - keep it calm */
       .stDataFrame {{
@@ -434,6 +531,34 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
       }}
       .lbtable a {{
         text-decoration: underline;
+      }}
+
+      /* Match history table (player page) */
+      .match-history-table table {{
+        width: 100%;
+        border-collapse: collapse;
+        background: var(--panel);
+        color: var(--text-primary);
+      }}
+      .match-history-table th,
+      .match-history-table td {{
+        padding: 8px 10px;
+        border-bottom: 1px solid var(--border);
+        text-align: left;
+        font-size: 0.85rem;
+      }}
+      .match-history-table th {{
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        font-size: 0.72rem;
+        color: var(--text-muted);
+        background: var(--table-stripe);
+      }}
+      .match-history-table tr:nth-child(even) td {{
+        background: var(--table-stripe);
+      }}
+      .match-history-table a {{
+        color: var(--link);
       }}
 
       /* Public link button fallback */
@@ -562,6 +687,90 @@ def pill(text: str, kind: str = "neutral") -> str:
     t = html.escape(text)
     k = html.escape(kind)
     return f'<span class="jupr-pill {k}">{t}</span>'
+
+
+def theme_override_css(mode: str) -> str:
+    """
+    Return CSS overrides for forcing light/dark tokens in a single session.
+    mode: "light" | "dark"
+    """
+    if mode == "light":
+        return """
+        :root {
+          --bg: #F6F7FB;
+          --panel: #FDFDFE;
+          --text: #111827;
+          --muted: #6B7280;
+          --text-primary: var(--text);
+          --text-secondary: #475569;
+          --text-muted: var(--muted);
+          --text-inverse: #FFFFFF;
+          --text-disabled: #9CA3AF;
+          --border: #E5E7EB;
+          --border-strong: #CBD5E1;
+          --shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+          --shadow-lg: 0 14px 32px rgba(15, 23, 42, 0.16);
+          --link: #1D4ED8;
+          --link-hover: #1E40AF;
+          --focus: rgba(59, 130, 246, 0.45);
+          --table-stripe: #F3F4F6;
+          --pill-bg: #F8FAFC;
+          --accent-soft: rgba(47, 111, 237, 0.12);
+          --accent-border: rgba(47, 111, 237, 0.30);
+          --status-success: #16A34A;
+          --status-warning: #D97706;
+          --status-danger: #DC2626;
+          --status-info: #2563EB;
+          --delta-pos: var(--status-success);
+          --delta-neg: var(--status-danger);
+          --delta-zero: var(--text-muted);
+          --result-win-bg: #1F7A6D;
+          --result-loss-bg: #5E6F82;
+          --result-draw-bg: #B9A874;
+          --result-win-text: var(--text-inverse);
+          --result-loss-text: var(--text-inverse);
+          --result-draw-text: var(--text-primary);
+        }
+        """
+    if mode == "dark":
+        return """
+        :root {
+          --bg: #0F1218;
+          --panel: #161B24;
+          --text: #E5E7EB;
+          --muted: #9CA3AF;
+          --text-primary: var(--text);
+          --text-secondary: #CBD5E1;
+          --text-muted: var(--muted);
+          --text-inverse: #0B0F14;
+          --text-disabled: #6B7280;
+          --border: #2B3240;
+          --border-strong: #3B4557;
+          --shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+          --shadow-lg: 0 16px 36px rgba(0, 0, 0, 0.55);
+          --link: #8CB4FF;
+          --link-hover: #B3CCFF;
+          --focus: rgba(96, 165, 250, 0.55);
+          --table-stripe: #1C2230;
+          --pill-bg: #1B2230;
+          --accent-soft: rgba(140, 180, 255, 0.16);
+          --accent-border: rgba(140, 180, 255, 0.35);
+          --status-success: #34D399;
+          --status-warning: #FBBF24;
+          --status-danger: #F87171;
+          --status-info: #93C5FD;
+          --delta-pos: var(--status-success);
+          --delta-neg: var(--status-danger);
+          --delta-zero: var(--text-muted);
+          --result-win-bg: #1F9E8F;
+          --result-loss-bg: #74839B;
+          --result-draw-bg: #CDBE84;
+          --result-win-text: var(--text-inverse);
+          --result-loss-text: var(--text-inverse);
+          --result-draw-text: #1A1D23;
+        }
+        """
+    return ""
 
 
 # Demo snippet (comment-only):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -320,6 +320,7 @@ def main():
             admin_tools,
             admin_guide,
             moneyball,
+            theme_gallery,
         )
 
         # ---- Router ----
@@ -340,6 +341,7 @@ def main():
             "📘 Admin Guide": admin_guide,
             "🛠️ Challenge Ladder Admin": challenge_ladder_admin,
             "💰 Moneyball": moneyball,
+            "🎨 Theme QA": theme_gallery,
         }
 
         PAGE_KEY_TO_LABEL = {
@@ -359,6 +361,7 @@ def main():
             "admin_guide": "📘 Admin Guide",
             "challenge_ladder_admin": "🛠️ Challenge Ladder Admin",
             "moneyball": "💰 Moneyball",
+            "theme_qa": "🎨 Theme QA",
         }
         LABEL_TO_PAGE_KEY = {v: k for k, v in PAGE_KEY_TO_LABEL.items()}
 
@@ -371,6 +374,7 @@ def main():
             "📘 Admin Guide",
             "🛠️ Challenge Ladder Admin",
             "💰 Moneyball",
+            "🎨 Theme QA",
         }
 
         # Visible labels based on auth

--- a/tests/test_ui_color_tokens.py
+++ b/tests/test_ui_color_tokens.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+HEX_OR_RGB_PATTERN = re.compile(r"(#[0-9a-fA-F]{3,8}|rgba?\()")
+
+
+def _iter_ui_files(root: Path) -> list[Path]:
+    ui_root = root / "jupr_app" / "ui"
+    return [path for path in ui_root.rglob("*.py")]
+
+
+def test_ui_files_do_not_use_hardcoded_colors():
+    repo_root = Path(__file__).resolve().parents[1]
+    allowlist = {
+        repo_root / "jupr_app" / "ui" / "theme_clean.py",
+    }
+    violations: list[str] = []
+
+    for path in _iter_ui_files(repo_root):
+        if path in allowlist:
+            continue
+        contents = path.read_text(encoding="utf-8")
+        for match in HEX_OR_RGB_PATTERN.finditer(contents):
+            line_no = contents.count("\n", 0, match.start()) + 1
+            violations.append(f"{path.relative_to(repo_root)}:{line_no} -> {match.group(0)}")
+
+    if violations:
+        joined = "\n".join(violations)
+        raise AssertionError(
+            "Hard-coded color literals detected in UI files. Use theme tokens instead:\n" + joined
+        )


### PR DESCRIPTION
### Motivation
- Fix multiple light/dark text contrast breakages caused by hard-coded colors and components not inheriting a consistent foreground token. 
- Standardize all text colors via a single theme token map so components render readable text in both light and dark themes. 
- Add a developer QA surface and an automated guardrail to prevent regressions when new UI code is added.

### Description
- Expanded the theme token palette in `jupr_app/ui/theme_clean.py` (added `--text-primary`, `--text-secondary`, `--text-muted`, `--text-inverse`, `--text-disabled`, status/delta/result tokens, and a `theme_override_css` helper) and created reusable CSS classes for result badges, deltas, and match-history tables. 
- Replaced ad-hoc color literals and inline color styles across UI pages so they reference tokens or token-aware classes; updated `jupr_app/ui/pages/leaderboards.py`, `jupr_app/ui/pages/league_results.py`, `jupr_app/ui/pages/players.py`, and `jupr_app/ui/pages/moneyball.py` to use the new tokens/classes. 
- Mapped `jupr_app/ui/theme.py` color helpers to use CSS variables (so programmatic helpers return theme-aware values). 
- Added an interactive Theme QA page at `jupr_app/ui/pages/theme_gallery.py` and exposed it in the app router (`streamlit_app.py`) so devs/admins can force Light/Dark previews (or open via `?page=theme_qa`) and visually validate all primitives (typography, buttons, cards, pills, tables, deltas, badges). 
- Added a CI-style test `tests/test_ui_color_tokens.py` that fails if hard-coded color literals (hex/RGB/rgba) appear in UI Python files outside the theme file, to prevent regressions.

Files changed/added (high-level): `jupr_app/ui/theme_clean.py` (tokens + classes + helper), `jupr_app/ui/theme.py` (token mappings), `jupr_app/ui/pages/leaderboards.py`, `jupr_app/ui/pages/league_results.py`, `jupr_app/ui/pages/players.py`, `jupr_app/ui/pages/moneyball.py` (refactors to tokens), `jupr_app/ui/pages/theme_gallery.py` (new QA page), `streamlit_app.py` (route), `jupr_app/ui/pages/__init__.py`, and `tests/test_ui_color_tokens.py` (new test). 

How to verify manually: open the app and go to the Theme QA page (`?page=theme_qa`) and switch the “Theme override” to `Force Light` and `Force Dark`, then review Leaderboards, League Results, Player Search (match history) and Moneyball printout to confirm text legibility and that badges/deltas use the new styling.

### Testing
- Ran the new regression test: `pytest tests/test_ui_color_tokens.py`, which passed (no hard-coded color literals detected outside `theme_clean.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697668e879ec83269742ca187e45c11f)