### PR TITLE
Make Badge Debug use audited filtered matches and honor league selection

### DIFF
--- a/jupr_app/domain/gamification/badge_debug.py
+++ b/jupr_app/domain/gamification/badge_debug.py
@@ -45,11 +45,16 @@ def build_badge_debug_report(
         raw_matches = df_matches.head(int(limit_matches)).copy()
 
     if filtered_matches is None or match_audit is None:
+        context_filters = {"club_id": club_id, "exclude_popups": True}
+        if league_id:
+            context_filters["league_name"] = league_id
         filtered_matches, match_audit = apply_match_filters_with_audit(
-            raw_matches, {"club_id": club_id, "exclude_popups": True}
+            raw_matches, context_filters
         )
 
-    evaluation = build_evaluation_context(ctx, club_id, league_id, as_of=None)
+    evaluation = build_evaluation_context(
+        ctx, club_id, league_id, as_of=None, df_matches_override=filtered_matches
+    )
     report = BadgeDebugReport(
         club_id=str(club_id),
         league_id=league_id,

--- a/jupr_app/domain/gamification/badge_rules.py
+++ b/jupr_app/domain/gamification/badge_rules.py
@@ -150,8 +150,12 @@ def compute_badge_awards(
     return awards, facts
 
 
-def build_player_match_facts(ctx) -> pd.DataFrame:
-    df_matches = getattr(ctx, "df_matches", None)
+def build_player_match_facts(
+    ctx, df_matches_override: pd.DataFrame | None = None, club_id_override: str | None = None
+) -> pd.DataFrame:
+    df_matches = df_matches_override
+    if df_matches is None:
+        df_matches = getattr(ctx, "df_matches", None)
     if df_matches is None or df_matches.empty:
         return _empty_facts()
 
@@ -163,7 +167,8 @@ def build_player_match_facts(ctx) -> pd.DataFrame:
         except Exception:
             rating_map = {}
 
-    filters = {"club_id": getattr(ctx, "club_id", None), "exclude_popups": True}
+    club_id = club_id_override if club_id_override is not None else getattr(ctx, "club_id", None)
+    filters = {"club_id": club_id, "exclude_popups": True}
     filtered = apply_match_filters(df_matches, filters)
     if filtered.empty:
         return _empty_facts()

--- a/jupr_app/domain/gamification/evaluators.py
+++ b/jupr_app/domain/gamification/evaluators.py
@@ -871,10 +871,18 @@ def evaluate_tournament_third_place(ctx: BadgeEvaluationContext) -> Iterable[Bad
     return [c for c in _cached_tournament_podium_candidates(ctx) if c.badge_id == "tournament_third_place"]
 
 
-def build_evaluation_context(ctx: Any, club_id: str, league_id: str | None, as_of: datetime | None) -> BadgeEvaluationContext:
-    facts = build_player_match_facts(ctx)
+def build_evaluation_context(
+    ctx: Any,
+    club_id: str,
+    league_id: str | None,
+    as_of: datetime | None,
+    df_matches_override: pd.DataFrame | None = None,
+) -> BadgeEvaluationContext:
+    facts = build_player_match_facts(ctx, df_matches_override=df_matches_override, club_id_override=club_id)
     if facts.empty:
-        matches = getattr(ctx, "df_matches", None)
+        matches = df_matches_override
+        if matches is None:
+            matches = getattr(ctx, "df_matches", None)
         if matches is None:
             matches = pd.DataFrame()
     else:


### PR DESCRIPTION
### Motivation
- Badge Debug needed to be truthful: the evaluator must run on the exact filtered matches shown by the audit, and the selected league must scope both the audit and the evaluator.
- The change must not modify badge logic or thresholds, only ensure the evaluation context is properly scoped to filtered match data.

### Description
- Added optional `df_matches_override` parameter to `build_evaluation_context(...)` so an evaluation can be run against a specific dataframe instead of `ctx.df_matches`.
- Updated `build_player_match_facts(...)` to accept `df_matches_override` and `club_id_override` so facts and filtering honor provided match data and club scoping.
- Updated `build_badge_debug_report(...)` to include league-aware `context_filters` when calling `apply_match_filters_with_audit(...)` and to pass the audited `filtered_matches` into `build_evaluation_context(...)` so the evaluator sees the same matches as the audit.
- No badge award logic, thresholds, or schemas were changed.

### Testing
- Ran `python -m pytest tests/test_badge_debug_report.py` and the test suite passed (1 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ebf56f2548326889aa997d6c4cb09)