### PR TITLE
Expose badge requirements from markdown in UI

### DIFF
--- a/jupr_app/domain/gamification/profile.py
+++ b/jupr_app/domain/gamification/profile.py
@@ -57,6 +57,7 @@ def build_gamification_summary(
     optional_columns = {
         "lore": "",
         "hint": "",
+        "requirements": "Requirements TBD",
         "rarity": None,
         "icon_key": None,
         "tier": None,
@@ -127,6 +128,7 @@ def build_gamification_summary(
                     "rarity": _resolve_rarity(first.get("rarity"), first.get("prestige", 0)),
                     "prestige": int(first.get("prestige", 0) or 0),
                     "lore": first.get("lore", ""),
+                    "requirements": first.get("requirements", "Requirements TBD"),
                     "is_stackable": bool(first.get("is_stackable", False)),
                     "icon_key": first.get("icon_key", None),
                     "tier": first.get("tier", None),
@@ -152,6 +154,7 @@ def build_gamification_summary(
                 "prestige": int(r(row, "prestige", 0) or 0),
                 "lore": r(row, "lore", ""),
                 "hint": r(row, "hint", ""),
+                "requirements": r(row, "requirements", "Requirements TBD"),
                 "is_stackable": bool(r(row, "is_stackable", False)),
                 "icon_key": r(row, "icon_key", None),
                 "tier": r(row, "tier", None),

--- a/jupr_app/domain/gamification/requirements.py
+++ b/jupr_app/domain/gamification/requirements.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+_REQUIREMENTS_CACHE: dict[str, str] | None = None
+
+_HEADING_RE = re.compile(r"^#{2,3}\s+([^\s]+)\s+[—–-]\s+.+$")
+_REQ_RE = re.compile(r"^(Unlock|Status):\s*(.+)$", re.IGNORECASE)
+
+
+def _requirements_paths() -> list[Path]:
+    repo_root = Path(__file__).resolve().parents[3]
+    return [
+        repo_root / "docs" / "badge_requirements.md",
+        Path(__file__).resolve().parent / "badge_requirements.md",
+    ]
+
+
+def _parse_requirements(text: str) -> dict[str, str]:
+    requirements: dict[str, str] = {}
+    current_badge_id: str | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        heading_match = _HEADING_RE.match(line)
+        if heading_match:
+            current_badge_id = heading_match.group(1).strip()
+            continue
+        if not current_badge_id:
+            continue
+        req_match = _REQ_RE.match(line)
+        if not req_match:
+            continue
+        if current_badge_id in requirements:
+            continue
+        requirement_text = req_match.group(2).strip()
+        if not requirement_text:
+            continue
+        requirements[current_badge_id] = " ".join(requirement_text.split())
+    return requirements
+
+
+def load_requirements() -> dict[str, str]:
+    global _REQUIREMENTS_CACHE
+    if _REQUIREMENTS_CACHE is not None:
+        return _REQUIREMENTS_CACHE
+    requirements: dict[str, str] = {}
+    for path in _requirements_paths():
+        if path.exists():
+            requirements = _parse_requirements(path.read_text(encoding="utf-8"))
+            break
+    _REQUIREMENTS_CACHE = requirements
+    return requirements
+
+
+def requirement_for(badge_id: str) -> str:
+    requirements = load_requirements()
+    return requirements.get(str(badge_id), "Requirements TBD")

--- a/jupr_app/ui/pages/badge_codex.py
+++ b/jupr_app/ui/pages/badge_codex.py
@@ -22,6 +22,11 @@ def _lore_text(value: object | None) -> str:
     return text if text else "No story yet."
 
 
+def _requirements_text(value: object | None) -> str:
+    text = str(value or "").strip()
+    return text if text else "Requirements TBD"
+
+
 def _player_options(df_players: pd.DataFrame) -> list[tuple[str, int]]:
     if df_players is None or df_players.empty:
         return []
@@ -122,6 +127,8 @@ def render(ctx) -> None:
                 icon = badge_icon(badge.get("badge_id"), badge.get("category"))
             st.markdown(f"**{icon} {name}**")
             st.caption(f"Prestige {prestige}")
+            requirements = html.escape(_requirements_text(badge.get("requirements")))
+            st.caption(f"Requirements: {requirements}")
             lore = html.escape(_lore_text(badge.get("lore")))
             if lore:
                 st.caption(lore)

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -12,6 +12,7 @@ from jupr_app.ui.layout import page_shell
 from jupr_app.ui.theme_clean import callout
 from jupr_app.ui.pages.players import badge_icon
 from jupr_app.ui.helpers import build_badge_story
+from jupr_app.domain.gamification.requirements import load_requirements
 from jupr_app.domain.story_stats import (
     build_best_partner_map,
     build_rival_map,
@@ -161,7 +162,11 @@ def _fetch_story_badges(ctx, player_ids):
         "badges.icon_key": "icon_key",
         "badges.rarity": "rarity",
     }
-    return story_df.rename(columns=column_map)
+    story_df = story_df.rename(columns=column_map)
+    if "badge_id" in story_df.columns and "requirements" not in story_df.columns:
+        requirements_map = load_requirements()
+        story_df["requirements"] = story_df["badge_id"].map(requirements_map).fillna("Requirements TBD")
+    return story_df
 
 
 def _build_story_badge_map(badges_df: pd.DataFrame) -> dict[int, list[dict]]:

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -14,6 +14,7 @@ from jupr_app.ui.layout import page_shell
 from jupr_app.domain.gamification.profile import (
     build_gamification_summary,
 )
+from jupr_app.domain.gamification.requirements import load_requirements
 from jupr_app.domain.gamification.trophies import get_player_tournament_trophies
 
 logger = logging.getLogger(__name__)
@@ -112,6 +113,9 @@ def fetch_player_badges(_supabase, club_id: str, pid: int) -> pd.DataFrame:
     if badges_df.empty:
         return pd.DataFrame()
 
+    requirements_map = load_requirements()
+    badges_df["requirements"] = badges_df["badge_id"].map(requirements_map).fillna("Requirements TBD")
+
     return pb_df.merge(badges_df, on="badge_id", how="left")
 
 
@@ -131,7 +135,11 @@ def fetch_badge_definitions(_supabase) -> pd.DataFrame:
             )
             .execute()
         )
-        return pd.DataFrame(resp.data or [])
+        df = pd.DataFrame(resp.data or [])
+        if not df.empty:
+            requirements_map = load_requirements()
+            df["requirements"] = df["badge_id"].map(requirements_map).fillna("Requirements TBD")
+        return df
     except Exception:
         logger.exception("Failed to load badge definitions")
         return pd.DataFrame()
@@ -459,6 +467,11 @@ def _badge_hint_text(value: object | None) -> str:
 def _badge_lore_text(value: object | None) -> str:
     text = str(value or "").strip()
     return text if text else "No story yet."
+
+
+def _badge_requirements_text(value: object | None) -> str:
+    text = str(value or "").strip()
+    return text if text else "Requirements TBD"
 
 
 def _trophy_display_name(row: pd.Series) -> str:
@@ -1255,6 +1268,7 @@ def render(ctx):
                     stack = badge.get("stack_count", 1)
                     stack_text = f" ×{stack}" if stack and stack > 1 else ""
                     lore = html.escape(_badge_lore_text(badge.get("lore")))
+                    requirements = html.escape(_badge_requirements_text(badge.get("requirements")))
                     featured_cards.append(
                         f"""
                     <div class="badge-card">
@@ -1263,6 +1277,7 @@ def render(ctx):
                             <span class="truncate-1">{html.escape(str(badge.get('name', 'Badge')))}{stack_text}</span>
                         </div>
                         <div class="badge-subtext">Prestige {int(badge.get('prestige', 0) or 0)}</div>
+                        <div class="badge-subtext truncate-2">Requirements: {requirements}</div>
                         <div class="badge-subtext truncate-1">{lore}</div>
                     </div>
                     """
@@ -1329,6 +1344,7 @@ def render(ctx):
                         stack_text = f" ×{stack}" if stack and stack > 1 else ""
                         if status == "locked":
                             hint = html.escape(_badge_hint_text(badge.get("hint")))
+                            requirements = html.escape(_badge_requirements_text(badge.get("requirements")))
                             card_items.append(
                                 f"""
                             <div class="badge-card silhouette">
@@ -1337,12 +1353,14 @@ def render(ctx):
                                     <span class="truncate-1">{name}{stack_text}</span>
                                 </div>
                                 <div class="badge-subtext">Prestige {prestige}</div>
+                                <div class="badge-subtext truncate-2">Requirements: {requirements}</div>
                                 <div class="badge-subtext truncate-2">{hint}</div>
                             </div>
                             """
                             )
                         else:
                             lore = html.escape(_badge_lore_text(badge.get("lore")))
+                            requirements = html.escape(_badge_requirements_text(badge.get("requirements")))
                             card_items.append(
                                 f"""
                             <div class="badge-card">
@@ -1351,6 +1369,7 @@ def render(ctx):
                                     <span class="truncate-1">{name}{stack_text}</span>
                                 </div>
                                 <div class="badge-subtext">Prestige {prestige}</div>
+                                <div class="badge-subtext truncate-2">Requirements: {requirements}</div>
                                 <div class="badge-subtext truncate-2">{lore}</div>
                             </div>
                             """
@@ -1407,6 +1426,10 @@ def render(ctx):
                             stack_text = f" x{stack}" if stack and stack > 1 else ""
                             icon = badge_icon(badge_id, getattr(badge, "category", None))
                             with st.expander(f"{icon} {badge_name}{stack_text}", expanded=False):
+                                requirements = _badge_requirements_text(
+                                    getattr(badge, "requirements", None)
+                                )
+                                st.caption(f"Requirements: {requirements}")
                                 rows = pb_df[pb_df.get("badge_id") == badge_id].copy()
                                 rows = rows.sort_values("earned_at_dt", ascending=False)
                                 cols = ["earned_at_dt", "match_id"]

--- a/tests/test_badge_requirements.py
+++ b/tests/test_badge_requirements.py
@@ -1,0 +1,20 @@
+from jupr_app.domain.gamification.requirements import load_requirements, requirement_for
+
+
+def test_requirements_loader_has_known_badges():
+    requirements = load_requirements()
+    expected = [
+        "participant",
+        "first_win",
+        "weekly_regular",
+        "iron_week",
+        "marathon_month",
+    ]
+    for badge_id in expected:
+        value = requirements.get(badge_id)
+        assert value is not None
+        assert value.strip()
+
+
+def test_requirement_for_missing_badge_returns_fallback():
+    assert requirement_for("no_such_badge") == "Requirements TBD"


### PR DESCRIPTION
### Motivation
- Surface per-badge unlock requirements to players without adding DB migrations by using the existing repository markdown as the source of truth.
- Make requirements directly available to the UI and gamification summary so the client can show locked and unlocked badges with their concise requirement text.

### Description
- Add a cached requirements loader `jupr_app/domain/gamification/requirements.py` that reads `docs/badge_requirements.md` (with a fallback) and exposes `load_requirements()` and `requirement_for()`.
- Inject a `requirements` column into badge definition dataframes via `fetch_badge_definitions()` and `fetch_player_badges()` in `jupr_app/ui/pages/players.py`, and into story badge fetches in `jupr_app/ui/pages/leaderboards.py` by mapping badge_id -> requirement text from `load_requirements()`.
- Extend `build_gamification_summary()` in `jupr_app/domain/gamification/profile.py` to treat `requirements` as an optional column and include `"requirements"` in both `unlocked_badges` and `locked_badges` payloads.
- Display requirements in the UI: show a `Requirements: ...` caption in the Trophy Room badge cards and expanders (`jupr_app/ui/pages/players.py`) and in the Badge Codex (`jupr_app/ui/pages/badge_codex.py`) while keeping lore/hint behavior unchanged.
- Add unit tests `tests/test_badge_requirements.py` to validate the loader returns entries for known badges and the `requirement_for()` fallback.

### Testing
- Ran `pytest -q tests/test_badge_requirements.py`, which executed 2 tests and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d032f40e48326868ce170cbf6eb68)