### PR TITLE
Add Badge Debug admin view + match filter audit and improved evaluator logging

### DIFF
--- a/docs/badge_debug.md
+++ b/docs/badge_debug.md
@@ -1,0 +1,22 @@
+# Badge Debug (Phase 0)
+
+## Enable the view
+
+1. Log in as an admin in the Streamlit app.
+2. Set one of the following environment variables before starting the app:
+   - `BADGE_DEBUG=1`
+   - `JUPR_ADMIN=1`
+
+With admin login + one of the flags enabled, the **🧪 Badge Debug** page appears in the admin sidebar. If the flag is missing, the page shows a friendly “disabled” message and exits early.
+
+## Use it to debug a player (e.g., Tyson)
+
+1. Open **🧪 Badge Debug**.
+2. Select:
+   - Club (defaults to the active club)
+   - League (or “All leagues”)
+   - Player (searchable by name/id)
+   - Badge
+3. Click **Run Badge Debug**.
+
+The page renders a single “truth table” row with counts, the evaluator candidate rows (including `context_id`, `match_id`, and `value_json`), and a full match filter audit that lists which match IDs were removed at each step. Use the raw vs filtered match ID expanders to pinpoint mismatches quickly.

--- a/jupr_app/domain/gamification/badge_debug.py
+++ b/jupr_app/domain/gamification/badge_debug.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import traceback
+from typing import Any
+
+import pandas as pd
+
+from jupr_app.domain.gamification.badge_registry import registry
+from jupr_app.domain.gamification.badge_types import BadgeCandidate
+from jupr_app.domain.gamification.evaluators import build_evaluation_context
+from jupr_app.domain.match_filters import MatchFilterAudit, MatchFilterAuditStep, apply_match_filters_with_audit
+
+
+@dataclass
+class BadgeDebugReport:
+    club_id: str
+    league_id: str | None
+    player_id: int
+    badge_id: str
+    matches_raw: list[str] = field(default_factory=list)
+    matches_filtered: list[str] = field(default_factory=list)
+    filter_audit_steps: list[MatchFilterAuditStep] = field(default_factory=list)
+    candidates: list[dict[str, Any]] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def build_badge_debug_report(
+    ctx: Any,
+    club_id: str,
+    league_id: str | None,
+    player_id: int,
+    badge_id: str,
+    *,
+    limit_matches: int | None = None,
+    filtered_matches: pd.DataFrame | None = None,
+    match_audit: MatchFilterAudit | None = None,
+) -> BadgeDebugReport:
+    df_matches = getattr(ctx, "df_matches", None)
+    if df_matches is None:
+        df_matches = pd.DataFrame()
+
+    raw_matches = df_matches
+    if limit_matches is not None and not df_matches.empty:
+        raw_matches = df_matches.head(int(limit_matches)).copy()
+
+    if filtered_matches is None or match_audit is None:
+        filtered_matches, match_audit = apply_match_filters_with_audit(
+            raw_matches, {"club_id": club_id, "exclude_popups": True}
+        )
+
+    evaluation = build_evaluation_context(ctx, club_id, league_id, as_of=None)
+    report = BadgeDebugReport(
+        club_id=str(club_id),
+        league_id=league_id,
+        player_id=int(player_id),
+        badge_id=str(badge_id),
+        matches_raw=list(match_audit.raw_match_ids),
+        matches_filtered=list(match_audit.final_match_ids),
+        filter_audit_steps=list(match_audit.steps),
+    )
+
+    spec = registry().get(str(badge_id))
+    if spec is None:
+        report.errors.append(f"Badge ID '{badge_id}' not found in registry.")
+        return report
+
+    try:
+        for candidate in spec.evaluator(evaluation):
+            if int(candidate.player_id) != int(player_id):
+                continue
+            report.candidates.append(_candidate_to_debug_row(candidate))
+    except Exception:
+        report.errors.append(traceback.format_exc())
+
+    return report
+
+
+def _candidate_to_debug_row(candidate: BadgeCandidate) -> dict[str, Any]:
+    match_id = candidate.match_id
+    derived_match_id = _derive_match_id(candidate)
+    if not match_id and derived_match_id:
+        match_id = derived_match_id
+    return {
+        "badge_id": candidate.badge_id,
+        "player_id": int(candidate.player_id),
+        "club_id": candidate.club_id,
+        "context_type": candidate.context_type,
+        "context_id": candidate.context_id,
+        "match_id": match_id,
+        "value_json": candidate.value_json,
+        "value_num": candidate.value_num,
+    }
+
+
+def _derive_match_id(candidate: BadgeCandidate) -> str | None:
+    if candidate.match_id:
+        return str(candidate.match_id)
+
+    context_type = (candidate.context_type or "").lower()
+    if "match" in context_type and candidate.context_id:
+        return str(candidate.context_id)
+
+    value_json = candidate.value_json
+    if isinstance(value_json, dict):
+        match_id = value_json.get("match_id")
+        if match_id:
+            return str(match_id)
+    return None

--- a/jupr_app/domain/gamification/badge_engine.py
+++ b/jupr_app/domain/gamification/badge_engine.py
@@ -36,7 +36,13 @@ def compute_candidates_for_player(
                     continue
                 candidates.append(candidate)
         except Exception:
-            logger.exception("Badge evaluator failed for %s", spec.badge_id)
+            logger.exception(
+                "Badge evaluator failed for %s (club_id=%s league_id=%s)",
+                spec.badge_id,
+                club_id,
+                league_id,
+                extra={"badge_id": spec.badge_id, "club_id": club_id, "league_id": league_id},
+            )
     return candidates
 
 
@@ -58,4 +64,10 @@ def compute_candidates_for_club(
         try:
             yield from spec.evaluator(evaluation)
         except Exception:
-            logger.exception("Badge evaluator failed for %s", spec.badge_id)
+            logger.exception(
+                "Badge evaluator failed for %s (club_id=%s league_id=%s)",
+                spec.badge_id,
+                club_id,
+                league_id,
+                extra={"badge_id": spec.badge_id, "club_id": club_id, "league_id": league_id},
+            )

--- a/jupr_app/domain/match_filters.py
+++ b/jupr_app/domain/match_filters.py
@@ -1,38 +1,98 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 import pandas as pd
 
 
+@dataclass
+class MatchFilterAuditStep:
+    step_name: str
+    before_count: int
+    after_count: int
+    removed_match_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
+class MatchFilterAudit:
+    raw_match_ids: list[str] = field(default_factory=list)
+    final_match_ids: list[str] = field(default_factory=list)
+    steps: list[MatchFilterAuditStep] = field(default_factory=list)
+
+
 def apply_match_filters(df_matches: pd.DataFrame, context_filters: dict | None) -> pd.DataFrame:
+    return _apply_match_filters(df_matches, context_filters, audit=None)
+
+
+def apply_match_filters_with_audit(
+    df_matches: pd.DataFrame, context_filters: dict | None
+) -> tuple[pd.DataFrame, MatchFilterAudit]:
+    audit = MatchFilterAudit()
+    filtered = _apply_match_filters(df_matches, context_filters, audit=audit)
+    return filtered, audit
+
+
+def resolve_match_id_column(df_matches: pd.DataFrame) -> str:
+    for col in ("match_id", "id", "matchId", "matchID"):
+        if col in df_matches.columns:
+            return col
+    raise ValueError(
+        "Match filter audit requires a match id column. "
+        f"Expected one of match_id/id/matchId/matchID, found {list(df_matches.columns)}."
+    )
+
+
+def _apply_match_filters(
+    df_matches: pd.DataFrame, context_filters: dict | None, audit: MatchFilterAudit | None
+) -> pd.DataFrame:
     if df_matches is None or df_matches.empty:
         return pd.DataFrame()
 
     df = df_matches.copy()
     context_filters = context_filters or {}
 
+    match_id_col = None
+    if audit is not None:
+        match_id_col = resolve_match_id_column(df)
+        audit.raw_match_ids = _match_id_list(df, match_id_col)
+
     club_id = context_filters.get("club_id")
     if club_id is not None and "club_id" in df.columns:
+        before = df
         df = df[df["club_id"].astype(str) == str(club_id)].copy()
+        _record_audit_step(audit, "club_id", before, df, match_id_col)
 
     league_name = context_filters.get("league_name")
     if league_name:
+        before = df
         df["league"] = df.get("league", "").fillna("").astype(str).str.strip()
         df = df[df["league"] == str(league_name).strip()].copy()
+        _record_audit_step(audit, "league_name", before, df, match_id_col)
 
     if context_filters.get("exclude_popups", False) and "match_type" in df.columns:
+        before = df
         df = df[df["match_type"].fillna("") != "PopUp"].copy()
+        _record_audit_step(audit, "exclude_popups", before, df, match_id_col)
 
     if "is_valid" in df.columns:
+        before = df
         df = df[df["is_valid"].fillna(True).astype(bool)].copy()
+        _record_audit_step(audit, "is_valid", before, df, match_id_col)
 
     if "context_type" in df.columns:
+        before = df
         df = df[df["context_type"].fillna("").astype(str).str.upper() != "TOURNAMENT"].copy()
+        _record_audit_step(audit, "exclude_context_type_tournament", before, df, match_id_col)
 
     if "tournament_id" in df.columns:
+        before = df
         df = df[df["tournament_id"].isna()].copy()
+        _record_audit_step(audit, "tournament_id_is_null", before, df, match_id_col)
 
     if "match_type" in df.columns:
+        before = df
         df = df[df["match_type"].fillna("").astype(str) != "Tournament"].copy()
+        _record_audit_step(audit, "exclude_match_type_tournament", before, df, match_id_col)
 
     for col in [
         "is_void",
@@ -44,7 +104,9 @@ def apply_match_filters(df_matches: pd.DataFrame, context_filters: dict | None) 
         "is_deleted",
     ]:
         if col in df.columns:
+            before = df
             df = df[~df[col].fillna(False).astype(bool)].copy()
+            _record_audit_step(audit, f"exclude_{col}", before, df, match_id_col)
 
     start_date = context_filters.get("start_date")
     end_date = context_filters.get("end_date")
@@ -52,25 +114,63 @@ def apply_match_filters(df_matches: pd.DataFrame, context_filters: dict | None) 
     if start_date is not None:
         start_dt = pd.to_datetime(start_date, utc=True, errors="coerce")
         if pd.notna(start_dt):
+            before = df
             df = df[df["date_dt"] >= start_dt].copy()
+            _record_audit_step(audit, "start_date", before, df, match_id_col)
     if end_date is not None:
         end_dt = pd.to_datetime(end_date, utc=True, errors="coerce")
         if pd.notna(end_dt):
+            before = df
             df = df[df["date_dt"] <= end_dt].copy()
+            _record_audit_step(audit, "end_date", before, df, match_id_col)
 
     eligible_ids = context_filters.get("eligible_player_ids")
     if eligible_ids:
         eligible_set = {int(pid) for pid in eligible_ids}
         player_cols = [c for c in ["t1_p1", "t1_p2", "t2_p1", "t2_p2"] if c in df.columns]
         if player_cols:
+            before = df
             mask = pd.Series(True, index=df.index)
             for col in player_cols:
                 values = df[col]
                 keep = values.isna() | values.map(lambda x: normalize_player_id(x) in eligible_set)
                 mask &= keep
             df = df[mask].copy()
+            _record_audit_step(audit, "eligible_player_ids", before, df, match_id_col)
+
+    if audit is not None and match_id_col is not None:
+        audit.final_match_ids = _match_id_list(df, match_id_col)
 
     return df
+
+
+def _match_id_list(df: pd.DataFrame, match_id_col: str) -> list[str]:
+    if df is None or df.empty:
+        return []
+    return df[match_id_col].astype(str).tolist()
+
+
+def _record_audit_step(
+    audit: MatchFilterAudit | None,
+    step_name: str,
+    before_df: pd.DataFrame,
+    after_df: pd.DataFrame,
+    match_id_col: str | None,
+) -> None:
+    if audit is None or match_id_col is None:
+        return
+    before_ids = _match_id_list(before_df, match_id_col)
+    after_ids = _match_id_list(after_df, match_id_col)
+    after_set = set(after_ids)
+    removed_ids = [mid for mid in before_ids if mid not in after_set]
+    audit.steps.append(
+        MatchFilterAuditStep(
+            step_name=step_name,
+            before_count=len(before_ids),
+            after_count=len(after_ids),
+            removed_match_ids=removed_ids,
+        )
+    )
 
 
 def normalize_player_id(value) -> int | None:

--- a/jupr_app/ui/pages/__init__.py
+++ b/jupr_app/ui/pages/__init__.py
@@ -4,6 +4,7 @@ from . import leaderboards
 from . import match_explorer
 from . import players
 from . import badge_codex
+from . import badge_debug
 from . import match_uploader
 from . import challenge_ladder
 from . import challenge_ladder_admin
@@ -26,6 +27,7 @@ __all__ = [
     "match_explorer",
     "players",
     "badge_codex",
+    "badge_debug",
     "match_uploader",
     "challenge_ladder",
     "challenge_ladder_admin",

--- a/jupr_app/ui/pages/badge_debug.py
+++ b/jupr_app/ui/pages/badge_debug.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+import os
+
+import pandas as pd
+import streamlit as st
+
+from jupr_app.domain.gamification.badge_debug import build_badge_debug_report
+from jupr_app.domain.match_filters import apply_match_filters_with_audit
+from jupr_app.ui.layout import page_shell
+
+
+def _is_badge_debug_enabled() -> bool:
+    return os.getenv("BADGE_DEBUG") == "1" or os.getenv("JUPR_ADMIN") == "1"
+
+
+@st.cache_data(show_spinner=False)
+def _cached_match_filter_audit(df_matches: pd.DataFrame, club_id: str, league_id: str | None):
+    _ = league_id
+    return apply_match_filters_with_audit(df_matches, {"club_id": club_id, "exclude_popups": True})
+
+
+def render(ctx):
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("🧪 Badge Debug", "Trace why a player earned (or missed) a badge.", mode_label=mode_label)
+
+    if not bool(getattr(ctx, "admin_logged_in", False)):
+        st.error("Admin login required.")
+        st.stop()
+
+    if not _is_badge_debug_enabled():
+        st.info("Badge Debug is disabled. Set BADGE_DEBUG=1 (or JUPR_ADMIN=1) to enable this view.")
+        st.stop()
+
+    df_players = getattr(ctx, "df_players_all", pd.DataFrame())
+    df_badges = getattr(ctx, "df_badges", pd.DataFrame())
+    df_meta = getattr(ctx, "df_meta", pd.DataFrame())
+    df_player_badges = getattr(ctx, "df_player_badges", pd.DataFrame())
+
+    club_id = str(ctx.club_id)
+
+    st.subheader("Inputs")
+    club_options = [club_id]
+    st.selectbox("Club", club_options, index=0, disabled=len(club_options) == 1)
+
+    league_options = ["All leagues"]
+    if df_meta is not None and not df_meta.empty and "league_name" in df_meta.columns:
+        league_options += sorted(df_meta["league_name"].dropna().astype(str).unique().tolist())
+    league_choice = st.selectbox("League", league_options)
+    league_id = None if league_choice == "All leagues" else str(league_choice).strip()
+
+    if df_players is None or df_players.empty or "id" not in df_players.columns:
+        st.warning("Player data is still loading or unavailable.")
+        st.stop()
+
+    player_ids = sorted(df_players["id"].dropna().astype(int).unique().tolist())
+    id_to_name = getattr(ctx, "id_to_name", {})
+    player_id = st.selectbox(
+        "Player",
+        player_ids,
+        format_func=lambda pid: f"{id_to_name.get(int(pid), 'Player')} (#{pid})",
+    )
+
+    if df_badges is None or df_badges.empty or "badge_id" not in df_badges.columns:
+        st.warning("Badge definitions are unavailable.")
+        st.stop()
+
+    badge_ids = df_badges["badge_id"].dropna().astype(str).unique().tolist()
+    badge_name_map = {
+        str(row.badge_id): str(getattr(row, "name", "Badge"))
+        for row in df_badges.itertuples(index=False)
+    }
+    badge_id = st.selectbox(
+        "Badge",
+        sorted(badge_ids),
+        format_func=lambda bid: f"{badge_name_map.get(str(bid), 'Badge')} ({bid})",
+    )
+
+    run = st.button("Run Badge Debug", type="primary")
+
+    if not run:
+        st.caption("Run the report to inspect evaluator outputs, raw matches, and filter removals.")
+        return
+
+    with st.spinner("Building badge debug report..."):
+        filtered_matches, audit = _cached_match_filter_audit(
+            getattr(ctx, "df_matches", pd.DataFrame()),
+            club_id,
+            league_id,
+        )
+        report = build_badge_debug_report(
+            ctx,
+            club_id=club_id,
+            league_id=league_id,
+            player_id=int(player_id),
+            badge_id=str(badge_id),
+            filtered_matches=filtered_matches,
+            match_audit=audit,
+        )
+
+    st.subheader("Truth Table")
+    awarded = False
+    if df_player_badges is not None and not df_player_badges.empty:
+        awarded = not df_player_badges[
+            (df_player_badges.get("player_id") == int(player_id))
+            & (df_player_badges.get("badge_id").astype(str) == str(badge_id))
+        ].empty
+
+    truth_row = {
+        "club_id": report.club_id,
+        "league_id": report.league_id or "ALL",
+        "player_id": report.player_id,
+        "badge_id": report.badge_id,
+        "raw_matches_count": len(report.matches_raw),
+        "filtered_matches_count": len(report.matches_filtered),
+        "candidates_count": len(report.candidates),
+        "awarded?": awarded,
+    }
+    st.dataframe(pd.DataFrame([truth_row]), use_container_width=True, hide_index=True)
+
+    if report.errors:
+        st.error("Evaluator error encountered.")
+        for idx, err in enumerate(report.errors, start=1):
+            with st.expander(f"Error {idx}"):
+                st.code(err)
+
+    st.subheader("Candidate Rows")
+    if not report.candidates:
+        st.info("No candidates returned by evaluator.")
+    else:
+        candidate_df = pd.DataFrame(report.candidates)
+        display_cols = [c for c in ["context_id", "match_id", "value_json"] if c in candidate_df.columns]
+        for col in ["context_type", "value_num"]:
+            if col in candidate_df.columns and col not in display_cols:
+                display_cols.append(col)
+        candidate_df["value_json"] = candidate_df["value_json"].apply(_format_value_json)
+        st.dataframe(candidate_df[display_cols], use_container_width=True, hide_index=True)
+
+        st.markdown("**Candidate details**")
+        for idx, row in candidate_df.iterrows():
+            with st.expander(f"Candidate {idx + 1} • context_id={row.get('context_id')}"):
+                st.json(report.candidates[idx].get("value_json", {}))
+
+    st.subheader("Match Filtering Audit")
+    if not report.filter_audit_steps:
+        st.info("No filter audit steps recorded.")
+    else:
+        audit_table = pd.DataFrame(
+            [
+                {
+                    "step_name": step.step_name,
+                    "before_count": step.before_count,
+                    "after_count": step.after_count,
+                    "removed_count": len(step.removed_match_ids),
+                }
+                for step in report.filter_audit_steps
+            ]
+        )
+        st.dataframe(audit_table, use_container_width=True, hide_index=True)
+
+        for idx, step in enumerate(report.filter_audit_steps):
+            removed_ids = step.removed_match_ids
+            with st.expander(f"{step.step_name} removed {len(removed_ids)} match(es)"):
+                _render_id_list(removed_ids, key=f"removed_{idx}")
+
+    st.subheader("Raw vs Filtered Match IDs")
+    col_left, col_right = st.columns(2)
+    with col_left:
+        st.markdown("**Raw match IDs**")
+        with st.expander(f"{len(report.matches_raw)} total"):
+            _render_id_list(report.matches_raw, key="raw_ids")
+    with col_right:
+        st.markdown("**Filtered match IDs**")
+        with st.expander(f"{len(report.matches_filtered)} total"):
+            _render_id_list(report.matches_filtered, key="filtered_ids")
+
+    raw_set = set(report.matches_raw)
+    filtered_set = set(report.matches_filtered)
+    removed = sorted(raw_set - filtered_set)
+    added = sorted(filtered_set - raw_set)
+
+    with st.expander("Diff: Raw \\ Filtered"):
+        _render_id_list(removed, key="raw_minus_filtered")
+    with st.expander("Diff: Filtered \\ Raw"):
+        _render_id_list(added, key="filtered_minus_raw")
+
+
+def _format_value_json(value) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, indent=2, sort_keys=True)
+    except Exception:
+        return str(value)
+
+
+def _render_id_list(ids: list[str], *, key: str, sample_size: int = 50) -> None:
+    if not ids:
+        st.caption("None")
+        return
+    show_all = st.checkbox("Show full list", value=len(ids) <= sample_size, key=f"{key}_show_all")
+    if show_all or len(ids) <= sample_size:
+        st.write(ids)
+    else:
+        st.write(ids[:sample_size])
+        st.caption(f"Showing first {sample_size} of {len(ids)} IDs.")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -303,6 +303,7 @@ def main():
             faqs,
             players,
             badge_codex,
+            badge_debug,
             challenge_ladder,
             challenge_ladder_admin,
             match_uploader,
@@ -324,6 +325,7 @@ def main():
             "🎯 Match Explorer": match_explorer,
             "🔍 Player Search": players,
             "📼 Badge Codex": badge_codex,
+            "🧪 Badge Debug": badge_debug,
             "🪜 Challenge Ladder": challenge_ladder,
             "❓ FAQs": faqs,
 
@@ -347,6 +349,7 @@ def main():
             "match_explorer": "🎯 Match Explorer",
             "players": "🔍 Player Search",
             "badge_codex": "📼 Badge Codex",
+            "badge_debug": "🧪 Badge Debug",
             "challenge_ladder": "🪜 Challenge Ladder",
             "faqs": "❓ FAQs",
 
@@ -377,6 +380,7 @@ def main():
             "🎨 Theme QA",
             "🏆 Tournaments",
             "🏆 Tournament Manager",
+            "🧪 Badge Debug",
         }
 
         # Visible labels based on auth

--- a/tests/test_badge_debug_report.py
+++ b/tests/test_badge_debug_report.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from jupr_app.domain.gamification.badge_debug import build_badge_debug_report
+
+
+class DummyContext:
+    def __init__(self):
+        self.club_id = "club-1"
+        self.df_matches = pd.DataFrame()
+        self.df_players_all = pd.DataFrame()
+
+
+def test_build_badge_debug_report_smoke():
+    ctx = DummyContext()
+    report = build_badge_debug_report(
+        ctx,
+        club_id="club-1",
+        league_id=None,
+        player_id=1,
+        badge_id="participant",
+    )
+
+    assert report.badge_id == "participant"
+    assert report.club_id == "club-1"
+    assert report.player_id == 1
+    assert report.errors == []

--- a/tests/test_match_filter_audit.py
+++ b/tests/test_match_filter_audit.py
@@ -1,0 +1,70 @@
+import pandas as pd
+
+from jupr_app.domain.match_filters import apply_match_filters_with_audit
+
+
+def test_apply_match_filters_with_audit_tracks_removed_ids():
+    df = pd.DataFrame(
+        [
+            {
+                "id": 1,
+                "club_id": "1",
+                "date": "2024-02-10",
+                "league": "Alpha",
+                "match_type": "League",
+                "is_valid": True,
+                "context_type": "",
+                "tournament_id": None,
+                "is_void": False,
+                "t1_p1": 1,
+                "t1_p2": None,
+                "t2_p1": 2,
+                "t2_p2": None,
+            },
+            {"id": 2, "club_id": "2", "date": "2024-02-11", "match_type": "League"},
+            {"id": 3, "club_id": "1", "date": "2024-02-12", "match_type": "PopUp"},
+            {"id": 4, "club_id": "1", "date": "2024-02-13", "is_valid": False},
+            {"id": 5, "club_id": "1", "date": "2024-02-14", "context_type": "TOURNAMENT"},
+            {"id": 6, "club_id": "1", "date": "2024-02-15", "tournament_id": "99"},
+            {"id": 7, "club_id": "1", "date": "2024-02-16", "match_type": "Tournament"},
+            {"id": 8, "club_id": "1", "date": "2024-02-17", "is_void": True},
+            {"id": 9, "club_id": "1", "date": "2024-01-05"},
+            {
+                "id": 10,
+                "club_id": "1",
+                "date": "2024-02-20",
+                "t1_p1": 1,
+                "t1_p2": None,
+                "t2_p1": 3,
+                "t2_p2": None,
+            },
+            {"id": 11, "club_id": "1", "date": "2024-03-05"},
+        ]
+    )
+
+    filtered, audit = apply_match_filters_with_audit(
+        df,
+        {
+            "club_id": "1",
+            "exclude_popups": True,
+            "start_date": "2024-02-01",
+            "end_date": "2024-02-28",
+            "eligible_player_ids": [1, 2],
+        },
+    )
+
+    assert audit.raw_match_ids == [str(i) for i in range(1, 12)]
+    assert audit.final_match_ids == ["1"]
+    assert filtered["id"].astype(str).tolist() == ["1"]
+
+    removed_by_step = {step.step_name: step.removed_match_ids for step in audit.steps}
+    assert removed_by_step["club_id"] == ["2"]
+    assert removed_by_step["exclude_popups"] == ["3"]
+    assert removed_by_step["is_valid"] == ["4"]
+    assert removed_by_step["exclude_context_type_tournament"] == ["5"]
+    assert removed_by_step["tournament_id_is_null"] == ["6"]
+    assert removed_by_step["exclude_match_type_tournament"] == ["7"]
+    assert removed_by_step["exclude_is_void"] == ["8"]
+    assert removed_by_step["start_date"] == ["9"]
+    assert removed_by_step["end_date"] == ["11"]
+    assert removed_by_step["eligible_player_ids"] == ["10"]


### PR DESCRIPTION
### Motivation
- Provide low-overhead, dev/admin-only tooling to answer “Why did a player get (or miss) a badge?” by exposing the exact raw matches, evaluator outputs, and which filters removed which matches.  
- Improve observability for evaluator failures by ensuring logs include `badge_id`, `club_id`, and `league_id` to speed up root-cause analysis.  

### Description
- Add audit-capable match filtering: `apply_match_filters_with_audit(...)`, `MatchFilterAudit`, and `MatchFilterAuditStep` in `jupr_app/domain/match_filters.py` that record `raw_match_ids`, per-step removals and `final_match_ids`.  
- Add a reusable backend builder `build_badge_debug_report(...)` in `jupr_app/domain/gamification/badge_debug.py` that runs filters with audit, constructs the production-like evaluation context (`build_evaluation_context`), invokes the single badge evaluator, and returns candidates + audit + any errors.  
- Expose an admin-gated Streamlit page `🧪 Badge Debug` at `jupr_app/ui/pages/badge_debug.py` (gated by `ctx.admin_logged_in` and env var `BADGE_DEBUG=1` or `JUPR_ADMIN=1`) that renders the truth-table summary, candidate rows, filter audit steps (with expanders), and raw vs filtered match diffs, and uses `st.cache_data` for safe caching.  
- Improve evaluator exception logging in `jupr_app/domain/gamification/badge_engine.py` to include `badge_id`, `club_id`, and `league_id` in the `logger.exception(...)` call (also added structured `extra={...}`).  
- Wire the page into the app router (`jupr_app/ui/pages/__init__.py`, `streamlit_app.py`), add docs `docs/badge_debug.md`, and add unit tests for the audit and report flows.  

### Testing
- Added unit tests `tests/test_match_filter_audit.py` and `tests/test_badge_debug_report.py` and ran `pytest tests/test_match_filter_audit.py tests/test_badge_debug_report.py`, and both tests passed.  
- Smoke test: `build_badge_debug_report(...)` returns a report object for a minimal `DummyContext` without raising errors.  
- Note: test run emitted benign FutureWarnings from pandas but all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e7e7b7a6c83268cfb8084bcf09d68)