### PR TITLE
Fix bulk week editor: use app-owned state and versioned widget key

### DIFF
--- a/jupr_app/ui/pages/match_log.py
+++ b/jupr_app/ui/pages/match_log.py
@@ -188,19 +188,33 @@ def render(ctx):
     bulk_view = df_bulk[bulk_cols].copy()
     bulk_view.insert(0, "Select", False)
 
-    if "bulk_week_editor" not in st.session_state:
-        st.session_state["bulk_week_editor"] = bulk_view
+    current_filters = (
+        bulk_league,
+        bulk_match_type,
+        bulk_week_tag,
+        tuple(date_range) if isinstance(date_range, tuple) else date_range,
+    )
+    if "bulk_week_editor_version" not in st.session_state:
+        st.session_state["bulk_week_editor_version"] = 0
+    if st.session_state.get("bulk_week_filters") != current_filters:
+        st.session_state["bulk_week_filters"] = current_filters
+        st.session_state["bulk_week_df"] = bulk_view.copy()
+        st.session_state["bulk_week_editor_version"] += 1
+    if "bulk_week_df" not in st.session_state:
+        st.session_state["bulk_week_df"] = bulk_view.copy()
 
     edited_bulk = st.data_editor(
-        bulk_view,
+        st.session_state["bulk_week_df"],
         column_config={"Select": st.column_config.CheckboxColumn(default=False)},
         hide_index=True,
         use_container_width=True,
-        key="bulk_week_editor",
+        key=f"bulk_week_editor_{st.session_state['bulk_week_editor_version']}",
     )
+    st.session_state["bulk_week_df"] = edited_bulk.copy()
 
     if st.button("Clear selection", key="bulk_week_clear"):
-        st.session_state["bulk_week_editor"] = bulk_view
+        st.session_state["bulk_week_df"] = bulk_view.copy()
+        st.session_state["bulk_week_editor_version"] += 1
         st.rerun()
 
     selected_bulk = edited_bulk[edited_bulk["Select"] == True].copy()
@@ -241,7 +255,8 @@ def render(ctx):
                     "club_id", str(ctx.club_id)
                 ).in_("id", selected_ids).execute()
                 st.success(f"Updated {len(selected_ids)} match(es).")
-                st.session_state["bulk_week_editor"] = bulk_view
+                st.session_state["bulk_week_df"] = bulk_view.copy()
+                st.session_state["bulk_week_editor_version"] += 1
                 st.rerun()
             except Exception as exc:
                 st.error(f"Unable to update week_tag: {exc}")


### PR DESCRIPTION
### Motivation
- Streamlit throws `StreamlitValueAssignmentNotAllowedError` when app code assigns to widget-owned keys like `bulk_week_editor`, so the widget state must be owned by Streamlit only. 
- The editor needs a safe way to reset and persist the app's working dataframe when filters change or after updates without writing to the widget key. 

### Description
- Removed all writes to `st.session_state["bulk_week_editor"]` and introduced app-owned session keys `bulk_week_df`, `bulk_week_filters`, and `bulk_week_editor_version` to manage data and resets. 
- Always pass `st.session_state["bulk_week_df"]` into `st.data_editor` and use a versioned widget key `f"bulk_week_editor_{...}"` so Streamlit creates a fresh editor when filters or resets occur. 
- Synchronize edits back into `st.session_state["bulk_week_df"]` after `st.data_editor` returns and reset/increment the editor version on Clear and after successful updates. 
- Searched the repo for other writes to `bulk_week_editor` and updated the single occurrence in `jupr_app/ui/pages/match_log.py`. 

### Testing
- Searched for occurrences with `rg -n "bulk_week_editor" -S .` and confirmed modifications applied to the target file. (succeeded) 
- Verified syntax by running `python -m py_compile jupr_app/ui/pages/match_log.py`. (succeeded) 
- Verified import by running `python -c "import jupr_app.ui.pages.match_log as m; print('ok')"`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976961fbefc832688eb2611104c2bfd)