### PR TITLE
Fix DataFrame truthiness in next roster override selection

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -866,7 +866,17 @@ def render(ctx):
                     st.session_state.ladder_state = "SETUP"
                     st.rerun()
 
-                new_roster = st.session_state.get("ladder_next_roster_override") or base_next_roster
+                override = st.session_state.get("ladder_next_roster_override")
+                if override is None:
+                    new_roster = base_next_roster
+                else:
+                    if hasattr(override, "empty"):
+                        new_roster = override if not override.empty else base_next_roster
+                    else:
+                        try:
+                            new_roster = override if len(override) > 0 else base_next_roster
+                        except Exception:
+                            new_roster = override
                 new_court_sizes = st.session_state.get("ladder_next_court_sizes") or [
                     int(x) for x in new_roster["court"].value_counts().sort_index().tolist()
                 ]


### PR DESCRIPTION
### Motivation
- Prevent a `ValueError` caused by evaluating a pandas `DataFrame` in boolean context when choosing the next-round roster override.

### Description
- Replace the boolean `or` expression `st.session_state.get("ladder_next_roster_override") or base_next_roster` with an explicit `override = st.session_state.get("ladder_next_roster_override")` and select `new_roster` using `override is None`, `override.empty` for DataFrames, or `len(override)` for other containers as a safe fallback; a repo search was performed and only this occurrence required modification.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/league_manager.py` and `python -c "import jupr_app.ui.pages.league_manager as m; print('ok')"`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69768caf0ae08326b07804a731ba23d9)