### PR TITLE
Add Create League UI flow and DB uniqueness constraint

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -899,6 +899,63 @@ def render(ctx):
     with tabs[1]:
         st.subheader("Settings")
 
+        with st.expander("➕ Create New League", expanded=False):
+            default_k = int(DEFAULT_K_FACTOR) if DEFAULT_K_FACTOR is not None else 32
+            league_name = st.text_input("League name (required)", key="create_league_name")
+            description = st.text_area("Description (optional)", key="create_league_description")
+            min_games = st.number_input("Minimum games", min_value=0, step=1, value=6, key="create_league_min_games")
+            k_factor = st.number_input(
+                "K-factor",
+                min_value=1,
+                step=1,
+                value=default_k,
+                key="create_league_k_factor",
+            )
+            is_active = st.checkbox("Active", value=True, key="create_league_active")
+
+            if st.button("Create League", type="primary"):
+                trimmed_name = str(league_name or "").strip()
+                if not trimmed_name:
+                    st.error("League name is required.")
+                    st.stop()
+
+                normalized_input = trimmed_name.lower()
+                if df_meta is not None and not df_meta.empty and "league_name" in df_meta.columns:
+                    existing = (
+                        df_meta["league_name"]
+                        .dropna()
+                        .astype(str)
+                        .str.strip()
+                        .str.lower()
+                        .tolist()
+                    )
+                    if normalized_input in existing:
+                        st.error("A league with that name already exists for this club.")
+                        st.stop()
+
+                payload = {
+                    "club_id": str(ctx.club_id),
+                    "league_name": trimmed_name,
+                    "description": str(description or "").strip(),
+                    "min_games": int(min_games or 0),
+                    "k_factor": int(k_factor or default_k),
+                    "is_active": bool(is_active),
+                }
+
+                try:
+                    resp = ctx.supabase.table("leagues_metadata").insert(payload).execute()
+                except Exception as exc:
+                    st.error(f"Could not create league: {exc}")
+                    st.stop()
+
+                if getattr(resp, "error", None):
+                    st.error(f"Could not create league: {resp.error}")
+                    st.stop()
+
+                st.session_state["force_data_refresh"] = True
+                st.success("League created.")
+                st.rerun()
+
         if df_meta is None or df_meta.empty:
             st.info("No league metadata loaded.")
             return

--- a/migrations/20260130_unique_leagues_metadata.sql
+++ b/migrations/20260130_unique_leagues_metadata.sql
@@ -1,0 +1,2 @@
+create unique index if not exists leagues_metadata_club_id_league_name_unique
+    on leagues_metadata (club_id, lower(league_name));


### PR DESCRIPTION
### Motivation
- Provide an in-UI pathway so admins can create leagues without manual Supabase edits and ensure duplicates are prevented at both UI and DB levels.
- Ensure newly created leagues appear immediately in the app by forcing a data refresh.

### Description
- Add a `➕ Create New League` expander to the League Manager Settings with inputs for `league_name` (required), `description`, `min_games` (default 6), `k_factor` (default `DEFAULT_K_FACTOR` or 32), and `is_active` (default True). 
- On submit the flow trims the name, rejects empty input, checks for duplicates against `df_meta` with case-insensitive normalization, inserts the new row into `leagues_metadata` via Supabase, sets `st.session_state["force_data_refresh"] = True`, and calls `st.rerun()` on success. 
- Insert is wrapped with `try/except` and checks `resp.error` to show `st.error` messages on failures. 
- Add a migration `migrations/20260130_unique_leagues_metadata.sql` that creates a unique index on `(club_id, lower(league_name))` to enforce uniqueness at the DB level.

### Testing
- No automated tests were executed in this change set. 
- The UI code includes defensive checks for `df_meta` being `None`/empty and handles Supabase insert exceptions by showing `st.error` and stopping gracefully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e5b7ee4908326978f1bf87dce1404)