### PR TITLE
Badge/Trophy CSS: add theme-safe fallbacks and preserve silhouette opacity

### DIFF
--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -554,19 +554,19 @@ def render(ctx):
             margin-bottom: 0.75rem;
         }
         .badge-stat {
-            background: var(--panel);
-            border: 1px solid var(--border);
-            box-shadow: var(--shadow);
+            background: var(--panel, rgba(255,255,255,0.04));
+            border: 1px solid var(--border, rgba(255,255,255,0.10));
+            box-shadow: var(--shadow, none);
             border-radius: 0.75rem;
             padding: 0.75rem 0.9rem;
             min-width: 120px;
-            color: var(--text-primary);
+            color: var(--text-primary, rgba(255,255,255,0.92));
         }
         .badge-stat-label {
             font-size: 0.7rem;
             text-transform: uppercase;
             letter-spacing: 0.08em;
-            color: var(--text-secondary);
+            color: var(--text-secondary, rgba(255,255,255,0.80));
         }
         .badge-stat-value {
             font-size: 1.6rem;
@@ -584,11 +584,11 @@ def render(ctx):
             align-items: center;
             padding: 0.25rem 0.5rem;
             border-radius: 999px;
-            border: 1px solid var(--border);
-            background: var(--pill-bg);
+            border: 1px solid var(--border, rgba(255,255,255,0.10));
+            background: var(--pill-bg, rgba(255,255,255,0.04));
             font-size: 0.8rem;
             max-width: 180px;
-            color: var(--text-primary);
+            color: var(--text-primary, rgba(255,255,255,0.92));
         }
         .trophy-section {
             display: flex;
@@ -600,7 +600,7 @@ def render(ctx):
             font-size: 0.7rem;
             text-transform: uppercase;
             letter-spacing: 0.08em;
-            color: var(--text-secondary);
+            color: var(--text-secondary, rgba(255,255,255,0.80));
         }
         .trophy-chip-row {
             display: flex;
@@ -614,12 +614,12 @@ def render(ctx):
             align-items: flex-start;
             padding: 0.35rem 0.6rem;
             border-radius: 0.75rem;
-            border: 1px solid var(--border);
-            background: var(--panel);
-            box-shadow: var(--shadow);
+            border: 1px solid var(--border, rgba(255,255,255,0.10));
+            background: var(--panel, rgba(255,255,255,0.04));
+            box-shadow: var(--shadow, none);
             font-size: 0.8rem;
             max-width: 320px;
-            color: var(--text-primary);
+            color: var(--text-primary, rgba(255,255,255,0.92));
         }
         .trophy-text {
             display: flex;
@@ -633,7 +633,7 @@ def render(ctx):
         }
         .trophy-body {
             font-size: 0.7rem;
-            color: var(--text-muted);
+            color: var(--text-muted, rgba(255,255,255,0.65));
         }
         .badge-grid {
             display: grid;
@@ -655,17 +655,17 @@ def render(ctx):
         }
         .badge-card {
             border-radius: 0.8rem;
-            border: 1px solid var(--border);
-            background: var(--panel);
-            box-shadow: var(--shadow);
+            border: 1px solid var(--border, rgba(255,255,255,0.10));
+            background: var(--panel, rgba(255,255,255,0.04));
+            box-shadow: var(--shadow, none);
             padding: 0.7rem 0.8rem;
             display: flex;
             flex-direction: column;
             gap: 0.35rem;
-            color: var(--text-primary);
+            color: var(--text-primary, rgba(255,255,255,0.92));
         }
         .badge-card.silhouette {
-            background: var(--panel);
+            background: var(--panel, rgba(255,255,255,0.04));
             opacity: 0.7;
         }
         .badge-card-header {
@@ -676,7 +676,7 @@ def render(ctx):
         }
         .badge-subtext {
             font-size: 0.75rem;
-            color: var(--text-muted);
+            color: var(--text-muted, rgba(255,255,255,0.65));
         }
         .truncate-1 {
             display: -webkit-box;


### PR DESCRIPTION
### Motivation
- The Trophy Room text became low-contrast after a dark/light CSS change because several `var(...)` references lacked safe fallbacks and fell back poorly in some themes.
- The goal is to make badge/trophy styles theme-safe so titles stay high-contrast and subtext remains readable in both dark and light modes.
- Silhouette opacity should only apply to locked badge cards and not to any container that wraps the whole Trophy Room.

### Description
- Updated the injected `<style>` block in `jupr_app/ui/pages/players.py` to add explicit fallbacks for CSS variables, e.g. `var(--text-primary, rgba(255,255,255,0.92))`, `var(--text-secondary, rgba(255,255,255,0.80))`, `var(--text-muted, rgba(255,255,255,0.65))`, `var(--panel, rgba(255,255,255,0.04))`, `var(--border, rgba(255,255,255,0.10))`, `var(--pill-bg, rgba(255,255,255,0.04))`, and `var(--shadow, none)` so styles remain contrast-safe across themes.
- Applied the fallback values to `.badge-stat`, `.badge-chip`, `.trophy-chip`, `.badge-card`, `.badge-subtext`, and related classes so card titles are high-contrast and subtext is muted but readable.
- Ensured no opacity is applied to wrapper containers like `.badge-summary` or `.badge-grid`, and kept `opacity: 0.7` only on `.badge-card.silhouette` to preserve the locked-card silhouette behavior while avoiding global dimming.
- Left Streamlit headings (e.g. `badge_markdown("### Badges & Trophies")`) and default Streamlit typography untouched so headlines use normal Streamlit styles.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697966b40c50832689e5ed6a28240720)