### PR TITLE
Remove lore/hint from badge loading and summaries

### DIFF
--- a/jupr_app/data/load.py
+++ b/jupr_app/data/load.py
@@ -75,7 +75,7 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
                 supabase.table("badges")
                 .select(
                     "badge_id,name,prestige,category,is_stackable,is_active,rarity,"
-                    "tier,icon_key,lore,hint,scope,created_at"
+                    "tier,icon_key,scope,created_at"
                 )
                 .execute()
             )

--- a/jupr_app/domain/gamification/badge_rules.py
+++ b/jupr_app/domain/gamification/badge_rules.py
@@ -259,7 +259,7 @@ def _seed_badges(supabase) -> None:
     existing_by_id = {}
     if not force_backfill:
         try:
-            resp = supabase.table("badges").select("badge_id,lore,hint").execute()
+            resp = supabase.table("badges").select("badge_id").execute()
             existing_by_id = {str(row.get("badge_id")): row for row in resp.data or []}
         except Exception:
             logger.exception("Failed to fetch badges for copy backfill")

--- a/jupr_app/domain/gamification/profile.py
+++ b/jupr_app/domain/gamification/profile.py
@@ -55,8 +55,6 @@ def build_gamification_summary(
     pb = df_player_badges.copy() if df_player_badges is not None else pd.DataFrame()
 
     optional_columns = {
-        "lore": "",
-        "hint": "",
         "requirements": "Requirements TBD",
         "rarity": None,
         "icon_key": None,
@@ -130,7 +128,6 @@ def build_gamification_summary(
                     "category": first.get("category", ""),
                     "rarity": _resolve_rarity(first.get("rarity"), first.get("prestige", 0)),
                     "prestige": int(first.get("prestige", 0) or 0),
-                    "lore": first.get("lore", ""),
                     "requirements": first.get("requirements", "Requirements TBD"),
                     "is_stackable": bool(first.get("is_stackable", False)),
                     "icon_key": first.get("icon_key", None),
@@ -158,8 +155,6 @@ def build_gamification_summary(
                 "category": r(row, "category", ""),
                 "rarity": _resolve_rarity(r(row, "rarity", None), r(row, "prestige", 0)),
                 "prestige": int(r(row, "prestige", 0) or 0),
-                "lore": r(row, "lore", ""),
-                "hint": r(row, "hint", ""),
                 "requirements": r(row, "requirements", "Requirements TBD"),
                 "is_stackable": bool(r(row, "is_stackable", False)),
                 "icon_key": r(row, "icon_key", None),

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -105,7 +105,7 @@ def fetch_player_badges(_supabase, club_id: str, pid: int) -> pd.DataFrame:
             _supabase.table("badges")
             .select(
                 "badge_id,name,prestige,category,is_stackable,is_active,rarity,tier,"
-                "icon_key,lore,hint,scope"
+                "icon_key,scope"
             )
             .in_("badge_id", badge_ids)
             .execute()
@@ -136,7 +136,7 @@ def fetch_badge_definitions(_supabase) -> pd.DataFrame:
             _supabase.table("badges")
             .select(
                 "badge_id,name,prestige,category,is_stackable,is_active,rarity,"
-                "tier,icon_key,lore,hint,scope,created_at"
+                "tier,icon_key,scope,created_at"
             )
             .execute()
         )

--- a/tests/test_badge_aggregation.py
+++ b/tests/test_badge_aggregation.py
@@ -12,8 +12,6 @@ def test_aggregation_counts_and_prestige():
                 "prestige": 75,
                 "category": "Rivalries",
                 "rarity": "legendary",
-                "lore": "The tape favors the fearless.",
-                "hint": "The mountain tips when the underdog swings.",
                 "is_active": True,
             },
             {
@@ -22,8 +20,6 @@ def test_aggregation_counts_and_prestige():
                 "prestige": 15,
                 "category": "Participation",
                 "rarity": "common",
-                "lore": "A first chapter.",
-                "hint": "There is always a first frame.",
                 "is_active": True,
             },
             {
@@ -32,8 +28,6 @@ def test_aggregation_counts_and_prestige():
                 "prestige": 50,
                 "category": "Momentum",
                 "rarity": "epic",
-                "lore": "Wins blur together.",
-                "hint": "The film strip barely cools.",
                 "is_active": True,
             },
         ]
@@ -70,7 +64,7 @@ def test_aggregation_counts_and_prestige():
     assert giant["latest_tape_excerpt"]
 
     locked = summary["locked_badges"]
-    assert any(b["badge_id"] == "hot_streak" and b["hint"] for b in locked)
+    assert any(b["badge_id"] == "hot_streak" for b in locked)
 
 
 def test_featured_badges_unique():

--- a/tests/test_copy_pack.py
+++ b/tests/test_copy_pack.py
@@ -62,8 +62,6 @@ def test_copy_pack_has_required_badges():
     assert "badges" in pack
     for badge_id in required:
         copy = get_badge_copy(badge_id)
-        assert copy["lore"]
-        assert copy["hint"]
         assert copy["tape_excerpts"]
 
 
@@ -85,8 +83,6 @@ def test_copy_pack_player_facing_words_clean():
         if not isinstance(entry, dict):
             continue
         texts = [
-            entry.get("lore", ""),
-            entry.get("hint", ""),
             *(entry.get("tape_excerpts", []) or []),
         ]
         highlight = entry.get("highlight", {}) or {}

--- a/tests/test_gamification_profile_story.py
+++ b/tests/test_gamification_profile_story.py
@@ -22,8 +22,6 @@ def test_profile_summary_locked_and_prestige():
                 "prestige": 15,
                 "category": "Participation & Habit Loop",
                 "rarity": "common",
-                "lore": "The first mark on the ledger.",
-                "hint": "There is always a first frame.",
                 "icon_key": "first_win",
                 "tier": None,
                 "scope": "overall",
@@ -34,8 +32,6 @@ def test_profile_summary_locked_and_prestige():
                 "prestige": 50,
                 "category": "Skill Growth & Momentum",
                 "rarity": "epic",
-                "lore": "Wins blur together.",
-                "hint": "The film strip barely cools.",
                 "icon_key": "hot_streak",
                 "tier": None,
                 "scope": "league",
@@ -58,7 +54,7 @@ def test_profile_summary_locked_and_prestige():
     assert summary["total_active_badge_types"] == 2
     assert summary["unlocked_badges"][0]["latest_tape_excerpt"]
     locked = summary["locked_badges"]
-    assert locked and locked[0]["hint"]
+    assert locked
     assert "requirements" in locked[0]
     assert locked[0]["requirements"] == "Requirements TBD"
 
@@ -167,8 +163,6 @@ def test_player_facing_copy_has_no_banned_words():
                 "prestige": 15,
                 "category": "Participation & Habit Loop",
                 "rarity": "common",
-                "lore": "The first mark on the ledger.",
-                "hint": "There is always a first frame.",
                 "icon_key": "first_win",
                 "tier": None,
                 "scope": "overall",
@@ -187,9 +181,11 @@ def test_player_facing_copy_has_no_banned_words():
     )
     summary = build_gamification_summary(9, df_badges, df_player_badges)
     for badge in summary.get("unlocked_badges", []):
-        assert_no_banned_words(" ".join([badge.get("name", ""), badge.get("lore", ""), badge.get("latest_tape_excerpt", "")]))
+        assert_no_banned_words(
+            " ".join([badge.get("name", ""), badge.get("latest_tape_excerpt", "")])
+        )
     for badge in summary.get("locked_badges", []):
-        assert_no_banned_words(" ".join([badge.get("name", ""), badge.get("lore", ""), badge.get("hint", "")]))
+        assert_no_banned_words(" ".join([badge.get("name", "")]))
 
 
 def test_story_cards_dedupe_by_type_and_context():


### PR DESCRIPTION
### Motivation
- Lore and hint text should no longer be loaded from Supabase or exposed in player-facing badge objects or UI renderers.
- Keep badge loading and summary construction robust so existing database schemas with `lore`/`hint` columns still work without requiring schema changes.

### Description
- Stop requesting `lore` and `hint` from Supabase badge queries by removing them from the select lists in `jupr_app/ui/pages/players.py` (`fetch_player_badges`, `fetch_badge_definitions`) and `jupr_app/data/load.py` (global badge load).
- Remove `lore`/`hint` from the gamification summary payload in `jupr_app/domain/gamification/profile.py` by dropping the optional defaults and removing the `lore`/`hint` keys from the unlocked and locked badge dicts.
- Avoid selecting `lore`/`hint` when fetching existing badges for copy backfill in `jupr_app/domain/gamification/badge_rules.py` to reduce reliance on those columns while preserving backfill/upsert behavior.
- Update unit tests to stop requiring or asserting `lore`/`hint` fields in test fixtures and assertions in `tests/test_copy_pack.py`, `tests/test_badge_aggregation.py`, and `tests/test_gamification_profile_story.py`.
- Changes are backward-compatible for databases that still contain `lore`/`hint` columns because code falls back to defaults and does not assume presence of those columns.

### Testing
- No automated test suite was executed as part of this change; only unit test files were updated to remove expectations for `lore`/`hint`.
- Updated tests: `tests/test_copy_pack.py`, `tests/test_badge_aggregation.py`, and `tests/test_gamification_profile_story.py` (modified to no longer reference `lore`/`hint`).
- Recommend running `pytest tests -q` to validate the test suite locally after pulling these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e5b24361c83268299938baca42514)