### PR TITLE
Add admin-only Tournament Manager page and sidebar nav

### DIFF
--- a/jupr_app/ui/pages/__init__.py
+++ b/jupr_app/ui/pages/__init__.py
@@ -19,6 +19,7 @@ from . import moneyball
 from . import league_results
 from . import theme_gallery
 from . import tournaments
+from . import tournament_manager
 
 __all__ = [
     "leaderboards",
@@ -38,4 +39,5 @@ __all__ = [
     "league_results",
     "theme_gallery",
     "tournaments",
+    "tournament_manager",
 ]

--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from jupr_app.ui.layout import page_shell
+
+
+def render(ctx):
+    mode_label = "Public" if bool(getattr(ctx, "public_mode", False)) else "Admin"
+    page_shell("🏆 Tournament Manager", "Admin-only tournament operations.", mode_label=mode_label)
+
+    if not bool(getattr(ctx, "admin_logged_in", False)):
+        st.error("Admin login required.")
+        st.stop()
+
+    st.info("Tournament Manager tools are under construction.")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -323,6 +323,7 @@ def main():
             moneyball,
             theme_gallery,
             tournaments,
+            tournament_manager,
         )
 
         # ---- Router ----
@@ -346,6 +347,7 @@ def main():
             "💰 Moneyball": moneyball,
             "🎨 Theme QA": theme_gallery,
             "🏆 Tournaments": tournaments,
+            "🏆 Tournament Manager": tournament_manager,
         }
 
         PAGE_KEY_TO_LABEL = {
@@ -368,6 +370,7 @@ def main():
             "moneyball": "💰 Moneyball",
             "theme_qa": "🎨 Theme QA",
             "tournaments": "🏆 Tournaments",
+            "tournament_manager": "🏆 Tournament Manager",
         }
         LABEL_TO_PAGE_KEY = {v: k for k, v in PAGE_KEY_TO_LABEL.items()}
 
@@ -382,6 +385,7 @@ def main():
             "💰 Moneyball",
             "🎨 Theme QA",
             "🏆 Tournaments",
+            "🏆 Tournament Manager",
         }
 
         # Visible labels based on auth


### PR DESCRIPTION
### Motivation
- Provide an admin-only entry for tournament operations in the app navigation so admins can access dedicated tournament management tools.
- Ensure the page is only visible to logged-in admins and enforces access control at render time.

### Description
- Added a new page module `jupr_app/ui/pages/tournament_manager.py` with a `render(ctx)` function that uses `page_shell` and enforces an admin guard via `st.error` + `st.stop()`.
- Registered the new page in the router by importing it in `streamlit_app.py` and adding the label `"🏆 Tournament Manager"` to the `PAGES` mapping and `PAGE_KEY_TO_LABEL` under the key `"tournament_manager"`.
- Marked the label as admin-only by adding it to `ADMIN_ONLY_LABELS` so it only appears in the sidebar when `admin_logged_in` is true and navigation uses `st.session_state["main_nav"]` as before.
- Exported the new module in the UI pages package by updating `jupr_app/ui/pages/__init__.py` and adding `"tournament_manager"` to `__all__`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a742686f08326ace73d23fab5b609)