### PR TITLE
Initialize supabase and club_id earlier in player view to avoid UnboundLocalError

### DIFF
--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -382,6 +382,8 @@ def render(ctx):
     pid = int(pick_id)
     row = players_df[players_df["id"] == pid].iloc[0]
     pick_name = str(row["name"])
+    _supabase = ctx.supabase
+    club_id = ctx.club_id
 
     try:
         current_overall_elo = float(row.get("rating", 1200.0) or 1200.0)
@@ -633,8 +635,6 @@ def render(ctx):
 
     st.divider()
 
-    _supabase = ctx.supabase
-    club_id = ctx.club_id
     matches = fetch_player_matches(_supabase, club_id, pid, limit=600)
 
     if matches.empty:


### PR DESCRIPTION
### Motivation
- Fix an `UnboundLocalError` raised in the player view when rendering badges because `_supabase` was referenced before being initialized.

### Description
- Initialize `ctx.supabase` and `ctx.club_id` earlier in `render` (in `jupr_app/ui/pages/players.py`) so `_supabase = ctx.supabase` and `club_id = ctx.club_id` are available for badge and story lookups, and remove the later duplicate initialization.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697939c2a1f883269034316915e1f17b)