### PR TITLE
Add admin-only tournament management

### DIFF
--- a/jupr_app/domain/match_filters.py
+++ b/jupr_app/domain/match_filters.py
@@ -25,6 +25,15 @@ def apply_match_filters(df_matches: pd.DataFrame, context_filters: dict | None) 
     if "is_valid" in df.columns:
         df = df[df["is_valid"].fillna(True).astype(bool)].copy()
 
+    if "context_type" in df.columns:
+        df = df[df["context_type"].fillna("").astype(str).str.upper() != "TOURNAMENT"].copy()
+
+    if "tournament_id" in df.columns:
+        df = df[df["tournament_id"].isna()].copy()
+
+    if "match_type" in df.columns:
+        df = df[df["match_type"].fillna("").astype(str) != "Tournament"].copy()
+
     for col in [
         "is_void",
         "voided",

--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -259,6 +259,10 @@ def process_matches(
                 "t1_p2_r_end": float(end_r2),
                 "t2_p1_r_end": float(end_r3),
                 "t2_p2_r_end": float(end_r4),
+                "context_type": m.get("context_type"),
+                "context_id": m.get("context_id"),
+                "tournament_id": m.get("tournament_id"),
+                "tournament_game_id": m.get("tournament_game_id"),
             }
         )
 

--- a/jupr_app/domain/tournaments.py
+++ b/jupr_app/domain/tournaments.py
@@ -1,0 +1,543 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+
+ROUND_ROBIN_TEMPLATES: dict[int, dict[str, Any]] = {
+    4: {
+        "teamCount": 4,
+        "rounds": [
+            {
+                "round": 1,
+                "games": [
+                    {"slot": 1, "teamA": 2, "teamB": 1},
+                    {"slot": 2, "teamA": 3, "teamB": 4},
+                ],
+                "byes": [],
+            },
+            {
+                "round": 2,
+                "games": [
+                    {"slot": 1, "teamA": 4, "teamB": 2},
+                    {"slot": 2, "teamA": 1, "teamB": 3},
+                ],
+                "byes": [],
+            },
+            {
+                "round": 3,
+                "games": [
+                    {"slot": 1, "teamA": 4, "teamB": 1},
+                    {"slot": 2, "teamA": 2, "teamB": 3},
+                ],
+                "byes": [],
+            },
+        ],
+    },
+    5: {
+        "teamCount": 5,
+        "rounds": [
+            {
+                "round": 1,
+                "games": [
+                    {"slot": 1, "teamA": 1, "teamB": 4},
+                    {"slot": 2, "teamA": 2, "teamB": 3},
+                ],
+                "byes": [5],
+            },
+            {
+                "round": 2,
+                "games": [
+                    {"slot": 1, "teamA": 3, "teamB": 1},
+                    {"slot": 2, "teamA": 4, "teamB": 5},
+                ],
+                "byes": [2],
+            },
+            {
+                "round": 3,
+                "games": [
+                    {"slot": 1, "teamA": 5, "teamB": 3},
+                    {"slot": 2, "teamA": 1, "teamB": 2},
+                ],
+                "byes": [4],
+            },
+            {
+                "round": 4,
+                "games": [
+                    {"slot": 1, "teamA": 2, "teamB": 5},
+                    {"slot": 2, "teamA": 3, "teamB": 4},
+                ],
+                "byes": [1],
+            },
+            {
+                "round": 5,
+                "games": [
+                    {"slot": 1, "teamA": 2, "teamB": 4},
+                    {"slot": 2, "teamA": 5, "teamB": 1},
+                ],
+                "byes": [3],
+            },
+        ],
+    },
+    7: {
+        "teamCount": 7,
+        "rounds": [
+            {
+                "round": 1,
+                "games": [
+                    {"slot": 1, "teamA": 1, "teamB": 6},
+                    {"slot": 2, "teamA": 2, "teamB": 5},
+                    {"slot": 3, "teamA": 3, "teamB": 4},
+                ],
+                "byes": [7],
+            },
+            {
+                "round": 2,
+                "games": [
+                    {"slot": 1, "teamA": 4, "teamB": 2},
+                    {"slot": 2, "teamA": 5, "teamB": 1},
+                    {"slot": 3, "teamA": 6, "teamB": 7},
+                ],
+                "byes": [3],
+            },
+            {
+                "round": 3,
+                "games": [
+                    {"slot": 1, "teamA": 2, "teamB": 7},
+                    {"slot": 2, "teamA": 3, "teamB": 6},
+                    {"slot": 3, "teamA": 4, "teamB": 5},
+                ],
+                "byes": [1],
+            },
+            {
+                "round": 4,
+                "games": [
+                    {"slot": 1, "teamA": 5, "teamB": 3},
+                    {"slot": 2, "teamA": 6, "teamB": 2},
+                    {"slot": 3, "teamA": 7, "teamB": 1},
+                ],
+                "byes": [4],
+            },
+            {
+                "round": 5,
+                "games": [
+                    {"slot": 1, "teamA": 3, "teamB": 1},
+                    {"slot": 2, "teamA": 4, "teamB": 7},
+                    {"slot": 3, "teamA": 5, "teamB": 6},
+                ],
+                "byes": [2],
+            },
+            {
+                "round": 6,
+                "games": [
+                    {"slot": 1, "teamA": 6, "teamB": 4},
+                    {"slot": 2, "teamA": 7, "teamB": 3},
+                    {"slot": 3, "teamA": 1, "teamB": 2},
+                ],
+                "byes": [5],
+            },
+            {
+                "round": 7,
+                "games": [
+                    {"slot": 1, "teamA": 7, "teamB": 5},
+                    {"slot": 2, "teamA": 1, "teamB": 4},
+                    {"slot": 3, "teamA": 2, "teamB": 3},
+                ],
+                "byes": [6],
+            },
+        ],
+    },
+    8: {
+        "teamCount": 8,
+        "rounds": [
+            {
+                "round": 1,
+                "games": [
+                    {"slot": 1, "teamA": 2, "teamB": 1},
+                    {"slot": 2, "teamA": 3, "teamB": 8},
+                    {"slot": 3, "teamA": 4, "teamB": 7},
+                    {"slot": 4, "teamA": 5, "teamB": 6},
+                ],
+                "byes": [],
+            },
+            {
+                "round": 2,
+                "games": [
+                    {"slot": 1, "teamA": 3, "teamB": 4},
+                    {"slot": 2, "teamA": 1, "teamB": 7},
+                    {"slot": 3, "teamA": 8, "teamB": 6},
+                    {"slot": 4, "teamA": 2, "teamB": 5},
+                ],
+                "byes": [],
+            },
+            {
+                "round": 3,
+                "games": [
+                    {"slot": 1, "teamA": 6, "teamB": 2},
+                    {"slot": 2, "teamA": 7, "teamB": 8},
+                    {"slot": 3, "teamA": 4, "teamB": 1},
+                    {"slot": 4, "teamA": 5, "teamB": 3},
+                ],
+                "byes": [],
+            },
+            {
+                "round": 4,
+                "games": [
+                    {"slot": 1, "teamA": 7, "teamB": 5},
+                    {"slot": 2, "teamA": 8, "teamB": 4},
+                    {"slot": 3, "teamA": 2, "teamB": 3},
+                    {"slot": 4, "teamA": 6, "teamB": 1},
+                ],
+                "byes": [],
+            },
+            {
+                "round": 5,
+                "games": [
+                    {"slot": 1, "teamA": 1, "teamB": 3},
+                    {"slot": 2, "teamA": 4, "teamB": 2},
+                    {"slot": 3, "teamA": 5, "teamB": 8},
+                    {"slot": 4, "teamA": 6, "teamB": 7},
+                ],
+                "byes": [],
+            },
+            {
+                "round": 6,
+                "games": [
+                    {"slot": 1, "teamA": 4, "teamB": 5},
+                    {"slot": 2, "teamA": 8, "teamB": 1},
+                    {"slot": 3, "teamA": 2, "teamB": 7},
+                    {"slot": 4, "teamA": 3, "teamB": 6},
+                ],
+                "byes": [],
+            },
+            {
+                "round": 7,
+                "games": [
+                    {"slot": 1, "teamA": 7, "teamB": 3},
+                    {"slot": 2, "teamA": 8, "teamB": 2},
+                    {"slot": 3, "teamA": 1, "teamB": 5},
+                    {"slot": 4, "teamA": 6, "teamB": 4},
+                ],
+                "byes": [],
+            },
+        ],
+    },
+}
+
+PLAYOFF_TEMPLATES: dict[int, dict[str, Any]] = {
+    4: {
+        "advanceCount": 4,
+        "games": [
+            {"id": "P1", "name": "Semifinal 1", "round": "SF", "slot": 1, "teamA": {"seed": 1}, "teamB": {"seed": 4}},
+            {"id": "P2", "name": "Semifinal 2", "round": "SF", "slot": 2, "teamA": {"seed": 2}, "teamB": {"seed": 3}},
+            {"id": "P3", "name": "Gold Medal Match", "round": "Final", "slot": 1, "teamA": {"winnerOf": "P1"}, "teamB": {"winnerOf": "P2"}},
+            {"id": "P4", "name": "Bronze Medal Match", "round": "Bronze", "slot": 1, "teamA": {"loserOf": "P1"}, "teamB": {"loserOf": "P2"}},
+        ],
+    },
+    5: {
+        "advanceCount": 5,
+        "games": [
+            {"id": "P1", "name": "Play-in", "round": "QF", "slot": 1, "teamA": {"seed": 4}, "teamB": {"seed": 5}},
+            {"id": "P2", "name": "Semifinal 1", "round": "SF", "slot": 1, "teamA": {"seed": 1}, "teamB": {"winnerOf": "P1"}},
+            {"id": "P3", "name": "Semifinal 2", "round": "SF", "slot": 2, "teamA": {"seed": 2}, "teamB": {"seed": 3}},
+            {"id": "P4", "name": "Gold Medal Match", "round": "Final", "slot": 1, "teamA": {"winnerOf": "P2"}, "teamB": {"winnerOf": "P3"}},
+            {"id": "P5", "name": "Bronze Medal Match", "round": "Bronze", "slot": 1, "teamA": {"loserOf": "P2"}, "teamB": {"loserOf": "P3"}},
+        ],
+    },
+    6: {
+        "advanceCount": 6,
+        "games": [
+            {"id": "P1", "name": "Quarterfinal 1", "round": "QF", "slot": 1, "teamA": {"seed": 4}, "teamB": {"seed": 5}},
+            {"id": "P2", "name": "Quarterfinal 2", "round": "QF", "slot": 2, "teamA": {"seed": 3}, "teamB": {"seed": 6}},
+            {"id": "P3", "name": "Semifinal 1", "round": "SF", "slot": 1, "teamA": {"seed": 1}, "teamB": {"winnerOf": "P1"}},
+            {"id": "P4", "name": "Semifinal 2", "round": "SF", "slot": 2, "teamA": {"seed": 2}, "teamB": {"winnerOf": "P2"}},
+            {"id": "P5", "name": "Gold Medal Match", "round": "Final", "slot": 1, "teamA": {"winnerOf": "P3"}, "teamB": {"winnerOf": "P4"}},
+            {"id": "P6", "name": "Bronze Medal Match", "round": "Bronze", "slot": 1, "teamA": {"loserOf": "P3"}, "teamB": {"loserOf": "P4"}},
+        ],
+    },
+}
+
+
+@dataclass
+class TeamStanding:
+    team_id: str
+    team_number: int
+    wins: int = 0
+    losses: int = 0
+    points_for: int = 0
+    points_against: int = 0
+
+    @property
+    def differential(self) -> int:
+        return self.points_for - self.points_against
+
+
+def build_round_robin_games(*, tournament_id: str, team_ids_by_number: dict[int, str]) -> list[dict[str, Any]]:
+    team_count = len(team_ids_by_number)
+    template = ROUND_ROBIN_TEMPLATES.get(team_count)
+    if not template:
+        raise ValueError(f"Unsupported team count: {team_count}")
+
+    games: list[dict[str, Any]] = []
+    for round_data in template["rounds"]:
+        for game in round_data["games"]:
+            team_a_num = int(game["teamA"])
+            team_b_num = int(game["teamB"])
+            games.append(
+                {
+                    "tournament_id": tournament_id,
+                    "stage": "ROUND_ROBIN",
+                    "rr_round_number": int(round_data["round"]),
+                    "rr_slot_number": int(game["slot"]),
+                    "team_a_id": team_ids_by_number[team_a_num],
+                    "team_b_id": team_ids_by_number[team_b_num],
+                }
+            )
+    return games
+
+
+def compute_round_robin_standings(
+    teams: list[dict[str, Any]],
+    games: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    standings = {t["id"]: TeamStanding(team_id=t["id"], team_number=int(t["team_number"])) for t in teams}
+
+    for game in games:
+        score_a = game.get("score_a")
+        score_b = game.get("score_b")
+        if score_a is None or score_b is None:
+            continue
+        try:
+            score_a = int(score_a)
+            score_b = int(score_b)
+        except Exception:
+            continue
+        if score_a == 0 and score_b == 0:
+            continue
+
+        team_a = standings.get(game.get("team_a_id"))
+        team_b = standings.get(game.get("team_b_id"))
+        if not team_a or not team_b:
+            continue
+
+        team_a.points_for += score_a
+        team_a.points_against += score_b
+        team_b.points_for += score_b
+        team_b.points_against += score_a
+
+        if score_a > score_b:
+            team_a.wins += 1
+            team_b.losses += 1
+        elif score_b > score_a:
+            team_b.wins += 1
+            team_a.losses += 1
+
+    standings_list = list(standings.values())
+
+    def base_key(s: TeamStanding):
+        return (-s.wins, -s.differential, -s.points_for, s.team_number)
+
+    standings_list.sort(key=base_key)
+
+    grouped: dict[tuple[int, int, int], list[TeamStanding]] = {}
+    for s in standings_list:
+        key = (s.wins, s.differential, s.points_for)
+        grouped.setdefault(key, []).append(s)
+
+    resolved: list[TeamStanding] = []
+    for key, group in grouped.items():
+        if len(group) == 2:
+            a, b = group
+            head_to_head_winner = _head_to_head_winner(a.team_id, b.team_id, games)
+            if head_to_head_winner == a.team_id:
+                resolved.extend([a, b])
+                continue
+            if head_to_head_winner == b.team_id:
+                resolved.extend([b, a])
+                continue
+        resolved.extend(sorted(group, key=lambda s: s.team_number))
+
+    results = []
+    for idx, s in enumerate(resolved, start=1):
+        results.append(
+            {
+                "team_id": s.team_id,
+                "team_number": s.team_number,
+                "wins": s.wins,
+                "losses": s.losses,
+                "points_for": s.points_for,
+                "points_against": s.points_against,
+                "differential": s.differential,
+                "seed": idx,
+            }
+        )
+    return results
+
+
+def _head_to_head_winner(team_a_id: str, team_b_id: str, games: list[dict[str, Any]]) -> str | None:
+    for game in games:
+        if {
+            game.get("team_a_id"),
+            game.get("team_b_id"),
+        } != {team_a_id, team_b_id}:
+            continue
+        score_a = game.get("score_a")
+        score_b = game.get("score_b")
+        if score_a is None or score_b is None:
+            continue
+        try:
+            score_a = int(score_a)
+            score_b = int(score_b)
+        except Exception:
+            continue
+        if score_a == score_b:
+            return None
+        return game.get("team_a_id") if score_a > score_b else game.get("team_b_id")
+    return None
+
+
+def build_playoff_games(
+    *,
+    tournament_id: str,
+    advance_count: int,
+    standings: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    template = PLAYOFF_TEMPLATES.get(int(advance_count))
+    if not template:
+        raise ValueError(f"Unsupported playoff advance count: {advance_count}")
+
+    seed_map = {int(row["seed"]): row["team_id"] for row in standings}
+    games: list[dict[str, Any]] = []
+
+    for game in template["games"]:
+        team_a_source = game["teamA"]
+        team_b_source = game["teamB"]
+        team_a_id = seed_map.get(int(team_a_source["seed"])) if "seed" in team_a_source else None
+        team_b_id = seed_map.get(int(team_b_source["seed"])) if "seed" in team_b_source else None
+        games.append(
+            {
+                "tournament_id": tournament_id,
+                "stage": "PLAYOFF",
+                "playoff_game_code": game["id"],
+                "playoff_round": game["round"],
+                "team_a_id": team_a_id,
+                "team_b_id": team_b_id,
+                "team_a_source": team_a_source,
+                "team_b_source": team_b_source,
+            }
+        )
+
+    return games
+
+
+def resolve_playoff_dependencies(games: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    updates: dict[str, dict[str, Any]] = {}
+    by_code = {g.get("playoff_game_code"): g for g in games if g.get("playoff_game_code")}
+
+    def resolve_source(source: Any) -> tuple[bool, str | None]:
+        if not source:
+            return False, None
+        if isinstance(source, str):
+            return False, None
+        if "winnerOf" in source:
+            return True, by_code.get(source["winnerOf"], {}).get("winner_team_id")
+        if "loserOf" in source:
+            return True, by_code.get(source["loserOf"], {}).get("loser_team_id")
+        return False, None
+
+    def set_update(game: dict[str, Any], field: str, value: Any) -> None:
+        gid = game["id"]
+        updates.setdefault(gid, {"id": gid})[field] = value
+
+    changed = True
+    local_games = [dict(g) for g in games]
+    while changed:
+        changed = False
+        by_code = {g.get("playoff_game_code"): g for g in local_games if g.get("playoff_game_code")}
+        for game in local_games:
+            if game.get("stage") != "PLAYOFF":
+                continue
+            dep_a, desired_a = resolve_source(_parse_source(game.get("team_a_source")))
+            dep_b, desired_b = resolve_source(_parse_source(game.get("team_b_source")))
+
+            for key, is_dep, desired in (
+                ("team_a_id", dep_a, desired_a),
+                ("team_b_id", dep_b, desired_b),
+            ):
+                if not is_dep:
+                    continue
+                if desired is None:
+                    if game.get(key) is not None:
+                        set_update(game, key, None)
+                        _clear_game_results(game, updates)
+                        game[key] = None
+                        changed = True
+                    continue
+                if game.get(key) != desired:
+                    set_update(game, key, desired)
+                    _clear_game_results(game, updates)
+                    game[key] = desired
+                    changed = True
+
+            for field in ["winner_team_id", "loser_team_id", "finalized_at"]:
+                if field in updates.get(game["id"], {}):
+                    game[field] = updates[game["id"]].get(field)
+            for field in ["score_a", "score_b"]:
+                if field in updates.get(game["id"], {}):
+                    game[field] = updates[game["id"]].get(field)
+
+    return list(updates.values())
+
+
+def _parse_source(source: Any) -> dict[str, Any] | None:
+    if source is None:
+        return None
+    if isinstance(source, dict):
+        return source
+    return None
+
+
+def _clear_game_results(game: dict[str, Any], updates: dict[str, dict[str, Any]]) -> None:
+    gid = game["id"]
+    upd = updates.setdefault(gid, {"id": gid})
+    upd.update(
+        {
+            "score_a": None,
+            "score_b": None,
+            "winner_team_id": None,
+            "loser_team_id": None,
+            "finalized_at": None,
+        }
+    )
+    game["score_a"] = None
+    game["score_b"] = None
+    game["winner_team_id"] = None
+    game["loser_team_id"] = None
+    game["finalized_at"] = None
+
+
+def finalize_game(game: dict[str, Any]) -> dict[str, Any]:
+    score_a = int(game.get("score_a") or 0)
+    score_b = int(game.get("score_b") or 0)
+    if score_a <= 0 and score_b <= 0:
+        raise ValueError("Scores are required to finalize a game.")
+    if score_a == score_b:
+        raise ValueError("Ties are not supported for tournament games.")
+    if game.get("team_a_id") is None or game.get("team_b_id") is None:
+        raise ValueError("Both teams must be assigned before scoring.")
+
+    if score_a > score_b:
+        winner_id = game.get("team_a_id")
+        loser_id = game.get("team_b_id")
+    else:
+        winner_id = game.get("team_b_id")
+        loser_id = game.get("team_a_id")
+
+    return {
+        "score_a": score_a,
+        "score_b": score_b,
+        "winner_team_id": winner_id,
+        "loser_team_id": loser_id,
+        "finalized_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/jupr_app/ui/pages/__init__.py
+++ b/jupr_app/ui/pages/__init__.py
@@ -18,6 +18,7 @@ from . import admin_guide
 from . import moneyball
 from . import league_results
 from . import theme_gallery
+from . import tournaments
 
 __all__ = [
     "leaderboards",
@@ -36,4 +37,5 @@ __all__ = [
     "moneyball",
     "league_results",
     "theme_gallery",
+    "tournaments",
 ]

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -1,0 +1,493 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pandas as pd
+import streamlit as st
+
+from jupr_app.domain.match_processing import process_matches
+from jupr_app.domain.tournaments import (
+    build_playoff_games,
+    build_round_robin_games,
+    compute_round_robin_standings,
+    finalize_game,
+    resolve_playoff_dependencies,
+)
+from jupr_app.ui.layout import page_shell
+
+
+def render(ctx):
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("🏆 Tournaments", "Admin-only tournament manager.", mode_label=mode_label)
+
+    if not bool(getattr(ctx, "admin_logged_in", False)):
+        st.error("Admin login required.")
+        st.stop()
+
+    supabase = getattr(ctx, "supabase", None)
+    club_id = getattr(ctx, "club_id", None)
+    df_players_all = getattr(ctx, "df_players_all", None)
+    name_to_id = getattr(ctx, "name_to_id", {})
+    id_to_name = getattr(ctx, "id_to_name", {})
+
+    if supabase is None or club_id is None:
+        st.error("Missing database context.")
+        st.stop()
+
+    if df_players_all is None or df_players_all.empty:
+        st.warning("No players loaded.")
+        st.stop()
+
+    player_names = sorted(df_players_all["name"].dropna().astype(str).tolist())
+
+    st.subheader("Create Tournament")
+    c1, c2, c3 = st.columns([3, 2, 1])
+    with c1:
+        tournament_name = st.text_input("Tournament name", key="tourney_create_name")
+    with c2:
+        team_count = st.selectbox("Team count", [4, 5, 7, 8], key="tourney_create_team_count")
+    with c3:
+        if st.button("Create", type="primary"):
+            if not tournament_name.strip():
+                st.error("Tournament name is required.")
+            else:
+                supabase.table("tournaments").insert(
+                    {
+                        "club_id": str(club_id),
+                        "name": tournament_name.strip(),
+                        "status": "DRAFT",
+                        "team_count": int(team_count),
+                    }
+                ).execute()
+                st.success("Tournament created.")
+                st.rerun()
+
+    st.divider()
+
+    tournaments_resp = (
+        supabase.table("tournaments")
+        .select("*")
+        .eq("club_id", str(club_id))
+        .order("created_at", desc=True)
+        .execute()
+    )
+    tournaments = tournaments_resp.data or []
+
+    if not tournaments:
+        st.info("No tournaments created yet.")
+        st.stop()
+
+    tournament_labels = [f"{t['name']} ({t['status']})" for t in tournaments]
+    selected_label = st.selectbox("Select tournament", tournament_labels)
+    selected_idx = tournament_labels.index(selected_label)
+    tournament = tournaments[selected_idx]
+    tournament_id = tournament["id"]
+
+    teams_resp = (
+        supabase.table("tournament_teams")
+        .select("*")
+        .eq("tournament_id", tournament_id)
+        .order("team_number")
+        .execute()
+    )
+    teams = teams_resp.data or []
+    teams_by_number = {int(t["team_number"]): t for t in teams}
+    teams_by_id = {t["id"]: t for t in teams}
+
+    games_resp = (
+        supabase.table("tournament_games")
+        .select("*")
+        .eq("tournament_id", tournament_id)
+        .order("rr_round_number", desc=False)
+        .order("rr_slot_number", desc=False)
+        .execute()
+    )
+    games = games_resp.data or []
+
+    rr_games = [g for g in games if g.get("stage") == "ROUND_ROBIN"]
+    playoff_games = [g for g in games if g.get("stage") == "PLAYOFF"]
+
+    tabs = st.tabs(["Teams", "Round Robin", "Standings", "Playoffs"])
+
+    with tabs[0]:
+        st.subheader("Teams")
+        team_count_locked = bool(games)
+        team_count_value = int(tournament.get("team_count", 4))
+
+        c1, c2 = st.columns([2, 1])
+        with c1:
+            st.caption("Team count is locked once games are generated.")
+        with c2:
+            new_team_count = st.selectbox(
+                "Team count",
+                [4, 5, 7, 8],
+                index=[4, 5, 7, 8].index(team_count_value),
+                disabled=team_count_locked,
+                key="tourney_team_count_select",
+            )
+        if not team_count_locked and st.button("Update team count"):
+            supabase.table("tournaments").update({"team_count": int(new_team_count)}).eq("id", tournament_id).execute()
+            st.success("Team count updated.")
+            st.rerun()
+
+        rows = []
+        for num in range(1, int(tournament.get("team_count", 4)) + 1):
+            team = teams_by_number.get(num)
+            p1_name = id_to_name.get(team.get("player1_id")) if team else None
+            p2_name = id_to_name.get(team.get("player2_id")) if team else None
+            rows.append({"Team": num, "Player 1": p1_name, "Player 2": p2_name})
+
+        editor_df = st.data_editor(
+            pd.DataFrame(rows),
+            use_container_width=True,
+            hide_index=True,
+            column_config={
+                "Player 1": st.column_config.SelectboxColumn("Player 1", options=player_names),
+                "Player 2": st.column_config.SelectboxColumn("Player 2", options=player_names),
+            },
+            key="tourney_team_editor",
+        )
+
+        if st.button("Save Teams"):
+            selected_ids = []
+            for _, row in editor_df.iterrows():
+                p1 = row.get("Player 1")
+                p2 = row.get("Player 2")
+                if p1 and p2 and p1 == p2:
+                    st.error("A team cannot use the same player twice.")
+                    st.stop()
+                if p1:
+                    selected_ids.append(name_to_id.get(p1))
+                if p2:
+                    selected_ids.append(name_to_id.get(p2))
+
+            duplicates = {pid for pid in selected_ids if pid is not None and selected_ids.count(pid) > 1}
+            if duplicates:
+                names = ", ".join(id_to_name.get(pid, str(pid)) for pid in duplicates)
+                st.error(f"Duplicate players detected: {names}.")
+                st.stop()
+
+            payload = []
+            for _, row in editor_df.iterrows():
+                payload.append(
+                    {
+                        "tournament_id": tournament_id,
+                        "team_number": int(row.get("Team")),
+                        "player1_id": name_to_id.get(row.get("Player 1")) if row.get("Player 1") else None,
+                        "player2_id": name_to_id.get(row.get("Player 2")) if row.get("Player 2") else None,
+                    }
+                )
+
+            supabase.table("tournament_teams").upsert(payload, on_conflict="tournament_id,team_number").execute()
+            st.success("Teams saved.")
+            st.rerun()
+
+    with tabs[1]:
+        st.subheader("Round Robin")
+        ready_teams = _teams_ready(teams_by_number, int(tournament.get("team_count", 4)))
+        if not rr_games:
+            st.info("No round robin games created yet.")
+        if not ready_teams:
+            st.warning("Assign exactly two players to every team to enable schedule generation.")
+
+        if st.button("Generate RR Schedule", disabled=bool(rr_games) or not ready_teams):
+            team_ids = {int(num): t["id"] for num, t in teams_by_number.items()}
+            games_payload = build_round_robin_games(tournament_id=tournament_id, team_ids_by_number=team_ids)
+            supabase.table("tournament_games").insert(games_payload).execute()
+            supabase.table("tournaments").update({"status": "ROUND_ROBIN"}).eq("id", tournament_id).execute()
+            st.success("Round robin schedule generated.")
+            st.rerun()
+
+        if rr_games:
+            with st.expander("Regenerate schedule"):
+                st.warning("This will delete all existing round robin and playoff games.")
+                confirm = st.text_input("Type RESET to confirm", key="rr_reset_confirm")
+                if st.button("Regenerate RR Schedule", disabled=confirm.strip().upper() != "RESET"):
+                    supabase.table("tournament_games").delete().eq("tournament_id", tournament_id).execute()
+                    supabase.table("tournament_teams").update({"seed": None}).eq("tournament_id", tournament_id).execute()
+                    supabase.table("tournaments").update({"status": "DRAFT", "playoff_advance_count": None}).eq("id", tournament_id).execute()
+                    st.success("Schedule cleared.")
+                    st.rerun()
+
+        if rr_games:
+            _render_games_table(
+                games=rr_games,
+                teams_by_id=teams_by_id,
+                id_to_name=id_to_name,
+                on_save=lambda updates: _save_games(
+                    ctx,
+                    tournament,
+                    teams_by_id,
+                    updates,
+                    stage="ROUND_ROBIN",
+                ),
+                key_prefix="rr",
+            )
+
+    with tabs[2]:
+        st.subheader("Standings")
+        if not rr_games:
+            st.info("Generate the round robin schedule and enter scores to see standings.")
+        else:
+            standings = compute_round_robin_standings(list(teams_by_id.values()), rr_games)
+            standings_df = pd.DataFrame(standings)
+            if not standings_df.empty:
+                display_df = standings_df.copy()
+                display_df["Team"] = display_df["team_number"]
+                display_df["Wins"] = display_df["wins"]
+                display_df["Losses"] = display_df["losses"]
+                display_df["PF"] = display_df["points_for"]
+                display_df["PA"] = display_df["points_against"]
+                display_df["Diff"] = display_df["differential"]
+                display_df["Seed"] = display_df["seed"]
+                st.dataframe(
+                    display_df[["Team", "Wins", "Losses", "PF", "PA", "Diff", "Seed"]],
+                    use_container_width=True,
+                    hide_index=True,
+                )
+
+                if st.button("Update Seeds"):
+                    for row in standings:
+                        supabase.table("tournament_teams").update({"seed": int(row["seed"])}).eq("id", row["team_id"]).execute()
+                    st.success("Seeds updated.")
+                    st.rerun()
+
+    with tabs[3]:
+        st.subheader("Playoffs")
+        if not rr_games:
+            st.info("Generate round robin games first.")
+            st.stop()
+
+        advance_options = [opt for opt in [4, 5, 6] if opt <= int(tournament.get("team_count", 4))]
+        current_advance = tournament.get("playoff_advance_count")
+        selected_advance = st.selectbox(
+            "Teams advancing",
+            advance_options,
+            index=advance_options.index(int(current_advance)) if current_advance in advance_options else 0,
+            key="playoff_advance_select",
+        )
+        if st.button("Save advance count"):
+            supabase.table("tournaments").update({"playoff_advance_count": int(selected_advance)}).eq("id", tournament_id).execute()
+            st.success("Advance count saved.")
+            st.rerun()
+
+        if not playoff_games:
+            st.info("No playoff bracket generated yet.")
+        if st.button("Generate Playoff Bracket", disabled=bool(playoff_games)):
+            standings = compute_round_robin_standings(list(teams_by_id.values()), rr_games)
+            if len(standings) < int(selected_advance):
+                st.error("Not enough seeded teams to generate the bracket.")
+                st.stop()
+            for row in standings:
+                supabase.table("tournament_teams").update({"seed": int(row["seed"])}).eq("id", row["team_id"]).execute()
+            games_payload = build_playoff_games(
+                tournament_id=tournament_id,
+                advance_count=int(selected_advance),
+                standings=standings,
+            )
+            supabase.table("tournament_games").insert(games_payload).execute()
+            supabase.table("tournaments").update(
+                {"status": "PLAYOFFS", "playoff_advance_count": int(selected_advance)}
+            ).eq("id", tournament_id).execute()
+            st.success("Playoff bracket generated.")
+            st.rerun()
+
+        if playoff_games:
+            _render_playoff_bracket(
+                games=playoff_games,
+                teams_by_id=teams_by_id,
+                id_to_name=id_to_name,
+                on_save=lambda updates: _save_games(
+                    ctx,
+                    tournament,
+                    teams_by_id,
+                    updates,
+                    stage="PLAYOFF",
+                ),
+            )
+
+
+def _teams_ready(teams_by_number: dict[int, dict], team_count: int) -> bool:
+    if len(teams_by_number) != team_count:
+        return False
+    for num in range(1, team_count + 1):
+        team = teams_by_number.get(num)
+        if not team:
+            return False
+        if not team.get("player1_id") or not team.get("player2_id"):
+            return False
+    return True
+
+
+def _render_games_table(*, games, teams_by_id, id_to_name, on_save, key_prefix: str):
+    rounds = sorted({int(g.get("rr_round_number", 0)) for g in games})
+    for round_num in rounds:
+        st.markdown(f"#### Round {round_num}")
+        round_games = [g for g in games if int(g.get("rr_round_number", 0)) == round_num]
+        scores = {}
+        with st.form(key=f"{key_prefix}_round_{round_num}"):
+            for game in round_games:
+                team_a = teams_by_id.get(game.get("team_a_id"), {})
+                team_b = teams_by_id.get(game.get("team_b_id"), {})
+                label_a = _team_label(team_a, id_to_name)
+                label_b = _team_label(team_b, id_to_name)
+                slot = game.get("rr_slot_number")
+
+                col1, col2, col3, col4 = st.columns([4, 1, 1, 2])
+                col1.write(f"Game {slot}: {label_a} vs {label_b}")
+                col2.number_input(
+                    "Score A",
+                    min_value=0,
+                    value=int(game.get("score_a") or 0),
+                    key=f"{key_prefix}_a_{game['id']}",
+                )
+                col3.number_input(
+                    "Score B",
+                    min_value=0,
+                    value=int(game.get("score_b") or 0),
+                    key=f"{key_prefix}_b_{game['id']}",
+                )
+                status = "Final" if game.get("finalized_at") else "Open"
+                col4.caption(status)
+                scores[game["id"]] = game
+
+            if st.form_submit_button("Save scores"):
+                on_save(scores)
+
+
+def _render_playoff_bracket(*, games, teams_by_id, id_to_name, on_save):
+    round_order = ["QF", "SF", "Final", "Bronze"]
+    for round_name in round_order:
+        round_games = [g for g in games if g.get("playoff_round") == round_name]
+        if not round_games:
+            continue
+        st.markdown(f"#### {round_name}")
+        with st.form(key=f"playoff_{round_name}"):
+            for game in round_games:
+                team_a = teams_by_id.get(game.get("team_a_id"), {})
+                team_b = teams_by_id.get(game.get("team_b_id"), {})
+                label_a = _team_label(team_a, id_to_name)
+                label_b = _team_label(team_b, id_to_name)
+                col1, col2, col3, col4 = st.columns([4, 1, 1, 2])
+                col1.write(f"{game.get('playoff_game_code')}: {label_a} vs {label_b}")
+                disabled = not game.get("team_a_id") or not game.get("team_b_id")
+                col2.number_input(
+                    "Score A",
+                    min_value=0,
+                    value=int(game.get("score_a") or 0),
+                    key=f"playoff_a_{game['id']}",
+                    disabled=disabled,
+                )
+                col3.number_input(
+                    "Score B",
+                    min_value=0,
+                    value=int(game.get("score_b") or 0),
+                    key=f"playoff_b_{game['id']}",
+                    disabled=disabled,
+                )
+                status = "Final" if game.get("finalized_at") else "Open"
+                col4.caption(status)
+
+            if st.form_submit_button("Save scores"):
+                on_save({g["id"]: g for g in round_games})
+
+
+def _team_label(team: dict, id_to_name: dict) -> str:
+    if not team:
+        return "TBD"
+    p1 = id_to_name.get(team.get("player1_id"), "?")
+    p2 = id_to_name.get(team.get("player2_id"), "?")
+    return f"Team {team.get('team_number')}: {p1} / {p2}"
+
+
+def _save_games(ctx, tournament, teams_by_id, game_map, stage: str):
+    supabase = ctx.supabase
+    df_players_all = ctx.df_players_all
+    df_leagues = ctx.df_leagues
+    df_meta = ctx.df_meta
+    name_to_id = ctx.name_to_id
+
+    updated_any = False
+    for game_id, game in game_map.items():
+        if game.get("finalized_at"):
+            continue
+        score_a = int(st.session_state.get(f"{_score_key(stage, 'a', game_id)}", 0))
+        score_b = int(st.session_state.get(f"{_score_key(stage, 'b', game_id)}", 0))
+
+        if score_a == 0 and score_b == 0:
+            if game.get("score_a") or game.get("score_b"):
+                supabase.table("tournament_games").update({"score_a": None, "score_b": None}).eq("id", game_id).execute()
+                updated_any = True
+            continue
+
+        supabase.table("tournament_games").update({"score_a": score_a, "score_b": score_b}).eq("id", game_id).execute()
+        updated_any = True
+
+        try:
+            finalize_payload = finalize_game({**game, "score_a": score_a, "score_b": score_b})
+        except ValueError:
+            continue
+
+        supabase.table("tournament_games").update(finalize_payload).eq("id", game_id).execute()
+
+        match_payload = _build_match_payload(
+            tournament,
+            game,
+            teams_by_id,
+            score_a=score_a,
+            score_b=score_b,
+        )
+        process_matches(
+            [match_payload],
+            supabase=supabase,
+            club_id=str(ctx.club_id),
+            name_to_id=name_to_id,
+            df_players_all=df_players_all,
+            df_leagues=df_leagues,
+            df_meta=df_meta,
+        )
+
+        if stage == "PLAYOFF":
+            playoff_games_resp = (
+                supabase.table("tournament_games")
+                .select("*")
+                .eq("tournament_id", tournament["id"])
+                .eq("stage", "PLAYOFF")
+                .execute()
+            )
+            playoff_games = playoff_games_resp.data or []
+            updates = resolve_playoff_dependencies(playoff_games)
+            for upd in updates:
+                supabase.table("tournament_games").update(upd).eq("id", upd["id"]).execute()
+
+    if updated_any:
+        st.success("Scores saved.")
+        st.rerun()
+
+
+def _build_match_payload(tournament, game, teams_by_id, *, score_a: int, score_b: int) -> dict:
+    team_a = teams_by_id.get(game.get("team_a_id"))
+    team_b = teams_by_id.get(game.get("team_b_id"))
+
+    return {
+        "t1_p1": team_a.get("player1_id") if team_a else None,
+        "t1_p2": team_a.get("player2_id") if team_a else None,
+        "t2_p1": team_b.get("player1_id") if team_b else None,
+        "t2_p2": team_b.get("player2_id") if team_b else None,
+        "s1": int(score_a),
+        "s2": int(score_b),
+        "date": datetime.now(timezone.utc).isoformat(),
+        "league": tournament.get("name", "Tournament"),
+        "match_type": "Tournament",
+        "week_tag": "Tournament",
+        "is_popup": True,
+        "context_type": "TOURNAMENT",
+        "context_id": tournament["id"],
+        "tournament_id": tournament["id"],
+        "tournament_game_id": game["id"],
+    }
+
+
+def _score_key(stage: str, side: str, game_id: str) -> str:
+    prefix = "playoff" if stage == "PLAYOFF" else "rr"
+    return f"{prefix}_{side}_{game_id}"

--- a/migrations/20250425_tournaments.sql
+++ b/migrations/20250425_tournaments.sql
@@ -1,0 +1,60 @@
+-- Tournament tables and match context columns
+
+ALTER TABLE public.matches
+  ADD COLUMN IF NOT EXISTS context_type text NULL,
+  ADD COLUMN IF NOT EXISTS context_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS tournament_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS tournament_game_id uuid NULL;
+
+CREATE INDEX IF NOT EXISTS idx_matches_tournament_id ON public.matches (tournament_id);
+CREATE INDEX IF NOT EXISTS idx_matches_context_type ON public.matches (context_type);
+
+CREATE TABLE IF NOT EXISTS public.tournaments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  club_id text NOT NULL,
+  name text NOT NULL,
+  status text NOT NULL DEFAULT 'DRAFT',
+  team_count integer NOT NULL,
+  playoff_advance_count integer NULL,
+  created_by_admin_id text NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tournaments_club_id ON public.tournaments (club_id);
+
+CREATE TABLE IF NOT EXISTS public.tournament_teams (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tournament_id uuid NOT NULL REFERENCES public.tournaments(id) ON DELETE CASCADE,
+  team_number integer NOT NULL,
+  player1_id integer NULL,
+  player2_id integer NULL,
+  seed integer NULL,
+  CONSTRAINT uq_tournament_team_number UNIQUE (tournament_id, team_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tournament_teams_tournament_id ON public.tournament_teams (tournament_id);
+
+CREATE TABLE IF NOT EXISTS public.tournament_games (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tournament_id uuid NOT NULL REFERENCES public.tournaments(id) ON DELETE CASCADE,
+  stage text NOT NULL,
+  rr_round_number integer NULL,
+  rr_slot_number integer NULL,
+  playoff_game_code text NULL,
+  playoff_round text NULL,
+  team_a_id uuid NULL REFERENCES public.tournament_teams(id),
+  team_b_id uuid NULL REFERENCES public.tournament_teams(id),
+  team_a_source jsonb NULL,
+  team_b_source jsonb NULL,
+  score_a integer NULL,
+  score_b integer NULL,
+  winner_team_id uuid NULL REFERENCES public.tournament_teams(id),
+  loser_team_id uuid NULL REFERENCES public.tournament_teams(id),
+  finalized_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tournament_games_tournament_id ON public.tournament_games (tournament_id);
+CREATE INDEX IF NOT EXISTS idx_tournament_games_stage ON public.tournament_games (stage);

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -322,6 +322,7 @@ def main():
             admin_guide,
             moneyball,
             theme_gallery,
+            tournaments,
         )
 
         # ---- Router ----
@@ -344,6 +345,7 @@ def main():
             "🛠️ Challenge Ladder Admin": challenge_ladder_admin,
             "💰 Moneyball": moneyball,
             "🎨 Theme QA": theme_gallery,
+            "🏆 Tournaments": tournaments,
         }
 
         PAGE_KEY_TO_LABEL = {
@@ -365,6 +367,7 @@ def main():
             "challenge_ladder_admin": "🛠️ Challenge Ladder Admin",
             "moneyball": "💰 Moneyball",
             "theme_qa": "🎨 Theme QA",
+            "tournaments": "🏆 Tournaments",
         }
         LABEL_TO_PAGE_KEY = {v: k for k, v in PAGE_KEY_TO_LABEL.items()}
 
@@ -378,6 +381,7 @@ def main():
             "🛠️ Challenge Ladder Admin",
             "💰 Moneyball",
             "🎨 Theme QA",
+            "🏆 Tournaments",
         }
 
         # Visible labels based on auth

--- a/tests/test_tournaments.py
+++ b/tests/test_tournaments.py
@@ -1,0 +1,134 @@
+import pytest
+
+from jupr_app.domain.tournaments import (
+    build_round_robin_games,
+    compute_round_robin_standings,
+    resolve_playoff_dependencies,
+)
+
+
+def test_round_robin_schedule_4():
+    team_ids = {1: "t1", 2: "t2", 3: "t3", 4: "t4"}
+    games = build_round_robin_games(tournament_id="tour1", team_ids_by_number=team_ids)
+
+    matchups = [
+        (g["rr_round_number"], g["rr_slot_number"], g["team_a_id"], g["team_b_id"]) for g in games
+    ]
+
+    assert matchups == [
+        (1, 1, "t2", "t1"),
+        (1, 2, "t3", "t4"),
+        (2, 1, "t4", "t2"),
+        (2, 2, "t1", "t3"),
+        (3, 1, "t4", "t1"),
+        (3, 2, "t2", "t3"),
+    ]
+
+
+def test_round_robin_standings_head_to_head():
+    teams = [
+        {"id": "t1", "team_number": 1},
+        {"id": "t2", "team_number": 2},
+        {"id": "t3", "team_number": 3},
+        {"id": "t4", "team_number": 4},
+    ]
+    games = [
+        {"team_a_id": "t1", "team_b_id": "t2", "score_a": 11, "score_b": 9},
+        {"team_a_id": "t1", "team_b_id": "t3", "score_a": 9, "score_b": 11},
+        {"team_a_id": "t1", "team_b_id": "t4", "score_a": 11, "score_b": 9},
+        {"team_a_id": "t2", "team_b_id": "t3", "score_a": 11, "score_b": 9},
+        {"team_a_id": "t2", "team_b_id": "t4", "score_a": 11, "score_b": 9},
+    ]
+
+    standings = compute_round_robin_standings(teams, games)
+    seeds = {row["team_id"]: row["seed"] for row in standings}
+
+    assert seeds["t1"] == 1
+    assert seeds["t2"] == 2
+
+
+def test_resolve_playoff_dependencies():
+    games = [
+        {
+            "id": "g1",
+            "playoff_game_code": "P1",
+            "stage": "PLAYOFF",
+            "team_a_id": "t1",
+            "team_b_id": "t4",
+            "team_a_source": {"seed": 1},
+            "team_b_source": {"seed": 4},
+            "score_a": 11,
+            "score_b": 5,
+            "winner_team_id": "t1",
+            "loser_team_id": "t4",
+            "finalized_at": "2024-01-01T00:00:00Z",
+        },
+        {
+            "id": "g2",
+            "playoff_game_code": "P2",
+            "stage": "PLAYOFF",
+            "team_a_id": "t2",
+            "team_b_id": "t3",
+            "team_a_source": {"seed": 2},
+            "team_b_source": {"seed": 3},
+            "score_a": 11,
+            "score_b": 7,
+            "winner_team_id": "t2",
+            "loser_team_id": "t3",
+            "finalized_at": "2024-01-01T00:00:00Z",
+        },
+        {
+            "id": "g3",
+            "playoff_game_code": "P3",
+            "stage": "PLAYOFF",
+            "team_a_id": None,
+            "team_b_id": None,
+            "team_a_source": {"winnerOf": "P1"},
+            "team_b_source": {"winnerOf": "P2"},
+            "score_a": None,
+            "score_b": None,
+            "winner_team_id": None,
+            "loser_team_id": None,
+            "finalized_at": None,
+        },
+        {
+            "id": "g4",
+            "playoff_game_code": "P4",
+            "stage": "PLAYOFF",
+            "team_a_id": None,
+            "team_b_id": None,
+            "team_a_source": {"loserOf": "P1"},
+            "team_b_source": {"loserOf": "P2"},
+            "score_a": None,
+            "score_b": None,
+            "winner_team_id": None,
+            "loser_team_id": None,
+            "finalized_at": None,
+        },
+    ]
+
+    updates = resolve_playoff_dependencies(games)
+    updates_by_id = {u["id"]: u for u in updates}
+
+    assert updates_by_id["g3"]["team_a_id"] == "t1"
+    assert updates_by_id["g3"]["team_b_id"] == "t2"
+    assert updates_by_id["g4"]["team_a_id"] == "t4"
+    assert updates_by_id["g4"]["team_b_id"] == "t3"
+
+    games[2]["team_a_id"] = "t1"
+    games[2]["team_b_id"] = "t2"
+    games[2]["score_a"] = 11
+    games[2]["score_b"] = 9
+    games[2]["winner_team_id"] = "t1"
+    games[2]["loser_team_id"] = "t2"
+    games[2]["finalized_at"] = "2024-01-01T00:00:00Z"
+
+    games[0]["winner_team_id"] = "t4"
+    games[0]["loser_team_id"] = "t1"
+
+    updates = resolve_playoff_dependencies(games)
+    updates_by_id = {u["id"]: u for u in updates}
+
+    assert updates_by_id["g3"]["team_a_id"] == "t4"
+    assert updates_by_id["g3"]["score_a"] is None
+    assert updates_by_id["g3"]["finalized_at"] is None


### PR DESCRIPTION
### Motivation

- Provide an admin-only tournament workflow that supports fixed two-player teams, exact Round Robin schedules, standings/seeding, and playoffs with seed/dependency resolution. 
- Ensure tournament matches are recorded for rating updates but excluded from public leaderboards and normal public match views. 

### Description

- Add tournament domain logic in `jupr_app/domain/tournaments.py` including the exact `ROUND_ROBIN_TEMPLATES` and `PLAYOFF_TEMPLATES`, RR schedule builder `build_round_robin_games`, standings/seeding computation `compute_round_robin_standings` (with tiebreakers and head-to-head), playoff bracket builder `build_playoff_games`, dependency resolver `resolve_playoff_dependencies`, and `finalize_game` helper. 
- Add an admin-only Streamlit UI at `jupr_app/ui/pages/tournaments.py` with pages/tabs to create tournaments, define teams, generate RR schedules (idempotent/regenerate flow), enter RR scores, view/update standings/seeds, select playoff advance count (4/5/6), generate playoff bracket, enter playoff scores, and auto-resolve/clear downstream dependencies. 
- Persist tournament metadata and game context via a DB migration `migrations/20250425_tournaments.sql` that adds `tournaments`, `tournament_teams`, `tournament_games` tables and extends `matches` with `context_type`, `context_id`, `tournament_id`, `tournament_game_id`. 
- Wire match insertion and rating pipeline to include tournament context by adding `context_type`, `context_id`, `tournament_id`, and `tournament_game_id` to match rows in `process_matches` (`jupr_app/domain/match_processing.py`) and ensure tournament matches are excluded from public leaderboards by filtering them out in `apply_match_filters` (`jupr_app/domain/match_filters.py`). 
- Add navigation and lazy-import registration (`jupr_app/ui/pages/__init__.py` and `streamlit_app.py`) for the admin-only Tournaments page. 
- Add unit tests `tests/test_tournaments.py` to validate RR schedule generation, standings/seed tiebreaks (including head-to-head), and playoff dependency resolution/clearing logic. 

### Testing

- Ran the new unit tests with `pytest -q tests/test_tournaments.py` and all tests passed: `3 passed in 0.02s`.
- The Streamlit UI was added and registered, but launching the app requires Supabase secrets (not run as part of automated tests in CI here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a6e3bfa3c8326bff8cbac4bb7020a)