### PR TITLE
Add tournament podium trophies to Trophy Room

### DIFF
--- a/jupr_app/domain/gamification/trophies.py
+++ b/jupr_app/domain/gamification/trophies.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+_PODIUM_CONTEXT_RE = re.compile(r"^(?P<tournament_id>.+):podium:(?P<placement>\d+)$")
+
+
+def _parse_value_json(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        if isinstance(value, bool):
+            return int(value)
+        cleaned = str(value).strip()
+        if cleaned == "":
+            return None
+        return int(float(cleaned))
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_teammate_names(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return []
+        if "," in raw:
+            return [chunk.strip() for chunk in raw.split(",") if chunk.strip()]
+        return [raw]
+    return []
+
+
+def parse_tournament_podium_context(
+    context_id: str | None,
+    value_num: Any | None = None,
+) -> tuple[str | None, int | None]:
+    tournament_id = None
+    placement = None
+    if context_id:
+        match = _PODIUM_CONTEXT_RE.match(str(context_id).strip())
+        if match:
+            tournament_id = match.group("tournament_id")
+            placement = _coerce_int(match.group("placement"))
+    if placement is None:
+        placement = _coerce_int(value_num)
+    return tournament_id, placement
+
+
+def _join_names(names: list[str]) -> str | None:
+    cleaned = [name.strip() for name in names if name.strip()]
+    if not cleaned:
+        return None
+    if len(cleaned) == 1:
+        return cleaned[0]
+    if len(cleaned) == 2:
+        return " & ".join(cleaned)
+    return ", ".join(cleaned)
+
+
+def get_player_tournament_trophies(
+    supabase: Any,
+    club_id: str,
+    player_id: int,
+) -> list[dict[str, Any]]:
+    if supabase is None or not club_id:
+        return []
+
+    try:
+        resp = (
+            supabase.table("player_badges")
+            .select("player_id,earned_at,context_id,value_num,value_json")
+            .eq("club_id", str(club_id))
+            .eq("player_id", int(player_id))
+            .eq("context_type", "tournament")
+            .like("context_id", "%:podium:%")
+            .order("earned_at", desc=True)
+            .execute()
+        )
+    except Exception:
+        logger.exception("Failed to fetch tournament podium trophies", extra={"player_id": player_id})
+        return []
+
+    rows = resp.data or []
+    if not rows:
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    tournament_ids: set[str] = set()
+    team_ids: set[str] = set()
+
+    for row in rows:
+        value_json = _parse_value_json(row.get("value_json"))
+        placement = _coerce_int(value_json.get("placement"))
+        context_id = str(row.get("context_id") or "")
+        tournament_id, parsed_placement = parse_tournament_podium_context(
+            context_id,
+            row.get("value_num"),
+        )
+        if placement is None:
+            placement = parsed_placement
+        tournament_id = str(value_json.get("tournament_id") or tournament_id or "").strip() or None
+        tournament_name = str(value_json.get("tournament_name") or "").strip() or None
+        teammate_names = _normalize_teammate_names(value_json.get("teammate_names"))
+        team_id = value_json.get("team_id")
+        if tournament_id:
+            tournament_ids.add(tournament_id)
+        if team_id and not teammate_names:
+            team_ids.add(str(team_id))
+
+        normalized.append(
+            {
+                "placement": placement,
+                "tournament_id": tournament_id,
+                "tournament_name": tournament_name,
+                "teammate_names": teammate_names,
+                "earned_at": row.get("earned_at"),
+                "team_id": str(team_id) if team_id else None,
+            }
+        )
+
+    tournament_name_map: dict[str, str] = {}
+    if tournament_ids:
+        try:
+            t_resp = (
+                supabase.table("tournaments")
+                .select("id,name")
+                .in_("id", list(tournament_ids))
+                .execute()
+            )
+            tournament_name_map = {str(row.get("id")): str(row.get("name")) for row in (t_resp.data or [])}
+        except Exception:
+            logger.exception("Failed to fetch tournament names", extra={"player_id": player_id})
+
+    team_player_map: dict[str, list[int]] = {}
+    if team_ids:
+        try:
+            teams_resp = (
+                supabase.table("tournament_teams")
+                .select("id,player1_id,player2_id")
+                .in_("id", list(team_ids))
+                .execute()
+            )
+            for team in teams_resp.data or []:
+                team_id = str(team.get("id"))
+                players = [team.get("player1_id"), team.get("player2_id")]
+                team_player_map[team_id] = [int(pid) for pid in players if pid]
+        except Exception:
+            logger.exception("Failed to fetch tournament teams", extra={"player_id": player_id})
+
+    player_ids: set[int] = set()
+    for ids in team_player_map.values():
+        player_ids.update(ids)
+
+    player_name_map: dict[int, str] = {}
+    if player_ids:
+        try:
+            players_resp = (
+                supabase.table("players")
+                .select("id,name")
+                .eq("club_id", str(club_id))
+                .in_("id", list(player_ids))
+                .execute()
+            )
+            player_name_map = {int(row.get("id")): str(row.get("name")) for row in (players_resp.data or [])}
+        except Exception:
+            logger.exception("Failed to fetch tournament player names", extra={"player_id": player_id})
+
+    for item in normalized:
+        if not item.get("tournament_name") and item.get("tournament_id"):
+            item["tournament_name"] = tournament_name_map.get(str(item["tournament_id"]))
+        if not item.get("teammate_names"):
+            team_id = item.get("team_id")
+            team_players = team_player_map.get(str(team_id), []) if team_id else []
+            teammate_list = [
+                player_name_map.get(pid, "")
+                for pid in team_players
+                if int(pid) != int(player_id)
+            ]
+            item["teammate_names"] = _normalize_teammate_names(teammate_list)
+        item["teammate_names"] = _join_names(item.get("teammate_names") or [])
+
+    return normalized

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -15,6 +15,7 @@ from jupr_app.domain.gamification.profile import (
     build_gamification_summary,
 )
 from jupr_app.domain.gamification.podium_awards import ensure_podium_awards_exist
+from jupr_app.domain.gamification.trophies import get_player_tournament_trophies
 from jupr_app.domain.gamification.top_performer_awards import ensure_league_top_performer_awards
 
 logger = logging.getLogger(__name__)
@@ -114,6 +115,11 @@ def fetch_player_badges(_supabase, club_id: str, pid: int) -> pd.DataFrame:
         return pd.DataFrame()
 
     return pb_df.merge(badges_df, on="badge_id", how="left")
+
+
+@st.cache_data(ttl=60)
+def fetch_player_tournament_trophies(_supabase, club_id: str, pid: int) -> list[dict]:
+    return get_player_tournament_trophies(_supabase, club_id, pid)
 
 
 @st.cache_data(ttl=120)
@@ -1116,6 +1122,65 @@ def render(ctx):
                     "No trophies yet. Win podium finishes or top performer awards in completed leagues.",
                     label="trophies.case.empty",
                 )
+
+        tournament_trophies = fetch_player_tournament_trophies(_supabase, club_id, pid)
+        if debug_render:
+            badge_code(
+                f"Tournament podium badge rows: {len(tournament_trophies)}",
+                label="trophies.tournaments.debug",
+            )
+
+        st.subheader("🏆 Tournament Trophies")
+        if not tournament_trophies:
+            badge_caption("No tournament trophies yet.", label="trophies.tournaments.empty")
+        else:
+            podium_labels = {
+                1: "🥇 Champion",
+                2: "🥈 Runner-up",
+                3: "🥉 Bronze",
+            }
+            trophy_cards = []
+            for trophy in tournament_trophies:
+                placement = trophy.get("placement")
+                medal_label = podium_labels.get(placement, "🏅 Podium")
+                tournament_name = trophy.get("tournament_name")
+                if not tournament_name:
+                    tournament_id = trophy.get("tournament_id")
+                    if tournament_id:
+                        tournament_name = f"Tournament {str(tournament_id)[:8]}"
+                    else:
+                        tournament_name = "Tournament"
+                teammate_line = trophy.get("teammate_names")
+                earned_at_label = _format_earned_at(trophy.get("earned_at"))
+                earned_at_label = f"Awarded {earned_at_label}" if earned_at_label else ""
+                teammate_html = (
+                    f"<div class=\"trophy-body truncate-1\">{html.escape(str(teammate_line))}</div>"
+                    if teammate_line
+                    else ""
+                )
+                earned_html = (
+                    f"<div class=\"trophy-body\">{html.escape(earned_at_label)}</div>"
+                    if earned_at_label
+                    else ""
+                )
+                card = f"""
+                <div class="trophy-chip">
+                    <span>{html.escape(medal_label)}</span>
+                    <div class="trophy-text">
+                        <div class="trophy-title truncate-1">{html.escape(str(tournament_name))}</div>
+                        {teammate_html}
+                        {earned_html}
+                    </div>
+                </div>
+                """
+                trophy_cards.append(card)
+
+            height = 130 + math.ceil(len(trophy_cards) / 2) * 90
+            render_badge_html(
+                f"<div class='trophy-chip-row'>{''.join(trophy_cards)}</div>",
+                label="trophies.tournaments.grid",
+                height=height,
+            )
 
         top_prestige_key = f"top_prestige_{pid}"
         if top_prestige_key in st.session_state:

--- a/tests/test_tournament_trophies.py
+++ b/tests/test_tournament_trophies.py
@@ -1,0 +1,15 @@
+from jupr_app.domain.gamification.trophies import parse_tournament_podium_context
+
+
+def test_parse_tournament_podium_context():
+    tournament_id, placement = parse_tournament_podium_context("abc123:podium:2")
+
+    assert tournament_id == "abc123"
+    assert placement == 2
+
+
+def test_parse_tournament_podium_context_fallbacks_to_value_num():
+    tournament_id, placement = parse_tournament_podium_context("abc123:podium:2", value_num=3)
+
+    assert tournament_id == "abc123"
+    assert placement == 2


### PR DESCRIPTION
### Motivation
- Tournament podium awards are written to `player_badges` but the Trophy Room only rendered league trophies, so tournament podium trophies were not visible on player profiles.
- Need a focused display of tournament podium trophies on the player Trophy Room without adding tournaments to leaderboards or changing badge earning logic.

### Description
- Added a new helper module `jupr_app/domain/gamification/trophies.py` implementing `parse_tournament_podium_context` and `get_player_tournament_trophies` to query `player_badges`, parse podium `context_id` (e.g. `tournament_id:podium:1`), extract placement, tournament/team metadata, and normalize teammate names.
- Wired the helper into the player UI by importing `get_player_tournament_trophies` and adding a cached wrapper `fetch_player_tournament_trophies` in `jupr_app/ui/pages/players.py`.
- Rendered a dedicated "🏆 Tournament Trophies" section in the Trophy Room that shows placement medal (`🥇🥈🥉`), tournament name (falls back to `Tournament {id[:8]}` if missing), teammate(s), and awarded date using the existing badge styling components and `render_badge_html`.
- Added a small admin debug output (visible via existing debug toggle) showing the number of fetched tournament trophy rows.
- Added unit tests in `tests/test_tournament_trophies.py` for podium context parsing (`parse_tournament_podium_context`).

### Testing
- Ran the new unit tests with `pytest -q tests/test_tournament_trophies.py` and they passed: `2 passed in 0.54s`.
- No other automated test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a87834ef08326ac37127881fada68)