### PR TITLE
Align participation counting with canonical match filters

### DIFF
--- a/jupr_app/domain/gamification/participation.py
+++ b/jupr_app/domain/gamification/participation.py
@@ -2,53 +2,88 @@ from __future__ import annotations
 
 import pandas as pd
 
+from jupr_app.domain.match_filters import apply_match_filters, normalize_player_id, normalize_score
 
-def compute_lifetime_games(ctx) -> dict[int, int]:
+
+def get_participation_player_match_pairs(ctx) -> pd.DataFrame:
+    """Return unique (player_id, match_id) pairs after canonical match filtering."""
     df_matches = getattr(ctx, "df_matches", None)
     if df_matches is None or df_matches.empty:
+        return pd.DataFrame(columns=["player_id", "match_id"])
+
+    filters = {"club_id": getattr(ctx, "club_id", None), "exclude_popups": True}
+    filtered = apply_match_filters(df_matches, filters)
+    if filtered.empty:
+        return pd.DataFrame(columns=["player_id", "match_id"])
+
+    filtered = filtered.copy()
+    match_id_col = _ensure_match_id_column(filtered)
+
+    if "player_id" in filtered.columns:
+        pairs = _pairs_from_player_rows(filtered, match_id_col)
+    else:
+        pairs = _pairs_from_match_rows(filtered, match_id_col)
+
+    if pairs.empty:
+        return pairs
+
+    pairs = pairs.dropna(subset=["player_id", "match_id"]).drop_duplicates(["player_id", "match_id"])
+    return pairs
+
+
+def compute_lifetime_games(ctx) -> dict[int, int]:
+    pairs = get_participation_player_match_pairs(ctx)
+    if pairs.empty:
         return {}
+    counts = pairs.groupby("player_id")["match_id"].nunique()
+    return counts.to_dict()
 
-    df = df_matches.copy()
-    club_id = str(getattr(ctx, "club_id", "") or "")
-    if club_id and "club_id" in df.columns:
-        df = df[df["club_id"].astype(str) == club_id]
 
-    if df.empty:
-        return {}
+def _ensure_match_id_column(df: pd.DataFrame) -> str:
+    for col in ("match_id", "id", "matchId", "matchID"):
+        if col in df.columns:
+            return col
+    df["match_id"] = range(1, len(df) + 1)
+    return "match_id"
 
+
+def _pairs_from_player_rows(df: pd.DataFrame, match_id_col: str) -> pd.DataFrame:
+    match_ids = df[match_id_col].where(df[match_id_col].notna(), pd.NA).astype("string")
+    player_ids = df["player_id"].map(normalize_player_id)
+    pairs = pd.DataFrame({"player_id": player_ids, "match_id": match_ids})
+    score_total = _score_total(df)
+    if score_total is not None:
+        pairs = pairs[score_total > 0]
+    return pairs
+
+
+def _pairs_from_match_rows(df: pd.DataFrame, match_id_col: str) -> pd.DataFrame:
+    records: list[dict[str, str | int]] = []
     score_cols = _score_columns(df)
-    if "player_id" in df.columns:
-        pid = pd.to_numeric(df["player_id"], errors="coerce")
-        valid = pid.notna()
+    for row in df.itertuples(index=False):
+        match_id = getattr(row, match_id_col, None)
+        if match_id is None or (isinstance(match_id, float) and pd.isna(match_id)):
+            continue
+
         if score_cols:
-            score_total = pd.to_numeric(df[score_cols[0]], errors="coerce").fillna(0) + pd.to_numeric(
-                df[score_cols[1]], errors="coerce"
-            ).fillna(0)
-            valid &= score_total > 0
-        pid = pid[valid].astype(int)
-        if pid.empty:
-            return {}
-        return pid.value_counts().to_dict()
+            s1 = normalize_score(getattr(row, score_cols[0], None))
+            s2 = normalize_score(getattr(row, score_cols[1], None))
+            if (s1 + s2) <= 0:
+                continue
 
-    player_cols = [c for c in ("t1_p1", "t1_p2", "t2_p1", "t2_p2") if c in df.columns]
-    if len(player_cols) < 1:
-        return {}
+        p1 = normalize_player_id(getattr(row, "t1_p1", None))
+        p2 = normalize_player_id(getattr(row, "t1_p2", None))
+        p3 = normalize_player_id(getattr(row, "t2_p1", None))
+        p4 = normalize_player_id(getattr(row, "t2_p2", None))
+        if not p1 or not p3:
+            continue
 
-    players = df[player_cols].apply(pd.to_numeric, errors="coerce")
-    valid = players.notna().all(axis=1)
-    if score_cols:
-        score_total = pd.to_numeric(df[score_cols[0]], errors="coerce").fillna(0) + pd.to_numeric(
-            df[score_cols[1]], errors="coerce"
-        ).fillna(0)
-        valid &= score_total > 0
+        for pid in {pid for pid in (p1, p2, p3, p4) if pid}:
+            records.append({"player_id": pid, "match_id": str(match_id)})
 
-    players = players[valid]
-    counts: dict[int, int] = {}
-    for _, row in players.iterrows():
-        ids = {int(pid) for pid in row.tolist() if pd.notna(pid)}
-        for pid in ids:
-            counts[pid] = counts.get(pid, 0) + 1
-    return counts
+    if not records:
+        return pd.DataFrame(columns=["player_id", "match_id"])
+    return pd.DataFrame.from_records(records)
 
 
 def _score_columns(df: pd.DataFrame) -> tuple[str, str] | None:
@@ -57,3 +92,12 @@ def _score_columns(df: pd.DataFrame) -> tuple[str, str] | None:
     if "s1" in df.columns and "s2" in df.columns:
         return "s1", "s2"
     return None
+
+
+def _score_total(df: pd.DataFrame) -> pd.Series | None:
+    score_cols = _score_columns(df)
+    if not score_cols:
+        return None
+    s1 = pd.to_numeric(df[score_cols[0]], errors="coerce").fillna(0)
+    s2 = pd.to_numeric(df[score_cols[1]], errors="coerce").fillna(0)
+    return s1 + s2

--- a/tests/test_badges_participation.py
+++ b/tests/test_badges_participation.py
@@ -60,31 +60,85 @@ class FakeSupabase:
         return FakeTable(self.storage, name)
 
 
-def test_compute_lifetime_games_counts_team_rows():
+def test_compute_lifetime_games_counts_match_rows_doubles():
     df_matches = pd.DataFrame(
         [
-            {"t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 8},
-            {"t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 9},
-            {"t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": None, "score_t1": 11, "score_t2": 9},
-            {"t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 0, "score_t2": 0},
+            {
+                "id": "m1",
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+                "score_t1": 11,
+                "score_t2": 8,
+                "club_id": "club",
+            }
         ]
     )
     ctx = SimpleNamespace(df_matches=df_matches, club_id="club")
     counts = compute_lifetime_games(ctx)
-    assert counts == {1: 2, 2: 2, 3: 2, 4: 2}
+    assert counts == {1: 1, 2: 1, 3: 1, 4: 1}
 
 
-def test_compute_lifetime_games_counts_player_rows():
+def test_compute_lifetime_games_counts_match_rows_singles():
     df_matches = pd.DataFrame(
         [
-            {"player_id": 10, "score_t1": 11, "score_t2": 6},
-            {"player_id": 10, "score_t1": 11, "score_t2": 9},
-            {"player_id": 11, "score_t1": 0, "score_t2": 0},
+            {"id": "m1", "t1_p1": 1, "t2_p1": 3, "score_t1": 11, "score_t2": 9, "club_id": "club"},
+            {"id": "m2", "t1_p1": 2, "t2_p1": 4, "score_t1": 11, "score_t2": 6, "club_id": "club"},
         ]
     )
     ctx = SimpleNamespace(df_matches=df_matches, club_id="club")
     counts = compute_lifetime_games(ctx)
-    assert counts == {10: 2}
+    assert counts == {1: 1, 2: 1, 3: 1, 4: 1}
+
+
+def test_compute_lifetime_games_counts_player_rows_dedupes():
+    df_matches = pd.DataFrame(
+        [
+            {"player_id": 10, "match_id": "m1", "score_t1": 11, "score_t2": 6, "club_id": "club"},
+            {"player_id": 10, "match_id": "m1", "score_t1": 11, "score_t2": 6, "club_id": "club"},
+            {"player_id": 10, "match_id": "m2", "score_t1": 11, "score_t2": 9, "club_id": "club"},
+            {"player_id": 11, "match_id": "m2", "score_t1": 11, "score_t2": 9, "club_id": "club"},
+        ]
+    )
+    ctx = SimpleNamespace(df_matches=df_matches, club_id="club")
+    counts = compute_lifetime_games(ctx)
+    assert counts == {10: 2, 11: 1}
+
+
+def test_compute_lifetime_games_filters_popups_and_invalid_scores():
+    df_matches = pd.DataFrame(
+        [
+            {
+                "id": "m1",
+                "t1_p1": 1,
+                "t2_p1": 2,
+                "score_t1": 11,
+                "score_t2": 8,
+                "match_type": "PopUp",
+                "club_id": "club",
+            },
+            {
+                "id": "m2",
+                "t1_p1": 1,
+                "t2_p1": 2,
+                "score_t1": 0,
+                "score_t2": 0,
+                "club_id": "club",
+            },
+            {
+                "id": "m3",
+                "t1_p1": 1,
+                "t2_p1": 2,
+                "score_t1": 11,
+                "score_t2": 6,
+                "club_id": "club",
+            },
+        ]
+    )
+    ctx = SimpleNamespace(df_matches=df_matches, club_id="club")
+    counts = compute_lifetime_games(ctx)
+    assert counts == {1: 1, 2: 1}
 
 
 def test_participation_badges_awarded_via_engine_idempotent():


### PR DESCRIPTION
### Motivation
- Participation totals were diverging from the badge engine because counting logic used df_matches shapes and local filtering rather than the canonical match-facts filters.
- The goal is to count unique (player_id, match_id) participations after applying the same hygiene filters (exclude popups, tournaments, void/invalid rows, zero-score matches) so participation badges align with W–L/standings.

### Description
- Added `get_participation_player_match_pairs(ctx)` which applies `apply_match_filters(...)` and yields deduped `(player_id, match_id)` pairs for both match-level and per-player schemas.
- Rewrote `compute_lifetime_games` to use the canonical pairs and compute per-player unique match counts via `groupby("player_id")["match_id"].nunique()`.
- Implemented robust handling of both schemas: ensures a match id column, expands match-level team rows into player pairs (handles singles when partner columns are missing), passes through per-player rows without double-expanding, drops NA and deduplicates pairs, and enforces non-zero score checks using `normalize_score`.
- Added a short docstring and preserved club/league scoping by passing `club_id` into the canonical filters.

### Testing
- Added/updated regression tests in `tests/test_badges_participation.py` covering doubles match rows, singles match rows, per-player deduping, and exclusion of popups/zero-score matches.
- Ran `pytest -q tests/test_badges_participation.py` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e846c19148326be5564adc9673a65)