### PR TITLE
Reactivate players and league_ratings on match creation

### DIFF
--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -339,6 +339,8 @@ def process_matches(
                 payload["wins"] += int(cur.get("wins", 0) or 0)
                 payload["losses"] += int(cur.get("losses", 0) or 0)
                 payload["matches_played"] += int(cur.get("matches_played", 0) or 0)
+                payload["is_active"] = True
+                payload["inactive_at"] = None
 
                 if cur.get("starting_rating") is not None:
                     payload["starting_rating"] = float(cur["starting_rating"])
@@ -350,6 +352,8 @@ def process_matches(
                 ))
             else:
                 payload["starting_rating"] = float(stats.get("start", 1200.0))
+                payload["is_active"] = True
+                payload["inactive_at"] = None
                 sb_retry(lambda payload=payload: supabase.table("league_ratings").insert(payload).execute())
 
     return {

--- a/jupr_app/domain/player_activity.py
+++ b/jupr_app/domain/player_activity.py
@@ -63,7 +63,7 @@ def build_player_activity_update(existing_last_game_at, match_time) -> dict:
     latest = max_activity_time(existing_last_game_at, match_time)
     if latest is None:
         return {}
-    return {"last_game_at": latest.isoformat(), "inactive_at": None}
+    return {"last_game_at": latest.isoformat(), "inactive_at": None, "active": True}
 
 
 def recompute_last_game_at_for_players(

--- a/tests/test_player_activity.py
+++ b/tests/test_player_activity.py
@@ -41,6 +41,7 @@ def test_build_player_activity_update_reactivates_and_sets_last_game_at():
     existing = "2024-01-01T00:00:00+00:00"
     match_time = datetime(2024, 1, 10, 12, 0, tzinfo=timezone.utc)
     payload = build_player_activity_update(existing, match_time)
+    assert payload["active"] is True
     assert payload["inactive_at"] is None
     assert payload["last_game_at"] == match_time.isoformat()
 


### PR DESCRIPTION
### Motivation
- Ensure players who are recorded in a new match are made active again so they become visible immediately in global and league views.
- Ensure `league_ratings` rows for non-popup leagues are also reactivated when affected by a match so per-league visibility is consistent.

### Description
- Update `build_player_activity_update` in `jupr_app/domain/player_activity.py` to include `"active": True` in the returned activity payload while keeping the existing logic that chooses the latest timestamp.
- Update `jupr_app/domain/match_processing.py` to set `payload["is_active"] = True` and `payload["inactive_at"] = None` for the league_ratings update path (when an existing row is present) and the insert path (when creating a new row) so league rows are reactivated on match processing.
- Extend `tests/test_player_activity.py` to assert that the activity payload includes `payload["active"] is True` in the reactivation test.
- This change only touches visibility/status flags and does not alter standings or rating computations.

### Testing
- Ran `pytest`, which collected 77 tests and resulted in `76 passed, 1 failed` indicating the changes did not break the player activity or league rating logic.
- The single failing test was `tests/test_ui_color_tokens.py::test_ui_files_do_not_use_hardcoded_colors`, which is unrelated to the match/reactivation changes.
- The modified player activity test (`tests/test_player_activity.py`) passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e59133e5483269203ea89f5ce6e7d)