### PR TITLE
Align badge queries with schema

### DIFF
--- a/jupr_app/data/load.py
+++ b/jupr_app/data/load.py
@@ -69,13 +69,23 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
             df_meta = pd.DataFrame(meta_resp.data or [])
 
             # Badges (global definitions)
-            badges_resp = supabase.table("badges").select("*").execute()
+            badges_resp = (
+                supabase.table("badges")
+                .select(
+                    "badge_id,name,prestige,category,is_stackable,is_active,rarity,"
+                    "tier,icon_key,lore,hint,scope,created_at"
+                )
+                .execute()
+            )
             df_badges = pd.DataFrame(badges_resp.data or [])
 
             # Player badges (club-scoped)
             pb_resp = (
                 supabase.table("player_badges")
-                .select("*")
+                .select(
+                    "id,club_id,player_id,badge_id,earned_at,context_type,context_id,"
+                    "match_id,value_num,value_json"
+                )
                 .eq("club_id", club_id)
                 .execute()
             )

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -137,7 +137,7 @@ def _fetch_story_badges(ctx, player_ids):
         resp = (
             ctx.supabase.table("player_badges")
             .select(
-                "player_id,badge_id,earned_at,created_at,"
+                "player_id,badge_id,earned_at,"
                 "badges:badges(badge_id,name,prestige,category,icon_key,rarity)"
             )
             .eq("club_id", str(ctx.club_id))

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -119,7 +119,14 @@ def fetch_player_badges(_supabase, club_id: str, pid: int) -> pd.DataFrame:
 @st.cache_data(ttl=120)
 def fetch_badge_definitions(_supabase) -> pd.DataFrame:
     try:
-        resp = _supabase.table("badges").select("*").execute()
+        resp = (
+            _supabase.table("badges")
+            .select(
+                "badge_id,name,prestige,category,is_stackable,is_active,rarity,"
+                "tier,icon_key,lore,hint,scope,created_at"
+            )
+            .execute()
+        )
         return pd.DataFrame(resp.data or [])
     except Exception:
         logger.exception("Failed to load badge definitions")


### PR DESCRIPTION
### Motivation
- UI and data loader code referenced badge and player_badge fields inconsistently with the database schema, causing potential missing-field fetches and mismatches (notably `created_at` on `player_badges`).
- Make selects explicit so downstream UI logic receives a stable set of columns and joins against `badges` / `player_badges` work reliably.

### Description
- Updated the global badge fetch in `jupr_app/data/load.py` to explicitly select `badge_id,name,prestige,category,is_stackable,is_active,rarity,tier,icon_key,lore,hint,scope,created_at` instead of `*`.
- Updated the club-scoped `player_badges` fetch in `jupr_app/data/load.py` to explicitly select `id,club_id,player_id,badge_id,earned_at,context_type,context_id,match_id,value_num,value_json` instead of `*`.
- Scoped the badge definitions fetch in `jupr_app/ui/pages/players.py` to the same explicit badge columns for consistency with the schema.
- Removed the non-existent `created_at` field from the inline `player_badges` select used by `jupr_app/ui/pages/leaderboards.py` when joining badge definitions returned under the `badges:` projection.

### Testing
- No automated tests were run for this change.
- Manual code inspection and `rg` searches were used to locate usages of `badge_name`, `title`, and `icon` and to verify updated selects align with the migrations/schema.
- Changes are limited to select lists and merges and should be safe for runtime but benefit from running the app and integration tests against a live DB to validate end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69797ea774bc83269fd2ddbaa0501516)