### PR TITLE
Integrate sports-documentary copy pack into gamification (badges, stories, UI)

### DIFF
--- a/jupr_app/domain/badges_participation.py
+++ b/jupr_app/domain/badges_participation.py
@@ -7,6 +7,8 @@ from uuid import uuid4
 
 import pandas as pd
 
+from jupr_app.domain.gamification.copy_pack import get_badge_copy, pick_variant, render_template
+
 logger = logging.getLogger(__name__)
 
 
@@ -155,14 +157,15 @@ def _insert_badges(supabase, rows: list[dict[str, Any]]) -> None:
 
 
 def _participation_excerpt(badge_id: str, games: int) -> str:
-    badge_line = {
-        "participant": "The first entries hit the logbook.",
-        "dedicated_participant_50": "The weekly reel keeps finding this name.",
-        "lifetime_participant_200": "The tape shelf keeps getting heavier.",
-    }.get(badge_id, "The tape room logged another chapter.")
+    copy = get_badge_copy(badge_id)
+    template = pick_variant(copy.get("tape_excerpts", []), f"{badge_id}:{games}")
+    rendered = render_template(template, {"games": games, "badge_name": copy.get("name", badge_id)})
+    lines = [line.strip() for line in rendered.splitlines() if line.strip()]
+    if lines:
+        return "\n".join(lines[:4])
     return "\n".join(
         [
-            badge_line,
+            "The tape room logged another chapter.",
             f"{games} matches live in the archive.",
         ]
     )

--- a/jupr_app/domain/gamification/badge_rules.py
+++ b/jupr_app/domain/gamification/badge_rules.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 import logging
-from typing import Any, Iterable
+import os
+from typing import Any
 from uuid import uuid4
 
 import pandas as pd
 
 from jupr_app.domain.gamification.badge_catalog import BADGE_DEFINITIONS
+from jupr_app.domain.gamification.copy_pack import (
+    get_badge_copy,
+    load_copy_pack,
+    pick_variant,
+    render_template,
+)
 from jupr_app.domain.gamification.story_engine import ensure_player_stories
 from jupr_app.domain.match_filters import apply_match_filters, normalize_player_id, normalize_score
 
@@ -57,6 +64,7 @@ def compute_badge_awards(
 
     awards: list[BadgeAward] = []
     now = datetime.now(timezone.utc)
+    badge_name_map = {b.badge_id: b.name for b in BADGE_DEFINITIONS}
 
     def add_badge(
         player_id: int,
@@ -72,6 +80,19 @@ def compute_badge_awards(
         if key in existing:
             return
         existing.add(key)
+        badge_name = badge_name_map.get(badge_id, badge_id)
+        data = dict(value_json or {})
+        data.setdefault("badge_name", badge_name)
+        data.setdefault("badge_id", badge_id)
+        seed = f"{player_id}:{badge_id}:{context_id}"
+        if not data.get("tape_excerpt"):
+            excerpt = _build_tape_excerpt(badge_id, seed, data)
+            if excerpt:
+                data["tape_excerpt"] = excerpt
+        if not data.get("tape_title"):
+            title = _build_tape_title(badge_id, seed, data)
+            if title:
+                data["tape_title"] = title
         awards.append(
             BadgeAward(
                 player_id=int(player_id),
@@ -80,7 +101,7 @@ def compute_badge_awards(
                 context_id=context_id,
                 match_id=match_id,
                 value_num=value_num,
-                value_json=value_json,
+                value_json=data,
             )
         )
 
@@ -216,6 +237,16 @@ def build_player_match_facts(ctx) -> pd.DataFrame:
 
 
 def _seed_badges(supabase) -> None:
+    force_backfill = str(os.getenv("FORCE_COPY_BACKFILL", "") or "").lower() in {"1", "true", "yes"}
+    copy_pack = {b.badge_id: get_badge_copy(b.badge_id) for b in BADGE_DEFINITIONS}
+    existing_by_id = {}
+    if not force_backfill:
+        try:
+            resp = supabase.table("badges").select("badge_id,lore,hint").execute()
+            existing_by_id = {str(row.get("badge_id")): row for row in resp.data or []}
+        except Exception:
+            logger.exception("Failed to fetch badges for copy backfill")
+
     payload = [
         {
             "badge_id": b.badge_id,
@@ -227,14 +258,33 @@ def _seed_badges(supabase) -> None:
             "rarity": b.rarity,
             "tier": b.tier,
             "icon_key": b.icon_key,
-            "lore": b.lore,
-            "hint": b.hint,
+            "lore": _resolve_copy_text(
+                b.badge_id,
+                "lore",
+                copy_pack.get(b.badge_id, {}),
+                b.lore,
+                existing_by_id.get(b.badge_id, {}),
+                force_backfill,
+            ),
+            "hint": _resolve_copy_text(
+                b.badge_id,
+                "hint",
+                copy_pack.get(b.badge_id, {}),
+                b.hint,
+                existing_by_id.get(b.badge_id, {}),
+                force_backfill,
+            ),
             "scope": b.scope,
         }
         for b in BADGE_DEFINITIONS
     ]
     try:
         supabase.table("badges").upsert(payload, on_conflict="badge_id").execute()
+        _backfill_copy_pack_badges(
+            supabase,
+            force_backfill=force_backfill,
+            existing_by_id=existing_by_id,
+        )
     except Exception:
         logger.exception("Failed to seed badges table")
 
@@ -294,20 +344,13 @@ def _award_first_win(facts: pd.DataFrame, add_badge, now: datetime) -> None:
         return
     first = wins.sort_values(["date_dt", "match_id"]).groupby("player_id", as_index=False).first()
     for row in first.itertuples(index=False):
-        tape = _tape_excerpt(
-            "first_win",
-            lines=[
-                "The first win hit the archive.",
-                "The film starts with a clean finish.",
-            ],
-        )
         add_badge(
             int(row.player_id),
             "first_win",
             context_type="overall",
             context_id="first_win",
             match_id=str(row.match_id),
-            value_json={"tape_excerpt": tape},
+            value_json={"match_id": str(row.match_id)},
         )
 
 
@@ -324,19 +367,12 @@ def _award_weekly_regular(facts: pd.DataFrame, add_badge) -> None:
         streak = _max_consecutive_weeks(weeks)
         if streak >= 4:
             year = weeks[-1].split("-W")[0]
-            tape = _tape_excerpt(
-                "weekly_regular",
-                lines=[
-                    "Four straight weeks on tape.",
-                    "The schedule stopped calling it luck.",
-                ],
-            )
             add_badge(
                 int(row.player_id),
                 "weekly_regular",
                 context_type="league",
                 context_id=f"{row.league}:{year}",
-                value_json={"tape_excerpt": tape},
+                value_json={"league": row.league, "year": year},
             )
 
 
@@ -348,19 +384,12 @@ def _award_iron_week(facts: pd.DataFrame, add_badge) -> None:
     )
     for row in counts.itertuples(index=False):
         if int(row.matches) >= 5:
-            tape = _tape_excerpt(
-                "iron_week",
-                lines=[
-                    "The week ran long and the tape kept rolling.",
-                    "Every day looked like game day.",
-                ],
-            )
             add_badge(
                 int(row.player_id),
                 "iron_week",
                 context_type="week",
                 context_id=f"{row.league}:{row.week_key}",
-                value_json={"tape_excerpt": tape},
+                value_json={"league": row.league, "week": row.week_key, "matches": int(row.matches)},
             )
 
 
@@ -372,19 +401,12 @@ def _award_marathon_month(facts: pd.DataFrame, add_badge) -> None:
     )
     for row in counts.itertuples(index=False):
         if int(row.matches) >= 40:
-            tape = _tape_excerpt(
-                "marathon_month",
-                lines=[
-                    "The month never slowed down.",
-                    "It kept adding chapters to the reel.",
-                ],
-            )
             add_badge(
                 int(row.player_id),
                 "marathon_month",
                 context_type="month",
                 context_id=f"{row.league}:{row.month_key}",
-                value_json={"tape_excerpt": tape},
+                value_json={"league": row.league, "month": row.month_key, "matches": int(row.matches)},
             )
 
 
@@ -403,19 +425,12 @@ def _award_level_up(ctx, add_badge) -> None:
             continue
         for milestone in milestones:
             if float(row.rating) >= milestone:
-                tape = _tape_excerpt(
-                    "level_up",
-                    lines=[
-                        "A new rung lights up on the ladder.",
-                        "The league keeps a close watch now.",
-                    ],
-                )
                 add_badge(
                     int(row.player_id),
                     "level_up",
                     context_type="league",
                     context_id=f"{row.league_name}:milestone:{milestone}",
-                    value_json={"tape_excerpt": tape, "milestone": milestone},
+                    value_json={"league": row.league_name, "milestone": milestone},
                 )
 
 
@@ -427,19 +442,12 @@ def _award_rocket_start(facts: pd.DataFrame, add_badge) -> None:
             continue
         wins = int(head["win"].sum())
         if wins >= 4:
-            tape = _tape_excerpt(
-                "rocket_start",
-                lines=[
-                    "The opening stretch shook the standings.",
-                    "The room leaned in early.",
-                ],
-            )
             add_badge(
                 int(player_id),
                 "rocket_start",
                 context_type="league",
                 context_id=f"{league}:rocket_start",
-                value_json={"tape_excerpt": tape},
+                value_json={"league": league},
             )
 
 
@@ -458,20 +466,13 @@ def _award_most_improved(facts: pd.DataFrame, add_badge) -> None:
         top = group.iloc[0]
         if pd.isna(top["elo_delta_signed"]) or float(top["elo_delta_signed"]) <= 0:
             continue
-        tape = _tape_excerpt(
-            "most_improved_monthly",
-            lines=[
-                "The month tilted in one direction.",
-                "The climb made the reel.",
-            ],
-        )
         add_badge(
             int(top["player_id"]),
             "most_improved_monthly",
             context_type="month",
             context_id=f"{league}:month:{month_key}",
             value_num=float(top["elo_delta_signed"]),
-            value_json={"tape_excerpt": tape},
+            value_json={"league": league, "month": month_key},
         )
 
 
@@ -499,20 +500,13 @@ def _award_mountain_climber(ctx, add_badge) -> None:
             rank_delta = int(row["start_rank"] - row["current_rank"])
             for tier in (5, 10, 20):
                 if rank_delta >= tier:
-                    tape = _tape_excerpt(
-                        "mountain_climber",
-                        lines=[
-                            "Ranks flipped on the way up.",
-                            "The climb left markers behind.",
-                        ],
-                    )
                     add_badge(
                         int(row["player_id"]),
                         "mountain_climber",
                         context_type="league",
                         context_id=f"{league_name}:tier:{tier}",
                         value_num=float(rank_delta),
-                        value_json={"tape_excerpt": tape, "tier": tier},
+                        value_json={"league": league_name, "tier": tier, "rank_delta": rank_delta},
                     )
 
 
@@ -525,13 +519,6 @@ def _award_hot_streaks(facts: pd.DataFrame, add_badge) -> None:
                 streak += 1
                 for tier in (5, 10, 20):
                     if streak == tier:
-                        tape = _tape_excerpt(
-                            "hot_streak",
-                            lines=[
-                                f"{tier} straight wins on the reel.",
-                                "The heat stayed on.",
-                            ],
-                        )
                         add_badge(
                             int(player_id),
                             "hot_streak",
@@ -539,7 +526,7 @@ def _award_hot_streaks(facts: pd.DataFrame, add_badge) -> None:
                             context_id=f"{league}:streak:{tier}:{row.match_id}",
                             match_id=str(row.match_id),
                             value_num=float(streak),
-                            value_json={"tape_excerpt": tape, "tier": tier},
+                            value_json={"league": league, "streak": streak, "tier": tier},
                         )
             else:
                 streak = 0
@@ -551,20 +538,13 @@ def _award_bounce_back(facts: pd.DataFrame, add_badge) -> None:
         prev_win = None
         for row in group.itertuples(index=False):
             if prev_win is False and row.win:
-                tape = _tape_excerpt(
-                    "bounce_back",
-                    lines=[
-                        "A stumble, then a reply.",
-                        "The next frame reset the tone.",
-                    ],
-                )
                 add_badge(
                     int(player_id),
                     "bounce_back",
                     context_type="match",
                     context_id=f"{row.match_id}:bounce_back",
                     match_id=str(row.match_id),
-                    value_json={"tape_excerpt": tape},
+                    value_json={"match_id": str(row.match_id)},
                 )
             prev_win = bool(row.win)
 
@@ -576,60 +556,39 @@ def _award_ice_in_veins(facts: pd.DataFrame, add_badge) -> None:
         return
     first = clutch.sort_values(["date_dt", "match_id"]).groupby("player_id", as_index=False).first()
     for row in first.itertuples(index=False):
-        tape = _tape_excerpt(
-            "ice_in_veins",
-            lines=[
-                "The margin tightened, the answer didn’t.",
-                "The tape stays calm under pressure.",
-            ],
-        )
         add_badge(
             int(row.player_id),
             "ice_in_veins",
             context_type="overall",
             context_id="ice_in_veins",
             match_id=str(row.match_id),
-            value_json={"tape_excerpt": tape},
+            value_json={"match_id": str(row.match_id)},
         )
 
 
 def _award_pickle_perfection(facts: pd.DataFrame, add_badge) -> None:
     shutouts = facts[(facts["win"] == True) & (facts["points_against"] == 0)]
     for row in shutouts.itertuples(index=False):
-        tape = _tape_excerpt(
-            "pickle_perfection",
-            lines=[
-                "The board stayed blank on the other side.",
-                "A quiet kind of dominance.",
-            ],
-        )
         add_badge(
             int(row.player_id),
             "pickle_perfection",
             context_type="match",
             context_id=f"{row.match_id}:pickle_perfection",
             match_id=str(row.match_id),
-            value_json={"tape_excerpt": tape},
+            value_json={"match_id": str(row.match_id), "score_against": int(row.points_against)},
         )
 
 
 def _award_blowout_artist(facts: pd.DataFrame, add_badge) -> None:
     blowouts = facts[(facts["win"] == True) & (facts["margin"] >= 8)]
     for row in blowouts.itertuples(index=False):
-        tape = _tape_excerpt(
-            "blowout_artist",
-            lines=[
-                "The gap opened and never closed.",
-                "The tape shows the distance.",
-            ],
-        )
         add_badge(
             int(row.player_id),
             "blowout_artist",
             context_type="match",
             context_id=f"{row.match_id}:blowout",
             match_id=str(row.match_id),
-            value_json={"tape_excerpt": tape},
+            value_json={"match_id": str(row.match_id), "margin": int(row.margin)},
         )
 
 
@@ -641,20 +600,13 @@ def _award_untouchable(facts: pd.DataFrame, add_badge) -> None:
             if row.win:
                 streak += 1
                 if streak >= 8:
-                    tape = _tape_excerpt(
-                        "untouchable",
-                        lines=[
-                            f"{streak} straight frames without a crack.",
-                            "The run kept the cameras up.",
-                        ],
-                    )
                     add_badge(
                         int(player_id),
                         "untouchable",
                         context_type="overall",
                         context_id=f"window_end:{row.match_id}:streak:{streak}",
                         match_id=str(row.match_id),
-                        value_json={"tape_excerpt": tape, "streak": streak},
+                        value_json={"streak": streak, "match_id": str(row.match_id)},
                     )
             else:
                 streak = 0
@@ -666,39 +618,25 @@ def _award_clean_sweep_week(facts: pd.DataFrame, add_badge) -> None:
         if len(group) < 3:
             continue
         if group["win"].all():
-            tape = _tape_excerpt(
-                "clean_sweep_week",
-                lines=[
-                    "Every clip that week ended the same way.",
-                    "No counterpunches on record.",
-                ],
-            )
             add_badge(
                 int(player_id),
                 "clean_sweep_week",
                 context_type="week",
                 context_id=f"{league}:{week_key}",
-                value_json={"tape_excerpt": tape},
+                value_json={"league": league, "week": week_key},
             )
 
 
 def _award_high_roller(facts: pd.DataFrame, add_badge) -> None:
     high = facts[(facts["win"] == True) & (facts["points_for"] >= 15) & (facts["margin"] >= 6)]
     for row in high.itertuples(index=False):
-        tape = _tape_excerpt(
-            "high_roller",
-            lines=[
-                "The tempo stayed high and the points kept coming.",
-                "The reel moved fast.",
-            ],
-        )
         add_badge(
             int(row.player_id),
             "high_roller",
             context_type="match",
             context_id=f"{row.match_id}:high_roller",
             match_id=str(row.match_id),
-            value_json={"tape_excerpt": tape},
+            value_json={"match_id": str(row.match_id), "points_for": int(row.points_for)},
         )
 
 
@@ -706,34 +644,20 @@ def _award_social_graph(facts: pd.DataFrame, add_badge) -> None:
     partners = facts.dropna(subset=["partner_id"]).groupby("player_id")["partner_id"].nunique()
     for player_id, count in partners.items():
         if count >= 20:
-            tape = _tape_excerpt(
-                "social_butterfly",
-                lines=[
-                    "The partner list turned into a montage.",
-                    "So many combinations on tape.",
-                ],
-            )
             add_badge(
                 int(player_id),
                 "social_butterfly",
                 context_type="overall",
                 context_id="milestone:20_partners",
-                value_json={"tape_excerpt": tape, "partners": int(count)},
+                value_json={"partners": int(count)},
             )
         if count >= 50:
-            tape = _tape_excerpt(
-                "network_builder",
-                lines=[
-                    "The network stretched across the club.",
-                    "So many reels, so many names.",
-                ],
-            )
             add_badge(
                 int(player_id),
                 "network_builder",
                 context_type="overall",
                 context_id="milestone:50_partners",
-                value_json={"tape_excerpt": tape, "partners": int(count)},
+                value_json={"partners": int(count)},
             )
 
 
@@ -742,19 +666,12 @@ def _award_draft_master(facts: pd.DataFrame, add_badge) -> None:
     grouped = wins.groupby(["player_id", "month_key"])["partner_id"].nunique().reset_index()
     for row in grouped.itertuples(index=False):
         if int(row.partner_id) >= 5:
-            tape = _tape_excerpt(
-                "draft_master",
-                lines=[
-                    "Different jerseys, same ending.",
-                    "The month kept changing partners.",
-                ],
-            )
             add_badge(
                 int(row.player_id),
                 "draft_master",
                 context_type="month",
                 context_id=f"{row.month_key}",
-                value_json={"tape_excerpt": tape, "partners": int(row.partner_id)},
+                value_json={"month": row.month_key, "partners": int(row.partner_id)},
             )
 
 
@@ -763,19 +680,12 @@ def _award_swiss_army_knife(facts: pd.DataFrame, add_badge) -> None:
     grouped = wins.groupby(["player_id", "season_key"])["league"].nunique().reset_index()
     for row in grouped.itertuples(index=False):
         if int(row.league) >= 3:
-            tape = _tape_excerpt(
-                "swiss_army_knife",
-                lines=[
-                    "Multiple stages, one steady edge.",
-                    "The season shows the range.",
-                ],
-            )
             add_badge(
                 int(row.player_id),
                 "swiss_army_knife",
                 context_type="season",
                 context_id=str(row.season_key),
-                value_json={"tape_excerpt": tape, "leagues": int(row.league)},
+                value_json={"season": str(row.season_key), "leagues": int(row.league)},
             )
 
 
@@ -785,40 +695,26 @@ def _award_giant_slayer(facts: pd.DataFrame, add_badge) -> None:
     for row in wins.itertuples(index=False):
         for tier in tiers:
             if float(row.opp_max_rating) >= tier:
-                tape = _tape_excerpt(
-                    "giant_slayer",
-                    lines=[
-                        "A taller shadow fell in this frame.",
-                        "The tape keeps the proof.",
-                    ],
-                )
                 add_badge(
                     int(row.player_id),
                     "giant_slayer",
                     context_type="match",
                     context_id=f"{row.match_id}:tier:{tier}",
                     match_id=str(row.match_id),
-                    value_json={"tape_excerpt": tape, "tier": tier},
+                    value_json={"match_id": str(row.match_id), "tier": tier},
                 )
 
 
 def _award_david_vs_goliath(facts: pd.DataFrame, add_badge) -> None:
     wins = facts[(facts["win"] == True) & (facts["expected_win_prob"] <= 0.25)]
     for row in wins.itertuples(index=False):
-        tape = _tape_excerpt(
-            "david_vs_goliath",
-            lines=[
-                "The mismatch didn’t survive the tape.",
-                "A different ending made the reel.",
-            ],
-        )
         add_badge(
             int(row.player_id),
             "david_vs_goliath",
             context_type="match",
             context_id=f"{row.match_id}:david_vs_goliath",
             match_id=str(row.match_id),
-            value_json={"tape_excerpt": tape},
+            value_json={"match_id": str(row.match_id), "expected_prob": float(row.expected_win_prob)},
         )
 
 
@@ -834,13 +730,6 @@ def _award_upset_champion(facts: pd.DataFrame, add_badge) -> None:
     match_stats = match_stats.sort_values(["league", "month_key", "expected_win_prob"])
     for (league, month_key), group in match_stats.groupby(["league", "month_key"]):
         top = group.iloc[0]
-        tape = _tape_excerpt(
-            "upset_champion",
-            lines=[
-                "The month’s loudest swing stayed on tape.",
-                "The record keeps the surprise.",
-            ],
-        )
         for pid in top.player_ids:
             add_badge(
                 int(pid),
@@ -849,27 +738,24 @@ def _award_upset_champion(facts: pd.DataFrame, add_badge) -> None:
                 context_id=f"{league}:month:{month_key}:match:{top.match_id}",
                 match_id=str(top.match_id),
                 value_num=float(top.expected_win_prob),
-                value_json={"tape_excerpt": tape, "league": league},
+                value_json={
+                    "league": league,
+                    "month": month_key,
+                    "expected_prob": float(top.expected_win_prob),
+                },
             )
 
 
 def _award_legendary_upset(facts: pd.DataFrame, add_badge) -> None:
     wins = facts[(facts["win"] == True) & (facts["expected_win_prob"] <= 0.15)]
     for row in wins.itertuples(index=False):
-        tape = _tape_excerpt(
-            "legendary_upset",
-            lines=[
-                "The tape caught a moment nobody predicted.",
-                "The room won’t forget this frame.",
-            ],
-        )
         add_badge(
             int(row.player_id),
             "legendary_upset",
             context_type="match",
             context_id=f"{row.match_id}:legendary_upset",
             match_id=str(row.match_id),
-            value_json={"tape_excerpt": tape},
+            value_json={"match_id": str(row.match_id), "expected_prob": float(row.expected_win_prob)},
         )
 
 
@@ -897,19 +783,12 @@ def _award_rivalries(facts: pd.DataFrame, add_badge) -> None:
         win_pct = wins / float(games) if games else 0.0
         if games >= 6 and win_pct <= 0.4:
             nemesis_map.add((player_id, opponent_id))
-            tape = _tape_excerpt(
-                "nemesis_found",
-                lines=[
-                    "A familiar face keeps appearing across the net.",
-                    "The rivalry has a name now.",
-                ],
-            )
             add_badge(
                 int(player_id),
                 "nemesis_found",
                 context_type="opponent",
                 context_id=f"opponent:{opponent_id}",
-                value_json={"tape_excerpt": tape, "opponent_id": opponent_id},
+                value_json={"opponent_id": opponent_id, "games": games},
             )
 
         streak = 0
@@ -920,38 +799,24 @@ def _award_rivalries(facts: pd.DataFrame, add_badge) -> None:
                 streak += 1
                 for tier in (3,):
                     if streak == tier:
-                        tape = _tape_excerpt(
-                            "rivalry_streak",
-                            lines=[
-                                "The rivalry reel leaned your way.",
-                                "The streak kept the pressure up.",
-                            ],
-                        )
                         add_badge(
                             int(player_id),
                             "rivalry_streak",
                             context_type="opponent",
                             context_id=f"{opponent_id}:streak:{row.match_id}",
                             match_id=str(row.match_id),
-                            value_json={"tape_excerpt": tape},
+                            value_json={"opponent_id": opponent_id, "streak": streak},
                         )
             else:
                 streak = 0
             if prev_losses > prev_wins and row.win and prev_wins + 1 == prev_losses:
-                tape = _tape_excerpt(
-                    "settled_the_score",
-                    lines=[
-                        "The ledger finally balanced.",
-                        "The tape called it even.",
-                    ],
-                )
                 add_badge(
                     int(player_id),
                     "settled_the_score",
                     context_type="opponent",
                     context_id=f"{opponent_id}:settled:{row.match_id}",
                     match_id=str(row.match_id),
-                    value_json={"tape_excerpt": tape},
+                    value_json={"opponent_id": opponent_id},
                 )
             prev_wins += 1 if row.win else 0
             prev_losses += 0 if row.win else 1
@@ -959,20 +824,13 @@ def _award_rivalries(facts: pd.DataFrame, add_badge) -> None:
     if nemesis_map:
         for row in opp_df.itertuples(index=False):
             if (int(row.player_id), int(row.opponent_id)) in nemesis_map and row.win:
-                tape = _tape_excerpt(
-                    "rivalry_win",
-                    lines=[
-                        "The rivalry leaned your way on this frame.",
-                        "The tape caught the shift.",
-                    ],
-                )
                 add_badge(
                     int(row.player_id),
                     "rivalry_win",
                     context_type="match",
                     context_id=f"{row.match_id}:rivalry_win",
                     match_id=str(row.match_id),
-                    value_json={"tape_excerpt": tape},
+                    value_json={"opponent_id": int(row.opponent_id)},
                 )
 
 
@@ -984,19 +842,12 @@ def _award_steady_hand(facts: pd.DataFrame, add_badge) -> None:
             continue
         win_pct = float(group["win"].mean())
         if win_pct >= 0.6:
-            tape = _tape_excerpt(
-                "steady_hand",
-                lines=[
-                    "The season stayed steady on the reel.",
-                    "No wild swings, just control.",
-                ],
-            )
             add_badge(
                 int(player_id),
                 "steady_hand",
                 context_type="season",
                 context_id=str(season_key),
-                value_json={"tape_excerpt": tape, "win_pct": win_pct},
+                value_json={"season": str(season_key), "win_pct": win_pct},
             )
 
 
@@ -1010,26 +861,79 @@ def _award_hall_of_fame_night(facts: pd.DataFrame, add_badge) -> None:
         threshold = values.quantile(0.95)
         for row in group.itertuples(index=False):
             if row.win and row.abs_elo_delta is not None and float(row.abs_elo_delta) >= float(threshold):
-                tape = _tape_excerpt(
-                    "hall_of_fame_night",
-                    lines=[
-                        "A night that pulled the cameras closer.",
-                        "The league will replay this one.",
-                    ],
-                )
                 add_badge(
                     int(row.player_id),
                     "hall_of_fame_night",
                     context_type="match",
                     context_id=f"{row.match_id}:hall_of_fame",
                     match_id=str(row.match_id),
-                    value_json={"tape_excerpt": tape},
+                    value_json={"match_id": str(row.match_id), "elo_delta": float(row.abs_elo_delta)},
                 )
 
+def _build_tape_excerpt(badge_id: str, seed: str, data: dict[str, Any]) -> str:
+    copy = get_badge_copy(badge_id)
+    excerpts = copy.get("tape_excerpts", []) if isinstance(copy, dict) else []
+    template = pick_variant(excerpts, seed)
+    rendered = render_template(template, data)
+    lines = [line.strip() for line in rendered.splitlines() if line.strip()]
+    return "\n".join(lines[:4])
 
-def _tape_excerpt(badge_id: str, lines: Iterable[str]) -> str:
-    excerpt_lines = [line.strip() for line in lines if line and line.strip()]
-    return "\n".join(excerpt_lines[:4])
+
+def _build_tape_title(badge_id: str, seed: str, data: dict[str, Any]) -> str:
+    copy = get_badge_copy(badge_id)
+    highlight = copy.get("highlight", {}) if isinstance(copy, dict) else {}
+    titles = highlight.get("titles", []) if isinstance(highlight, dict) else []
+    template = pick_variant(titles, f"{seed}:title")
+    rendered = render_template(template, data)
+    return rendered or str(data.get("badge_name") or badge_id)
+
+
+def _resolve_copy_text(
+    badge_id: str,
+    field: str,
+    copy_pack: dict[str, Any],
+    fallback: str,
+    existing: dict[str, Any],
+    force_backfill: bool,
+) -> str:
+    existing_text = str(existing.get(field) or "").strip()
+    if existing_text and not force_backfill:
+        return existing_text
+    candidate = str(copy_pack.get(field) or "").strip()
+    if candidate:
+        return candidate
+    return fallback
+
+
+def _backfill_copy_pack_badges(
+    supabase,
+    *,
+    force_backfill: bool,
+    existing_by_id: dict[str, Any],
+) -> None:
+    pack = load_copy_pack()
+    badges = pack.get("badges", {}) if isinstance(pack, dict) else {}
+    if not isinstance(badges, dict):
+        return
+    defined_ids = {b.badge_id for b in BADGE_DEFINITIONS}
+    for badge_id, entry in badges.items():
+        if badge_id in defined_ids:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        existing = existing_by_id.get(str(badge_id), {})
+        if not existing and not force_backfill:
+            continue
+        lore = _resolve_copy_text(badge_id, "lore", entry, "", existing, force_backfill)
+        hint = _resolve_copy_text(badge_id, "hint", entry, "", existing, force_backfill)
+        if not lore and not hint:
+            continue
+        if not force_backfill and existing and (existing.get("lore") or existing.get("hint")):
+            continue
+        try:
+            supabase.table("badges").update({"lore": lore, "hint": hint}).eq("badge_id", badge_id).execute()
+        except Exception:
+            logger.exception("Failed to backfill badge copy", extra={"badge_id": badge_id})
 
 
 def _avg(values: Iterable[float | None]) -> float | None:

--- a/jupr_app/domain/gamification/copy_pack.py
+++ b/jupr_app/domain/gamification/copy_pack.py
@@ -1,0 +1,861 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+COPY_PACK: dict[str, Any] = {
+    "style_guide": {
+        "voice": "Sports documentary. Poetic, archival, tape-room cadence.",
+        "tone": "Confident, observational, never instructional.",
+        "notes": [
+            "Avoid explicit rules or checklists.",
+            "Hints are cryptic, lore is reflective, tape excerpts are short reels.",
+            "Foreshadowing implies proximity without commands.",
+        ],
+    },
+    "badges": {
+        "participant": {
+            "name": "Participant",
+            "lore": "The first log entries mark a new presence in the archive.",
+            "hint": "Every reel begins with a single frame.",
+            "tape_excerpts": [
+                "The first entry hit the logbook.\nThe reel has a new name.",
+                "Opening tape, fresh ink.\nThe archive starts keeping score.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — A First Entry"],
+                "bodies": [
+                    "{tape_excerpt}\nThe record stamps {badge_name} into the archive.",
+                    "{tape_excerpt}\nA new reel adds {badge_name}.",
+                ],
+            },
+        },
+        "dedicated_participant_50": {
+            "name": "Dedicated Participant",
+            "lore": "Fifty clips deep, the routine has its own rhythm.",
+            "hint": "The schedule keeps circling back.",
+            "tape_excerpts": [
+                "The ledger flips to page fifty.\nConsistency leaves a trail.",
+                "Fifty matches in the archive.\nThe reel keeps calling.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Fifty Deep"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} stays on repeat.",
+                    "{tape_excerpt}\nThe tape room files another {badge_name} moment.",
+                ],
+            },
+        },
+        "lifetime_participant_200": {
+            "name": "Lifetime Participant",
+            "lore": "Two hundred chapters in, the archive knows the cadence.",
+            "hint": "The tape shelf keeps getting heavier.",
+            "tape_excerpts": [
+                "Two hundred matches live on tape.\nThe archive remembers every frame.",
+                "The reel count hit 200.\nThe story keeps stacking.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — 200 on Tape"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} belongs to the long haul.",
+                    "{tape_excerpt}\nA long-form reel earns {badge_name}.",
+                ],
+            },
+        },
+        "first_win": {
+            "name": "First Win",
+            "lore": "The first mark on the ledger. The tape starts rolling for real.",
+            "hint": "There is always a first frame on the reel.",
+            "tape_excerpts": [
+                "The first win hit the archive.\nThe film starts with a clean finish.",
+                "Opening night made the reel.\nThe ledger finally has a checkmark.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — First Win on Tape"],
+                "bodies": [
+                    "{tape_excerpt}\nThe record adds {badge_name} to the reel.",
+                    "{tape_excerpt}\nThe documentary notes {badge_name}.",
+                ],
+            },
+        },
+        "weekly_regular": {
+            "name": "Weekly Regular",
+            "lore": "The schedule starts to recognize the face. The weeks keep stacking.",
+            "hint": "The calendar keeps calling.",
+            "tape_excerpts": [
+                "Four straight weeks on tape.\nThe routine left a mark.",
+                "The weekly reel stayed full.\nThe calendar kept the rhythm.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Weekly Regular"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} is now part of the schedule.",
+                    "{tape_excerpt}\nThe archive files {badge_name}.",
+                ],
+            },
+            "foreshadow": {
+                "titles": ["Foreshadowing — {badge_name}", "Foreshadowing — Weekly Rhythm"],
+                "bodies": [
+                    "Three straight weeks on tape.\nThe calendar keeps circling.",
+                    "The weeks are lining up.\nThe story is close to {badge_name}.",
+                ],
+            },
+        },
+        "iron_week": {
+            "name": "Iron Week",
+            "lore": "A week packed tight with tape. The grind leaves a signature.",
+            "hint": "Some weeks barely have room to breathe.",
+            "tape_excerpts": [
+                "The week ran long and the tape kept rolling.\nEvery day looked like game day.",
+                "A full week in the archive.\nNo idle frames.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — The Week Ran Hot"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} lands on the reel.",
+                    "{tape_excerpt}\nThe archive stamps {badge_name}.",
+                ],
+            },
+        },
+        "marathon_month": {
+            "name": "Marathon Month",
+            "lore": "A month that never slowed down. Every day kept its own clip.",
+            "hint": "The month is still writing.",
+            "tape_excerpts": [
+                "The month never slowed down.\nIt kept adding chapters to the reel.",
+                "Thirty-plus days of action.\nThe archive barely cooled.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Marathon Month"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} gets a full reel.",
+                    "{tape_excerpt}\nThe month files {badge_name}.",
+                ],
+            },
+            "foreshadow": {
+                "titles": ["Foreshadowing — {badge_name}", "Foreshadowing — The Month Builds"],
+                "bodies": [
+                    "Thirty matches already on tape.\nThe month is still writing.",
+                    "The reel is heavy this month.\n{badge_name} feels close.",
+                ],
+            },
+        },
+        "level_up": {
+            "name": "Level Up",
+            "lore": "Another rung claimed. The league notices the climb.",
+            "hint": "A new number appears on the nameplate.",
+            "tape_excerpts": [
+                "A new rung lights up on the ladder.\nThe league keeps a close watch now.",
+                "A number clicked higher on the board.\nThe climb caught the lens.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — The Climb"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} lands on the reel.",
+                    "{tape_excerpt}\nThe archive stamps {badge_name}.",
+                ],
+            },
+        },
+        "rocket_start": {
+            "name": "Rocket Start",
+            "lore": "The opening run shook the scoreboard. The room leaned in early.",
+            "hint": "The first stretch left a streak on the floor.",
+            "tape_excerpts": [
+                "The opening stretch shook the standings.\nThe room leaned in early.",
+                "A fast start lit up the reel.\nThe tape caught the spark.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Fast Start"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} hits the record.",
+                    "{tape_excerpt}\nThe doc crew notes {badge_name}.",
+                ],
+            },
+        },
+        "most_improved_monthly": {
+            "name": "Most Improved",
+            "lore": "A month where the climb couldn’t be ignored.",
+            "hint": "One month tilted harder than the rest.",
+            "tape_excerpts": [
+                "The month tilted in one direction.\nThe climb made the reel.",
+                "One month swung the loudest.\nThe archive kept the proof.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — The Month Jumps"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} captures the climb.",
+                    "{tape_excerpt}\nThe tape files {badge_name}.",
+                ],
+            },
+        },
+        "mountain_climber": {
+            "name": "Mountain Climber",
+            "lore": "Ranks flipped. The ascent left landmarks.",
+            "hint": "The ladder looks different now.",
+            "tape_excerpts": [
+                "Ranks flipped on the way up.\nThe climb left markers behind.",
+                "The ascent carved a new path.\nThe archive remembers the shift.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — The Ascent"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} climbs onto the reel.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "hot_streak": {
+            "name": "Hot Streak",
+            "lore": "Wins blur together on the tape. The run keeps rolling.",
+            "hint": "The film strip barely cools off.",
+            "tape_excerpts": [
+                "{streak} straight wins on the reel.\nThe heat stayed on.",
+                "The run kept rolling.\n{streak} frames burned bright.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — The Run"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} owns the reel.",
+                    "{tape_excerpt}\nThe archive tags {badge_name}.",
+                ],
+            },
+            "foreshadow": {
+                "titles": ["Foreshadowing — {badge_name}", "Foreshadowing — Heat Check"],
+                "bodies": [
+                    "{streak} straight wins on tape.\nThe next frame could tilt the season.",
+                    "The reel is running hot.\n{badge_name} feels close.",
+                ],
+            },
+        },
+        "bounce_back": {
+            "name": "Bounce Back",
+            "lore": "A stumble, then a reply. The echo lands clean.",
+            "hint": "The next frame told a different story.",
+            "tape_excerpts": [
+                "A stumble, then a reply.\nThe next frame reset the tone.",
+                "The reel caught a quick answer.\nMomentum flipped back fast.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — The Reply"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} shows the response.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "clutch_performer": {
+            "name": "Clutch Performer",
+            "lore": "Close frames keep leaning the same way.",
+            "hint": "The last points keep finding the same jersey.",
+            "tape_excerpts": [
+                "The last points keep finding the same jersey.\nThe tape keeps the proof.",
+                "Close frames lean one way.\nThe reel shows the nerve.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Close-Frame Control"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} stays calm on the reel.",
+                    "{tape_excerpt}\nThe archive stamps {badge_name}.",
+                ],
+            },
+        },
+        "ice_in_veins": {
+            "name": "Ice in Veins",
+            "lore": "When the margin tightened, the answer didn’t.",
+            "hint": "Cold hands don’t shake the camera.",
+            "tape_excerpts": [
+                "The margin tightened, the answer didn’t.\nThe tape stays calm under pressure.",
+                "A cold moment on tape.\nThe finish stayed steady.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Calm Under Lights"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} writes the finish.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "pickle_perfection": {
+            "name": "Pickle Perfection",
+            "lore": "A shutout with no extra narration needed.",
+            "hint": "Sometimes the other side never shows up on the scoreboard.",
+            "tape_excerpts": [
+                "The board stayed blank on the other side.\nA quiet kind of dominance.",
+                "No numbers for the other side.\nThe tape stayed clean.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Clean Sheet"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} ends the reel.",
+                    "{tape_excerpt}\nThe archive tags {badge_name}.",
+                ],
+            },
+        },
+        "blowout_artist": {
+            "name": "Blowout Artist",
+            "lore": "The gap grew and never closed.",
+            "hint": "The margin kept widening.",
+            "tape_excerpts": [
+                "The gap opened and never closed.\nThe tape shows the distance.",
+                "A wide frame on tape.\nThe lead never blinked.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Wide Margin"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} hits the archive.",
+                    "{tape_excerpt}\nThe reel keeps {badge_name}.",
+                ],
+            },
+        },
+        "untouchable": {
+            "name": "Untouchable",
+            "lore": "A run that didn’t flinch. The tape shows no breaks.",
+            "hint": "The run feels unbroken.",
+            "tape_excerpts": [
+                "{streak} straight frames without a crack.\nThe run kept the cameras up.",
+                "The reel stays unbroken.\n{streak} wins stayed stitched together.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — The Unbroken Run"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} keeps rolling.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "clean_sweep_week": {
+            "name": "Clean Sweep Week",
+            "lore": "Every clip in the week ended the same way.",
+            "hint": "A week with no counterpunches.",
+            "tape_excerpts": [
+                "Every clip that week ended the same way.\nNo counterpunches on record.",
+                "The week stayed spotless on tape.\nNo rewrites needed.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Week on Clean Film"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} seals the week.",
+                    "{tape_excerpt}\nThe archive tags {badge_name}.",
+                ],
+            },
+        },
+        "high_roller": {
+            "name": "High Roller",
+            "lore": "The pace stayed high and the points kept pouring.",
+            "hint": "The scoreboard got a workout.",
+            "tape_excerpts": [
+                "The tempo stayed high and the points kept coming.\nThe reel moved fast.",
+                "Fast tape, loud numbers.\nThe pace never let up.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — High Pace"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} lands on the reel.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "social_butterfly": {
+            "name": "Social Butterfly",
+            "lore": "The partner list turned into a montage.",
+            "hint": "So many different pairings on the same reel.",
+            "tape_excerpts": [
+                "The partner list turned into a montage.\nSo many combinations on tape.",
+                "The reel kept swapping jerseys.\nThe archive caught every pairing.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Partner Montage"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} broadens the reel.",
+                    "{tape_excerpt}\nThe archive tags {badge_name}.",
+                ],
+            },
+            "foreshadow": {
+                "titles": ["Foreshadowing — {badge_name}", "Foreshadowing — Partner Reel"],
+                "bodies": [
+                    "The partner reel is almost full.\nAnother pairing changes the story.",
+                    "The montage keeps growing.\n{badge_name} feels close.",
+                ],
+            },
+        },
+        "network_builder": {
+            "name": "Network Builder",
+            "lore": "The web stretches across the club.",
+            "hint": "The partner map keeps expanding.",
+            "tape_excerpts": [
+                "The network stretched across the club.\nSo many reels, so many names.",
+                "The partner map kept growing.\nThe tape shows the reach.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — The Web Expands"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} spans the reel.",
+                    "{tape_excerpt}\nThe archive tags {badge_name}.",
+                ],
+            },
+        },
+        "draft_master": {
+            "name": "Draft Master",
+            "lore": "Different pairings, same result. The tape shows the range.",
+            "hint": "This month keeps swapping jerseys.",
+            "tape_excerpts": [
+                "Different jerseys, same ending.\nThe month kept changing partners.",
+                "The reel kept rotating partners.\nThe wins stayed steady.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Draft Day"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} lands on the reel.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+            "foreshadow": {
+                "titles": ["Foreshadowing — {badge_name}", "Foreshadowing — Rotating Lineup"],
+                "bodies": [
+                    "Three different winning pairings this month.\nThe tape hints at one more.",
+                    "The lineup keeps shifting.\n{badge_name} feels close.",
+                ],
+            },
+        },
+        "swiss_army_knife": {
+            "name": "Swiss Army Knife",
+            "lore": "Versatility on the record. Different stages, same sharp edge.",
+            "hint": "The season shows more than one role.",
+            "tape_excerpts": [
+                "Multiple stages, one steady edge.\nThe season shows the range.",
+                "The reel cuts across leagues.\nVersatility leaves the mark.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Versatile Tape"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} earns a wide reel.",
+                    "{tape_excerpt}\nThe archive tags {badge_name}.",
+                ],
+            },
+        },
+        "giant_slayer": {
+            "name": "Giant Slayer",
+            "lore": "A giant hit the floor and the camera never blinked.",
+            "hint": "A higher shadow fell.",
+            "tape_excerpts": [
+                "A taller shadow fell in this frame.\nThe tape keeps the proof.",
+                "The reel caught the giant stumble.\nThe lens never shook.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Giant on Tape"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} hits the archive.",
+                    "{tape_excerpt}\nThe record stamps {badge_name}.",
+                ],
+            },
+        },
+        "david_vs_goliath": {
+            "name": "David vs Goliath",
+            "lore": "The mismatch didn’t stay a mismatch.",
+            "hint": "The odds were heavy on one side.",
+            "tape_excerpts": [
+                "The mismatch didn’t survive the tape.\nA different ending made the reel.",
+                "The odds leaned hard.\nThe tape flipped the script.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — The Mismatch Flip"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} lands on the reel.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "upset_champion": {
+            "name": "Upset Champion",
+            "lore": "The month’s biggest swing stayed on the reel.",
+            "hint": "One month holds the loudest turn.",
+            "tape_excerpts": [
+                "The month’s loudest swing stayed on tape.\nThe record keeps the surprise.",
+                "One month flipped the reel.\nThe tape keeps the shock.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Month of Upset"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} anchors the month.",
+                    "{tape_excerpt}\nThe archive tags {badge_name}.",
+                ],
+            },
+        },
+        "hall_of_fame_night": {
+            "name": "Hall of Fame Night",
+            "lore": "A night that pulled the cameras in closer.",
+            "hint": "Some nights feel larger than the rest.",
+            "tape_excerpts": [
+                "A night that pulled the cameras closer.\nThe league will replay this one.",
+                "The reel has a favorite night.\nThe archive won’t forget it.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Hall of Fame Night"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} stays in the spotlight.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "legendary_upset": {
+            "name": "Legendary Upset",
+            "lore": "The tape caught a moment nobody predicted.",
+            "hint": "The odds looked impossible on this frame.",
+            "tape_excerpts": [
+                "The tape caught a moment nobody predicted.\nThe room won’t forget this frame.",
+                "The reel locked a stunner.\nThe archive keeps the shock.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Legendary Upset"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} seals the moment.",
+                    "{tape_excerpt}\nThe archive tags {badge_name}.",
+                ],
+            },
+        },
+        "nemesis_found": {
+            "name": "Nemesis Found",
+            "lore": "A name keeps showing up across the net.",
+            "hint": "The same opponent keeps reappearing.",
+            "tape_excerpts": [
+                "A familiar face keeps appearing across the net.\nThe rivalry has a name now.",
+                "The reel keeps replaying one matchup.\nThe story has a foil.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — A Name Returns"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} marks the rivalry.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "rivalry_win": {
+            "name": "Rivalry Win",
+            "lore": "The rivalry leaned your way on this frame.",
+            "hint": "One chapter shifted the rivalry.",
+            "tape_excerpts": [
+                "The rivalry leaned your way on this frame.\nThe tape caught the shift.",
+                "A key frame swung the rivalry.\nThe reel keeps the proof.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Rivalry Swing"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} changes the reel.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "rivalry_streak": {
+            "name": "Rivalry Streak",
+            "lore": "The rivalry kept tilting, frame after frame.",
+            "hint": "The rivalry reel runs long.",
+            "tape_excerpts": [
+                "The rivalry reel leaned your way.\nThe streak kept the pressure up.",
+                "Frame after frame, the rivalry tilted.\nThe tape shows the run.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Rivalry Run"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} stretches the rivalry.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "settled_the_score": {
+            "name": "Settled the Score",
+            "lore": "The ledger finally balanced, the tape agreed.",
+            "hint": "A long account just evened out.",
+            "tape_excerpts": [
+                "The ledger finally balanced.\nThe tape called it even.",
+                "The rivalry ledger closed a chapter.\nThe reel kept the proof.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — The Ledger Balances"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} caps the rivalry.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "steady_hand": {
+            "name": "Steady Hand",
+            "lore": "The season stayed smooth, even when the lights changed.",
+            "hint": "The season never wandered far.",
+            "tape_excerpts": [
+                "The season stayed steady on the reel.\nNo wild swings, just control.",
+                "A calm season on tape.\nThe archive stayed level.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Steady Season"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} stays locked in.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "mr_reliable": {
+            "name": "Mr. Reliable",
+            "lore": "Week after week, the reel looks the same.",
+            "hint": "Reliable tape needs reliable history.",
+            "tape_excerpts": [
+                "Week after week, the reel looks the same.\nReliability makes a pattern.",
+                "The archive trusts the steady tape.\nReliability stays on repeat.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Always There"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} sits in the archive.",
+                    "{tape_excerpt}\nThe reel logs {badge_name}.",
+                ],
+            },
+        },
+        "league_champion": {
+            "name": "League Champion",
+            "lore": "A season ends with your name at the top.",
+            "hint": "The final table has a single line above the rest.",
+            "tape_excerpts": [
+                "The season closed with your name on top.\nThe archive keeps the final frame.",
+                "The top line belongs to you.\nThe tape seals the season.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Season Crown"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} closes the season.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "podium": {
+            "name": "Podium",
+            "lore": "A season ends with your name on the stage.",
+            "hint": "The podium holds only a few.",
+            "tape_excerpts": [
+                "The season ended on the stage.\nThe archive keeps the podium frame.",
+                "A podium finish hits the tape.\nThe reel shows the stage.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Podium Frame"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} takes the stage.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "good_sport": {
+            "name": "Good Sport",
+            "lore": "The tape shows respect running both ways.",
+            "hint": "Sportsmanship leaves quieter fingerprints.",
+            "tape_excerpts": [
+                "Respect showed on tape.\nThe reel kept the tone.",
+                "A quiet moment of class.\nThe archive remembers it.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Quiet Class"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} holds the tone.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "community_builder": {
+            "name": "Community Builder",
+            "lore": "The club grew around the moments you hosted.",
+            "hint": "Some stories start before the match.",
+            "tape_excerpts": [
+                "The club grew around your moments.\nThe archive credits the spark.",
+                "Community scenes made the reel.\nThe tape remembers the gathering.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Community Frame"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} holds the room.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "mentor": {
+            "name": "Mentor",
+            "lore": "The tape shows the lesson without saying a word.",
+            "hint": "The gap was wide, the guidance wider.",
+            "tape_excerpts": [
+                "The lesson showed on tape.\nThe archive kept the quiet moment.",
+                "A guiding frame made the reel.\nThe tape kept the lesson.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — The Lesson"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} keeps the tone.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "breakthrough": {
+            "name": "Breakthrough",
+            "lore": "A sudden step forward caught the lens.",
+            "hint": "One day the tape just looks different.",
+            "tape_excerpts": [
+                "A sudden step forward caught the lens.\nThe reel felt different.",
+                "The tape turned a page.\nThe archive kept the breakthrough.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Breakthrough Frame"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} changes the reel.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "above_expectations": {
+            "name": "Above Expectations",
+            "lore": "The film shows a stretch beyond the usual script.",
+            "hint": "The reel leans higher than it used to.",
+            "tape_excerpts": [
+                "The reel leaned higher than usual.\nThe archive kept the proof.",
+                "A stretch beyond the script.\nThe tape stayed surprised.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Above the Script"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} lifts the reel.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "dominant_run": {
+            "name": "Dominant Run",
+            "lore": "A stretch of tape with no soft frames.",
+            "hint": "The reel keeps leaning one way.",
+            "tape_excerpts": [
+                "A stretch of tape with no soft frames.\nThe run kept control.",
+                "The reel leaned one way for a while.\nDominance made the cut.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Commanding Run"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} owns the reel.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "high_output": {
+            "name": "High Output",
+            "lore": "The points kept pouring into the reel.",
+            "hint": "The scoreboard got busy.",
+            "tape_excerpts": [
+                "The points kept pouring into the reel.\nThe archive barely kept up.",
+                "A high-output frame on tape.\nThe score kept climbing.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Scoreboard Surge"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} lights up the reel.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "battle_tested": {
+            "name": "Battle Tested",
+            "lore": "The tape shows hard frames and steady answers.",
+            "hint": "The reel holds pressure and poise.",
+            "tape_excerpts": [
+                "Hard frames, steady answers.\nThe tape keeps the grit.",
+                "The archive captured the grind.\nThe reel stayed composed.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Tested on Tape"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} earns its place.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "consistency": {
+            "name": "Consistency",
+            "lore": "The reel keeps the same steady rhythm.",
+            "hint": "The tape keeps finding the same pulse.",
+            "tape_excerpts": [
+                "The reel kept the same steady rhythm.\nThe archive knows the pace.",
+                "No wild swings on tape.\nThe rhythm stayed even.",
+            ],
+            "highlight": {
+                "titles": ["Highlight — {badge_name}", "Highlight — Steady Rhythm"],
+                "bodies": [
+                    "{tape_excerpt}\n{badge_name} stays even.",
+                    "{tape_excerpt}\nThe archive logs {badge_name}.",
+                ],
+            },
+        },
+        "signature_win": {
+            "name": "Signature Win",
+            "lore": "",
+            "hint": "",
+            "tape_excerpts": [],
+            "highlight": {
+                "titles": ["Highlight — Signature Win", "Highlight — A Signature Frame"],
+                "bodies": [
+                    "The tape shows a win nobody penciled in.\nThe league is starting to notice the pattern.",
+                    "A signature frame made the reel.\nThe archive keeps the surprise.",
+                ],
+            },
+        },
+    },
+}
+
+
+def load_copy_pack() -> dict[str, Any]:
+    return COPY_PACK
+
+
+def pick_variant(options: list[str], seed_str: str) -> str:
+    if not options:
+        return ""
+    seed = seed_str or ""
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+    idx = int(digest, 16) % len(options)
+    return str(options[idx])
+
+
+_TEMPLATE_RE = re.compile(r"{([^{}]+)}")
+
+
+def render_template(text: str, data: dict[str, Any]) -> str:
+    if not text:
+        return ""
+
+    def _format_value(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, float):
+            rendered = f"{value:.2f}"
+            rendered = rendered.rstrip("0").rstrip(".")
+            return rendered
+        return str(value)
+
+    def _replace(match: re.Match) -> str:
+        key = match.group(1).strip()
+        if not key:
+            return ""
+        return _format_value(data.get(key))
+
+    rendered = _TEMPLATE_RE.sub(_replace, text)
+    lines = []
+    for line in rendered.splitlines():
+        cleaned = " ".join(line.split())
+        if cleaned:
+            lines.append(cleaned)
+    return "\n".join(lines)
+
+
+def get_badge_copy(badge_id: str) -> dict[str, Any]:
+    pack = load_copy_pack()
+    badges = pack.get("badges", {})
+    badge_copy = badges.get(str(badge_id), {}) if isinstance(badges, dict) else {}
+    return {
+        "name": badge_copy.get("name", ""),
+        "lore": badge_copy.get("lore", ""),
+        "hint": badge_copy.get("hint", ""),
+        "tape_excerpts": list(badge_copy.get("tape_excerpts", []) or []),
+        "highlight": badge_copy.get("highlight", {}) or {},
+        "foreshadow": badge_copy.get("foreshadow", {}) or {},
+    }

--- a/jupr_app/domain/gamification/profile.py
+++ b/jupr_app/domain/gamification/profile.py
@@ -62,6 +62,7 @@ def build_gamification_summary(
         "tier": None,
         "scope": None,
         "category": "",
+        "is_stackable": False,
     }
     for col, default in optional_columns.items():
         if col not in badge_defs.columns:
@@ -126,6 +127,7 @@ def build_gamification_summary(
                     "rarity": _resolve_rarity(first.get("rarity"), first.get("prestige", 0)),
                     "prestige": int(first.get("prestige", 0) or 0),
                     "lore": first.get("lore", ""),
+                    "is_stackable": bool(first.get("is_stackable", False)),
                     "icon_key": first.get("icon_key", None),
                     "tier": first.get("tier", None),
                     "scope": first.get("scope", None),
@@ -150,6 +152,7 @@ def build_gamification_summary(
                 "prestige": int(r(row, "prestige", 0) or 0),
                 "lore": r(row, "lore", ""),
                 "hint": r(row, "hint", ""),
+                "is_stackable": bool(r(row, "is_stackable", False)),
                 "icon_key": r(row, "icon_key", None),
                 "tier": r(row, "tier", None),
                 "scope": r(row, "scope", None),

--- a/jupr_app/domain/gamification/story_engine.py
+++ b/jupr_app/domain/gamification/story_engine.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import pandas as pd
 
 from jupr_app.domain.gamification.badge_catalog import BADGE_DEFINITIONS
+from jupr_app.domain.gamification.copy_pack import get_badge_copy, pick_variant, render_template
 
 logger = logging.getLogger(__name__)
 
@@ -79,36 +80,33 @@ def compute_story_cards(ctx, facts: pd.DataFrame, awards) -> list[dict[str, Any]
         tape = ""
         if award.value_json and award.value_json.get("tape_excerpt"):
             tape = str(award.value_json["tape_excerpt"])
-        title = f"Highlight — {badge.name}"
-        body = f"{tape}\nThe record adds {badge.name} to the reel.".strip()
+        story_data = dict(award.value_json or {})
+        story_data.setdefault("badge_name", badge.name)
+        story_data.setdefault("tape_excerpt", tape)
+        title, body = _build_highlight_copy(
+            award.badge_id,
+            award.player_id,
+            award.context_id or "",
+            badge.name,
+            tape,
+            story_data,
+        )
         importance = _badge_importance(badge.rarity, badge.prestige)
         add_story(
             award.player_id,
-            "highlight.badge",
+            f"highlight.badge.{award.badge_id}",
             award.context_type,
             f"{award.badge_id}:{award.context_id}",
             title,
             body,
             match_id=award.match_id,
             importance=importance,
-            value_json={"badge_id": award.badge_id, "rarity": badge.rarity},
+            value_json={
+                "badge_id": award.badge_id,
+                "rarity": badge.rarity,
+                "tape_excerpt": tape,
+            },
         )
-
-        if award.badge_id in {"giant_slayer", "legendary_upset", "clean_sweep_week"}:
-            spotlight_type = f"highlight.{award.badge_id}"
-            spotlight_title = f"Highlight — {badge.name}"
-            spotlight_body = tape or f"The tape keeps a clean record of {badge.name}."
-            add_story(
-                award.player_id,
-                spotlight_type,
-                award.context_type,
-                str(award.context_id),
-                spotlight_title,
-                spotlight_body,
-                match_id=award.match_id,
-                importance=min(100, importance + 10),
-                value_json={"badge_id": award.badge_id},
-            )
 
     rows.extend(_signature_win_stories(facts, now, add_story))
     rows.extend(_foreshadow_weekly_regular(facts, add_story))
@@ -130,10 +128,13 @@ def _signature_win_stories(facts: pd.DataFrame, now: datetime, add_story) -> lis
     wins = wins.sort_values(["player_id", "expected_win_prob", "date_dt"])
     for player_id, group in wins.groupby("player_id"):
         row = group.iloc[0]
-        title = "Highlight — Signature Win"
-        body = (
-            "The tape shows a win nobody penciled in.\n"
-            "The league is starting to notice the pattern."
+        title, body = _build_highlight_copy(
+            "signature_win",
+            int(player_id),
+            f"signature_win:{row.match_id}",
+            "Signature Win",
+            "",
+            {"expected_prob": float(row.expected_win_prob)},
         )
         add_story(
             int(player_id),
@@ -162,8 +163,12 @@ def _foreshadow_weekly_regular(facts: pd.DataFrame, add_story) -> list[dict[str,
             continue
         streak, end_week = _current_week_streak(weeks)
         if streak == 3:
-            title = "Foreshadowing — Weekly Regular"
-            body = "Three straight weeks are on tape.\nOne more and the story changes."
+            title, body = _build_foreshadow_copy(
+                "weekly_regular",
+                int(row.player_id),
+                f"{row.league}:{end_week}",
+                {"league": row.league, "streak": streak, "week": end_week},
+            )
             add_story(
                 int(row.player_id),
                 "foreshadow.weekly_regular",
@@ -185,10 +190,11 @@ def _foreshadow_hot_streak(facts: pd.DataFrame, add_story) -> list[dict[str, Any
             if row.win:
                 streak += 1
                 if streak in {4, 9, 19}:
-                    title = "Foreshadowing — Hot Streak"
-                    body = (
-                        f"{streak} straight wins on tape.\n"
-                        "The next frame could tilt the season."
+                    title, body = _build_foreshadow_copy(
+                        "hot_streak",
+                        int(player_id),
+                        f"{league}:{streak}:{row.match_id}",
+                        {"league": league, "streak": streak, "match_id": str(row.match_id)},
                     )
                     add_story(
                         int(player_id),
@@ -214,8 +220,12 @@ def _foreshadow_marathon_month(facts: pd.DataFrame, now: datetime, add_story) ->
     counts = current.groupby(["player_id", "month_key"]).size().reset_index(name="matches")
     for row in counts.itertuples(index=False):
         if int(row.matches) >= 30:
-            title = "Foreshadowing — Marathon Month"
-            body = "Thirty matches already on tape.\nThe month is still writing."
+            title, body = _build_foreshadow_copy(
+                "marathon_month",
+                int(row.player_id),
+                f"{row.month_key}",
+                {"month": row.month_key, "matches": int(row.matches)},
+            )
             add_story(
                 int(row.player_id),
                 "foreshadow.marathon_month",
@@ -233,8 +243,12 @@ def _foreshadow_social_butterfly(facts: pd.DataFrame, add_story) -> list[dict[st
     partners = facts.dropna(subset=["partner_id"]).groupby("player_id")["partner_id"].nunique()
     for player_id, count in partners.items():
         if 15 <= int(count) <= 19:
-            title = "Foreshadowing — Social Butterfly"
-            body = "The partner reel is almost full.\nAnother pairing changes the story."
+            title, body = _build_foreshadow_copy(
+                "social_butterfly",
+                int(player_id),
+                "milestone:20_partners",
+                {"partners": int(count)},
+            )
             add_story(
                 int(player_id),
                 "foreshadow.social_butterfly",
@@ -257,8 +271,12 @@ def _foreshadow_draft_master(facts: pd.DataFrame, now: datetime, add_story) -> l
     grouped = wins.groupby("player_id")["partner_id"].nunique().reset_index()
     for row in grouped.itertuples(index=False):
         if 3 <= int(row.partner_id) <= 4:
-            title = "Foreshadowing — Draft Master"
-            body = "Three different winning pairings this month.\nThe tape hints at one more."
+            title, body = _build_foreshadow_copy(
+                "draft_master",
+                int(row.player_id),
+                f"{current_month}",
+                {"month": current_month, "partners": int(row.partner_id)},
+            )
             add_story(
                 int(row.player_id),
                 "foreshadow.draft_master",
@@ -320,3 +338,50 @@ def _trim_story_feed(supabase, club_id: str, player_ids: set[int]) -> None:
                 supabase.table("player_stories").delete().in_("id", ids).execute()
         except Exception:
             logger.exception("Failed trimming story feed", extra={"player_id": player_id})
+
+
+def _build_highlight_copy(
+    badge_id: str,
+    player_id: int,
+    context_id: str,
+    badge_name: str,
+    tape_excerpt: str,
+    data: dict[str, Any],
+) -> tuple[str, str]:
+    copy = get_badge_copy(badge_id)
+    highlight = copy.get("highlight", {}) if isinstance(copy, dict) else {}
+    titles = highlight.get("titles", []) if isinstance(highlight, dict) else []
+    bodies = highlight.get("bodies", []) if isinstance(highlight, dict) else []
+    seed = f"{player_id}:{badge_id}:{context_id}:highlight"
+    title_template = pick_variant(titles, f"{seed}:title")
+    body_template = pick_variant(bodies, f"{seed}:body")
+    story_data = dict(data)
+    story_data.setdefault("badge_name", badge_name)
+    story_data.setdefault("tape_excerpt", tape_excerpt)
+    title = render_template(title_template, story_data) or f"Highlight — {badge_name}"
+    body = render_template(body_template, story_data)
+    if not body:
+        body = f"{tape_excerpt}\nThe record adds {badge_name} to the reel.".strip()
+    return title, body
+
+
+def _build_foreshadow_copy(
+    badge_id: str,
+    player_id: int,
+    context_id: str,
+    data: dict[str, Any],
+) -> tuple[str, str]:
+    copy = get_badge_copy(badge_id)
+    foreshadow = copy.get("foreshadow", {}) if isinstance(copy, dict) else {}
+    titles = foreshadow.get("titles", []) if isinstance(foreshadow, dict) else []
+    bodies = foreshadow.get("bodies", []) if isinstance(foreshadow, dict) else []
+    seed = f"{player_id}:{badge_id}:{context_id}:foreshadow"
+    title_template = pick_variant(titles, f"{seed}:title")
+    body_template = pick_variant(bodies, f"{seed}:body")
+    story_data = dict(data)
+    story_data.setdefault("badge_name", copy.get("name", badge_id))
+    title = render_template(title_template, story_data) or f"Foreshadowing — {story_data['badge_name']}"
+    body = render_template(body_template, story_data)
+    if not body:
+        body = "The reel is leaning close.\nThe next frame could change the story."
+    return title, body

--- a/jupr_app/ui/pages/__init__.py
+++ b/jupr_app/ui/pages/__init__.py
@@ -3,6 +3,7 @@
 from . import leaderboards
 from . import match_explorer
 from . import players
+from . import badge_codex
 from . import match_uploader
 from . import challenge_ladder
 from . import challenge_ladder_admin
@@ -22,6 +23,7 @@ __all__ = [
     "leaderboards",
     "match_explorer",
     "players",
+    "badge_codex",
     "match_uploader",
     "challenge_ladder",
     "challenge_ladder_admin",

--- a/jupr_app/ui/pages/badge_codex.py
+++ b/jupr_app/ui/pages/badge_codex.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import html
+import logging
+
+import pandas as pd
+import streamlit as st
+
+from jupr_app.domain.gamification.profile import build_gamification_summary
+from jupr_app.ui.pages.players import badge_icon
+
+logger = logging.getLogger(__name__)
+
+
+def _player_options(df_players: pd.DataFrame) -> list[tuple[str, int]]:
+    if df_players is None or df_players.empty:
+        return []
+    if "id" not in df_players.columns or "name" not in df_players.columns:
+        return []
+    options = []
+    for row in df_players.itertuples(index=False):
+        try:
+            pid = int(getattr(row, "id"))
+        except Exception:
+            continue
+        name = str(getattr(row, "name", "") or "").strip() or f"Player {pid}"
+        options.append((name, pid))
+    return sorted(options, key=lambda x: x[0].lower())
+
+
+def render(ctx) -> None:
+    st.header("Badge Codex")
+    st.caption("A full ledger of badges, with reels for the ones already on tape.")
+
+    df_players = getattr(ctx, "df_players_active", None)
+    if df_players is None or df_players.empty:
+        df_players = getattr(ctx, "df_players_all", None)
+
+    options = _player_options(df_players)
+    if not options:
+        st.info("No player list available.")
+        return
+
+    names = [name for name, _ in options]
+    selected_name = st.selectbox("Player", names, index=0)
+    player_id = next(pid for name, pid in options if name == selected_name)
+
+    badge_defs = getattr(ctx, "df_badges", None)
+    player_badges = getattr(ctx, "df_player_badges", None)
+    if badge_defs is None or player_badges is None:
+        st.info("Badge data is still loading.")
+        return
+
+    summary = build_gamification_summary(player_id, badge_defs, player_badges)
+    unlocked_badges = summary.get("unlocked_badges", [])
+    locked_badges = summary.get("locked_badges", [])
+
+    stat_cols = st.columns(2)
+    stat_cols[0].metric("Prestige", int(summary.get("prestige_total", 0)))
+    stat_cols[1].metric(
+        "Collection",
+        f"{summary.get('collected_unique_count', 0)}/{summary.get('total_active_badge_types', 0)}",
+    )
+
+    all_badges = []
+    for badge in unlocked_badges:
+        badge_copy = dict(badge)
+        badge_copy["status"] = "unlocked"
+        all_badges.append(badge_copy)
+    for badge in locked_badges:
+        badge_copy = dict(badge)
+        badge_copy["status"] = "locked"
+        all_badges.append(badge_copy)
+
+    categories = sorted({b.get("category") or "Other" for b in all_badges})
+    rarities = sorted({b.get("rarity") or "common" for b in all_badges})
+
+    with st.expander("Filters", expanded=False):
+        selected_categories = st.multiselect("Category", categories, default=categories)
+        selected_rarities = st.multiselect("Rarity", rarities, default=rarities)
+        show_unlocked = st.checkbox("Show unlocked", value=True)
+        show_locked = st.checkbox("Show locked", value=True)
+        show_stackable = st.checkbox("Only stackable", value=False)
+
+    def _visible(badge: dict) -> bool:
+        category = badge.get("category") or "Other"
+        rarity = badge.get("rarity") or "common"
+        if category not in selected_categories or rarity not in selected_rarities:
+            return False
+        if badge.get("status") == "unlocked" and not show_unlocked:
+            return False
+        if badge.get("status") == "locked" and not show_locked:
+            return False
+        if show_stackable and not bool(badge.get("stack_count", 0) > 1 or badge.get("is_stackable")):
+            return False
+        return True
+
+    visible_badges = [b for b in all_badges if _visible(b)]
+    if not visible_badges:
+        st.caption("No badges match the filters.")
+        return
+
+    grid_cols = st.columns(4)
+    for idx, badge in enumerate(visible_badges):
+        with grid_cols[idx % len(grid_cols)]:
+            status = badge.get("status")
+            name = badge.get("name", "Badge")
+            prestige = int(badge.get("prestige", 0) or 0)
+            if status == "locked":
+                icon = "🔒"
+            else:
+                icon = badge_icon(badge.get("badge_id"), badge.get("category"))
+            st.markdown(f"**{icon} {name}**")
+            st.caption(f"Prestige {prestige}")
+            lore = html.escape(str(badge.get("lore") or ""))
+            if lore:
+                st.caption(lore)
+            if status == "locked":
+                hint = html.escape(str(badge.get("hint") or "A reel still missing."))
+                st.caption(hint)
+            else:
+                excerpt = html.escape(str(badge.get("latest_tape_excerpt") or ""))
+                if excerpt:
+                    st.caption(excerpt)

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -488,6 +488,9 @@ def render(ctx):
                     stack_text = f" x{stack}" if stack and stack > 1 else ""
                     st.markdown(f"**{icon} {badge.get('name', 'Badge')}{stack_text}**")
                     st.caption(f"Prestige {int(badge.get('prestige', 0) or 0)}")
+                    lore = html.escape(str(badge.get("lore") or ""))
+                    if lore:
+                        st.caption(lore)
                     excerpt = html.escape(str(badge.get("latest_tape_excerpt") or ""))
                     if excerpt:
                         st.caption(excerpt)
@@ -511,6 +514,9 @@ def render(ctx):
                         stack = badge.get("stack_count", 1)
                         stack_text = f" x{stack}" if stack and stack > 1 else ""
                         st.markdown(f"{icon} {badge.get('name', 'Badge')}{stack_text}")
+                        lore = html.escape(str(badge.get("lore") or ""))
+                        if lore:
+                            st.caption(lore)
                         excerpt = html.escape(str(badge.get("latest_tape_excerpt") or ""))
                         if excerpt:
                             st.caption(excerpt)
@@ -524,6 +530,9 @@ def render(ctx):
                 with missing_cols[idx % len(missing_cols)]:
                     icon = badge_icon(badge.get("badge_id"), badge.get("category"))
                     st.markdown(f"**{icon} {badge.get('name', 'Badge')}**")
+                    lore = html.escape(str(badge.get("lore") or ""))
+                    if lore:
+                        st.caption(lore)
                     hint = html.escape(str(badge.get("hint") or "A reel still missing."))
                     st.caption(hint)
 

--- a/migrations/20250410_badges_copy_pack.sql
+++ b/migrations/20250410_badges_copy_pack.sql
@@ -1,0 +1,9 @@
+alter table badges
+    alter column rarity set default 'common',
+    alter column lore set default '',
+    alter column hint set default '',
+    alter column scope set default 'overall';
+
+update badges
+set rarity = coalesce(rarity, 'common')
+where rarity is null;

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -311,6 +311,7 @@ def main():
             match_explorer,
             faqs,
             players,
+            badge_codex,
             challenge_ladder,
             challenge_ladder_admin,
             match_uploader,
@@ -329,6 +330,7 @@ def main():
             "📊 League Results": league_results,
             "🎯 Match Explorer": match_explorer,
             "🔍 Player Search": players,
+            "📼 Badge Codex": badge_codex,
             "🪜 Challenge Ladder": challenge_ladder,
             "❓ FAQs": faqs,
 
@@ -349,6 +351,7 @@ def main():
             "league_results": "📊 League Results",
             "match_explorer": "🎯 Match Explorer",
             "players": "🔍 Player Search",
+            "badge_codex": "📼 Badge Codex",
             "challenge_ladder": "🪜 Challenge Ladder",
             "faqs": "❓ FAQs",
 
@@ -385,7 +388,15 @@ def main():
             visible_labels = all_labels
 
         # Public nav order (old UX)
-        PUBLIC_NAV_KEYS = ["leaderboards", "league_results", "match_explorer", "players", "challenge_ladder", "faqs"]
+        PUBLIC_NAV_KEYS = [
+            "leaderboards",
+            "league_results",
+            "match_explorer",
+            "players",
+            "badge_codex",
+            "challenge_ladder",
+            "faqs",
+        ]
         public_labels_in_order = [PAGE_KEY_TO_LABEL[k] for k in PUBLIC_NAV_KEYS if PAGE_KEY_TO_LABEL.get(k)]
 
         # -------------------------

--- a/tests/test_copy_pack.py
+++ b/tests/test_copy_pack.py
@@ -1,0 +1,91 @@
+from jupr_app.domain.gamification.copy_pack import get_badge_copy, load_copy_pack, pick_variant, render_template
+
+
+def test_copy_pack_has_required_badges():
+    required = [
+        "participant",
+        "dedicated_participant_50",
+        "lifetime_participant_200",
+        "first_win",
+        "weekly_regular",
+        "iron_week",
+        "marathon_month",
+        "level_up",
+        "rocket_start",
+        "most_improved_monthly",
+        "mountain_climber",
+        "hot_streak",
+        "bounce_back",
+        "clutch_performer",
+        "ice_in_veins",
+        "pickle_perfection",
+        "blowout_artist",
+        "untouchable",
+        "clean_sweep_week",
+        "high_roller",
+        "social_butterfly",
+        "network_builder",
+        "draft_master",
+        "swiss_army_knife",
+        "giant_slayer",
+        "david_vs_goliath",
+        "upset_champion",
+        "hall_of_fame_night",
+        "legendary_upset",
+        "nemesis_found",
+        "rivalry_win",
+        "rivalry_streak",
+        "settled_the_score",
+        "steady_hand",
+        "mr_reliable",
+        "league_champion",
+        "podium",
+        "good_sport",
+        "community_builder",
+        "mentor",
+        "breakthrough",
+        "above_expectations",
+        "dominant_run",
+        "high_output",
+        "battle_tested",
+        "consistency",
+    ]
+    pack = load_copy_pack()
+    assert "badges" in pack
+    for badge_id in required:
+        copy = get_badge_copy(badge_id)
+        assert copy["lore"]
+        assert copy["hint"]
+        assert copy["tape_excerpts"]
+
+
+def test_pick_variant_deterministic():
+    options = ["alpha", "bravo", "charlie"]
+    assert pick_variant(options, "seed-123") == pick_variant(options, "seed-123")
+
+
+def test_render_template_removes_missing_placeholders():
+    rendered = render_template("Hello {name} {missing}", {"name": "Riley"})
+    assert rendered == "Hello Riley"
+
+
+def test_copy_pack_player_facing_words_clean():
+    forbidden = ["requirement", "criteria", "unlock condition", "formula", "threshold"]
+    pack = load_copy_pack()
+    for badge_id, entry in pack.get("badges", {}).items():
+        if not isinstance(entry, dict):
+            continue
+        texts = [
+            entry.get("lore", ""),
+            entry.get("hint", ""),
+            *(entry.get("tape_excerpts", []) or []),
+        ]
+        highlight = entry.get("highlight", {}) or {}
+        foreshadow = entry.get("foreshadow", {}) or {}
+        texts.extend(highlight.get("titles", []) or [])
+        texts.extend(highlight.get("bodies", []) or [])
+        texts.extend(foreshadow.get("titles", []) or [])
+        texts.extend(foreshadow.get("bodies", []) or [])
+        joined = " ".join(str(t) for t in texts).lower()
+        for word in forbidden:
+            assert word not in joined, f"{badge_id} includes forbidden word: {word}"

--- a/tests/test_gamification_badges.py
+++ b/tests/test_gamification_badges.py
@@ -34,6 +34,8 @@ def test_first_win_idempotent():
     awards, _ = compute_badge_awards(ctx, existing=set())
     first_win = [a for a in awards if a.badge_id == "first_win"]
     assert len(first_win) == 1
+    assert first_win[0].value_json
+    assert first_win[0].value_json.get("tape_excerpt")
 
     existing = {(str(a.player_id), a.badge_id, a.context_id) for a in awards}
     awards_again, _ = compute_badge_awards(ctx, existing=existing)

--- a/tests/test_gamification_profile_story.py
+++ b/tests/test_gamification_profile_story.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pandas as pd
 
 from jupr_app.domain.gamification.profile import build_gamification_summary
+from jupr_app.domain.gamification.copy_pack import get_badge_copy, pick_variant, render_template
 from jupr_app.domain.gamification.story_engine import compute_story_cards
 from jupr_app.domain.gamification.badge_rules import BadgeAward
 
@@ -138,5 +139,14 @@ def test_story_generation_highlight_and_foreshadow_dedupe():
     ctx = SimpleNamespace(club_id="club")
     stories = compute_story_cards(ctx, facts, awards)
     story_types = {(s["story_type"], s["context_id"]) for s in stories}
-    assert any(st[0] == "highlight.badge" for st in story_types)
+    assert any(st[0].startswith("highlight.badge.") for st in story_types)
     assert any(st[0].startswith("foreshadow.") for st in story_types)
+
+    highlight = next(story for story in stories if story["story_type"].startswith("highlight.badge."))
+    badge_copy = get_badge_copy("first_win")
+    seed = "1:first_win:first_win:highlight"
+    expected_title = render_template(
+        pick_variant(badge_copy["highlight"]["titles"], f"{seed}:title"),
+        {"badge_name": "First Win", "tape_excerpt": "The first win hit the archive."},
+    ) or "Highlight — First Win"
+    assert highlight["title"] == expected_title


### PR DESCRIPTION
### Motivation
- Make badges and story feed feel authored by adding a sports-documentary copy pack and surfacing lore/hints/tape excerpts without exposing rules to players.
- Store human-facing copy in the database and use deterministic templates so highlights and foreshadowing read like documentary narration rather than checklists.

### Description
- Added a Copy Pack and helpers: `jupr_app/domain/gamification/copy_pack.py` with `load_copy_pack()`, `pick_variant()`, `render_template()` and `get_badge_copy()` for deterministic variant selection and safe template rendering; the pack contains badge lore/hint/tape_excerpts/highlight/foreshadow templates. 
- Seed/backfill and award changes: `jupr_app/domain/gamification/badge_rules.py` now seeds `lore`/`hint` from the copy pack (with a `FORCE_COPY_BACKFILL` env flag), builds deterministic `tape_excerpt` and `tape_title` for each award and writes them into `player_badges.value_json`, and uses copy-pack-driven rendering when creating awards. 
- Participation badges: `jupr_app/domain/badges_participation.py` now sources participation tape excerpts from the copy pack instead of fixed strings. 
- Story feed integration: `jupr_app/domain/gamification/story_engine.py` uses copy pack highlight/foreshadow templates for highlight and foreshadow story cards (including a signature win spotlight), and story_type values include badge ids for clearer dedupe (`highlight.badge.{badge_id}`). 
- Player profile & UI: `jupr_app/domain/gamification/profile.py` now includes lore/hint/is_stackable in summary output and surface latest tape excerpts; `jupr_app/ui/pages/players.py` shows lore + tape excerpts for unlocked badges and lore + cryptic hint for locked badges; added a new `Badge Codex` page at `jupr_app/ui/pages/badge_codex.py` and registered it in the app navigation (`streamlit_app.py`, `jupr_app/ui/pages/__init__.py`). 
- Migrations: new migration `migrations/20250410_badges_copy_pack.sql` adds sensible defaults for `rarity`, `lore`, `hint`, and `scope`. 
- Tests: added `tests/test_copy_pack.py` to validate copy pack coverage, deterministic variants, placeholder rendering and forbid player-facing words like “requirement/criteria/formula/threshold”; updated/extended existing tests to assert `tape_excerpt` presence and story title rendering.

### Testing
- Ran the full test suite with `pytest`; all tests passed: 45 passed, 12 warnings (pyiceberg/pyparsing/pydantic deprecation warnings in `test_imports`).
- New tests added: `tests/test_copy_pack.py` (checks copy presence, deterministic variants, template rendering, and forbidden words); existing tests `tests/test_gamification_badges.py` and `tests/test_gamification_profile_story.py` were updated to validate `tape_excerpt` population and story title generation and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69793555435c8326832b4ed4a4d7c68e)