### PR TITLE
Fix High Roller badge win counting

### DIFF
--- a/jupr_app/domain/gamification/evaluators.py
+++ b/jupr_app/domain/gamification/evaluators.py
@@ -459,8 +459,8 @@ def evaluate_clean_sweep_week(ctx: BadgeEvaluationContext) -> Iterable[BadgeCand
 
 def evaluate_high_roller(ctx: BadgeEvaluationContext) -> Iterable[BadgeCandidate]:
     facts = _as_of_filter(ctx.facts, ctx.as_of)
-    wins = facts[facts["win"] == True]
-    grouped = wins.groupby("player_id").size()
+    wins = facts[facts["win"] == True].dropna(subset=["match_id"])
+    grouped = wins.groupby("player_id")["match_id"].nunique()
     candidates: list[BadgeCandidate] = []
     for player_id, win_count in grouped.items():
         if int(win_count) >= 100:

--- a/tests/test_high_roller_badge.py
+++ b/tests/test_high_roller_badge.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from jupr_app.domain.gamification.badge_types import BadgeEvaluationContext
+from jupr_app.domain.gamification.evaluators import evaluate_high_roller
+
+
+def _context_with_facts(facts: pd.DataFrame) -> BadgeEvaluationContext:
+    return BadgeEvaluationContext(
+        club_id="club",
+        league_id=None,
+        as_of=None,
+        ctx=SimpleNamespace(),
+        facts=facts,
+        matches=facts,
+    )
+
+
+def test_high_roller_counts_distinct_match_wins():
+    rows = []
+    for match_index in range(1, 25):
+        match_id = f"m{match_index}"
+        for _ in range(5):
+            rows.append({"player_id": 1, "match_id": match_id, "win": True})
+    facts = pd.DataFrame(rows)
+    ctx = _context_with_facts(facts)
+
+    candidates = list(evaluate_high_roller(ctx))
+
+    assert candidates == []
+
+
+def test_high_roller_awards_at_100_wins():
+    rows = [{"player_id": 7, "match_id": f"win-{i}", "win": True} for i in range(100)]
+    rows.extend({"player_id": 7, "match_id": f"loss-{i}", "win": False} for i in range(20))
+    facts = pd.DataFrame(rows)
+    ctx = _context_with_facts(facts)
+
+    candidates = list(evaluate_high_roller(ctx))
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.player_id == 7
+    assert candidate.value_json["wins"] == 100


### PR DESCRIPTION
### Motivation
- The High Roller badge ("Record 100+ lifetime match wins") was being awarded incorrectly due to over-counting in the facts table, likely from row duplication after joins or counting games/points instead of matches.
- Badge logic must count one win per match at the match grain and only award when lifetime_match_wins >= 100 so players with e.g. 24 wins are not eligible.

### Description
- Change `evaluate_high_roller` to compute wins by distinct matches by filtering winning rows and using `.dropna(subset=["match_id"])` and `.groupby("player_id")["match_id"].nunique()` instead of counting rows.
- This enforces the correct grain (one win per `match_id`) and is robust to duplicate rows from joins.
- Add `tests/test_high_roller_badge.py` with two regression tests: `test_high_roller_counts_distinct_match_wins` (duplicates per match do not inflate the count) and `test_high_roller_awards_at_100_wins` (exact 100 distinct wins earns the badge).

### Testing
- Ran the full test suite with `pytest -q`, and all tests passed: `86 passed, 12 warnings` (including the two new tests).
- The new tests verify de-duplication and the 100-win threshold and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e79760f7c832682c3611cd67165eb)