### PR TITLE
Add Select all to bulk match selector

### DIFF
--- a/jupr_app/ui/pages/match_log.py
+++ b/jupr_app/ui/pages/match_log.py
@@ -203,19 +203,35 @@ def render(ctx):
     if "bulk_week_df" not in st.session_state:
         st.session_state["bulk_week_df"] = bulk_view.copy()
 
+    editor_key = f"bulk_week_editor_{st.session_state['bulk_week_editor_version']}"
     edited_bulk = st.data_editor(
         st.session_state["bulk_week_df"],
         column_config={"Select": st.column_config.CheckboxColumn(default=False)},
         hide_index=True,
         use_container_width=True,
-        key=f"bulk_week_editor_{st.session_state['bulk_week_editor_version']}",
+        key=editor_key,
     )
     st.session_state["bulk_week_df"] = edited_bulk.copy()
 
-    if st.button("Clear selection", key="bulk_week_clear"):
-        st.session_state["bulk_week_df"] = bulk_view.copy()
-        st.session_state["bulk_week_editor_version"] += 1
-        st.rerun()
+    selected_count = int(edited_bulk["Select"].sum()) if "Select" in edited_bulk.columns else 0
+    total_count = int(len(edited_bulk))
+    c_select, c_clear, c_summary = st.columns([1, 1, 2])
+    with c_select:
+        if st.button("Select all", key="bulk_week_select_all", disabled=total_count == 0):
+            df_select = st.session_state["bulk_week_df"].copy()
+            df_select["Select"] = True
+            st.session_state["bulk_week_df"] = df_select
+            st.session_state["bulk_week_editor_version"] += 1
+            st.rerun()
+    with c_clear:
+        if st.button("Clear selection", key="bulk_week_clear", disabled=total_count == 0):
+            df_clear = st.session_state["bulk_week_df"].copy()
+            df_clear["Select"] = False
+            st.session_state["bulk_week_df"] = df_clear
+            st.session_state["bulk_week_editor_version"] += 1
+            st.rerun()
+    with c_summary:
+        st.caption(f"Selected: {selected_count} / {total_count}")
 
     selected_bulk = edited_bulk[edited_bulk["Select"] == True].copy()
     selected_ids = selected_bulk["id"].astype(int).tolist() if not selected_bulk.empty else []


### PR DESCRIPTION
### Motivation
- Provide an easy way to select all visible rows in the week_tag bulk editor so admins can update many matches at once.
- Ensure selection changes are made via app-owned dataframe state and that programmatic updates reliably remount the Streamlit editor so changes appear immediately.

### Description
- Added a versioned editor key `editor_key = f"bulk_week_editor_{st.session_state['bulk_week_editor_version']}"` and use it for `st.data_editor` so programmatic updates force a remount.
- Added `Select all` and `Clear selection` buttons rendered alongside a small summary caption and wired them to update `st.session_state['bulk_week_df']` (setting `Select` to `True`/`False`) and increment `st.session_state['bulk_week_editor_version']` before calling `st.rerun()`.
- Kept the existing behavior that resets `st.session_state['bulk_week_df']` and bumps the editor version when filters change, and persisted user edits back into `st.session_state['bulk_week_df']` after `st.data_editor` returns.
- Kept the UI and logic for performing the bulk `week_tag` preview and update unchanged, scoped to the current filtered dataset.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/match_log.py` which succeeded.
- Launched the app and executed a Playwright script to navigate and capture a screenshot of the updated bulk editor UI, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697697b7c5c883268127ab3a57086eaf)