### PR TITLE
Fix invalid escaped f-string in leaderboards story insert

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -1253,7 +1253,7 @@ def render(ctx):
                     if partner:
                         inserts.append(_build_partner_story(partner, id_to_name))
                 if inserts:
-                    story_text = f\"{story_text} {' '.join(inserts)}\".strip()
+                    story_text = f"{story_text} {' '.join(inserts)}".strip()
             story_text_html = f'<div class="lb-story-text">{html.escape(story_text)}</div>'
             st.markdown(
                 f"""


### PR DESCRIPTION
### Motivation
- Fix a SyntaxError on Streamlit import caused by an invalid escaped-quote f-string in `jupr_app/ui/pages/leaderboards.py` that prevented the app from starting.

### Description
- Replace the invalid escaped f-string `story_text = f\"{story_text} {' '.join(inserts)}\".strip()` with the correct Python f-string `story_text = f"{story_text} {' '.join(inserts)}".strip()` and scan the file for other improper escaping, making no other behavioral changes.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/leaderboards.py` (success), `python -c "import jupr_app.ui.pages.leaderboards as m; print('ok')"` (printed `ok`), and launched Streamlit with `streamlit run streamlit_app.py --server.headless true --server.port 8501` which started but was stopped after a short timeout in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976723002e08326a65bd63a0a64cca2)