### PR TITLE
Badge Codex: compact sectioned grid and detail dialog

### DIFF
--- a/jupr_app/ui/pages/badge_codex.py
+++ b/jupr_app/ui/pages/badge_codex.py
@@ -11,6 +11,9 @@ logger = logging.getLogger(__name__)
 
 EARNS_PAGE_SIZE = 25
 
+SECTION_ORDER = ["Common", "Uncommon", "Rare", "Legendary", "Unclaimed", "Unranked", "Other"]
+
+
 def _badge_earner_counts(df_player_badges) -> dict[str, int]:
     if df_player_badges is None or df_player_badges.empty:
         return {}
@@ -44,6 +47,74 @@ def get_all_badges(df_badges, df_player_badges) -> list[dict]:
             }
         )
     return sorted(badges, key=lambda item: item["name"].lower())
+
+
+def _summarize_requirement(requirements) -> str:
+    text = display_requirement_text(requirements)
+    if not text:
+        return "Req: -"
+    normalized = " ".join(str(text).split())
+    if len(normalized) > 40:
+        normalized = f"{normalized[:37].rstrip()}..."
+    return f"Req: {normalized}"
+
+
+def _group_badges(badges: list[dict]) -> list[tuple[str, list[dict]]]:
+    has_category = any(badge.get("category") for badge in badges)
+    sections: dict[str, list[dict]] = {}
+
+    for badge in badges:
+        if has_category:
+            section = badge.get("category") or "Other"
+        else:
+            earners_count = badge.get("earners_count")
+            if earners_count is None:
+                section = "Unranked"
+            elif earners_count == 0:
+                section = "Unclaimed"
+            elif earners_count >= 100:
+                section = "Common"
+            elif earners_count >= 25:
+                section = "Uncommon"
+            elif earners_count >= 5:
+                section = "Rare"
+            else:
+                section = "Legendary"
+        sections.setdefault(section, []).append(badge)
+
+    if has_category:
+        ordered_sections = sorted(sections.items(), key=lambda item: str(item[0]).lower())
+    else:
+        order_index = {name: idx for idx, name in enumerate(SECTION_ORDER)}
+        ordered_sections = sorted(
+            sections.items(),
+            key=lambda item: (order_index.get(item[0], len(order_index)), str(item[0]).lower()),
+        )
+
+    return [(section, sorted(items, key=lambda item: item["name"].lower())) for section, items in ordered_sections]
+
+
+def _render_badge_card(badge: dict, column, open_key: str) -> None:
+    badge_id = badge.get("badge_id", "")
+    name = badge.get("name", "Badge")
+    icon = badge_icon(badge_id, badge.get("category"))
+    requirements_summary = _summarize_requirement(badge.get("requirements"))
+    earners_count = badge.get("earners_count")
+
+    with column:
+        st.markdown(
+            f"""
+            <div class="badge-card">
+                <div class="badge-card__icon">{icon}</div>
+                <div class="badge-card__name" title="{name}">{name}</div>
+                <div class="badge-card__req">{requirements_summary}</div>
+                <div class="badge-card__meta">{'' if earners_count is None else f'{earners_count} earners'}</div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        if st.button("View details", key=open_key, use_container_width=True):
+            st.session_state["badge_codex_open"] = badge_id
 
 
 def get_badge_earners_page(
@@ -123,6 +194,51 @@ def render(ctx) -> None:
     st.header("Badge Codex")
     st.caption("A full ledger of badges, with reels for the ones already on tape.")
 
+    st.markdown(
+        """
+        <style>
+            .badge-card {
+                border: 1px solid var(--border);
+                border-radius: 12px;
+                padding: 12px;
+                min-height: 170px;
+                display: flex;
+                flex-direction: column;
+                justify-content: space-between;
+                background: var(--panel);
+            }
+            .badge-card__icon {
+                font-size: 32px;
+                line-height: 1;
+            }
+            .badge-card__name {
+                font-weight: 600;
+                font-size: 0.95rem;
+                line-height: 1.2;
+                display: -webkit-box;
+                -webkit-line-clamp: 2;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                min-height: 2.4em;
+            }
+            .badge-card__req {
+                font-size: 0.8rem;
+                color: var(--text-muted);
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+            .badge-card__meta {
+                font-size: 0.75rem;
+                color: var(--text-muted);
+                min-height: 1.2em;
+            }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
     df_players = getattr(ctx, "df_players_all", None)
 
     badge_defs = getattr(ctx, "df_badges", None)
@@ -136,54 +252,72 @@ def render(ctx) -> None:
         st.caption("No badges are available yet.")
         return
 
-    for badge in badges:
-        badge_id = badge.get("badge_id", "")
-        name = badge.get("name", "Badge")
-        icon = badge_icon(badge_id, badge.get("category"))
-        requirements = display_requirement_text(badge.get("requirements"))
-        earners_count = badge.get("earners_count")
+    sections = _group_badges(badges)
 
-        with st.container():
-            st.markdown(f"**{icon} {name}**")
-            st.markdown(requirements)
-            if earners_count is not None:
-                st.caption(f"{earners_count} earners")
+    for section_name, items in sections:
+        st.subheader(section_name)
+        columns = st.columns(3)
+        for idx, badge in enumerate(items):
+            _render_badge_card(
+                badge,
+                columns[idx % 3],
+                open_key=f"badge_codex_open_{badge.get('badge_id', '')}",
+            )
+        st.markdown("<div style='height: 0.5rem'></div>", unsafe_allow_html=True)
 
-            expanded = st.toggle("Show earners", key=f"badge_codex_toggle_{badge_id}")
-            if expanded:
-                state = _get_badge_state(badge_id, earners_count)
-                if earners_count == 0:
-                    st.caption("No one has earned this badge yet.")
+    selected_badge_id = st.session_state.get("badge_codex_open")
+    if selected_badge_id:
+        selected_badge = next((badge for badge in badges if badge.get("badge_id") == selected_badge_id), None)
+        if selected_badge:
+            badge_id = selected_badge.get("badge_id", "")
+            name = selected_badge.get("name", "Badge")
+            icon = badge_icon(badge_id, selected_badge.get("category"))
+            requirements = display_requirement_text(selected_badge.get("requirements"))
+            earners_count = selected_badge.get("earners_count")
 
-                if (
-                    earners_count != 0
-                    and not state["earners"]
-                    and not state["loading"]
-                    and state["error"] is None
-                ):
-                    _load_more_earners(state, badge_id, player_badges, df_players)
+            with st.dialog(f"{icon} {name}"):
+                st.markdown(requirements)
+                st.caption(f"{earners_count} earners" if earners_count is not None else "Earners")
 
-                if state["error"]:
-                    st.error(f"Could not load earners. {state['error']}")
-                    if st.button("Retry", key=f"badge_codex_retry_{badge_id}"):
-                        state["error"] = None
+                expanded = st.toggle("Show earners", key=f"badge_codex_toggle_{badge_id}")
+                if expanded:
+                    state = _get_badge_state(badge_id, earners_count)
+                    if earners_count == 0:
+                        st.caption("No one has earned this badge yet.")
+
+                    if (
+                        earners_count != 0
+                        and not state["earners"]
+                        and not state["loading"]
+                        and state["error"] is None
+                    ):
                         _load_more_earners(state, badge_id, player_badges, df_players)
 
-                if state["loading"]:
-                    st.info("Loading earners...")
+                    if state["error"]:
+                        st.error(f"Couldn’t load earners. {state['error']}")
+                        if st.button("Retry", key=f"badge_codex_retry_{badge_id}"):
+                            state["error"] = None
+                            _load_more_earners(state, badge_id, player_badges, df_players)
 
-                if state["earners"]:
-                    st.caption(
-                        f"Earned by {state['total']} players" if state.get("total") is not None else "Earners"
-                    )
-                    for earner in state["earners"]:
-                        st.markdown(f"- 👤 {earner['name']}")
+                    if state["loading"]:
+                        st.info("Loading earners...")
 
-                if earners_count != 0 and state.get("total") == 0 and not state["loading"] and state["error"] is None:
-                    st.caption("No one has earned this badge yet.")
+                    if state["earners"]:
+                        st.caption(
+                            f"Earned by {state['total']} players" if state.get("total") is not None else "Earners"
+                        )
+                        for earner in state["earners"]:
+                            st.markdown(f"- 👤 {earner['name']}")
 
-                if state.get("has_more") and not state["loading"]:
-                    if st.button("Load more", key=f"badge_codex_load_more_{badge_id}"):
-                        _load_more_earners(state, badge_id, player_badges, df_players)
+                    if (
+                        earners_count != 0
+                        and state.get("total") == 0
+                        and not state["loading"]
+                        and state["error"] is None
+                    ):
+                        st.caption("No one has earned this badge yet.")
 
-            st.divider()
+                    if state.get("has_more") and not state["loading"]:
+                        if st.button("Load more", key=f"badge_codex_load_more_{badge_id}"):
+                            _load_more_earners(state, badge_id, player_badges, df_players)
+            st.session_state["badge_codex_open"] = None

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -872,19 +872,19 @@ def render(ctx):
             margin-bottom: 0.75rem;
         }
         .badge-stat {
-            background: var(--panel, rgba(255,255,255,0.04));
-            border: 1px solid var(--border, rgba(255,255,255,0.10));
+            background: var(--panel);
+            border: 1px solid var(--border);
             box-shadow: var(--shadow, none);
             border-radius: 0.75rem;
             padding: 0.75rem 0.9rem;
             min-width: 120px;
-            color: var(--text-primary, rgba(255,255,255,0.92));
+            color: var(--text-primary);
         }
         .badge-stat-label {
             font-size: 0.7rem;
             text-transform: uppercase;
             letter-spacing: 0.08em;
-            color: var(--text-secondary, rgba(255,255,255,0.80));
+            color: var(--text-secondary);
         }
         .badge-stat-value {
             font-size: 1.6rem;
@@ -902,11 +902,11 @@ def render(ctx):
             align-items: center;
             padding: 0.25rem 0.5rem;
             border-radius: 999px;
-            border: 1px solid var(--border, rgba(255,255,255,0.10));
-            background: var(--pill-bg, rgba(255,255,255,0.04));
+            border: 1px solid var(--border);
+            background: var(--pill-bg);
             font-size: 0.8rem;
             max-width: 180px;
-            color: var(--text-primary, rgba(255,255,255,0.92));
+            color: var(--text-primary);
         }
         .trophy-section {
             display: flex;
@@ -918,7 +918,7 @@ def render(ctx):
             font-size: 0.7rem;
             text-transform: uppercase;
             letter-spacing: 0.08em;
-            color: var(--text-secondary, rgba(255,255,255,0.80));
+            color: var(--text-secondary);
         }
         .trophy-chip-row {
             display: flex;
@@ -928,7 +928,7 @@ def render(ctx):
         }
         .trophy-league {
             font-size: 0.78rem;
-            color: var(--text-muted, rgba(255,255,255,0.65));
+            color: var(--text-muted);
         }
         .trophy-chip {
             display: inline-flex;
@@ -936,12 +936,12 @@ def render(ctx):
             align-items: flex-start;
             padding: 0.35rem 0.6rem;
             border-radius: 0.75rem;
-            border: 1px solid var(--border, rgba(255,255,255,0.10));
-            background: var(--panel, rgba(255,255,255,0.04));
+            border: 1px solid var(--border);
+            background: var(--panel);
             box-shadow: var(--shadow, none);
             font-size: 0.8rem;
             max-width: 320px;
-            color: var(--text-primary, rgba(255,255,255,0.92));
+            color: var(--text-primary);
         }
         .trophy-text {
             display: flex;
@@ -955,7 +955,7 @@ def render(ctx):
         }
         .trophy-body {
             font-size: 0.7rem;
-            color: var(--text-muted, rgba(255,255,255,0.65));
+            color: var(--text-muted);
         }
         .trophy-case-grid {
             display: grid;
@@ -964,14 +964,14 @@ def render(ctx):
         }
         .trophy-case-card {
             border-radius: 0.85rem;
-            border: 1px solid var(--border, rgba(255,255,255,0.12));
-            background: var(--panel, rgba(255,255,255,0.04));
+            border: 1px solid var(--border);
+            background: var(--panel);
             box-shadow: var(--shadow, none);
             padding: 0.8rem 0.85rem;
             display: flex;
             flex-direction: column;
             gap: 0.35rem;
-            color: var(--text-primary, rgba(255,255,255,0.92));
+            color: var(--text-primary);
         }
         .trophy-case-header {
             display: flex;
@@ -981,7 +981,7 @@ def render(ctx):
         }
         .trophy-case-meta {
             font-size: 0.75rem;
-            color: var(--text-muted, rgba(255,255,255,0.65));
+            color: var(--text-muted);
         }
         .badge-grid {
             display: grid;
@@ -1003,17 +1003,17 @@ def render(ctx):
         }
         .badge-card {
             border-radius: 0.8rem;
-            border: 1px solid var(--border, rgba(255,255,255,0.10));
-            background: var(--panel, rgba(255,255,255,0.04));
+            border: 1px solid var(--border);
+            background: var(--panel);
             box-shadow: var(--shadow, none);
             padding: 0.7rem 0.8rem;
             display: flex;
             flex-direction: column;
             gap: 0.35rem;
-            color: var(--text-primary, rgba(255,255,255,0.92));
+            color: var(--text-primary);
         }
         .badge-card.silhouette {
-            background: var(--panel, rgba(255,255,255,0.04));
+            background: var(--panel);
             opacity: 0.7;
         }
         .badge-card-header {
@@ -1024,7 +1024,7 @@ def render(ctx):
         }
         .badge-subtext {
             font-size: 0.75rem;
-            color: var(--text-muted, rgba(255,255,255,0.65));
+            color: var(--text-muted);
         }
         .badge-subtext p {
             margin: 0;


### PR DESCRIPTION
### Motivation
- The Badge Codex was becoming too verbose and hard to scan, so the UI needs to return to a compact, square-card grid for faster visual scanning.
- Users should still be able to see full requirements and the earners list without breaking the grid layout, so a compact detail surface is required.
- The UI should avoid hard-coded color literals and rely on theme tokens for consistent theming across screens.

### Description
- Replaced the old vertical/accordion list with a sectioned grid of compact square badge cards and a deterministic grouping strategy via `category` or fallback rarity buckets (Common/Uncommon/Rare/Legendary/Unclaimed/Unranked/Other). (`jupr_app/ui/pages/badge_codex.py`)
- Each card shows the badge icon, truncated name, a one-line requirement summary (`_summarize_requirement`), and an optional earners count, and opens a compact detail dialog when tapped (`_render_badge_card` + dialog rendering). (`jupr_app/ui/pages/badge_codex.py`)
- Badge detail is presented in a dialog that shows full requirements and the earners section which is lazy-loaded, paginated, cached per-badge, and surfaces per-badge empty/error states with retry and `Load more` support. (`_get_badge_state`, `_load_more_earners`, earners rendering)
- Aligned CSS in the players/trophy views to use theme variables instead of hard-coded `rgba` literals (replaced inline color literals with `var(--...)` tokens) to satisfy theming rules. (`jupr_app/ui/pages/players.py`)

### Testing
- Ran the full test suite with `pytest` and all tests passed (`83 passed`).
- Verified the color-token test failure was addressed by switching hard-coded CSS color usages to theme variables, after which the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e6a102d5c8326b9185a4003b4f21a)