### PR TITLE
Hide Top Performers on OVERALL; show per-league with min-games in title

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -1022,24 +1022,20 @@ def render(ctx):
     min_games_for_awards = 0
     if target_league != "OVERALL":
         min_games_for_awards = int(min_games_req or 0)
-    if min_games_for_awards > 0:
-        qualified_df = standings[standings["matches_played"] >= min_games_for_awards].copy()
-    else:
-        qualified_df = standings.copy()
 
-    top_perf_title = "Top Performers"
     if target_league != "OVERALL" and min_games_for_awards > 0:
+        qualified_df = standings[standings["matches_played"] >= min_games_for_awards].copy()
         top_perf_title = f"Top Performers (Min {min_games_for_awards} Games)"
-    if qualified_df.empty:
-        st.markdown(f"### {top_perf_title}")
-        st.caption("Not enough games recorded yet for awards.")
-    else:
-        render_top_performers_cards(
-            qualified_df=qualified_df,
-            title=top_perf_title,
-            public_mode=PUBLIC_MODE,
-            ctx=ctx,
-        )
+        if qualified_df.empty:
+            st.markdown(f"### {top_perf_title}")
+            st.caption("Not enough games recorded yet for awards.")
+        else:
+            render_top_performers_cards(
+                qualified_df=qualified_df,
+                title=top_perf_title,
+                public_mode=PUBLIC_MODE,
+                ctx=ctx,
+            )
 
     if view_mode == "Stats View":
         st.markdown("#### Standings Table")


### PR DESCRIPTION
### Motivation
- The OVERALL leaderboard should not display the Top Performers awards area, and Top Performers should only appear on league pages that have a configured minimum-games requirement.
- Use the League Manager `min_games_req` to indicate eligibility and show it in the Top Performers title so users see the award threshold.

### Description
- Updated `jupr_app/ui/pages/leaderboards.py` to gate the `render_top_performers_cards` call so it only runs when `target_league != "OVERALL"` and the league has a positive `min_games_req` value.
- Use `min_games_req` (as `min_games_for_awards`) to build the title as `"Top Performers (Min {min_games_for_awards} Games)"` when rendering the cards.
- If `min_games_req` is `0` or missing for a league, the Top Performers section is not rendered at all; if configured but no qualified players exist, show the title and caption `"Not enough games recorded yet for awards."`.
- File changed: `jupr_app/ui/pages/leaderboards.py` (gated rendering and title change around the `render_top_performers_cards` call).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979645f21748326bfc1b1662f6a03a4)