### PR TITLE
Add bulk week_tag edit to Match Log admin UI

### DIFF
--- a/jupr_app/domain/match_admin.py
+++ b/jupr_app/domain/match_admin.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def preview_week_tag_update(
+    df_matches: pd.DataFrame,
+    selected_ids: list[int],
+    new_week_tag: str,
+) -> dict[str, object]:
+    if df_matches is None or df_matches.empty:
+        return {"count": 0, "old_tags": [], "new_tag": new_week_tag}
+
+    if not selected_ids:
+        return {"count": 0, "old_tags": [], "new_tag": new_week_tag}
+
+    subset = df_matches[df_matches["id"].isin(selected_ids)].copy()
+    if subset.empty:
+        return {"count": 0, "old_tags": [], "new_tag": new_week_tag}
+
+    old_tags = (
+        subset.get("week_tag", "")
+        .fillna("")
+        .astype(str)
+        .str.strip()
+        .replace("", "(blank)")
+        .unique()
+        .tolist()
+    )
+    old_tags_sorted = sorted(old_tags)
+
+    return {
+        "count": int(len(subset)),
+        "old_tags": old_tags_sorted,
+        "new_tag": new_week_tag,
+    }

--- a/jupr_app/ui/pages/match_log.py
+++ b/jupr_app/ui/pages/match_log.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 
 from jupr_app.domain.dupes import canonical_dup_key
+from jupr_app.domain.match_admin import preview_week_tag_update
 from jupr_app.ui.layout import page_shell
 
 def render(ctx):
@@ -105,6 +106,145 @@ def render(ctx):
                         ctx.supabase.table("matches").delete().eq("club_id", str(ctx.club_id)).in_("id", ids_to_delete).execute()
                         st.success("Deleted duplicates. Now run Admin Tools → Replay History → ALL.")
                         st.rerun()
+
+    st.divider()
+
+    # Bulk edit week tag UI
+    st.subheader("✏️ Bulk Edit Week Tag")
+    st.caption("Filter league matches, select rows, and update week tags in bulk.")
+
+    df_bulk = df_matches.copy()
+    if "match_type" in df_bulk.columns:
+        df_bulk["match_type"] = df_bulk["match_type"].fillna("").astype(str).str.strip()
+
+    league_options = ["All"]
+    if "league" in df_bulk.columns:
+        league_options += sorted(
+            df_bulk["league"].fillna("").astype(str).str.strip().replace("", "Unspecified").unique().tolist()
+        )
+
+    match_type_options = ["All"]
+    if "match_type" in df_bulk.columns:
+        match_type_options += sorted(
+            df_bulk["match_type"].fillna("").astype(str).str.strip().replace("", "Unspecified").unique().tolist()
+        )
+
+    week_tag_options = ["All"]
+    if "week_tag" in df_bulk.columns:
+        week_tag_options += sorted(
+            df_bulk["week_tag"].fillna("").astype(str).str.strip().replace("", "Unspecified").unique().tolist()
+        )
+
+    df_bulk["date_dt"] = pd.to_datetime(df_bulk.get("date", None), errors="coerce", utc=True)
+    date_min = df_bulk["date_dt"].min()
+    date_max = df_bulk["date_dt"].max()
+
+    f1, f2, f3, f4 = st.columns([2, 2, 2, 2])
+    with f1:
+        bulk_league = st.selectbox("League", league_options, index=0, key="bulk_week_league")
+    with f2:
+        bulk_match_type = st.selectbox("Match type", match_type_options, index=0, key="bulk_week_match_type")
+    with f3:
+        bulk_week_tag = st.selectbox("Current week_tag", week_tag_options, index=0, key="bulk_week_tag")
+    with f4:
+        if pd.notna(date_min) and pd.notna(date_max):
+            default_start = (date_max - pd.Timedelta(days=7)).date()
+            default_end = date_max.date()
+            date_range = st.date_input(
+                "Date range",
+                value=(default_start, default_end),
+                key="bulk_week_date_range",
+            )
+        else:
+            date_range = st.date_input("Date range", value=(), key="bulk_week_date_range")
+
+    if bulk_league != "All" and "league" in df_bulk.columns:
+        bulk_league_value = "" if bulk_league == "Unspecified" else bulk_league
+        df_bulk = df_bulk[df_bulk["league"].fillna("").astype(str).str.strip() == bulk_league_value].copy()
+
+    if bulk_match_type != "All" and "match_type" in df_bulk.columns:
+        bulk_match_type_value = "" if bulk_match_type == "Unspecified" else bulk_match_type
+        df_bulk = df_bulk[df_bulk["match_type"].fillna("").astype(str).str.strip() == bulk_match_type_value].copy()
+
+    if bulk_week_tag != "All" and "week_tag" in df_bulk.columns:
+        bulk_week_value = "" if bulk_week_tag == "Unspecified" else bulk_week_tag
+        df_bulk = df_bulk[df_bulk["week_tag"].fillna("").astype(str).str.strip() == bulk_week_value].copy()
+
+    if isinstance(date_range, tuple) and len(date_range) == 2:
+        start_date, end_date = date_range
+        if start_date and end_date:
+            df_bulk = df_bulk[
+                (df_bulk["date_dt"].dt.date >= start_date)
+                & (df_bulk["date_dt"].dt.date <= end_date)
+            ].copy()
+
+    st.caption(f"{len(df_bulk)} match(es) match the filters.")
+
+    bulk_cols = [c for c in [
+        "id", "date", "league", "week_tag", "match_type",
+        "t1_p1", "t1_p2", "t2_p1", "t2_p2", "score_t1", "score_t2"
+    ] if c in df_bulk.columns]
+
+    bulk_view = df_bulk[bulk_cols].copy()
+    bulk_view.insert(0, "Select", False)
+
+    if "bulk_week_editor" not in st.session_state:
+        st.session_state["bulk_week_editor"] = bulk_view
+
+    edited_bulk = st.data_editor(
+        bulk_view,
+        column_config={"Select": st.column_config.CheckboxColumn(default=False)},
+        hide_index=True,
+        use_container_width=True,
+        key="bulk_week_editor",
+    )
+
+    if st.button("Clear selection", key="bulk_week_clear"):
+        st.session_state["bulk_week_editor"] = bulk_view
+        st.rerun()
+
+    selected_bulk = edited_bulk[edited_bulk["Select"] == True].copy()
+    selected_ids = selected_bulk["id"].astype(int).tolist() if not selected_bulk.empty else []
+
+    st.markdown("**New week_tag**")
+    new_tag_options = [f"Week {i}" for i in range(1, 21)] + ["Custom..."]
+    new_tag_choice = st.selectbox("Select new week_tag", new_tag_options, key="bulk_week_new_tag")
+    if new_tag_choice == "Custom...":
+        new_week_tag = st.text_input("Custom week_tag", value="", key="bulk_week_custom_tag").strip()
+    else:
+        new_week_tag = new_tag_choice
+
+    preview = preview_week_tag_update(df_bulk, selected_ids, new_week_tag)
+    old_tags = preview.get("old_tags", [])
+    old_tags_text = ", ".join(old_tags) if old_tags else "(none)"
+    st.info(
+        f"You are about to update {preview.get('count', 0)} match(es) "
+        f"from {old_tags_text} to {preview.get('new_tag', '') or '(blank)'}."
+    )
+
+    confirm_update = st.checkbox(
+        "Confirm bulk update",
+        value=False,
+        help="Updates week_tag for the selected matches.",
+        key="bulk_week_confirm",
+    )
+
+    update_disabled = not selected_ids or not new_week_tag or not confirm_update
+    if st.button("Update week_tag for selected", type="primary", disabled=update_disabled):
+        if not selected_ids:
+            st.warning("Select at least one match to update.")
+        elif not new_week_tag:
+            st.warning("Enter a new week_tag before updating.")
+        else:
+            try:
+                ctx.supabase.table("matches").update({"week_tag": new_week_tag}).eq(
+                    "club_id", str(ctx.club_id)
+                ).in_("id", selected_ids).execute()
+                st.success(f"Updated {len(selected_ids)} match(es).")
+                st.session_state["bulk_week_editor"] = bulk_view
+                st.rerun()
+            except Exception as exc:
+                st.error(f"Unable to update week_tag: {exc}")
 
     st.divider()
 

--- a/tests/test_match_admin.py
+++ b/tests/test_match_admin.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from jupr_app.domain.match_admin import preview_week_tag_update
+
+
+def test_preview_week_tag_update_collects_counts_and_tags():
+    df = pd.DataFrame(
+        [
+            {"id": 1, "week_tag": "Week 1"},
+            {"id": 2, "week_tag": "Week 1"},
+            {"id": 3, "week_tag": "Week 2"},
+        ]
+    )
+
+    preview = preview_week_tag_update(df, [1, 3], "Week 4")
+
+    assert preview["count"] == 2
+    assert preview["new_tag"] == "Week 4"
+    assert preview["old_tags"] == ["Week 1", "Week 2"]


### PR DESCRIPTION
### Motivation
- Admins need a fast, safe way to correct `week_tag` on batches of league matches without deleting or recreating rows.
- The UI should allow filtering, multi-row selection, preview of changes, explicit confirmation, and use the existing Supabase/DB layer.

### Description
- Added `preview_week_tag_update` helper in `jupr_app/domain/match_admin.py` to summarize selected rows and existing `week_tag` values for a preview message.
- Added a new "✏️ Bulk Edit Week Tag" section to `jupr_app/ui/pages/match_log.py` with filters for `league`, `match_type`, `date range`, and `current week_tag`, a selectable results table via `st.data_editor`, a preset (Week 1..Week 20) + custom input for the new tag, a preview line and explicit confirmation checkbox, and a bulk update action that calls `ctx.supabase.table("matches").update({"week_tag": new_week_tag}).eq("club_id", str(ctx.club_id)).in_("id", selected_ids).execute()`.
- Kept the existing bulk delete section intact and used `st.session_state` to retain/clear selection state; errors from the update call are caught and surfaced via `st.error`.
- Added a unit test `tests/test_match_admin.py` that verifies the preview helper collects counts and distinct old tags using `preview_week_tag_update`.

### Testing
- Ran the unit test `pytest tests/test_match_admin.py` which passed (1 test, 1 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976932271dc832681ccca7b3fd8eb1b)