### PR TITLE
Revamp player badge aggregation, cabinet UI, and integrity guardrails

### DIFF
--- a/jupr_app/domain/badges_participation.py
+++ b/jupr_app/domain/badges_participation.py
@@ -92,6 +92,7 @@ def ensure_participation_badges(ctx) -> None:
                 if key in existing:
                     continue
                 existing.add(key)
+                tape_excerpt = _participation_excerpt(badge_id, int(games))
                 rows.append(
                     {
                         "id": str(uuid4()),
@@ -102,6 +103,7 @@ def ensure_participation_badges(ctx) -> None:
                         "context_type": "overall",
                         "context_id": None,
                         "value_num": float(games),
+                        "value_json": {"tape_excerpt": tape_excerpt, "games": int(games)},
                     }
                 )
 
@@ -146,4 +148,21 @@ def _fetch_existing_badges(supabase, club_id: str, badge_ids: list[str]) -> set[
 def _insert_badges(supabase, rows: list[dict[str, Any]]) -> None:
     chunk = 200
     for i in range(0, len(rows), chunk):
-        supabase.table("player_badges").insert(rows[i : i + chunk]).execute()
+        supabase.table("player_badges").upsert(
+            rows[i : i + chunk],
+            on_conflict="club_id,player_id,badge_id,context_id",
+        ).execute()
+
+
+def _participation_excerpt(badge_id: str, games: int) -> str:
+    badge_line = {
+        "participant": "The first entries hit the logbook.",
+        "dedicated_participant_50": "The weekly reel keeps finding this name.",
+        "lifetime_participant_200": "The tape shelf keeps getting heavier.",
+    }.get(badge_id, "The tape room logged another chapter.")
+    return "\n".join(
+        [
+            badge_line,
+            f"{games} matches live in the archive.",
+        ]
+    )

--- a/jupr_app/domain/gamification/badge_integrity.py
+++ b/jupr_app/domain/gamification/badge_integrity.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import pandas as pd
+
+
+def dedupe_player_badges_rows(rows: Iterable[dict]) -> pd.DataFrame:
+    df = pd.DataFrame(rows)
+    if df.empty:
+        return df
+    required = ["club_id", "player_id", "badge_id", "context_id"]
+    for col in required:
+        if col not in df.columns:
+            df[col] = None
+    df["earned_at_dt"] = pd.to_datetime(df.get("earned_at", None), utc=True, errors="coerce")
+    df = df.sort_values(["earned_at_dt", "id"], ascending=[True, True], na_position="last")
+    deduped = df.drop_duplicates(subset=required, keep="first").copy()
+    return deduped.drop(columns=["earned_at_dt"], errors="ignore")

--- a/jupr_app/domain/gamification/profile.py
+++ b/jupr_app/domain/gamification/profile.py
@@ -5,6 +5,39 @@ from typing import Any
 import pandas as pd
 
 
+def select_featured_badges(
+    unlocked_badges: list[dict[str, Any]],
+    *,
+    max_count: int = 5,
+    sort_mode: str = "recent",
+) -> list[dict[str, Any]]:
+    if not unlocked_badges:
+        return []
+
+    def sort_key(badge: dict[str, Any]) -> tuple:
+        last_earned = pd.to_datetime(badge.get("last_earned_at"), utc=True, errors="coerce")
+        prestige = _coerce_int(badge.get("prestige"), 0)
+        if sort_mode == "prestige":
+            return (-prestige, last_earned if pd.notna(last_earned) else pd.Timestamp.min)
+        return (
+            -(last_earned.timestamp() if pd.notna(last_earned) else 0.0),
+            -prestige,
+        )
+
+    ordered = sorted(unlocked_badges, key=sort_key)
+    seen: set[str] = set()
+    featured: list[dict[str, Any]] = []
+    for badge in ordered:
+        badge_id = str(badge.get("badge_id"))
+        if badge_id in seen:
+            continue
+        seen.add(badge_id)
+        featured.append(badge)
+        if len(featured) >= max_count:
+            break
+    return featured
+
+
 def build_gamification_summary(
     player_id: int,
     df_badges: pd.DataFrame,
@@ -14,11 +47,16 @@ def build_gamification_summary(
     pb = df_player_badges.copy() if df_player_badges is not None else pd.DataFrame()
 
     badge_defs["badge_id"] = badge_defs.get("badge_id", "").astype(str)
+    if "is_active" not in badge_defs.columns:
+        badge_defs["is_active"] = True
+    badge_defs["is_active"] = badge_defs["is_active"].fillna(True)
+    active_badges = badge_defs[badge_defs["is_active"] != False].copy()
+
     pb = pb[pb.get("player_id") == int(player_id)].copy() if not pb.empty else pd.DataFrame()
-    if pb.empty or badge_defs.empty:
+    if pb.empty or active_badges.empty:
         unlocked = []
     else:
-        merged = pb.merge(badge_defs, on="badge_id", how="left")
+        merged = pb.merge(active_badges, on="badge_id", how="left")
         merged["earned_at_dt"] = pd.to_datetime(merged.get("earned_at", None), utc=True, errors="coerce")
         merged["prestige"] = pd.to_numeric(merged.get("prestige", 0), errors="coerce").fillna(0)
 
@@ -33,6 +71,11 @@ def build_gamification_summary(
                 latest_excerpt = str(value_json.get("tape_excerpt") or "")
             except Exception:
                 latest_excerpt = ""
+            if not latest_excerpt.strip():
+                latest_excerpt = _fallback_tape_excerpt(
+                    str(first.get("name") or "Badge"),
+                    str(first.get("category") or "season"),
+                )
 
             unlocked.append(
                 {
@@ -54,7 +97,7 @@ def build_gamification_summary(
 
     unlocked_ids = {u["badge_id"] for u in unlocked}
     locked = []
-    for row in badge_defs.itertuples(index=False):
+    for row in active_badges.itertuples(index=False):
         if str(row.badge_id) in unlocked_ids:
             continue
         locked.append(
@@ -66,13 +109,15 @@ def build_gamification_summary(
                 "prestige": int(getattr(row, "prestige", 0) or 0),
                 "lore": row.lore,
                 "hint": row.hint,
-                "icon_key": row.icon_key,
-                "tier": row.tier,
-                "scope": row.scope,
+                "icon_key": getattr(row, "icon_key", None),
+                "tier": getattr(row, "tier", None),
+                "scope": getattr(row, "scope", None),
             }
         )
 
     prestige_total = int(sum(u.get("prestige", 0) * u.get("stack_count", 1) for u in unlocked))
+    collected_unique_count = len(unlocked)
+    total_active_badge_types = int(len(active_badges))
     collected_by_category: dict[str, int] = {}
     for badge in unlocked:
         category = badge.get("category") or "Other"
@@ -80,12 +125,33 @@ def build_gamification_summary(
 
     summary = {
         "prestige_total": prestige_total,
+        "collected_unique_count": collected_unique_count,
+        "total_active_badge_types": total_active_badge_types,
         "unlocked_badges": unlocked,
         "locked_badges": locked,
         "collection_stats": {
-            "collected_count": len(unlocked),
-            "total_count": int(len(badge_defs)),
+            "collected_count": collected_unique_count,
+            "total_count": total_active_badge_types,
             "collected_by_category": collected_by_category,
         },
     }
     return summary
+
+
+def _fallback_tape_excerpt(name: str, category: str) -> str:
+    safe_name = name.strip() or "The badge"
+    safe_category = category.strip() or "season"
+    lines = [
+        f"{safe_name} lives in the tape room archives.",
+        f"The {safe_category.lower()} reel keeps the moment on loop.",
+    ]
+    return "\n".join(lines)
+
+
+def _coerce_int(value: Any, fallback: int) -> int:
+    try:
+        if value is None:
+            return fallback
+        return int(value)
+    except Exception:
+        return fallback

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -1,3 +1,4 @@
+import html
 import logging
 
 import streamlit as st
@@ -5,6 +6,10 @@ import pandas as pd
 
 from jupr_app.ui.helpers import qp_get, build_match_explorer_link
 from jupr_app.ui.layout import page_shell
+from jupr_app.domain.gamification.profile import (
+    build_gamification_summary,
+    select_featured_badges,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +105,34 @@ def fetch_player_badges(_supabase, club_id: str, pid: int) -> pd.DataFrame:
         return pd.DataFrame()
 
     return pb_df.merge(badges_df, on="badge_id", how="left")
+
+
+@st.cache_data(ttl=120)
+def fetch_badge_definitions(_supabase) -> pd.DataFrame:
+    try:
+        resp = _supabase.table("badges").select("*").execute()
+        return pd.DataFrame(resp.data or [])
+    except Exception:
+        logger.exception("Failed to load badge definitions")
+        return pd.DataFrame()
+
+
+@st.cache_data(ttl=60)
+def fetch_player_stories(_supabase, club_id: str, pid: int, limit: int = 6) -> pd.DataFrame:
+    try:
+        resp = (
+            _supabase.table("player_stories")
+            .select("story_type,context_id,created_at,title,body,importance,match_id")
+            .eq("club_id", str(club_id))
+            .eq("player_id", int(pid))
+            .order("created_at", desc=True)
+            .limit(int(limit) * 3)
+            .execute()
+        )
+        return pd.DataFrame(resp.data or [])
+    except Exception:
+        logger.exception("Failed to load player stories")
+        return pd.DataFrame()
 
 
 BADGE_ICONS = {
@@ -415,64 +448,132 @@ def render(ctx):
         st.caption("No league ratings table entries found for this player yet.")
 
     st.markdown("### Badges")
-    badges_df = pd.DataFrame()
-    if getattr(ctx, "df_player_badges", None) is not None and getattr(ctx, "df_badges", None) is not None:
-        pb_df = ctx.df_player_badges
-        b_df = ctx.df_badges
-        if isinstance(pb_df, pd.DataFrame) and isinstance(b_df, pd.DataFrame) and not pb_df.empty:
-            pb_df = pb_df[pb_df.get("player_id") == int(pid)].copy()
-            if not pb_df.empty and "badge_id" in pb_df.columns:
-                badges_df = pb_df.merge(b_df, on="badge_id", how="left")
+    badge_defs = getattr(ctx, "df_badges", None)
+    if badge_defs is None or (isinstance(badge_defs, pd.DataFrame) and badge_defs.empty):
+        badge_defs = fetch_badge_definitions(_supabase)
 
-    if badges_df.empty:
+    player_badges = getattr(ctx, "df_player_badges", None)
+    if player_badges is None or (isinstance(player_badges, pd.DataFrame) and player_badges.empty):
         try:
-            badges_df = fetch_player_badges(_supabase, club_id, pid)
+            player_badges = fetch_player_badges(_supabase, club_id, pid)
         except Exception:
             logger.exception("Failed to fetch badges for player view")
-            badges_df = pd.DataFrame()
+            player_badges = pd.DataFrame()
 
-    if badges_df.empty:
-        st.caption("No badges earned yet.")
+    summary = build_gamification_summary(pid, badge_defs, player_badges)
+    prestige_total = summary.get("prestige_total", 0)
+    collected_unique = summary.get("collected_unique_count", 0)
+    total_active = summary.get("total_active_badge_types", 0)
+
+    stat_cols = st.columns(2)
+    stat_cols[0].metric("Prestige", int(prestige_total))
+    stat_cols[1].metric("Collection", f"{collected_unique}/{total_active}")
+
+    unlocked_badges = summary.get("unlocked_badges", [])
+    locked_badges = summary.get("locked_badges", [])
+
+    if not unlocked_badges and not locked_badges:
+        st.caption("No badges available yet.")
     else:
-        badges_df["earned_at_dt"] = pd.to_datetime(badges_df.get("earned_at", None), utc=True, errors="coerce")
-        badges_df["prestige"] = pd.to_numeric(badges_df.get("prestige", 0), errors="coerce").fillna(0)
-        badges_df = badges_df.sort_values(["prestige", "earned_at_dt"], ascending=[False, False])
-
-        participation_order = ["lifetime_participant_200", "dedicated_participant_50", "participant"]
-        participation_df = badges_df[badges_df["badge_id"].isin(participation_order)].copy()
-        participation_badge = None
-        if not participation_df.empty:
-            participation_df["tier_rank"] = participation_df["badge_id"].map(
-                {badge_id: idx for idx, badge_id in enumerate(participation_order)}
-            )
-            participation_df = participation_df.sort_values(["tier_rank", "earned_at_dt"])
-            participation_badge = participation_df.iloc[0]
-
-        st.subheader("Participation")
-        if participation_badge is None:
-            st.caption("No participation badge earned yet.")
+        st.subheader("Featured Cuts")
+        featured = select_featured_badges(unlocked_badges, max_count=5, sort_mode="recent")
+        if not featured:
+            st.caption("The tape room is quiet—new reels arrive after the next run.")
         else:
-            icon = badge_icon(participation_badge.get("badge_id"), participation_badge.get("category"))
-            st.markdown(f"**{icon} {participation_badge.get('name', 'Badge')}**")
-            st.caption(f"Prestige {int(participation_badge.get('prestige', 0) or 0)}")
+            feat_cols = st.columns(min(len(featured), 5))
+            for idx, badge in enumerate(featured):
+                with feat_cols[idx]:
+                    icon = badge_icon(badge.get("badge_id"), badge.get("category"))
+                    stack = badge.get("stack_count", 1)
+                    stack_text = f" x{stack}" if stack and stack > 1 else ""
+                    st.markdown(f"**{icon} {badge.get('name', 'Badge')}{stack_text}**")
+                    st.caption(f"Prestige {int(badge.get('prestige', 0) or 0)}")
+                    excerpt = html.escape(str(badge.get("latest_tape_excerpt") or ""))
+                    if excerpt:
+                        st.caption(excerpt)
 
-        st.subheader("All badges")
-        top_badges = badges_df.head(3).copy()
-        cols = st.columns(len(top_badges))
-        for idx, (_, row) in enumerate(top_badges.iterrows()):
-            with cols[idx]:
-                icon = badge_icon(row.get("badge_id"), row.get("category"))
-                st.markdown(f"**{icon} {row.get('name', 'Badge')}**")
-                st.caption(f"Prestige {int(row.get('prestige', 0) or 0)}")
+        st.subheader("Cabinet by Category")
+        if not unlocked_badges:
+            st.caption("No cabinet reels yet. The shelf is waiting.")
+        else:
+            by_category: dict[str, list[dict]] = {}
+            for badge in unlocked_badges:
+                category = badge.get("category") or "Other"
+                by_category.setdefault(category, []).append(badge)
 
-        with st.expander("View all badges", expanded=False):
-            show_cols = ["name", "prestige", "category", "earned_at_dt"]
-            show_df = badges_df[show_cols].rename(
+            for category in sorted(by_category.keys()):
+                st.markdown(f"**{category}**")
+                row_badges = by_category[category]
+                row_cols = st.columns(min(len(row_badges), 4))
+                for idx, badge in enumerate(row_badges):
+                    with row_cols[idx % len(row_cols)]:
+                        icon = badge_icon(badge.get("badge_id"), badge.get("category"))
+                        stack = badge.get("stack_count", 1)
+                        stack_text = f" x{stack}" if stack and stack > 1 else ""
+                        st.markdown(f"{icon} {badge.get('name', 'Badge')}{stack_text}")
+                        excerpt = html.escape(str(badge.get("latest_tape_excerpt") or ""))
+                        if excerpt:
+                            st.caption(excerpt)
+
+        st.subheader("Missing Badges")
+        if not locked_badges:
+            st.caption("Cabinet complete. Every reel has a slot.")
+        else:
+            missing_cols = st.columns(min(len(locked_badges), 4))
+            for idx, badge in enumerate(locked_badges):
+                with missing_cols[idx % len(missing_cols)]:
+                    icon = badge_icon(badge.get("badge_id"), badge.get("category"))
+                    st.markdown(f"**{icon} {badge.get('name', 'Badge')}**")
+                    hint = html.escape(str(badge.get("hint") or "A reel still missing."))
+                    st.caption(hint)
+
+        st.subheader("Story Cards")
+        story_df = fetch_player_stories(_supabase, club_id, pid, limit=6)
+        if story_df.empty:
+            st.caption("No new stories in the tape room yet.")
+        else:
+            story_df = story_df.drop_duplicates(subset=["story_type", "context_id"], keep="first")
+            story_df = story_df.sort_values("created_at", ascending=False)
+            highlights = story_df[story_df["story_type"].str.startswith("highlight", na=False)].head(3)
+            foreshadow = story_df[story_df["story_type"].str.startswith("foreshadow", na=False)].head(3)
+            highlight_col, foreshadow_col = st.columns(2)
+            with highlight_col:
+                st.markdown("**Highlights**")
+                if highlights.empty:
+                    st.caption("No highlights yet.")
+                else:
+                    for _, row in highlights.iterrows():
+                        title = html.escape(str(row.get("title") or "Highlight"))
+                        body = html.escape(str(row.get("body") or ""))
+                        st.markdown(f"**{title}**")
+                        st.caption(body)
+            with foreshadow_col:
+                st.markdown("**Foreshadowing**")
+                if foreshadow.empty:
+                    st.caption("No foreshadowing yet.")
+                else:
+                    for _, row in foreshadow.iterrows():
+                        title = html.escape(str(row.get("title") or "Foreshadowing"))
+                        body = html.escape(str(row.get("body") or ""))
+                        st.markdown(f"**{title}**")
+                        st.caption(body)
+
+        st.subheader("View All Badges")
+        if unlocked_badges:
+            summary_df = pd.DataFrame(unlocked_badges)
+            summary_df["last_earned_at_dt"] = pd.to_datetime(
+                summary_df.get("last_earned_at", None), utc=True, errors="coerce"
+            )
+            summary_df = summary_df.sort_values(
+                ["last_earned_at_dt", "prestige"], ascending=[False, False]
+            )
+            show_df = summary_df[["name", "category", "prestige", "stack_count", "last_earned_at_dt"]].rename(
                 columns={
                     "name": "Badge",
-                    "prestige": "Prestige",
                     "category": "Category",
-                    "earned_at_dt": "Earned",
+                    "prestige": "Prestige",
+                    "stack_count": "Count",
+                    "last_earned_at_dt": "Last Earned",
                 }
             )
             st.dataframe(
@@ -481,9 +582,45 @@ def render(ctx):
                 hide_index=True,
                 column_config={
                     "Prestige": st.column_config.NumberColumn(format="%d"),
-                    "Earned": st.column_config.DatetimeColumn(format="YYYY-MM-DD"),
+                    "Last Earned": st.column_config.DatetimeColumn(format="YYYY-MM-DD"),
                 },
             )
+
+            admin_debug = False
+            if bool(getattr(ctx, "admin_logged_in", False)):
+                admin_debug = st.toggle("Show debug columns", value=False)
+
+            if isinstance(player_badges, pd.DataFrame) and not player_badges.empty:
+                pb_df = player_badges.copy()
+                pb_df = pb_df[pb_df.get("player_id") == int(pid)].copy()
+                pb_df["earned_at_dt"] = pd.to_datetime(pb_df.get("earned_at", None), utc=True, errors="coerce")
+                for badge in summary_df.itertuples(index=False):
+                    badge_id = getattr(badge, "badge_id", "")
+                    badge_name = getattr(badge, "name", "Badge")
+                    stack = getattr(badge, "stack_count", 1)
+                    stack_text = f" x{stack}" if stack and stack > 1 else ""
+                    icon = badge_icon(badge_id, getattr(badge, "category", None))
+                    with st.expander(f"{icon} {badge_name}{stack_text}", expanded=False):
+                        rows = pb_df[pb_df.get("badge_id") == badge_id].copy()
+                        rows = rows.sort_values("earned_at_dt", ascending=False)
+                        cols = ["earned_at_dt", "match_id"]
+                        if admin_debug:
+                            cols.append("context_id")
+                        show_rows = rows[cols].rename(
+                            columns={
+                                "earned_at_dt": "Earned",
+                                "match_id": "Match",
+                                "context_id": "Context",
+                            }
+                        )
+                        st.dataframe(
+                            show_rows,
+                            use_container_width=True,
+                            hide_index=True,
+                            column_config={
+                                "Earned": st.column_config.DatetimeColumn(format="YYYY-MM-DD"),
+                            },
+                        )
 
     st.divider()
 

--- a/migrations/20250325_player_badges_dedupe.sql
+++ b/migrations/20250325_player_badges_dedupe.sql
@@ -1,0 +1,17 @@
+with ranked as (
+    select
+        id,
+        row_number() over (
+            partition by club_id, player_id, badge_id, context_id
+            order by earned_at asc, id asc
+        ) as rn
+    from player_badges
+)
+delete from player_badges
+where id in (select id from ranked where rn > 1);
+
+alter table player_badges
+    drop constraint if exists player_badges_unique_context,
+    drop constraint if exists player_badges_club_id_player_id_badge_id_context_id_key,
+    drop constraint if exists player_badges_unique_context_type,
+    add constraint player_badges_unique_context unique (club_id, player_id, badge_id, context_id);

--- a/tests/test_badge_aggregation.py
+++ b/tests/test_badge_aggregation.py
@@ -1,0 +1,84 @@
+import pandas as pd
+
+from jupr_app.domain.gamification.profile import build_gamification_summary, select_featured_badges
+
+
+def test_aggregation_counts_and_prestige():
+    df_badges = pd.DataFrame(
+        [
+            {
+                "badge_id": "giant_slayer",
+                "name": "Giant Slayer",
+                "prestige": 75,
+                "category": "Rivalries",
+                "rarity": "legendary",
+                "lore": "The tape favors the fearless.",
+                "hint": "The mountain tips when the underdog swings.",
+                "is_active": True,
+            },
+            {
+                "badge_id": "first_win",
+                "name": "First Win",
+                "prestige": 15,
+                "category": "Participation",
+                "rarity": "common",
+                "lore": "A first chapter.",
+                "hint": "There is always a first frame.",
+                "is_active": True,
+            },
+            {
+                "badge_id": "hot_streak",
+                "name": "Hot Streak",
+                "prestige": 50,
+                "category": "Momentum",
+                "rarity": "epic",
+                "lore": "Wins blur together.",
+                "hint": "The film strip barely cools.",
+                "is_active": True,
+            },
+        ]
+    )
+    df_player_badges = pd.DataFrame(
+        [
+            {
+                "player_id": 5,
+                "badge_id": "giant_slayer",
+                "earned_at": "2024-01-02T00:00:00Z",
+                "value_json": {},
+            },
+            {
+                "player_id": 5,
+                "badge_id": "giant_slayer",
+                "earned_at": "2024-02-02T00:00:00Z",
+                "value_json": {},
+            },
+            {
+                "player_id": 5,
+                "badge_id": "first_win",
+                "earned_at": "2024-03-02T00:00:00Z",
+                "value_json": {"tape_excerpt": "A first win hit the logbook."},
+            },
+        ]
+    )
+    summary = build_gamification_summary(5, df_badges, df_player_badges)
+    assert summary["prestige_total"] == 165
+    assert summary["collected_unique_count"] == 2
+    assert summary["total_active_badge_types"] == 3
+
+    giant = next(b for b in summary["unlocked_badges"] if b["badge_id"] == "giant_slayer")
+    assert giant["stack_count"] == 2
+    assert giant["latest_tape_excerpt"]
+
+    locked = summary["locked_badges"]
+    assert any(b["badge_id"] == "hot_streak" and b["hint"] for b in locked)
+
+
+def test_featured_badges_unique():
+    unlocked = [
+        {"badge_id": "giant_slayer", "prestige": 75, "last_earned_at": "2024-02-02T00:00:00Z"},
+        {"badge_id": "giant_slayer", "prestige": 75, "last_earned_at": "2024-01-02T00:00:00Z"},
+        {"badge_id": "first_win", "prestige": 15, "last_earned_at": "2024-03-02T00:00:00Z"},
+    ]
+    featured = select_featured_badges(unlocked, max_count=5, sort_mode="recent")
+    badge_ids = [b["badge_id"] for b in featured]
+    assert len(badge_ids) == len(set(badge_ids))

--- a/tests/test_badge_integrity.py
+++ b/tests/test_badge_integrity.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from jupr_app.domain.gamification.badge_integrity import dedupe_player_badges_rows
+from jupr_app.domain.gamification.badge_rules import BadgeAward, _insert_badges
+from jupr_app.domain.badges_participation import _insert_badges as insert_participation_badges
+
+
+class CaptureTable:
+    def __init__(self):
+        self.on_conflict = None
+        self.rows = []
+
+    def upsert(self, rows, on_conflict=None):
+        self.on_conflict = on_conflict
+        self.rows.extend(rows)
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=self.rows)
+
+
+class CaptureSupabase:
+    def __init__(self):
+        self.table_ref = CaptureTable()
+
+    def table(self, _name):
+        return self.table_ref
+
+
+def test_dedupe_player_badges_rows_keeps_earliest():
+    rows = [
+        {
+            "id": "1",
+            "club_id": "club",
+            "player_id": 9,
+            "badge_id": "giant_slayer",
+            "context_id": "match:1",
+            "earned_at": "2024-01-05T00:00:00Z",
+        },
+        {
+            "id": "2",
+            "club_id": "club",
+            "player_id": 9,
+            "badge_id": "giant_slayer",
+            "context_id": "match:1",
+            "earned_at": "2024-01-06T00:00:00Z",
+        },
+        {
+            "id": "3",
+            "club_id": "club",
+            "player_id": 9,
+            "badge_id": "first_win",
+            "context_id": "overall",
+            "earned_at": "2024-01-02T00:00:00Z",
+        },
+    ]
+    deduped = dedupe_player_badges_rows(rows)
+    assert len(deduped) == 2
+    assert set(deduped["id"]) == {"1", "3"}
+
+
+def test_badge_awards_insert_uses_upsert_conflict():
+    supabase = CaptureSupabase()
+    awards = [
+        BadgeAward(
+            player_id=1,
+            badge_id="first_win",
+            context_type="overall",
+            context_id="first_win",
+            match_id="m1",
+            value_num=None,
+            value_json={"tape_excerpt": "The first win hit the archive."},
+        )
+    ]
+    _insert_badges(supabase, "club", awards)
+    assert supabase.table_ref.on_conflict == "club_id,player_id,badge_id,context_id"
+
+
+def test_participation_insert_uses_upsert_conflict():
+    supabase = CaptureSupabase()
+    rows = [
+        {
+            "id": "1",
+            "club_id": "club",
+            "player_id": 1,
+            "badge_id": "participant",
+            "earned_at": "2024-01-01T00:00:00Z",
+            "context_type": "overall",
+            "context_id": None,
+            "value_num": 5,
+        }
+    ]
+    insert_participation_badges(supabase, rows)
+    assert supabase.table_ref.on_conflict == "club_id,player_id,badge_id,context_id"

--- a/tests/test_badges_participation.py
+++ b/tests/test_badges_participation.py
@@ -26,6 +26,21 @@ class FakeTable:
         self.storage.setdefault(self.name, []).extend(rows)
         return self
 
+    def upsert(self, rows, on_conflict=None):
+        existing = self.storage.setdefault(self.name, [])
+        if not on_conflict:
+            existing.extend(rows)
+            return self
+        keys = [c.strip() for c in str(on_conflict).split(",") if c.strip()]
+        existing_keys = {tuple(row.get(k) for k in keys) for row in existing}
+        for row in rows:
+            key = tuple(row.get(k) for k in keys)
+            if key in existing_keys:
+                continue
+            existing.append(row)
+            existing_keys.add(key)
+        return self
+
     def execute(self):
         data = list(self.storage.get(self.name, []))
         for op, column, value in self.filters:

--- a/tests/test_gamification_profile_story.py
+++ b/tests/test_gamification_profile_story.py
@@ -48,6 +48,8 @@ def test_profile_summary_locked_and_prestige():
     )
     summary = build_gamification_summary(7, df_badges, df_player_badges)
     assert summary["prestige_total"] == 15
+    assert summary["collected_unique_count"] == 1
+    assert summary["total_active_badge_types"] == 2
     assert summary["unlocked_badges"][0]["latest_tape_excerpt"]
     locked = summary["locked_badges"]
     assert locked and locked[0]["hint"]


### PR DESCRIPTION
### Motivation

- Fix duplicated badge instances and race-condition inserts while shifting the player profile UX to a "sports documentary" tape-room experience where unlock truth is told through story excerpts and cryptic hints. 
- Surface collection progress and prestige on the profile, aggregate stackable badges by type, and show locked badges as mysterious hints rather than explicit requirement text. 
- Provide a repeatable, testable aggregation module and a one-time migration to clean existing DB duplicates and enforce uniqueness going forward.

### Description

- Add a pure aggregation API `build_gamification_summary` and helper `select_featured_badges` to compute `prestige_total`, `collected_unique_count`, `total_active_badge_types`, unlocked badge types with stack counts and tape excerpts, and locked badge hint rows; fallback tape excerpts are generated at read time when missing. (file: `jupr_app/domain/gamification/profile.py`)
- Prevent duplicate player_badges by switching participation badge writes to use `upsert`/`on_conflict` and adding documentary `value_json.tape_excerpt` for participation awards. (file: `jupr_app/domain/badges_participation.py`)
- Add a dedupe helper `dedupe_player_badges_rows` and a one-time SQL migration that deletes duplicate rows (keeping earliest `earned_at`) and adds the DB-level unique constraint `UNIQUE (club_id, player_id, badge_id, context_id)`. (files: `jupr_app/domain/gamification/badge_integrity.py`, `migrations/20250325_player_badges_dedupe.sql`)
- Update the Streamlit player profile to show `Prestige` and `Collection` KPIs, a Featured row (unique badge types, show `xN` when stacked), a Cabinet view grouped by category, Missing Badges with cryptic hints, Story Cards (Highlights + Foreshadowing), and a “View All Badges” view that shows unique badge types with expanders to reveal instances and optional admin debug columns. (file: `jupr_app/ui/pages/players.py`)
- Add tests exercising aggregation, featured-uniqueness, dedupe helper, and upsert behavior for badge inserts, and update small existing tests to assert new summary fields. (files: `tests/test_badge_aggregation.py`, `tests/test_badge_integrity.py`, updated `tests/test_gamification_profile_story.py`, `tests/test_badges_participation.py`)

### Testing

- Ran the automated test suite with `pytest -q`; all tests passed locally with `41 passed` and no failures. 
- New unit tests added validate aggregation counts and prestige, uniqueness of featured badges, locked-badge hints presence, the dedupe helper preserves earliest rows, and insert code paths use `upsert` with the `club_id,player_id,badge_id,context_id` conflict key. 
- Attempted to capture a Streamlit screenshot but the local headless render returned an empty response; UI changes are described above and can be previewed by running the app with updated code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69792d1996c083269e4c94a1acba4af8)