### PR TITLE
Fix badge cabinet expander state handling

### DIFF
--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -696,10 +696,13 @@ def render(ctx):
                 label="badges.featured.grid",
             )
 
-        if st.button("See more cuts", key="badge_cabinet_open"):
-            st.session_state["badge_cabinet_open"] = True
+        if "badge_cabinet_is_open" not in st.session_state:
+            st.session_state["badge_cabinet_is_open"] = False
 
-        cabinet_open = st.session_state.get("badge_cabinet_open", False)
+        if st.button("See more cuts", key="badge_cabinet_open_btn"):
+            st.session_state["badge_cabinet_is_open"] = True
+
+        cabinet_open = st.session_state.get("badge_cabinet_is_open", False)
         with st.expander("Open Cabinet", expanded=cabinet_open):
             filter_cols = st.columns(2)
             show_unlocked = filter_cols[0].checkbox("Unlocked", value=True, key="badge_filter_unlocked")


### PR DESCRIPTION
### Motivation
- Prevent a StreamlitAPIException caused by using the same widget key for the button and then mutating `st.session_state` after the widget was instantiated, and ensure clicking "See more cuts" reliably opens the expander.

### Description
- Initialize a stable session key `badge_cabinet_is_open` once and use it as the expander state, change the button key to `badge_cabinet_open_btn`, and update the expander to use `st.session_state['badge_cabinet_is_open']` for the `expanded` flag.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69795d4876708326b62918faf451765e)