### PR TITLE
Simplify badge card requirement display

### DIFF
--- a/jupr_app/ui/helpers.py
+++ b/jupr_app/ui/helpers.py
@@ -1,9 +1,26 @@
 from __future__ import annotations
 
+import re
 import urllib.parse
 
 import pandas as pd
 import streamlit as st
+from markdown_it import MarkdownIt
+
+_REQUIREMENT_MARKDOWN = MarkdownIt("commonmark", {"html": False})
+
+
+def display_requirement_text(raw: str | None) -> str:
+    text = str(raw or "").strip()
+    if not text:
+        return "Requirements TBD"
+    cleaned = re.sub(r"^(requirements?)\s*:\s*", "", text, flags=re.IGNORECASE)
+    return cleaned.strip() or "Requirements TBD"
+
+
+def render_requirement_inline_html(raw: str | None) -> str:
+    text = display_requirement_text(raw)
+    return _REQUIREMENT_MARKDOWN.renderInline(text)
 
 
 def qp_get(key: str, default: str = "") -> str:

--- a/jupr_app/ui/pages/badge_codex.py
+++ b/jupr_app/ui/pages/badge_codex.py
@@ -1,37 +1,15 @@
 from __future__ import annotations
 
-import html
 import logging
 
 import pandas as pd
 import streamlit as st
 
 from jupr_app.domain.gamification.profile import build_gamification_summary
+from jupr_app.ui.helpers import display_requirement_text
 from jupr_app.ui.pages.players import badge_icon
 
 logger = logging.getLogger(__name__)
-
-
-def _hint_text(value: object | None) -> str:
-    text = str(value or "").strip()
-    return text if text else "No hint yet."
-
-
-def _lore_text(value: object | None) -> str:
-    text = str(value or "").strip()
-    return text if text else "No story yet."
-
-
-def _requirements_text(value: object | None) -> str:
-    text = str(value or "").strip()
-    return text if text else "Requirements TBD"
-
-
-def _badge_status_label(value: object | None) -> str:
-    status = str(value or "").strip().lower()
-    if not status or status == "live":
-        return ""
-    return f"Status: {status.title()}"
 
 
 def _player_options(df_players: pd.DataFrame) -> list[tuple[str, int]]:
@@ -134,14 +112,5 @@ def render(ctx) -> None:
                 icon = badge_icon(badge.get("badge_id"), badge.get("category"))
             st.markdown(f"**{icon} {name}**")
             st.caption(f"Prestige {prestige}")
-            status_label = _badge_status_label(badge.get("badge_status"))
-            if status_label:
-                st.caption(status_label)
-            requirements = html.escape(_requirements_text(badge.get("requirements")))
-            st.caption(f"Requirements: {requirements}")
-            lore = html.escape(_lore_text(badge.get("lore")))
-            if lore:
-                st.caption(lore)
-            if status == "locked":
-                hint = html.escape(_hint_text(badge.get("hint")))
-                st.caption(hint)
+            requirements = display_requirement_text(badge.get("requirements"))
+            st.markdown(requirements)

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -9,7 +9,12 @@ import streamlit as st
 import pandas as pd
 from streamlit.components.v1 import html as st_html
 
-from jupr_app.ui.helpers import qp_get, build_match_explorer_link
+from jupr_app.ui.helpers import (
+    qp_get,
+    build_match_explorer_link,
+    display_requirement_text,
+    render_requirement_inline_html,
+)
 from jupr_app.ui.layout import page_shell
 from jupr_app.domain.gamification.profile import (
     build_gamification_summary,
@@ -457,28 +462,6 @@ def _format_top_performer_metric(category_key: str | None, metric_value: object 
     if category_key == "most_wins":
         return f"{int(round(value))}"
     return str(metric_value)
-
-
-def _badge_hint_text(value: object | None) -> str:
-    text = str(value or "").strip()
-    return text if text else "No hint yet."
-
-
-def _badge_lore_text(value: object | None) -> str:
-    text = str(value or "").strip()
-    return text if text else "No story yet."
-
-
-def _badge_requirements_text(value: object | None) -> str:
-    text = str(value or "").strip()
-    return text if text else "Requirements TBD"
-
-
-def _badge_status_label(value: object | None) -> str:
-    status = str(value or "").strip().lower()
-    if not status or status == "live":
-        return ""
-    return f"Status: {status.title()}"
 
 
 def _trophy_display_name(row: pd.Series) -> str:
@@ -1014,6 +997,17 @@ def render(ctx):
             font-size: 0.75rem;
             color: var(--text-muted, rgba(255,255,255,0.65));
         }
+        .badge-subtext p {
+            margin: 0;
+        }
+        .badge-subtext ul,
+        .badge-subtext ol {
+            margin: 0 0 0 1rem;
+            padding: 0;
+        }
+        .badge-subtext li {
+            margin: 0;
+        }
         .truncate-1 {
             display: -webkit-box;
             -webkit-line-clamp: 1;
@@ -1274,9 +1268,7 @@ def render(ctx):
                     icon = badge_icon(badge.get("badge_id"), badge.get("category"))
                     stack = badge.get("stack_count", 1)
                     stack_text = f" ×{stack}" if stack and stack > 1 else ""
-                    lore = html.escape(_badge_lore_text(badge.get("lore")))
-                    requirements = html.escape(_badge_requirements_text(badge.get("requirements")))
-                    status_label = html.escape(_badge_status_label(badge.get("badge_status")))
+                    requirements_html = render_requirement_inline_html(badge.get("requirements"))
                     featured_cards.append(
                         f"""
                     <div class="badge-card">
@@ -1285,9 +1277,7 @@ def render(ctx):
                             <span class="truncate-1">{html.escape(str(badge.get('name', 'Badge')))}{stack_text}</span>
                         </div>
                         <div class="badge-subtext">Prestige {int(badge.get('prestige', 0) or 0)}</div>
-                        {f'<div class="badge-subtext">{status_label}</div>' if status_label else ''}
-                        <div class="badge-subtext truncate-2">Requirements: {requirements}</div>
-                        <div class="badge-subtext truncate-1">{lore}</div>
+                        <div class="badge-subtext truncate-2">{requirements_html}</div>
                     </div>
                     """
                     )
@@ -1352,9 +1342,7 @@ def render(ctx):
                         stack = badge.get("stack_count", 1)
                         stack_text = f" ×{stack}" if stack and stack > 1 else ""
                         if status == "locked":
-                            hint = html.escape(_badge_hint_text(badge.get("hint")))
-                            requirements = html.escape(_badge_requirements_text(badge.get("requirements")))
-                            status_label = html.escape(_badge_status_label(badge.get("badge_status")))
+                            requirements_html = render_requirement_inline_html(badge.get("requirements"))
                             card_items.append(
                                 f"""
                             <div class="badge-card silhouette">
@@ -1363,16 +1351,12 @@ def render(ctx):
                                     <span class="truncate-1">{name}{stack_text}</span>
                                 </div>
                                 <div class="badge-subtext">Prestige {prestige}</div>
-                                {f'<div class="badge-subtext">{status_label}</div>' if status_label else ''}
-                                <div class="badge-subtext truncate-2">Requirements: {requirements}</div>
-                                <div class="badge-subtext truncate-2">{hint}</div>
+                                <div class="badge-subtext truncate-2">{requirements_html}</div>
                             </div>
                             """
                             )
                         else:
-                            lore = html.escape(_badge_lore_text(badge.get("lore")))
-                            requirements = html.escape(_badge_requirements_text(badge.get("requirements")))
-                            status_label = html.escape(_badge_status_label(badge.get("badge_status")))
+                            requirements_html = render_requirement_inline_html(badge.get("requirements"))
                             card_items.append(
                                 f"""
                             <div class="badge-card">
@@ -1381,9 +1365,7 @@ def render(ctx):
                                     <span class="truncate-1">{name}{stack_text}</span>
                                 </div>
                                 <div class="badge-subtext">Prestige {prestige}</div>
-                                {f'<div class="badge-subtext">{status_label}</div>' if status_label else ''}
-                                <div class="badge-subtext truncate-2">Requirements: {requirements}</div>
-                                <div class="badge-subtext truncate-2">{lore}</div>
+                                <div class="badge-subtext truncate-2">{requirements_html}</div>
                             </div>
                             """
                             )
@@ -1439,10 +1421,10 @@ def render(ctx):
                             stack_text = f" x{stack}" if stack and stack > 1 else ""
                             icon = badge_icon(badge_id, getattr(badge, "category", None))
                             with st.expander(f"{icon} {badge_name}{stack_text}", expanded=False):
-                                requirements = _badge_requirements_text(
+                                requirements = display_requirement_text(
                                     getattr(badge, "requirements", None)
                                 )
-                                st.caption(f"Requirements: {requirements}")
+                                st.markdown(requirements)
                                 rows = pb_df[pb_df.get("badge_id") == badge_id].copy()
                                 rows = rows.sort_values("earned_at_dt", ascending=False)
                                 cols = ["earned_at_dt", "match_id"]

--- a/tests/test_badge_ui_rendering.py
+++ b/tests/test_badge_ui_rendering.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import re
+
+
+BADGE_RENDER_FILES = [
+    Path("jupr_app/ui/pages/badge_codex.py"),
+    Path("jupr_app/ui/pages/players.py"),
+]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_badge_renderers_do_not_label_requirements():
+    for path in BADGE_RENDER_FILES:
+        content = _read(path)
+        assert "Requirements:" not in content, f"Found Requirements: label in {path}"
+
+
+def test_badge_renderers_do_not_use_lore_or_hint_fields():
+    patterns = [
+        r"badge\.get\([\"']lore[\"']\)",
+        r"badge\.get\([\"']hint[\"']\)",
+        r"badge\.get\([\"']description[\"']\)",
+        r"badge\.get\([\"']flavor[\"']\)",
+        r"badge\.get\([\"']tagline[\"']\)",
+    ]
+    for path in BADGE_RENDER_FILES:
+        content = _read(path)
+        for pattern in patterns:
+            assert re.search(pattern, content) is None, f"Unexpected lore/hint usage in {path}: {pattern}"


### PR DESCRIPTION
### Motivation
- Badge cards previously rendered a literal "Requirements:" prefix plus lore/flavor/hint/explanatory text, but the UI must show only title (and icon/lock), prestige, and the raw requirement text (with markdown preserved). 
- Apply this consistently across all non-admin badge views to avoid exposing extra narrative copy or duplicate labels.

### Description
- Add shared requirement helpers `display_requirement_text` and `render_requirement_inline_html` to `jupr_app/ui/helpers.py` that strip leading "Requirements:"/"Requirement:" prefixes and render inline markdown. 
- Replace badge card rendering in `jupr_app/ui/pages/badge_codex.py` and `jupr_app/ui/pages/players.py` to emit only: title/icon, prestige, and a single requirement text block (using the new helpers), and remove UI references to lore, flavor, hint, and the literal "Requirements:" label. 
- Adjust badge card HTML/CSS to allow rendered markdown inline without extra paragraph margins. 
- Add a lightweight UI-focused test `tests/test_badge_ui_rendering.py` to assert no renderer contains the exact prefix `Requirements:` and to detect any usage of `lore`/`hint`/`description`/`flavor`/`tagline` fields in badge render paths. 
- Files changed: `jupr_app/ui/helpers.py`, `jupr_app/ui/pages/badge_codex.py`, `jupr_app/ui/pages/players.py`, and `tests/test_badge_ui_rendering.py`.

Before (conceptual):
- `st.caption(f"Requirements: {requirements}")` plus additional `lore`/`hint` captions.

After (current):
- Title/icon (unchanged), prestige (unchanged), then `st.markdown(display_requirement_text(badge.get("requirements")))` or inline HTML via `render_requirement_inline_html` so exactly one body block (the requirement text) appears per card.

### Testing
- Ran the new pytest file with `pytest -q tests/test_badge_ui_rendering.py` which passed (2 passed). 
- Ran a repo grep to verify remaining occurrences of the exact prefix; the only match for patterns like `"Requirements:"` found was inside the new test file, confirming UI renderers no longer emit the literal label. 
- No other automated tests were modified; changes are non-breaking with badge IDs/prestige/award logic untouched.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d77d8fee08326b813ea545d4b7d13)