### PR TITLE
Fix indentation in admin replay history section

### DIFF
--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -73,23 +73,23 @@ def render(ctx):
 
     target_reset = st.selectbox("Replay scope", league_opts)
 
-        if st.button(f"⚠️ Replay History for: {target_reset}"):
-            bar = st.progress(0.0)
-            with st.spinner("Crunching..."):
-                result = replay_history(
-                    supabase=supabase,
-                    club_id=club_id,
-                    df_meta=df_meta,
-                    target_reset=str(target_reset),
-                    progress_cb=lambda x: bar.progress(float(x)),
-                )
-    
-            st.info(f"Skipped incomplete doubles rows: {result['skipped_incomplete']}")
-            st.info(f"Matches to rewrite snapshots for: {result['matches_rewritten']}")
-            st.info(f"League ratings rows rebuilt: {result['league_ratings_rows']}")
-            st.success("Replay complete.")
-            time.sleep(0.6)
-            st.rerun()
+    if st.button(f"⚠️ Replay History for: {target_reset}"):
+        bar = st.progress(0.0)
+        with st.spinner("Crunching..."):
+            result = replay_history(
+                supabase=supabase,
+                club_id=club_id,
+                df_meta=df_meta,
+                target_reset=str(target_reset),
+                progress_cb=lambda x: bar.progress(float(x)),
+            )
+
+        st.info(f"Skipped incomplete doubles rows: {result['skipped_incomplete']}")
+        st.info(f"Matches to rewrite snapshots for: {result['matches_rewritten']}")
+        st.info(f"League ratings rows rebuilt: {result['league_ratings_rows']}")
+        st.success("Replay complete.")
+        time.sleep(0.6)
+        st.rerun()
 
 
     st.divider()


### PR DESCRIPTION
### Motivation
- The Streamlit app crashed with an `IndentationError` in `jupr_app/ui/pages/admin_tools.py` around the Replay History block, caused by inconsistent indentation on the `if st.button(...)` line and its body.

### Description
- Normalize indentation for the Replay History block so `if st.button(...)` is indented exactly 4 spaces inside `render(ctx)` and its body is one additional level (8 spaces), preserving original logic.
- Converted the adjusted region to use 4-space indentation (spaces only) to eliminate mixed/misaligned whitespace.
- Only whitespace changes were made to `jupr_app/ui/pages/admin_tools.py`; no behavior or logic was modified.

### Testing
- Ran `python -m tabnanny jupr_app/ui/pages/admin_tools.py` which completed with no tabnanny errors.
- Ran `python -m py_compile jupr_app/ui/pages/admin_tools.py` which completed successfully and the file compiles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb6de67ac83268f0f31de8e0475dc)