### PR TITLE
Add global player inactivity (14d) with migration, backfill, daily job, and Leaderboards toggle

### DIFF
--- a/docs/inactivity.md
+++ b/docs/inactivity.md
@@ -1,0 +1,31 @@
+# Player Inactivity (14-day global rule)
+
+## Overview
+Players are marked **inactive** if they have not logged any recorded match in **14 days** across all leagues. Inactive players are hidden by default across leaderboards, standings, and ladders. A player with no recorded games uses `created_at` as the baseline for inactivity.
+
+## Data model
+The `players` table stores:
+
+- `last_game_at`: the most recent match timestamp across all leagues.
+- `inactive_at`: set when a player crosses the 14-day inactivity threshold. A player is active if `inactive_at IS NULL`.
+
+## Daily job
+The migration installs a daily `pg_cron` job:
+
+- **Job name**: `mark-inactive-players-daily`
+- **Schedule**: `0 3 * * *` (03:00 UTC)
+- **Action**: runs `public.mark_inactive_players()` (idempotent).
+
+To run the job manually:
+
+```sql
+SELECT public.mark_inactive_players();
+```
+
+## Backfill
+The migration backfills `last_game_at` from `matches` and marks inactive players by comparing
+`COALESCE(last_game_at, created_at)` to `NOW() - INTERVAL '14 days'`.
+
+## Match deletions/voids
+If matches are deleted/voided and you need to refresh activity timestamps for affected players,
+use the admin match log flow. It recomputes `last_game_at` for impacted player IDs after deletions.

--- a/jupr_app/data/load.py
+++ b/jupr_app/data/load.py
@@ -1,6 +1,8 @@
 import time
 import pandas as pd
 
+from jupr_app.domain.player_activity import add_activity_columns
+
 
 def load_data(supabase, club_id: str, match_limit: int = 5000):
     """
@@ -26,7 +28,9 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
             )
             df_players_all = pd.DataFrame(p_resp.data or [])
 
-            # Active players
+            df_players_all = add_activity_columns(df_players_all)
+
+            # Active players (inactive_at is authoritative when present)
             if not df_players_all.empty and "active" in df_players_all.columns:
                 df_players_active = df_players_all[df_players_all["active"] == True].copy()
             else:
@@ -91,7 +95,17 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
             else:
                 id_to_name, name_to_id = {}, {}
                 df_players_all = pd.DataFrame(
-                    columns=["id", "name", "rating", "wins", "losses", "matches_played", "active"]
+                    columns=[
+                        "id",
+                        "name",
+                        "rating",
+                        "wins",
+                        "losses",
+                        "matches_played",
+                        "active",
+                        "last_game_at",
+                        "inactive_at",
+                    ]
                 )
                 df_players_active = df_players_all.copy()
 

--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable
 
 from jupr_app.domain.ratings import calculate_hybrid_elo
+from jupr_app.domain.player_activity import (
+    build_player_activity_update,
+    coerce_utc_datetime,
+    max_activity_time,
+)
 
 
 def process_matches(
@@ -40,6 +45,7 @@ def process_matches(
     db_matches: list[dict[str, Any]] = []
     overall_updates: dict[int, dict[str, Any]] = {}   # pid -> {"r","w","l","mp"}
     island_updates: dict[tuple[int, str], dict[str, Any]] = {}  # (pid, league) -> {"r","start","w","l","mp"}
+    last_game_updates: dict[int, datetime] = {}
 
     skipped_incomplete = 0
     skipped_empty = 0
@@ -178,15 +184,10 @@ def process_matches(
         is_popup = bool(m.get("is_popup", False)) or (match_type == "PopUp")
 
         dt_val = m.get("date", None)
-        try:
-            if dt_val is None:
-                dt_val = datetime.now().isoformat()
-            elif hasattr(dt_val, "isoformat"):
-                dt_val = dt_val.isoformat()
-            else:
-                dt_val = str(dt_val)
-        except Exception:
-            dt_val = str(dt_val) if dt_val is not None else str(datetime.now())
+        match_dt = coerce_utc_datetime(dt_val)
+        if match_dt is None:
+            match_dt = datetime.now(timezone.utc)
+        dt_val = match_dt.isoformat()
 
         ro1, ro2, ro3, ro4 = get_overall_r(p1), get_overall_r(p2), get_overall_r(p3), get_overall_r(p4)
 
@@ -231,6 +232,9 @@ def process_matches(
         end_r3 = apply_updates(p3, do2, di2, t2_outcome, is_popup, league_name)
         end_r4 = apply_updates(p4, do2, di2, t2_outcome, is_popup, league_name)
 
+        for pid in (p1, p2, p3, p4):
+            last_game_updates[pid] = max_activity_time(last_game_updates.get(pid), match_dt)
+
         stored_elo_delta = abs(do1) if (t1_outcome is True) else abs(do2)
 
         db_matches.append(
@@ -270,7 +274,7 @@ def process_matches(
     # -------------------------
     # Update overall player rows
     # -------------------------
-    def update_player_row(row):
+    def update_player_row(row, activity_update: dict):
         pid = int(row["id"])
         payload = {
             "rating": float(row["rating"]),
@@ -278,6 +282,8 @@ def process_matches(
             "losses": int(row["losses"]),
             "matches_played": int(row["matches_played"]),
         }
+        if activity_update:
+            payload.update(activity_update)
         res = supabase.table("players").update(payload).eq("club_id", club_id).eq("id", pid).execute()
         if not res.data:
             payload_ins = {"club_id": club_id, "id": pid, **payload}
@@ -291,7 +297,13 @@ def process_matches(
             "losses": int(stats["l"]),
             "matches_played": int(stats["mp"]),
         }
-        sb_retry(lambda row=row: update_player_row(row))
+        existing_last_game_at = None
+        pr = get_player_row(int(pid))
+        if pr is not None:
+            existing_last_game_at = pr.get("last_game_at")
+        latest_match_at = last_game_updates.get(int(pid))
+        activity_update = build_player_activity_update(existing_last_game_at, latest_match_at)
+        sb_retry(lambda row=row, activity_update=activity_update: update_player_row(row, activity_update))
 
     # -------------------------
     # Update league ratings

--- a/jupr_app/domain/player_activity.py
+++ b/jupr_app/domain/player_activity.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Iterable
+
+import pandas as pd
+
+INACTIVITY_DAYS = 14
+INACTIVITY_THRESHOLD = timedelta(days=INACTIVITY_DAYS)
+
+
+def coerce_utc_datetime(value) -> datetime | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        try:
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except Exception:
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def max_activity_time(current, candidate) -> datetime | None:
+    cur_dt = coerce_utc_datetime(current)
+    cand_dt = coerce_utc_datetime(candidate)
+    if cur_dt is None:
+        return cand_dt
+    if cand_dt is None:
+        return cur_dt
+    return max(cur_dt, cand_dt)
+
+
+def should_mark_inactive(
+    last_game_at,
+    created_at,
+    *,
+    now_utc: datetime | None = None,
+    threshold: timedelta = INACTIVITY_THRESHOLD,
+) -> bool:
+    """Use created_at when the player has never logged a recorded game."""
+    now = now_utc or datetime.now(timezone.utc)
+    baseline = coerce_utc_datetime(last_game_at) or coerce_utc_datetime(created_at)
+    if baseline is None:
+        return False
+    return (now - baseline) >= threshold
+
+
+def add_activity_columns(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty:
+        return df
+    data = df.copy()
+    if "inactive_at" in data.columns:
+        inactive_at = pd.to_datetime(data["inactive_at"], utc=True, errors="coerce")
+        data["active"] = inactive_at.isna()
+    return data
+
+
+def build_player_activity_update(existing_last_game_at, match_time) -> dict:
+    latest = max_activity_time(existing_last_game_at, match_time)
+    if latest is None:
+        return {}
+    return {"last_game_at": latest.isoformat(), "inactive_at": None}
+
+
+def recompute_last_game_at_for_players(
+    *,
+    supabase,
+    club_id: str,
+    player_ids: Iterable[int],
+) -> None:
+    """Recompute last_game_at for players after match deletions/voids."""
+    for pid in {int(pid) for pid in player_ids if pid is not None}:
+        resp = (
+            supabase.table("matches")
+            .select("date,score_t1,score_t2")
+            .eq("club_id", str(club_id))
+            .or_(f"t1_p1.eq.{pid},t1_p2.eq.{pid},t2_p1.eq.{pid},t2_p2.eq.{pid}")
+            .order("date", desc=True)
+            .limit(50)
+            .execute()
+        )
+        rows = resp.data or []
+        df = pd.DataFrame(rows)
+        if df.empty:
+            latest = None
+        else:
+            df["score_t1"] = pd.to_numeric(df.get("score_t1", 0), errors="coerce").fillna(0).astype(int)
+            df["score_t2"] = pd.to_numeric(df.get("score_t2", 0), errors="coerce").fillna(0).astype(int)
+            df = df[(df["score_t1"] + df["score_t2"]) > 0].copy()
+            if df.empty:
+                latest = None
+            else:
+                df["date_dt"] = pd.to_datetime(df.get("date", None), errors="coerce", utc=True)
+                latest = df["date_dt"].max()
+                if pd.isna(latest):
+                    latest = None
+        payload = {"last_game_at": latest.isoformat()} if latest is not None else {"last_game_at": None}
+        supabase.table("players").update(payload).eq("club_id", str(club_id)).eq("id", pid).execute()

--- a/jupr_app/ui/pages/challenge_ladder.py
+++ b/jupr_app/ui/pages/challenge_ladder.py
@@ -136,6 +136,10 @@ def render(ctx):
 
     settings = ladder_fetch_settings(ctx.supabase, ctx.club_id)
     df_roster, df_flags, df_ch, df_pass = ladder_load_core(ctx.supabase, ctx.club_id)
+    active_ids = None
+    if getattr(ctx, "df_players_active", None) is not None and not ctx.df_players_active.empty:
+        if "id" in ctx.df_players_active.columns:
+            active_ids = set(ctx.df_players_active["id"].astype(int).tolist())
 
     tab_ladder, tab_active, tab_quick = st.tabs(["🪜 Ladder", "⚔️ Active Challenges", "📘 Quick Rules"])
 
@@ -163,6 +167,8 @@ def render(ctx):
                     sub = df_roster.copy()
                     if "is_active" in sub.columns:
                         sub = sub[sub["is_active"] == True]
+                    if active_ids is not None and "player_id" in sub.columns:
+                        sub = sub[sub["player_id"].astype(int).isin(active_ids)]
                     if "tier_id" in sub.columns:
                         sub = sub[sub["tier_id"].astype(str) == str(tid)]
                     else:

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -101,6 +101,16 @@ def _build_player_link(pid, name, public_mode, ctx):
     return f'<a href="{url}" target="_self" class="lb-link">{safe_name}</a>'
 
 
+def select_leaderboard_players(
+    df_players_active: pd.DataFrame | None,
+    df_players_all: pd.DataFrame | None,
+    view_option: str,
+) -> pd.DataFrame | None:
+    if view_option == "See all":
+        return df_players_all
+    return df_players_active
+
+
 def _fetch_story_badges(ctx, player_ids):
     if not player_ids:
         return pd.DataFrame()
@@ -354,7 +364,6 @@ def render_top_performers_cards(
 
 def render(ctx):
     # Always use 4-space indentation in this file.
-    df_players = ctx.df_players_active
     df_players_all = ctx.df_players_all
     df_leagues = ctx.df_leagues
     df_meta = ctx.df_meta
@@ -369,6 +378,10 @@ def render(ctx):
 
     mode_label = "Public" if PUBLIC_MODE else "Admin"
     page_shell("Leaderboards", "Standings and standout moments by league.", mode_label=mode_label)
+
+    view_choice = st.radio("Show", ["Active", "See all"], index=0, horizontal=True)
+
+    df_players = select_leaderboard_players(ctx.df_players_active, df_players_all, view_choice)
     st.markdown(
         """
         <style>

--- a/jupr_app/ui/pages/match_log.py
+++ b/jupr_app/ui/pages/match_log.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 from jupr_app.domain.dupes import canonical_dup_key
 from jupr_app.domain.match_admin import preview_week_tag_update
+from jupr_app.domain.player_activity import recompute_last_game_at_for_players
 from jupr_app.ui.layout import page_shell
 
 def render(ctx):
@@ -103,7 +104,18 @@ def render(ctx):
                 confirm = st.text_input("Type DELETE to confirm", value="", key="dup_delete_confirm")
                 if st.button("🗑️ Delete duplicates now", type="primary", disabled=(confirm.strip().upper() != "DELETE")):
                     if ids_to_delete:
+                        deleted_rows = dup_only[dup_only["id"].astype(int).isin(ids_to_delete)]
+                        deleted_pids = set()
+                        for col in ["t1_p1", "t1_p2", "t2_p1", "t2_p2"]:
+                            if col in deleted_rows.columns:
+                                deleted_pids.update(deleted_rows[col].dropna().astype(int).tolist())
                         ctx.supabase.table("matches").delete().eq("club_id", str(ctx.club_id)).in_("id", ids_to_delete).execute()
+                        if deleted_pids:
+                            recompute_last_game_at_for_players(
+                                supabase=ctx.supabase,
+                                club_id=str(ctx.club_id),
+                                player_ids=deleted_pids,
+                            )
                         st.success("Deleted duplicates. Now run Admin Tools → Replay History → ALL.")
                         st.rerun()
 
@@ -301,6 +313,17 @@ def render(ctx):
         st.warning(f"Ready to delete {len(to_delete)} match(es).")
         confirm2 = st.text_input("Type DELETE to confirm bulk delete", value="", key="bulk_delete_confirm")
         if st.button(f"Delete {len(to_delete)} Matches", type="primary", disabled=(confirm2.strip().upper() != "DELETE")):
-            ctx.supabase.table("matches").delete().eq("club_id", str(ctx.club_id)).in_("id", to_delete["id"].astype(int).tolist()).execute()
+            delete_ids = to_delete["id"].astype(int).tolist()
+            deleted_pids = set()
+            for col in ["t1_p1", "t1_p2", "t2_p1", "t2_p2"]:
+                if col in to_delete.columns:
+                    deleted_pids.update(to_delete[col].dropna().astype(int).tolist())
+            ctx.supabase.table("matches").delete().eq("club_id", str(ctx.club_id)).in_("id", delete_ids).execute()
+            if deleted_pids:
+                recompute_last_game_at_for_players(
+                    supabase=ctx.supabase,
+                    club_id=str(ctx.club_id),
+                    player_ids=deleted_pids,
+                )
             st.success("Deleted. Run Replay ALL if you want ratings to be consistent.")
             st.rerun()

--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -36,6 +36,7 @@ def render(ctx):
                     "losses": 0,
                     "matches_played": 0,
                     "active": True,
+                    "inactive_at": None,
                 }
                 supabase.table("players").insert(payload).execute()
                 st.success("Added. Use Refresh in sidebar to reload cached data.")
@@ -144,13 +145,29 @@ def render(ctx):
     st.caption("Rewires Source → Target in matches + league_ratings. After merge: run Admin Tools → Replay History → ALL.")
 
     # Load all players live
-    allp = supabase.table("players").select("id,name,active").eq("club_id", club_id).order("name", desc=False).execute().data or []
+    allp = (
+        supabase.table("players")
+        .select("id,name,active,inactive_at")
+        .eq("club_id", club_id)
+        .order("name", desc=False)
+        .execute()
+        .data
+        or []
+    )
     dfp = pd.DataFrame(allp)
     if dfp.empty:
         st.info("No players found.")
         return
 
-    dfp["label"] = dfp.apply(lambda r: f"{r['name']} (#{int(r['id'])})" + ("" if bool(r.get("active", True)) else " [inactive]"), axis=1)
+    def _is_active(row) -> bool:
+        if "inactive_at" in row and pd.notna(row.get("inactive_at")):
+            return False
+        return bool(row.get("active", True))
+
+    dfp["label"] = dfp.apply(
+        lambda r: f"{r['name']} (#{int(r['id'])})" + ("" if _is_active(r) else " [inactive]"),
+        axis=1,
+    )
     label_to_id = dict(zip(dfp["label"], dfp["id"]))
 
     cA, cB = st.columns(2)
@@ -190,7 +207,14 @@ def render(ctx):
         dst_p = supabase.table("players").select("name").eq("club_id", club_id).eq("id", int(dst_id)).limit(1).execute().data
         src_name = str(src_p[0]["name"]) if src_p else f"#{src_id}"
         dst_name = str(dst_p[0]["name"]) if dst_p else f"#{dst_id}"
-        supabase.table("players").update({"active": False, "name": f"{src_name} (MERGED into {dst_name} #{dst_id})"}).eq("club_id", club_id).eq("id", int(src_id)).execute()
+        now_iso = datetime.now(timezone.utc).isoformat()
+        supabase.table("players").update(
+            {
+                "active": False,
+                "inactive_at": now_iso,
+                "name": f"{src_name} (MERGED into {dst_name} #{dst_id})",
+            }
+        ).eq("club_id", club_id).eq("id", int(src_id)).execute()
 
         st.success("Merge completed. Now run Admin Tools → Replay History → ALL.")
         time.sleep(0.4)

--- a/migrations/20250301_player_inactivity.sql
+++ b/migrations/20250301_player_inactivity.sql
@@ -1,0 +1,64 @@
+ALTER TABLE public.players
+  ADD COLUMN IF NOT EXISTS last_game_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS inactive_at timestamptz NULL;
+
+-- Backfill last_game_at from recorded matches (global across leagues).
+WITH player_matches AS (
+  SELECT club_id, t1_p1 AS player_id, "date" AS game_at, score_t1, score_t2 FROM public.matches
+  UNION ALL
+  SELECT club_id, t1_p2 AS player_id, "date" AS game_at, score_t1, score_t2 FROM public.matches
+  UNION ALL
+  SELECT club_id, t2_p1 AS player_id, "date" AS game_at, score_t1, score_t2 FROM public.matches
+  UNION ALL
+  SELECT club_id, t2_p2 AS player_id, "date" AS game_at, score_t1, score_t2 FROM public.matches
+),
+player_max AS (
+  SELECT
+    club_id,
+    player_id,
+    MAX(game_at) AS max_game_at
+  FROM player_matches
+  WHERE COALESCE(score_t1, 0) + COALESCE(score_t2, 0) > 0
+  GROUP BY club_id, player_id
+)
+UPDATE public.players p
+SET last_game_at = pm.max_game_at
+FROM player_max pm
+WHERE p.club_id = pm.club_id
+  AND p.id = pm.player_id;
+
+-- Never-played players use created_at for inactivity baseline.
+UPDATE public.players
+SET inactive_at = NOW()
+WHERE inactive_at IS NULL
+  AND COALESCE(last_game_at, created_at) <= (NOW() - INTERVAL '14 days');
+
+CREATE INDEX IF NOT EXISTS idx_players_inactive_at ON public.players (inactive_at);
+CREATE INDEX IF NOT EXISTS idx_players_last_game_at ON public.players (last_game_at);
+
+CREATE OR REPLACE FUNCTION public.mark_inactive_players() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  UPDATE public.players
+  SET inactive_at = NOW()
+  WHERE inactive_at IS NULL
+    AND COALESCE(last_game_at, created_at) <= (NOW() - INTERVAL '14 days');
+END;
+$$;
+
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'mark-inactive-players-daily'
+  ) THEN
+    PERFORM cron.schedule(
+      'mark-inactive-players-daily',
+      '0 3 * * *',
+      $$SELECT public.mark_inactive_players();$$
+    );
+  END IF;
+END
+$$;

--- a/tests/test_player_activity.py
+++ b/tests/test_player_activity.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+
+from jupr_app.domain.player_activity import (
+    add_activity_columns,
+    build_player_activity_update,
+    should_mark_inactive,
+)
+from jupr_app.ui.pages.leaderboards import select_leaderboard_players
+
+
+def test_should_mark_inactive_threshold_boundary():
+    now = datetime(2024, 1, 15, 12, 0, tzinfo=timezone.utc)
+    last_game = now - timedelta(days=14)
+    assert should_mark_inactive(last_game, None, now_utc=now) is True
+
+    just_under = now - timedelta(days=14) + timedelta(seconds=1)
+    assert should_mark_inactive(just_under, None, now_utc=now) is False
+
+
+def test_should_mark_inactive_uses_created_at_when_no_games():
+    now = datetime(2024, 1, 15, 12, 0, tzinfo=timezone.utc)
+    created = now - timedelta(days=15)
+    assert should_mark_inactive(None, created, now_utc=now) is True
+
+
+def test_add_activity_columns_sets_active_flag():
+    df = pd.DataFrame(
+        {
+            "id": [1, 2],
+            "inactive_at": [None, "2024-01-01T00:00:00Z"],
+        }
+    )
+    out = add_activity_columns(df)
+    assert bool(out.loc[0, "active"]) is True
+    assert bool(out.loc[1, "active"]) is False
+
+
+def test_build_player_activity_update_reactivates_and_sets_last_game_at():
+    existing = "2024-01-01T00:00:00+00:00"
+    match_time = datetime(2024, 1, 10, 12, 0, tzinfo=timezone.utc)
+    payload = build_player_activity_update(existing, match_time)
+    assert payload["inactive_at"] is None
+    assert payload["last_game_at"] == match_time.isoformat()
+
+
+def test_select_leaderboard_players_respects_toggle():
+    df_all = pd.DataFrame({"id": [1, 2, 3]})
+    df_active = df_all[df_all["id"] != 3].copy()
+
+    assert select_leaderboard_players(df_active, df_all, "Active").equals(df_active)
+    assert select_leaderboard_players(df_active, df_all, "See all").equals(df_all)


### PR DESCRIPTION
### Motivation
- Implement a global inactivity rule where players who haven't recorded any match in `14 days` are hidden by default from leaderboards/standings/ladders while remaining in the DB. 
- Ensure players are reactivated immediately when a new match is recorded and provide a way to recompute activity state after match deletions/voids. 
- Surface a Leaderboards UI control so admins/public can toggle between `Active` (default) and `See all` views.

### Description
- Added `jupr_app/domain/player_activity.py` containing helpers for `last_game_at`/`inactive_at` coercion, activity update payloads, and `recompute_last_game_at_for_players()` for deletions/voids. 
- Updated match processing (`process_matches`) to compute per-player `last_game_at`, update `players` rows with `last_game_at` and `inactive_at = NULL` on new matches, and use UTC timestamps. 
- Updated data loading and UI: `jupr_app/data/load.py` applies `add_activity_columns()` and builds `df_players_active` by default; `jupr_app/ui/pages/leaderboards.py` adds an `Active / See all` toggle and selection helper; `jupr_app/ui/pages/challenge_ladder.py` and other UI pages now filter rosters by active players by default. 
- Added recompute logic when matches are deleted in `jupr_app/ui/pages/match_log.py` and ensure player merges/set inactive set `inactive_at` in `jupr_app/ui/pages/player_editor.py`. 
- Added a Supabase-compatible migration `migrations/20250301_player_inactivity.sql` that adds `last_game_at` and `inactive_at`, backfills `last_game_at` from `matches`, marks inactive players where `COALESCE(last_game_at, created_at) <= NOW() - INTERVAL '14 days'`, creates helpful indexes, defines `public.mark_inactive_players()` and schedules an idempotent daily `pg_cron` job `mark-inactive-players-daily`. 
- Added docs `docs/inactivity.md` summarizing the feature and an automated test file `tests/test_player_activity.py` covering boundary cases and toggle behavior. 

### Testing
- Ran unit tests in `tests/test_player_activity.py` which exercise the inactivity boundary, created-at fallback, activity-column derivation, activity payload creation, and the leaderboard toggle helper; all tests passed (`5 passed`). 
- Migration and DB job were added as SQL in `migrations/20250301_player_inactivity.sql` and are idempotent by design (`ALTER TABLE ... IF NOT EXISTS`, function updates guarded by `inactive_at IS NULL`, and `pg_cron` schedule existence check).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979165432f48326afbd6902ee1caae7)