### PR TITLE
Badge Codex: open details view and lazy-load paginated Earners

### DIFF
--- a/jupr_app/ui/pages/badge_codex.py
+++ b/jupr_app/ui/pages/badge_codex.py
@@ -115,6 +115,7 @@ def _render_badge_card(badge: dict, column, open_key: str) -> None:
         )
         if st.button("View details", key=open_key, use_container_width=True):
             st.session_state["badge_codex_open"] = badge_id
+            st.session_state["badge_codex_details_open"] = True
 
 
 def get_badge_earners_page(
@@ -190,6 +191,73 @@ def _load_more_earners(state: dict, badge_id: str, df_player_badges, df_players)
         state["loading"] = False
 
 
+def _render_earners_section(badge_id: str, earners_count, df_player_badges, df_players) -> None:
+    state = _get_badge_state(badge_id, earners_count)
+
+    if (
+        earners_count != 0
+        and not state["earners"]
+        and not state["loading"]
+        and state["error"] is None
+        and state.get("offset", 0) == 0
+    ):
+        with st.spinner("Loading earners..."):
+            _load_more_earners(state, badge_id, df_player_badges, df_players)
+
+    with st.expander(
+        f"Earners ({earners_count})" if earners_count is not None else "Earners",
+        expanded=False,
+    ):
+        if earners_count == 0:
+            st.caption("No one has earned this badge yet.")
+
+        if state["error"]:
+            st.error(f"Couldn’t load earners. {state['error']}")
+            if st.button("Retry", key=f"badge_codex_retry_{badge_id}"):
+                state["error"] = None
+                with st.spinner("Loading earners..."):
+                    _load_more_earners(state, badge_id, df_player_badges, df_players)
+
+        if state["loading"]:
+            st.info("Loading earners...")
+
+        if state["earners"]:
+            st.caption(f"Earned by {state['total']} players" if state.get("total") is not None else "Earners")
+            for earner in state["earners"]:
+                st.markdown(f"- 👤 {earner['name']}")
+
+        if (
+            earners_count != 0
+            and state.get("total") == 0
+            and not state["loading"]
+            and state["error"] is None
+        ):
+            st.caption("No one has earned this badge yet.")
+
+        if state.get("has_more") and not state["loading"]:
+            if st.button("Load more", key=f"badge_codex_load_more_{badge_id}"):
+                with st.spinner("Loading earners..."):
+                    _load_more_earners(state, badge_id, df_player_badges, df_players)
+
+
+def _render_badge_details(selected_badge: dict, df_player_badges, df_players) -> None:
+    badge_id = selected_badge.get("badge_id", "")
+    name = selected_badge.get("name", "Badge")
+    icon = badge_icon(badge_id, selected_badge.get("category"))
+    requirements = display_requirement_text(selected_badge.get("requirements"))
+    earners_count = selected_badge.get("earners_count")
+
+    st.markdown(f"### {icon} {name}")
+    st.markdown(requirements)
+    st.caption(f"{earners_count} earners" if earners_count is not None else "Earners")
+    _render_earners_section(badge_id, earners_count, df_player_badges, df_players)
+
+    if st.button("Close", key=f"badge_codex_close_{badge_id}"):
+        st.session_state["badge_codex_open"] = None
+        st.session_state["badge_codex_details_open"] = False
+        st.rerun()
+
+
 def render(ctx) -> None:
     st.header("Badge Codex")
     st.caption("A full ledger of badges, with reels for the ones already on tape.")
@@ -254,6 +322,21 @@ def render(ctx) -> None:
 
     sections = _group_badges(badges)
 
+    selected_badge_id = st.session_state.get("badge_codex_open")
+    details_open = st.session_state.get("badge_codex_details_open")
+    selected_badge = None
+    if selected_badge_id:
+        selected_badge = next((badge for badge in badges if badge.get("badge_id") == selected_badge_id), None)
+
+    dialog = getattr(st, "dialog", None)
+    if details_open and selected_badge:
+        if callable(dialog):
+            with dialog("Badge details"):
+                _render_badge_details(selected_badge, player_badges, df_players)
+        else:
+            with st.container(border=True):
+                _render_badge_details(selected_badge, player_badges, df_players)
+
     for section_name, items in sections:
         st.subheader(section_name)
         columns = st.columns(3)
@@ -264,60 +347,3 @@ def render(ctx) -> None:
                 open_key=f"badge_codex_open_{badge.get('badge_id', '')}",
             )
         st.markdown("<div style='height: 0.5rem'></div>", unsafe_allow_html=True)
-
-    selected_badge_id = st.session_state.get("badge_codex_open")
-    if selected_badge_id:
-        selected_badge = next((badge for badge in badges if badge.get("badge_id") == selected_badge_id), None)
-        if selected_badge:
-            badge_id = selected_badge.get("badge_id", "")
-            name = selected_badge.get("name", "Badge")
-            icon = badge_icon(badge_id, selected_badge.get("category"))
-            requirements = display_requirement_text(selected_badge.get("requirements"))
-            earners_count = selected_badge.get("earners_count")
-
-            with st.dialog(f"{icon} {name}"):
-                st.markdown(requirements)
-                st.caption(f"{earners_count} earners" if earners_count is not None else "Earners")
-
-                expanded = st.toggle("Show earners", key=f"badge_codex_toggle_{badge_id}")
-                if expanded:
-                    state = _get_badge_state(badge_id, earners_count)
-                    if earners_count == 0:
-                        st.caption("No one has earned this badge yet.")
-
-                    if (
-                        earners_count != 0
-                        and not state["earners"]
-                        and not state["loading"]
-                        and state["error"] is None
-                    ):
-                        _load_more_earners(state, badge_id, player_badges, df_players)
-
-                    if state["error"]:
-                        st.error(f"Couldn’t load earners. {state['error']}")
-                        if st.button("Retry", key=f"badge_codex_retry_{badge_id}"):
-                            state["error"] = None
-                            _load_more_earners(state, badge_id, player_badges, df_players)
-
-                    if state["loading"]:
-                        st.info("Loading earners...")
-
-                    if state["earners"]:
-                        st.caption(
-                            f"Earned by {state['total']} players" if state.get("total") is not None else "Earners"
-                        )
-                        for earner in state["earners"]:
-                            st.markdown(f"- 👤 {earner['name']}")
-
-                    if (
-                        earners_count != 0
-                        and state.get("total") == 0
-                        and not state["loading"]
-                        and state["error"] is None
-                    ):
-                        st.caption("No one has earned this badge yet.")
-
-                    if state.get("has_more") and not state["loading"]:
-                        if st.button("Load more", key=f"badge_codex_load_more_{badge_id}"):
-                            _load_more_earners(state, badge_id, player_badges, df_players)
-            st.session_state["badge_codex_open"] = None


### PR DESCRIPTION
### Motivation
- Users could click “View details” but nothing happened and there was no way to inspect the list of players who earned a badge. This change implements the missing detail view and earners UI. 
- The earners list must be loaded lazily, paginated, and cached per-badge to avoid fetching all earners on page load and to provide retry/empty/error states.

### Description
- Wire up the card `View details` button to set `st.session_state['badge_codex_open']` and `st.session_state['badge_codex_details_open']` so clicking a badge opens its detail view. 
- Add a badge detail rendering flow that shows the badge icon, name, full requirements (via `display_requirement_text`), and the earners count in a dialog or inline fallback. 
- Implement an earners expander with per-badge state (`badge_codex_state_<id>`) that lazy-loads the first page, supports `Load more` pagination (page size `EARNS_PAGE_SIZE`), caches results per badge, and surfaces loading/empty/error/retry states. 
- Key file changed: `jupr_app/ui/pages/badge_codex.py` (adds `_render_earners_section`, `_render_badge_details`, and wiring for opening/closing details). 
- Manual test steps: open Badge Codex, click `View details` on a badge, verify full requirements and earners count, expand `Earners` to load the list, click `Load more` when available, and verify the empty state for a badge with 0 earners.

### Testing
- No automated tests were executed for this change (UI-only update).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e6d3e9f548326b4d17017cfd0a8ca)