### PR TITLE
Badge Codex: switch to badge-first catalog with lazy-loaded, paginated earners

### DIFF
--- a/jupr_app/ui/pages/badge_codex.py
+++ b/jupr_app/ui/pages/badge_codex.py
@@ -2,115 +2,188 @@ from __future__ import annotations
 
 import logging
 
-import pandas as pd
 import streamlit as st
 
-from jupr_app.domain.gamification.profile import build_gamification_summary
 from jupr_app.ui.helpers import display_requirement_text
 from jupr_app.ui.pages.players import badge_icon
 
 logger = logging.getLogger(__name__)
 
+EARNS_PAGE_SIZE = 25
 
-def _player_options(df_players: pd.DataFrame) -> list[tuple[str, int]]:
-    if df_players is None or df_players.empty:
+def _badge_earner_counts(df_player_badges) -> dict[str, int]:
+    if df_player_badges is None or df_player_badges.empty:
+        return {}
+    if "badge_id" not in df_player_badges.columns or "player_id" not in df_player_badges.columns:
+        return {}
+    unique = df_player_badges.drop_duplicates(subset=["badge_id", "player_id"])
+    counts = unique["badge_id"].astype(str).value_counts()
+    return {str(k): int(v) for k, v in counts.to_dict().items()}
+
+
+def get_all_badges(df_badges, df_player_badges) -> list[dict]:
+    if df_badges is None or df_badges.empty:
         return []
-    if "id" not in df_players.columns or "name" not in df_players.columns:
-        return []
-    options = []
-    for row in df_players.itertuples(index=False):
-        try:
-            pid = int(getattr(row, "id"))
-        except Exception:
-            continue
-        name = str(getattr(row, "name", "") or "").strip() or f"Player {pid}"
-        options.append((name, pid))
-    return sorted(options, key=lambda x: x[0].lower())
+    earners_map = _badge_earner_counts(df_player_badges)
+    has_player_badges = df_player_badges is not None
+    badges = []
+    for row in df_badges.itertuples(index=False):
+        badge_id = str(getattr(row, "badge_id", "") or "")
+        name = str(getattr(row, "name", "") or "Badge")
+        earners_count = earners_map.get(badge_id)
+        if earners_count is None and has_player_badges:
+            earners_count = 0
+        badges.append(
+            {
+                "badge_id": badge_id,
+                "name": name,
+                "category": getattr(row, "category", None),
+                "prestige": getattr(row, "prestige", 0),
+                "requirements": getattr(row, "requirements", None),
+                "earners_count": earners_count,
+            }
+        )
+    return sorted(badges, key=lambda item: item["name"].lower())
+
+
+def get_badge_earners_page(
+    df_player_badges,
+    df_players,
+    badge_id: str,
+    offset: int,
+    limit: int,
+) -> tuple[list[dict], int]:
+    if df_player_badges is None or df_player_badges.empty:
+        return [], 0
+    if "badge_id" not in df_player_badges.columns or "player_id" not in df_player_badges.columns:
+        raise ValueError("Player badge data is missing required columns.")
+    badge_id = str(badge_id)
+    df_filtered = df_player_badges[df_player_badges["badge_id"].astype(str) == badge_id]
+    if df_filtered.empty:
+        return [], 0
+    if "earned_at" in df_filtered.columns:
+        df_filtered = df_filtered.sort_values("earned_at", ascending=False)
+    df_filtered = df_filtered.drop_duplicates(subset=["player_id"])
+    total = len(df_filtered)
+    df_page = df_filtered.iloc[int(offset) : int(offset) + int(limit)]
+
+    player_names = {}
+    if df_players is not None and not df_players.empty and "id" in df_players.columns:
+        names = df_players["name"] if "name" in df_players.columns else None
+        if names is not None:
+            player_names = dict(zip(df_players["id"], names.astype(str)))
+
+    earners = []
+    for row in df_page.itertuples(index=False):
+        player_id = getattr(row, "player_id", None)
+        name = player_names.get(player_id, f"Player {player_id}")
+        earners.append({"player_id": player_id, "name": name})
+
+    return earners, total
+
+
+def _get_badge_state(badge_id: str, total_known: int | None) -> dict:
+    key = f"badge_codex_state_{badge_id}"
+    if key not in st.session_state:
+        st.session_state[key] = {
+            "earners": [],
+            "offset": 0,
+            "total": total_known,
+            "has_more": total_known is None or total_known > 0,
+            "loading": False,
+            "error": None,
+        }
+    return st.session_state[key]
+
+
+def _load_more_earners(state: dict, badge_id: str, df_player_badges, df_players) -> None:
+    if state["loading"] or state.get("has_more") is False:
+        return
+    state["loading"] = True
+    try:
+        new_earners, total = get_badge_earners_page(
+            df_player_badges,
+            df_players,
+            badge_id,
+            state["offset"],
+            EARNS_PAGE_SIZE,
+        )
+        state["earners"].extend(new_earners)
+        state["offset"] += len(new_earners)
+        state["total"] = total
+        state["has_more"] = state["offset"] < total
+        state["error"] = None
+    except Exception as exc:  # noqa: BLE001 - surface per-badge errors
+        state["error"] = str(exc)
+    finally:
+        state["loading"] = False
 
 
 def render(ctx) -> None:
     st.header("Badge Codex")
     st.caption("A full ledger of badges, with reels for the ones already on tape.")
 
-    df_players = getattr(ctx, "df_players_active", None)
-    if df_players is None or df_players.empty:
-        df_players = getattr(ctx, "df_players_all", None)
-
-    options = _player_options(df_players)
-    if not options:
-        st.info("No player list available.")
-        return
-
-    names = [name for name, _ in options]
-    selected_name = st.selectbox("Player", names, index=0)
-    player_id = next(pid for name, pid in options if name == selected_name)
+    df_players = getattr(ctx, "df_players_all", None)
 
     badge_defs = getattr(ctx, "df_badges", None)
     player_badges = getattr(ctx, "df_player_badges", None)
-    if badge_defs is None or player_badges is None:
+    if badge_defs is None:
         st.info("Badge data is still loading.")
         return
 
-    summary = build_gamification_summary(player_id, badge_defs, player_badges)
-    unlocked_badges = summary.get("unlocked_badges", [])
-    locked_badges = summary.get("locked_badges", [])
-
-    stat_cols = st.columns(2)
-    stat_cols[0].metric("Prestige", int(summary.get("prestige_total", 0)))
-    stat_cols[1].metric(
-        "Collection",
-        f"{summary.get('collected_unique_count', 0)}/{summary.get('total_active_badge_types', 0)}",
-    )
-
-    all_badges = []
-    for badge in unlocked_badges:
-        badge_copy = dict(badge)
-        badge_copy["status"] = "unlocked"
-        all_badges.append(badge_copy)
-    for badge in locked_badges:
-        badge_copy = dict(badge)
-        badge_copy["status"] = "locked"
-        all_badges.append(badge_copy)
-
-    categories = sorted({b.get("category") or "Other" for b in all_badges})
-    rarities = sorted({b.get("rarity") or "common" for b in all_badges})
-
-    with st.expander("Filters", expanded=False):
-        selected_categories = st.multiselect("Category", categories, default=categories)
-        selected_rarities = st.multiselect("Rarity", rarities, default=rarities)
-        show_unlocked = st.checkbox("Show unlocked", value=True)
-        show_locked = st.checkbox("Show locked", value=True)
-        show_stackable = st.checkbox("Only stackable", value=False)
-
-    def _visible(badge: dict) -> bool:
-        category = badge.get("category") or "Other"
-        rarity = badge.get("rarity") or "common"
-        if category not in selected_categories or rarity not in selected_rarities:
-            return False
-        if badge.get("status") == "unlocked" and not show_unlocked:
-            return False
-        if badge.get("status") == "locked" and not show_locked:
-            return False
-        if show_stackable and not bool(badge.get("stack_count", 0) > 1 or badge.get("is_stackable")):
-            return False
-        return True
-
-    visible_badges = [b for b in all_badges if _visible(b)]
-    if not visible_badges:
-        st.caption("No badges match the filters.")
+    badges = get_all_badges(badge_defs, player_badges)
+    if not badges:
+        st.caption("No badges are available yet.")
         return
 
-    grid_cols = st.columns(4)
-    for idx, badge in enumerate(visible_badges):
-        with grid_cols[idx % len(grid_cols)]:
-            status = badge.get("status")
-            name = badge.get("name", "Badge")
-            prestige = int(badge.get("prestige", 0) or 0)
-            if status == "locked":
-                icon = "🔒"
-            else:
-                icon = badge_icon(badge.get("badge_id"), badge.get("category"))
+    for badge in badges:
+        badge_id = badge.get("badge_id", "")
+        name = badge.get("name", "Badge")
+        icon = badge_icon(badge_id, badge.get("category"))
+        requirements = display_requirement_text(badge.get("requirements"))
+        earners_count = badge.get("earners_count")
+
+        with st.container():
             st.markdown(f"**{icon} {name}**")
-            st.caption(f"Prestige {prestige}")
-            requirements = display_requirement_text(badge.get("requirements"))
             st.markdown(requirements)
+            if earners_count is not None:
+                st.caption(f"{earners_count} earners")
+
+            expanded = st.toggle("Show earners", key=f"badge_codex_toggle_{badge_id}")
+            if expanded:
+                state = _get_badge_state(badge_id, earners_count)
+                if earners_count == 0:
+                    st.caption("No one has earned this badge yet.")
+
+                if (
+                    earners_count != 0
+                    and not state["earners"]
+                    and not state["loading"]
+                    and state["error"] is None
+                ):
+                    _load_more_earners(state, badge_id, player_badges, df_players)
+
+                if state["error"]:
+                    st.error(f"Could not load earners. {state['error']}")
+                    if st.button("Retry", key=f"badge_codex_retry_{badge_id}"):
+                        state["error"] = None
+                        _load_more_earners(state, badge_id, player_badges, df_players)
+
+                if state["loading"]:
+                    st.info("Loading earners...")
+
+                if state["earners"]:
+                    st.caption(
+                        f"Earned by {state['total']} players" if state.get("total") is not None else "Earners"
+                    )
+                    for earner in state["earners"]:
+                        st.markdown(f"- 👤 {earner['name']}")
+
+                if earners_count != 0 and state.get("total") == 0 and not state["loading"] and state["error"] is None:
+                    st.caption("No one has earned this badge yet.")
+
+                if state.get("has_more") and not state["loading"]:
+                    if st.button("Load more", key=f"badge_codex_load_more_{badge_id}"):
+                        _load_more_earners(state, badge_id, player_badges, df_players)
+
+            st.divider()

--- a/tests/test_badge_codex_badge_first.py
+++ b/tests/test_badge_codex_badge_first.py
@@ -1,0 +1,51 @@
+import pandas as pd
+
+from jupr_app.ui.pages.badge_codex import get_all_badges, get_badge_earners_page
+
+
+def test_get_all_badges_includes_requirements_and_counts():
+    df_badges = pd.DataFrame(
+        [
+            {"badge_id": "b1", "name": "Alpha", "requirements": "Win 1 match"},
+            {"badge_id": "b2", "name": "Beta", "requirements": "Win 2 matches"},
+        ]
+    )
+    df_player_badges = pd.DataFrame(
+        [
+            {"badge_id": "b1", "player_id": 1, "earned_at": "2023-01-01"},
+            {"badge_id": "b1", "player_id": 1, "earned_at": "2023-02-01"},
+            {"badge_id": "b1", "player_id": 2, "earned_at": "2023-03-01"},
+        ]
+    )
+
+    badges = get_all_badges(df_badges, df_player_badges)
+
+    assert [badge["badge_id"] for badge in badges] == ["b1", "b2"]
+    assert badges[0]["requirements"] == "Win 1 match"
+    assert badges[0]["earners_count"] == 2
+    assert badges[1]["earners_count"] == 0
+
+
+def test_get_badge_earners_page_paginates_and_maps_names():
+    df_player_badges = pd.DataFrame(
+        [
+            {"badge_id": "b1", "player_id": 1, "earned_at": "2023-01-01"},
+            {"badge_id": "b1", "player_id": 2, "earned_at": "2023-02-01"},
+            {"badge_id": "b1", "player_id": 3, "earned_at": "2023-03-01"},
+        ]
+    )
+    df_players = pd.DataFrame(
+        [
+            {"id": 1, "name": "Ada"},
+            {"id": 2, "name": "Bela"},
+            {"id": 3, "name": "Chen"},
+        ]
+    )
+
+    page_one, total = get_badge_earners_page(df_player_badges, df_players, "b1", 0, 2)
+    page_two, total_two = get_badge_earners_page(df_player_badges, df_players, "b1", 2, 2)
+
+    assert total == 3
+    assert total_two == 3
+    assert [row["name"] for row in page_one] == ["Chen", "Bela"]
+    assert [row["name"] for row in page_two] == ["Ada"]


### PR DESCRIPTION
### Motivation
- Move the Codex away from a player-first view to a badge-first encyclopedia so users can browse all badge definitions by default. 
- Avoid fetching all badge earners eagerly and provide per-badge lazy loading to keep the list performant and resilient to large clubs.

### Description
- Replaced player selector flow and profile-based badge aggregation with a badge catalog rendered from `df_badges` via a new `get_all_badges` helper. 
- Added paginated, lazy-loading earner retrieval via `get_badge_earners_page`, plus per-badge session-state caching and `_load_more_earners` to avoid refetching and to guard concurrent loads. 
- UI changes render each badge collapsed with icon, name, and requirements, and an expandable section that loads earners on demand with inline loading, error + retry, and "Load more" pagination. 
- Key files changed: `jupr_app/ui/pages/badge_codex.py` (primary UI + helpers) and new tests `tests/test_badge_codex_badge_first.py`.

### Testing
- Ran `pytest tests/test_badge_codex_badge_first.py` and the new tests passed (2 passed). 
- Unit tests cover `get_all_badges` for requirements and earner counts and `get_badge_earners_page` for pagination and name mapping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e614d20f88326882378aa4cad73ad)