### PR TITLE
Remove mis-indented `st.divider()` in match_log.py

### DIFF
--- a/jupr_app/ui/pages/match_log.py
+++ b/jupr_app/ui/pages/match_log.py
@@ -122,8 +122,6 @@ def render(ctx):
 
     st.divider()
 
-       st.divider()
-
     # Bulk match editor UI
     st.subheader("✏️ Bulk Match Editor")
     st.caption("Filter matches, select rows, edit league/date/week_tag/match_type/notes/is_active, preview impact, then apply safely.")


### PR DESCRIPTION
### Motivation
- A stray, mis-indented `st.divider()` immediately after the duplicate scanner block caused an `IndentationError` on import and needed removal to restore correct parsing.

### Description
- Remove the single erroneous mis-indented `st.divider()` line while keeping the surrounding code and indentation (4 spaces per level) unchanged.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/match_log.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb1c679a88326bc7dd63fe5c656e4)