### PR TITLE
Harden streamlit_app import path handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,15 @@ def _render_boot_error(exc: Exception) -> None:
 
 def _import_streamlit_app():
     this_dir = Path(__file__).resolve().parent
+    sys.path = [
+        entry
+        for entry in sys.path
+        if not (
+            isinstance(entry, str)
+            and entry
+            and entry.endswith(".py")
+        )
+    ]
     if str(this_dir) not in sys.path:
         sys.path.insert(0, str(this_dir))
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,5 @@
+import importlib
+
+
+def test_streamlit_app_imports():
+    importlib.import_module("streamlit_app")


### PR DESCRIPTION
### Motivation
- Startup could fail to import the top-level `streamlit_app` because `sys.path` contained file paths (e.g. `/.../app.py`) which broke import resolution and masked the real exception as a `KeyError` during production import.

### Description
- In `_import_streamlit_app()` sanitize `sys.path` by removing any entries that are file paths (strings ending with `.py`) before inserting the package directory and importing `streamlit_app`.
- Add a lightweight smoke test `tests/test_imports.py` that asserts `importlib.import_module('streamlit_app')` imports without raising.

### Testing
- Ran `python -m py_compile streamlit_app.py` which succeeded. 
- Ran `python -c "import importlib; importlib.import_module('streamlit_app'); print('ok')"` which printed `ok`.
- Ran `pytest -q tests/test_imports.py` which passed (1 passed, warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766c47ab5c83268ad09ee0e58355dd)