### PR TITLE
End League workflow and gate Top Performer awards to closed leagues

### DIFF
--- a/jupr_app/domain/gamification/evaluators.py
+++ b/jupr_app/domain/gamification/evaluators.py
@@ -16,6 +16,7 @@ from jupr_app.domain.gamification.top_performer_awards import (
     _build_league_standings,
     _min_games_for_league,
 )
+from jupr_app.domain.leagues import get_league_meta_row, is_league_ended
 from jupr_app.domain.tournament_podium import build_tournament_podium_candidates
 
 
@@ -782,6 +783,9 @@ def _cached_top_performer_candidates(ctx: BadgeEvaluationContext) -> list[BadgeC
     )
     candidates = []
     for league_id in league_ids:
+        meta_row = get_league_meta_row(df_meta, league_id)
+        if not is_league_ended(meta_row):
+            continue
         min_games = _min_games_for_league(df_meta, league_id)
         if min_games <= 0:
             continue

--- a/jupr_app/domain/leagues.py
+++ b/jupr_app/domain/leagues.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, Mapping
+
+import pandas as pd
+
+from jupr_app.domain.awards import compute_top_performer_awards
+from jupr_app.domain.gamification.top_performer_awards import (
+    _build_league_standings,
+    _min_games_for_league,
+)
+
+
+_COMPLETED_STATUSES = {"archived", "completed", "complete", "done"}
+
+
+def get_league_meta_row(df_meta: pd.DataFrame | None, league_id: str) -> dict[str, Any] | None:
+    if df_meta is None or df_meta.empty or "league_name" not in df_meta.columns:
+        return None
+    league_key = str(league_id or "").strip()
+    if not league_key:
+        return None
+    meta = df_meta.copy()
+    meta["league_name"] = meta["league_name"].fillna("").astype(str).str.strip()
+    hit = meta[meta["league_name"] == league_key]
+    if hit.empty:
+        return None
+    return hit.iloc[0].to_dict()
+
+
+def is_league_ended(meta_row: Mapping[str, Any] | None) -> bool:
+    if not meta_row:
+        return False
+    ended_at = meta_row.get("ended_at")
+    if ended_at is not None and not pd.isna(ended_at):
+        return True
+    status = str(meta_row.get("status") or "").strip().lower()
+    if status in _COMPLETED_STATUSES:
+        return True
+    is_active = meta_row.get("is_active")
+    if is_active is None or (isinstance(is_active, float) and pd.isna(is_active)):
+        return False
+    return not bool(is_active)
+
+
+def compute_top_performer_preview(
+    df_leagues: pd.DataFrame | None,
+    df_meta: pd.DataFrame | None,
+    id_to_name: Mapping[int, str] | None,
+    league_id: str,
+    *,
+    winners_per_category: int = 1,
+) -> list[dict[str, Any]]:
+    min_games = _min_games_for_league(df_meta, league_id)
+    if min_games <= 0:
+        return []
+    standings = _build_league_standings(df_leagues, league_id, dict(id_to_name or {}))
+    if standings.empty:
+        return []
+    qualified = standings[standings["matches_played"] >= int(min_games)].copy()
+    if qualified.empty:
+        return []
+    awards = compute_top_performer_awards(qualified, min_games=min_games, winners_per_category=winners_per_category)
+    name_map = {
+        int(row._pid): str(getattr(row, "name", "") or "")
+        for row in qualified.itertuples(index=False)
+        if getattr(row, "_pid", None) is not None
+    }
+    for award in awards:
+        pid = award.get("player_id")
+        award["player_name"] = name_map.get(int(pid)) if pid is not None else ""
+    return awards
+
+
+def _apply_league_end_to_meta(
+    df_meta: pd.DataFrame | None,
+    league_id: str,
+    *,
+    ended_at: str,
+    ended_by: str | None,
+    status: str,
+    end_awards: dict[str, Any],
+) -> pd.DataFrame | None:
+    if df_meta is None or df_meta.empty or "league_name" not in df_meta.columns:
+        return df_meta
+    meta = df_meta.copy()
+    meta["league_name"] = meta["league_name"].fillna("").astype(str).str.strip()
+    league_key = str(league_id or "").strip()
+    if not league_key:
+        return meta
+    mask = meta["league_name"] == league_key
+    if not mask.any():
+        return meta
+    if "ended_at" not in meta.columns:
+        meta["ended_at"] = pd.NA
+    if "ended_by" not in meta.columns:
+        meta["ended_by"] = pd.NA
+    if "status" not in meta.columns:
+        meta["status"] = pd.NA
+    if "is_active" not in meta.columns:
+        meta["is_active"] = pd.NA
+    if "end_awards" not in meta.columns:
+        meta["end_awards"] = pd.NA
+    meta.loc[mask, "ended_at"] = ended_at
+    meta.loc[mask, "ended_by"] = ended_by
+    meta.loc[mask, "status"] = status
+    meta.loc[mask, "is_active"] = False
+    meta.loc[mask, "end_awards"] = end_awards
+    return meta
+
+
+def end_league_and_award_top_performers(
+    ctx: Any,
+    league_id: str,
+    *,
+    admin_id: str | None = None,
+) -> dict[str, Any]:
+    from jupr_app.domain.gamification.ensure_badges import ensure_badges
+
+    supabase = getattr(ctx, "supabase", None)
+    club_id = str(getattr(ctx, "club_id", "") or "")
+    if supabase is None or not club_id:
+        return {"ended": False, "awards": [], "created": []}
+
+    league_key = str(league_id or "").strip()
+    if not league_key:
+        return {"ended": False, "awards": [], "created": []}
+
+    meta_row: dict[str, Any] | None = None
+    try:
+        resp = (
+            supabase.table("leagues_metadata")
+            .select("*")
+            .eq("club_id", club_id)
+            .eq("league_name", league_key)
+            .execute()
+        )
+        meta_row = (resp.data or [None])[0]
+    except Exception:
+        meta_row = get_league_meta_row(getattr(ctx, "df_meta", None), league_key)
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    awards = compute_top_performer_preview(
+        getattr(ctx, "df_leagues", None),
+        getattr(ctx, "df_meta", None),
+        getattr(ctx, "id_to_name", None),
+        league_key,
+        winners_per_category=1,
+    )
+    end_awards = {"top_performers": awards}
+    already_ended = is_league_ended(meta_row)
+    if not already_ended:
+        update_payload = {
+            "is_active": False,
+            "status": "completed",
+            "ended_at": now_iso,
+            "ended_by": admin_id,
+            "end_awards": end_awards,
+        }
+        supabase.table("leagues_metadata").update(update_payload).eq("club_id", club_id).eq(
+            "league_name", league_key
+        ).execute()
+
+    updated_meta = _apply_league_end_to_meta(
+        getattr(ctx, "df_meta", None),
+        league_key,
+        ended_at=now_iso,
+        ended_by=admin_id,
+        status="completed",
+        end_awards=end_awards,
+    )
+    attrs = dict(vars(ctx)) if hasattr(ctx, "__dict__") else {}
+    attrs["df_meta"] = updated_meta
+    evaluation_ctx = SimpleNamespace(**attrs)
+    created = ensure_badges(
+        evaluation_ctx,
+        club_id=club_id,
+        league_id=league_key,
+        status="seasonal",
+        award_timing="on_league_close",
+    )
+    return {"ended": True, "awards": awards, "created": created}

--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -18,6 +18,12 @@ from jupr_app.domain.league_night_roster import (
     roster_change_availability,
     suggest_court_sizes,
 )
+from jupr_app.domain.leagues import (
+    compute_top_performer_preview,
+    end_league_and_award_top_performers,
+    get_league_meta_row,
+    is_league_ended,
+)
 from jupr_app.domain.match_processing import process_matches
 from jupr_app.domain.roster import (
     compress_courts,
@@ -959,6 +965,67 @@ def render(ctx):
         if df_meta is None or df_meta.empty:
             st.info("No league metadata loaded.")
             return
+
+        with st.expander("🏁 End League", expanded=False):
+            league_names = (
+                df_meta["league_name"].dropna().astype(str).str.strip().unique().tolist()
+                if "league_name" in df_meta.columns
+                else []
+            )
+            if not league_names:
+                st.info("No leagues available to end.")
+            else:
+                league_names = sorted({name for name in league_names if name})
+                end_league_id = st.selectbox("League to end", league_names, key="end_league_select")
+                meta_row = get_league_meta_row(df_meta, end_league_id) or {}
+                already_ended = is_league_ended(meta_row)
+                if already_ended:
+                    ended_at = meta_row.get("ended_at")
+                    ended_label = f" (ended {ended_at})" if ended_at else ""
+                    st.warning(f"League already ended{ended_label}.")
+
+                preview_awards = compute_top_performer_preview(
+                    df_leagues,
+                    df_meta,
+                    id_to_name,
+                    end_league_id,
+                    winners_per_category=1,
+                )
+                if preview_awards:
+                    preview_rows = [
+                        {
+                            "Category": award.get("category_label") or award.get("category_key"),
+                            "Winner": award.get("player_name") or award.get("player_id"),
+                            "Rank": award.get("rank"),
+                            "Metric": award.get("metric_display"),
+                        }
+                        for award in preview_awards
+                    ]
+                    st.dataframe(pd.DataFrame(preview_rows), hide_index=True, use_container_width=True)
+                else:
+                    st.info("No top performer winners found (check min games or standings).")
+
+                confirm = st.checkbox(
+                    "I confirm these Top Performer winners.",
+                    disabled=already_ended,
+                    key="end_league_confirm",
+                )
+                if st.button(
+                    "End League",
+                    type="primary",
+                    disabled=already_ended or not confirm,
+                    key="end_league_submit",
+                ):
+                    result = end_league_and_award_top_performers(
+                        ctx,
+                        end_league_id,
+                        admin_id="admin",
+                    )
+                    if result.get("ended"):
+                        st.session_state["force_data_refresh"] = True
+                        st.success("League ended and Top Performer trophies awarded.")
+                        st.rerun()
+                    st.error("Unable to end league. Check logs for details.")
 
         cols = [c for c in ["id", "league_name", "is_active", "min_games", "description", "k_factor"] if c in df_meta.columns]
         editor = st.data_editor(

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -20,6 +20,7 @@ from jupr_app.domain.gamification.profile import (
     build_gamification_summary,
 )
 from jupr_app.domain.gamification.requirements import load_requirements_map
+from jupr_app.domain.gamification.top_performer_awards import TOP_PERFORMER_BADGE_IDS
 from jupr_app.domain.gamification.trophies import get_player_tournament_trophies
 
 logger = logging.getLogger(__name__)
@@ -473,6 +474,34 @@ def _trophy_display_name(row: pd.Series) -> str:
         if cleaned:
             return cleaned
     return "Trophy"
+
+
+def _is_top_performer_badge(badge_id: str | None) -> bool:
+    badge_key = str(badge_id or "").strip()
+    if not badge_key:
+        return False
+    if badge_key.startswith("top_performer_"):
+        return True
+    return badge_key in set(TOP_PERFORMER_BADGE_IDS.values())
+
+
+def _format_top_performer_title(badge_name: str | None, category_label: str | None) -> str:
+    base = str(category_label or badge_name or "Top Performer").strip()
+    if not base:
+        base = "Top Performer"
+    if base.lower().startswith("top performer"):
+        return base
+    return f"Top Performer: {base}"
+
+
+def _format_top_performer_rank(value_json: dict) -> str:
+    rank = value_json.get("rank")
+    if rank is None:
+        return ""
+    try:
+        return f"#{int(rank)}"
+    except Exception:
+        return f"#{rank}"
 
 
 def _decorate_trophies_with_leagues(
@@ -1090,16 +1119,23 @@ def render(ctx):
                     continue
                 icon = "🏆"
                 value_json = _parse_value_json(row.get("value_json"))
-                category_label = value_json.get("category_label")
-                trophy_title = category_label or _trophy_display_name(row)
+                badge_name = _trophy_display_name(row)
+                if _is_top_performer_badge(row.get("badge_id")):
+                    trophy_title = _format_top_performer_title(badge_name, value_json.get("category_label"))
+                    rank_label = _format_top_performer_rank(value_json)
+                else:
+                    trophy_title = badge_name
+                    rank_label = ""
                 metric_display = value_json.get("metric_display")
                 if not metric_display:
                     metric_display = _format_top_performer_metric(
                         value_json.get("category_key"),
                         value_json.get("metric_value"),
                     )
-                if not metric_display and value_json.get("rank") is not None:
-                    metric_display = f"Rank {value_json.get('rank')}"
+                if rank_label:
+                    metric_display = f"{rank_label} • {metric_display}" if metric_display else rank_label
+                elif not metric_display and value_json.get("rank") is not None:
+                    metric_display = f"#{value_json.get('rank')}"
                 league_label = str(row.get("league_label") or "League")
                 earned_at_label = _format_earned_at(row.get("earned_at"))
                 earned_at_label = f"Earned {earned_at_label}" if earned_at_label else ""

--- a/migrations/20260215_end_league_top_performers.sql
+++ b/migrations/20260215_end_league_top_performers.sql
@@ -1,0 +1,30 @@
+alter table if exists public.leagues_metadata
+    add column if not exists ended_at timestamptz,
+    add column if not exists ended_by text,
+    add column if not exists status text,
+    add column if not exists end_awards jsonb;
+
+create index if not exists leagues_metadata_ended_at_idx
+    on public.leagues_metadata (ended_at);
+
+create index if not exists leagues_metadata_status_idx
+    on public.leagues_metadata (status);
+
+insert into public.badges (badge_id, name, prestige, category, is_stackable, is_active, rarity, tier, icon_key, lore, hint, scope)
+values
+    ('top_performer_highest_rating', 'Top Performer: Highest Rating', 130, 'Top Performer Awards', true, true, 'legendary', null, 'trophy', 'The league closes with your rating on the peak.', 'Finish the season with the highest mark.', 'league'),
+    ('top_performer_most_improved', 'Top Performer: Most Improved', 125, 'Top Performer Awards', true, true, 'legendary', null, 'trophy', 'The biggest climb shows up in the final tape.', 'Make the largest rating leap in the league.', 'league'),
+    ('top_performer_best_win_pct', 'Top Performer: Best Win %', 120, 'Top Performer Awards', true, true, 'legendary', null, 'trophy', 'The league’s cleanest record shines at the top.', 'Finish with the best win percentage.', 'league'),
+    ('top_performer_most_wins', 'Top Performer: Most Wins', 115, 'Top Performer Awards', true, true, 'legendary', null, 'trophy', 'No one stacks wins faster when the season closes.', 'Lead the league in total wins.', 'league')
+on conflict (badge_id) do update set
+    name = excluded.name,
+    prestige = excluded.prestige,
+    category = excluded.category,
+    is_stackable = excluded.is_stackable,
+    is_active = excluded.is_active,
+    rarity = excluded.rarity,
+    tier = excluded.tier,
+    icon_key = excluded.icon_key,
+    lore = excluded.lore,
+    hint = excluded.hint,
+    scope = excluded.scope;

--- a/tests/test_end_league_top_performers.py
+++ b/tests/test_end_league_top_performers.py
@@ -1,0 +1,161 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from jupr_app.domain.gamification.badge_engine import compute_candidates_for_club
+from jupr_app.domain.gamification.top_performer_awards import TOP_PERFORMER_BADGE_IDS
+from jupr_app.domain.leagues import end_league_and_award_top_performers
+
+
+class FakeTable:
+    def __init__(self, storage, name):
+        self.storage = storage
+        self.name = name
+        self.filters = []
+        self.pending_update = None
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, column, value):
+        self.filters.append(("eq", column, value))
+        return self
+
+    def in_(self, column, values):
+        self.filters.append(("in", column, set(values)))
+        return self
+
+    def update(self, payload):
+        self.pending_update = payload
+        return self
+
+    def upsert(self, rows, on_conflict=None):
+        existing = self.storage.setdefault(self.name, [])
+        keys = [c.strip() for c in str(on_conflict or "").split(",") if c.strip()]
+        existing_keys = {tuple(row.get(k) for k in keys) for row in existing} if keys else set()
+        for row in rows:
+            key = tuple(row.get(k) for k in keys) if keys else None
+            if key is not None and key in existing_keys:
+                continue
+            existing.append(row)
+            if key is not None:
+                existing_keys.add(key)
+        return self
+
+    def execute(self):
+        data = list(self.storage.get(self.name, []))
+        for op, column, value in self.filters:
+            if op == "eq":
+                data = [row for row in data if str(row.get(column)) == str(value)]
+            elif op == "in":
+                data = [row for row in data if str(row.get(column)) in {str(v) for v in value}]
+        if self.pending_update is not None:
+            for row in data:
+                row.update(self.pending_update)
+            self.storage[self.name] = self.storage.get(self.name, [])
+            return SimpleNamespace(data=data)
+        return SimpleNamespace(data=data)
+
+
+class FakeSupabase:
+    def __init__(self, storage=None):
+        self.storage = storage or {}
+
+    def table(self, name):
+        return FakeTable(self.storage, name)
+
+
+def _build_league_context(is_active: bool) -> SimpleNamespace:
+    df_leagues = pd.DataFrame(
+        [
+            {
+                "league_name": "Spring 2024 Ladder",
+                "player_id": 1,
+                "rating": 1600,
+                "starting_rating": 1400,
+                "wins": 9,
+                "losses": 3,
+                "matches_played": 12,
+            },
+            {
+                "league_name": "Spring 2024 Ladder",
+                "player_id": 2,
+                "rating": 1700,
+                "starting_rating": 1500,
+                "wins": 10,
+                "losses": 2,
+                "matches_played": 12,
+            },
+        ]
+    )
+    df_meta = pd.DataFrame(
+        [
+            {
+                "league_name": "Spring 2024 Ladder",
+                "min_games": 6,
+                "is_active": is_active,
+                "status": "completed" if not is_active else "active",
+            }
+        ]
+    )
+    return SimpleNamespace(
+        df_leagues=df_leagues,
+        df_meta=df_meta,
+        id_to_name={1: "Ace", 2: "Blaze"},
+        club_id="club",
+    )
+
+
+def test_top_performer_candidates_require_ended_league():
+    active_ctx = _build_league_context(is_active=True)
+    active_candidates = list(
+        compute_candidates_for_club(
+            "club",
+            league_id="Spring 2024 Ladder",
+            ctx=active_ctx,
+            status="seasonal",
+            award_timing="on_league_close",
+        )
+    )
+    top_performer_ids = set(TOP_PERFORMER_BADGE_IDS.values())
+    assert not [c for c in active_candidates if c.badge_id in top_performer_ids]
+
+    ended_ctx = _build_league_context(is_active=False)
+    ended_candidates = list(
+        compute_candidates_for_club(
+            "club",
+            league_id="Spring 2024 Ladder",
+            ctx=ended_ctx,
+            status="seasonal",
+            award_timing="on_league_close",
+        )
+    )
+    assert [c for c in ended_candidates if c.badge_id in top_performer_ids]
+
+
+def test_end_league_award_is_idempotent():
+    storage = {
+        "leagues_metadata": [
+            {
+                "club_id": "club",
+                "league_name": "Spring 2024 Ladder",
+                "is_active": True,
+                "status": "active",
+                "min_games": 6,
+            }
+        ]
+    }
+    supabase = FakeSupabase(storage)
+    ctx = _build_league_context(is_active=True)
+    ctx.supabase = supabase
+    ctx.public_mode = False
+
+    end_league_and_award_top_performers(ctx, "Spring 2024 Ladder", admin_id="admin")
+    end_league_and_award_top_performers(ctx, "Spring 2024 Ladder", admin_id="admin")
+
+    inserted = storage.get("player_badges", [])
+    unique_keys = {
+        (row.get("club_id"), row.get("player_id"), row.get("badge_id"), row.get("context_id"))
+        for row in inserted
+    }
+    assert len(unique_keys) == len(inserted)

--- a/tests/test_player_trophy_room.py
+++ b/tests/test_player_trophy_room.py
@@ -5,6 +5,8 @@ import pandas as pd
 from jupr_app.domain.gamification.podium_awards import award_league_podium_badges
 from jupr_app.ui.pages.players import (
     _decorate_trophies_with_leagues,
+    _format_top_performer_rank,
+    _format_top_performer_title,
     build_inactive_league_options,
     filter_player_league_trophies,
     get_player_trophy_case,
@@ -236,3 +238,12 @@ def test_decorate_trophies_handles_missing_prestige_column():
     decorated = _decorate_trophies_with_leagues(df, {})
 
     assert decorated["prestige_num"].tolist() == [0, 0]
+
+
+def test_top_performer_title_uses_category_label_without_badge_name():
+    title = _format_top_performer_title(None, "Most Wins")
+    assert "Most Wins" in title
+
+
+def test_top_performer_rank_formats_rank():
+    assert _format_top_performer_rank({"rank": 1}) == "#1"

--- a/tests/test_top_performer_awards.py
+++ b/tests/test_top_performer_awards.py
@@ -140,6 +140,7 @@ def test_ensure_league_top_performer_awards_is_idempotent():
             {
                 "league_name": "Spring 2024 Ladder",
                 "min_games": 6,
+                "is_active": False,
             }
         ]
     )


### PR DESCRIPTION
### Motivation
- Ensure Top Performer badges are only computed and awarded when a league is closed, and provide an admin workflow to end a league and confirm winners before awarding.
- Make the Player Trophy Case render Top Performer category and rank even when the badge `name` is missing.
- Keep awarding idempotent and backwards-compatible with existing league metadata.

### Description
- Added a new domain helper `jupr_app/domain/leagues.py` with `get_league_meta_row`, `is_league_ended`, `compute_top_performer_preview`, and `end_league_and_award_top_performers` to snapshot winners, update metadata, and call the badge engine for awarding.
- Gated Top Performer candidate generation by league-ended predicate by importing `get_league_meta_row` / `is_league_ended` into `jupr_app/domain/gamification/evaluators.py` so Top Performer candidates are only produced for ended leagues.
- Wired an admin UI in `jupr_app/ui/pages/league_manager.py` under an “End League” expander that shows a preview table of Top Performer winners, requires confirmation, then marks the league ended (`is_active=false`, `status='completed'`, `ended_at`, `ended_by`, `end_awards`) and triggers awarding via the badge engine.
- Improved Player Trophy Case rendering in `jupr_app/ui/pages/players.py` to display `Top Performer: {category_label}` and show rank (e.g. `#1`) taken from `value_json`, defending against missing badge rows or `name` values.
- Added a migration `migrations/20260215_end_league_top_performers.sql` that adds `ended_at`, `ended_by`, `status`, and `end_awards` to `leagues_metadata` and upserts the four Top Performer badge definitions into `badges` (on conflict DO UPDATE).
- Tests and helpers reused existing `ensure_badges` / `upsert_player_badges` which employ upsert-on-conflict and the existing unique constraint on `player_badges` to keep awarding idempotent.

### Testing
- Added `tests/test_end_league_top_performers.py` and updated `tests/test_top_performer_awards.py` and `tests/test_player_trophy_room.py` to cover gating, idempotency, and trophy formatting.
- Ran: `pytest tests/test_end_league_top_performers.py tests/test_top_performer_awards.py tests/test_player_trophy_room.py` and all tests passed (12 passed).
- Unit tests verify that active leagues do not produce Top Performer candidates, ended leagues do, `end_league_and_award_top_performers` is idempotent, and trophy title/rank formatting works when badge names are missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e5df359b48326aa7a9856f45a0461)