### PR TITLE
Align inactivity filtering with inactive_at and activity updates

### DIFF
--- a/jupr_app/data/load.py
+++ b/jupr_app/data/load.py
@@ -31,7 +31,9 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
             df_players_all = add_activity_columns(df_players_all)
 
             # Active players (inactive_at is authoritative when present)
-            if not df_players_all.empty and "active" in df_players_all.columns:
+            if not df_players_all.empty and "inactive_at" in df_players_all.columns:
+                df_players_active = df_players_all[df_players_all["inactive_at"].isna()].copy()
+            elif not df_players_all.empty and "active" in df_players_all.columns:
                 df_players_active = df_players_all[df_players_all["active"] == True].copy()
             else:
                 df_players_active = df_players_all.copy()

--- a/jupr_app/domain/player_ops.py
+++ b/jupr_app/domain/player_ops.py
@@ -38,6 +38,8 @@ def safe_add_player(
         "losses": 0,
         "matches_played": 0,
         "active": True,
+        "last_game_at": None,
+        "inactive_at": None,
     }
 
     try:

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -298,7 +298,9 @@ def render(ctx):
         return
 
     players_df = df_players_all.copy()
-    if "active" in players_df.columns:
+    if "inactive_at" in players_df.columns:
+        players_df = players_df[players_df["inactive_at"].isna()].copy()
+    elif "active" in players_df.columns:
         players_df = players_df[players_df["active"] == True].copy()
 
     if players_df.empty:

--- a/tests/test_player_activity.py
+++ b/tests/test_player_activity.py
@@ -45,6 +45,13 @@ def test_build_player_activity_update_reactivates_and_sets_last_game_at():
     assert payload["last_game_at"] == match_time.isoformat()
 
 
+def test_build_player_activity_update_uses_latest_match_time():
+    existing = "2024-01-12T00:00:00+00:00"
+    match_time = datetime(2024, 1, 10, 12, 0, tzinfo=timezone.utc)
+    payload = build_player_activity_update(existing, match_time)
+    assert payload["last_game_at"] == "2024-01-12T00:00:00+00:00"
+
+
 def test_select_leaderboard_players_respects_toggle():
     df_all = pd.DataFrame({"id": [1, 2, 3]})
     df_active = df_all[df_all["id"] != 3].copy()


### PR DESCRIPTION
### Motivation
- Ensure active player sets are driven by the authoritative DB timestamp `inactive_at` so leaderboards/standings/ladders honor the global 14‑day inactivity rule.
- Ensure newly created players have explicit `last_game_at`/`inactive_at` defaults so inactivity logic behaves consistently.
- Guarantee that posting a new match immediately reactivates a player by preserving the latest `last_game_at` and clearing `inactive_at`.

### Description
- Updated `jupr_app/data/load.py` to compute `df_players_active` from `inactive_at IS NULL` when the column exists, with a fallback to legacy `active` logic (`inactive_at` authoritative).
- Updated `jupr_app/ui/pages/players.py` to filter the player search listing using `inactive_at.isna()` when present, with a fallback to `active == True` for older schemas.
- Updated `jupr_app/domain/player_ops.py` to include `last_game_at = None` and `inactive_at = None` in the payload for newly created players so defaults are explicit.
- Added a regression test in `tests/test_player_activity.py` (`test_build_player_activity_update_uses_latest_match_time`) to assert `build_player_activity_update` preserves the latest existing `last_game_at` when a newer match time is not present.
- No changes required to `jupr_app/domain/match_processing.py` because it already calls `build_player_activity_update(...)` to set `last_game_at` and clear `inactive_at` on match logging.

### Testing
- Ran `pytest tests/test_player_activity.py` and all tests passed (`6 passed`).
- Existing unit tests confirming threshold behavior, `add_activity_columns`, reactivation payload, and the leaderboards toggle continue to pass after changes.
- Manual inspection verified the migration `migrations/20250301_player_inactivity.sql` and `docs/inactivity.md` describe and implement the daily `pg_cron` job and backfill logic used by the code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979243254ac8326bd5f2be70319c191)