### PR TITLE
Extract badge match-facts to canonical `match_facts` module and update evaluators

### DIFF
--- a/jupr_app/domain/gamification/badge_rules.py
+++ b/jupr_app/domain/gamification/badge_rules.py
@@ -18,36 +18,9 @@ from jupr_app.domain.gamification.copy_pack import (
     pick_variant,
     render_template,
 )
-from jupr_app.domain.match_filters import apply_match_filters, normalize_player_id, normalize_score
+from jupr_app.domain.gamification.match_facts import build_player_match_facts
 
 logger = logging.getLogger(__name__)
-
-
-_FACT_COLUMNS = [
-    "club_id",
-    "player_id",
-    "match_id",
-    "league",
-    "date_dt",
-    "week_key",
-    "month_key",
-    "season_key",
-    "win",
-    "points_for",
-    "points_against",
-    "margin",
-    "partner_id",
-    "opponent_ids",
-    "expected_win_prob",
-    "elo_delta_signed",
-    "abs_elo_delta",
-    "opp_max_rating",
-    "lobby_avg_rating",
-]
-
-
-def _empty_facts() -> pd.DataFrame:
-    return pd.DataFrame(columns=_FACT_COLUMNS)
 
 
 @dataclass(frozen=True)
@@ -148,114 +121,6 @@ def compute_badge_awards(
     _award_hall_of_fame_night(facts, add_badge)
 
     return awards, facts
-
-
-def build_player_match_facts(
-    ctx, df_matches_override: pd.DataFrame | None = None, club_id_override: str | None = None
-) -> pd.DataFrame:
-    df_matches = df_matches_override
-    if df_matches is None:
-        df_matches = getattr(ctx, "df_matches", None)
-    if df_matches is None or df_matches.empty:
-        return _empty_facts()
-
-    df_players = getattr(ctx, "df_players_all", None)
-    rating_map: dict[int, float] = {}
-    if df_players is not None and not df_players.empty:
-        try:
-            rating_map = dict(zip(df_players["id"].astype(int), df_players["rating"].astype(float)))
-        except Exception:
-            rating_map = {}
-
-    club_id = club_id_override if club_id_override is not None else getattr(ctx, "club_id", None)
-    filters = {"club_id": club_id, "exclude_popups": True}
-    filtered = apply_match_filters(df_matches, filters)
-    if filtered.empty:
-        return _empty_facts()
-
-    filtered = filtered.copy()
-    if "id" not in filtered.columns:
-        filtered["id"] = range(1, len(filtered) + 1)
-    filtered["date_dt"] = pd.to_datetime(filtered.get("date", None), utc=True, errors="coerce")
-    filtered = filtered.dropna(subset=["date_dt"]).sort_values(["date_dt", "id"], ascending=[True, True])
-
-    records: list[dict[str, Any]] = []
-    for row in filtered.itertuples(index=False):
-        match_id = str(getattr(row, "id", "") or "")
-        league = str(getattr(row, "league", "") or "").strip() or "OVERALL"
-        club_id = str(getattr(row, "club_id", "") or "")
-        date_dt = getattr(row, "date_dt", pd.NaT)
-        if not match_id or pd.isna(date_dt):
-            continue
-
-        s1 = normalize_score(getattr(row, "score_t1", None))
-        s2 = normalize_score(getattr(row, "score_t2", None))
-        if (s1 + s2) <= 0:
-            continue
-
-        p1 = normalize_player_id(getattr(row, "t1_p1", None))
-        p2 = normalize_player_id(getattr(row, "t1_p2", None))
-        p3 = normalize_player_id(getattr(row, "t2_p1", None))
-        p4 = normalize_player_id(getattr(row, "t2_p2", None))
-        if not p1 or not p3:
-            continue
-
-        r1 = _safe_rating(getattr(row, "t1_p1_r", None), rating_map.get(p1))
-        r2 = _safe_rating(getattr(row, "t1_p2_r", None), rating_map.get(p2))
-        r3 = _safe_rating(getattr(row, "t2_p1_r", None), rating_map.get(p3))
-        r4 = _safe_rating(getattr(row, "t2_p2_r", None), rating_map.get(p4))
-
-        team1 = [pid for pid in (p1, p2) if pid]
-        team2 = [pid for pid in (p3, p4) if pid]
-        if not team1 or not team2:
-            continue
-
-        t1_avg = _avg([r1, r2] if p2 else [r1])
-        t2_avg = _avg([r3, r4] if p4 else [r3])
-        expected_t1 = _expected_share(t1_avg, t2_avg)
-
-        winner_team = 1 if s1 > s2 else 2 if s2 > s1 else 0
-        delta_abs = _safe_float(getattr(row, "elo_delta", None))
-
-        lobby_avg_rating = _avg([r for r in [r1, r2, r3, r4] if r is not None])
-
-        for pid, team, partner, opp_ids, my_score, opp_score, opp_avg, opp_max, expected_win in (
-            (p1, 1, p2, team2, s1, s2, _avg([r3, r4] if p4 else [r3]), _max_rating([r3, r4]), expected_t1),
-            (p2, 1, p1, team2, s1, s2, _avg([r3, r4] if p4 else [r3]), _max_rating([r3, r4]), expected_t1),
-            (p3, 2, p4, team1, s2, s1, _avg([r1, r2] if p2 else [r1]), _max_rating([r1, r2]), 1.0 - expected_t1),
-            (p4, 2, p3, team1, s2, s1, _avg([r1, r2] if p2 else [r1]), _max_rating([r1, r2]), 1.0 - expected_t1),
-        ):
-            if not pid:
-                continue
-            win = winner_team == team
-            signed_delta = None
-            if delta_abs is not None:
-                signed_delta = float(delta_abs) if win else -float(delta_abs)
-            records.append(
-                {
-                    "club_id": club_id,
-                    "player_id": int(pid),
-                    "match_id": match_id,
-                    "league": league,
-                    "date_dt": date_dt,
-                    "week_key": _week_key(date_dt),
-                    "month_key": _month_key(date_dt),
-                    "season_key": _season_key(date_dt),
-                    "win": bool(win),
-                    "points_for": int(my_score),
-                    "points_against": int(opp_score),
-                    "margin": int(my_score - opp_score),
-                    "partner_id": int(partner) if partner else None,
-                    "opponent_ids": [int(x) for x in opp_ids if x],
-                    "expected_win_prob": float(expected_win),
-                    "elo_delta_signed": signed_delta,
-                    "abs_elo_delta": abs(delta_abs) if delta_abs is not None else None,
-                    "opp_max_rating": float(opp_max) if opp_max is not None else None,
-                    "lobby_avg_rating": float(lobby_avg_rating) if lobby_avg_rating is not None else None,
-                }
-            )
-
-    return pd.DataFrame.from_records(records)
 
 
 def _seed_badges(supabase) -> None:
@@ -956,60 +821,6 @@ def _backfill_copy_pack_badges(
             supabase.table("badges").update({"lore": lore, "hint": hint}).eq("badge_id", badge_id).execute()
         except Exception:
             logger.exception("Failed to backfill badge copy", extra={"badge_id": badge_id})
-
-
-def _avg(values: Iterable[float | None]) -> float | None:
-    nums = [v for v in values if v is not None]
-    if not nums:
-        return None
-    return float(sum(nums) / len(nums))
-
-
-def _max_rating(values: Iterable[float | None]) -> float | None:
-    nums = [v for v in values if v is not None]
-    if not nums:
-        return None
-    return float(max(nums))
-
-
-def _safe_float(value) -> float | None:
-    try:
-        if value is None or (isinstance(value, float) and pd.isna(value)):
-            return None
-        return float(value)
-    except Exception:
-        return None
-
-
-def _safe_rating(value, fallback: float | None) -> float | None:
-    v = _safe_float(value)
-    if v is not None:
-        return v
-    if fallback is not None:
-        return float(fallback)
-    return None
-
-
-def _expected_share(team_avg: float | None, opp_avg: float | None) -> float:
-    try:
-        if team_avg is None or opp_avg is None:
-            return 0.5
-        return 1.0 / (1.0 + 10 ** ((float(opp_avg) - float(team_avg)) / 400.0))
-    except Exception:
-        return 0.5
-
-
-def _week_key(date_dt: pd.Timestamp) -> str:
-    iso = date_dt.isocalendar()
-    return f"{iso.year}-W{int(iso.week):02d}"
-
-
-def _month_key(date_dt: pd.Timestamp) -> str:
-    return date_dt.strftime("%Y-%m")
-
-
-def _season_key(date_dt: pd.Timestamp) -> str:
-    return date_dt.strftime("%Y")
 
 
 def _max_consecutive_weeks(weeks: list[str]) -> int:

--- a/jupr_app/domain/gamification/evaluators.py
+++ b/jupr_app/domain/gamification/evaluators.py
@@ -8,8 +8,8 @@ from typing import Any
 import pandas as pd
 
 from jupr_app.domain.awards import compute_top_performer_awards
-from jupr_app.domain.gamification.badge_rules import build_player_match_facts
 from jupr_app.domain.gamification.badge_types import BadgeCandidate, BadgeEvaluationContext
+from jupr_app.domain.gamification.match_facts import build_player_match_facts
 from jupr_app.domain.gamification.participation import compute_lifetime_games
 from jupr_app.domain.gamification.top_performer_awards import (
     TOP_PERFORMER_BADGE_IDS,

--- a/jupr_app/domain/gamification/match_facts.py
+++ b/jupr_app/domain/gamification/match_facts.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+"""This module is the single source of truth for badge match-facts.
+
+Match facts are generated after applying match filters (club_id scoping,
+exclude_popups, invalid/void/deleted flags, tournament exclusions, and
+standard score normalization) to ensure badge evaluations stay consistent.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+
+import pandas as pd
+
+from jupr_app.domain.match_filters import apply_match_filters, normalize_player_id, normalize_score
+
+
+_FACT_COLUMNS = [
+    "club_id",
+    "player_id",
+    "match_id",
+    "league",
+    "date_dt",
+    "week_key",
+    "month_key",
+    "season_key",
+    "win",
+    "points_for",
+    "points_against",
+    "margin",
+    "partner_id",
+    "opponent_ids",
+    "expected_win_prob",
+    "elo_delta_signed",
+    "abs_elo_delta",
+    "opp_max_rating",
+    "lobby_avg_rating",
+]
+
+
+def _empty_facts() -> pd.DataFrame:
+    return pd.DataFrame(columns=_FACT_COLUMNS)
+
+
+def build_player_match_facts(
+    ctx, df_matches_override: pd.DataFrame | None = None, club_id_override: str | None = None
+) -> pd.DataFrame:
+    df_matches = df_matches_override
+    if df_matches is None:
+        df_matches = getattr(ctx, "df_matches", None)
+    if df_matches is None or df_matches.empty:
+        return _empty_facts()
+
+    df_players = getattr(ctx, "df_players_all", None)
+    rating_map: dict[int, float] = {}
+    if df_players is not None and not df_players.empty:
+        try:
+            rating_map = dict(zip(df_players["id"].astype(int), df_players["rating"].astype(float)))
+        except Exception:
+            rating_map = {}
+
+    club_id = club_id_override if club_id_override is not None else getattr(ctx, "club_id", None)
+    filters = {"club_id": club_id, "exclude_popups": True}
+    filtered = apply_match_filters(df_matches, filters)
+    if filtered.empty:
+        return _empty_facts()
+
+    filtered = filtered.copy()
+    if "id" not in filtered.columns:
+        filtered["id"] = range(1, len(filtered) + 1)
+    filtered["date_dt"] = pd.to_datetime(filtered.get("date", None), utc=True, errors="coerce")
+    filtered = filtered.dropna(subset=["date_dt"]).sort_values(["date_dt", "id"], ascending=[True, True])
+
+    records: list[dict[str, Any]] = []
+    for row in filtered.itertuples(index=False):
+        match_id = str(getattr(row, "id", "") or "")
+        league = str(getattr(row, "league", "") or "").strip() or "OVERALL"
+        club_id = str(getattr(row, "club_id", "") or "")
+        date_dt = getattr(row, "date_dt", pd.NaT)
+        if not match_id or pd.isna(date_dt):
+            continue
+
+        s1 = normalize_score(getattr(row, "score_t1", None))
+        s2 = normalize_score(getattr(row, "score_t2", None))
+        if (s1 + s2) <= 0:
+            continue
+
+        p1 = normalize_player_id(getattr(row, "t1_p1", None))
+        p2 = normalize_player_id(getattr(row, "t1_p2", None))
+        p3 = normalize_player_id(getattr(row, "t2_p1", None))
+        p4 = normalize_player_id(getattr(row, "t2_p2", None))
+        if not p1 or not p3:
+            continue
+
+        r1 = _safe_rating(getattr(row, "t1_p1_r", None), rating_map.get(p1))
+        r2 = _safe_rating(getattr(row, "t1_p2_r", None), rating_map.get(p2))
+        r3 = _safe_rating(getattr(row, "t2_p1_r", None), rating_map.get(p3))
+        r4 = _safe_rating(getattr(row, "t2_p2_r", None), rating_map.get(p4))
+
+        team1 = [pid for pid in (p1, p2) if pid]
+        team2 = [pid for pid in (p3, p4) if pid]
+        if not team1 or not team2:
+            continue
+
+        t1_avg = _avg([r1, r2] if p2 else [r1])
+        t2_avg = _avg([r3, r4] if p4 else [r3])
+        expected_t1 = _expected_share(t1_avg, t2_avg)
+
+        winner_team = 1 if s1 > s2 else 2 if s2 > s1 else 0
+        delta_abs = _safe_float(getattr(row, "elo_delta", None))
+
+        lobby_avg_rating = _avg([r for r in [r1, r2, r3, r4] if r is not None])
+
+        for pid, team, partner, opp_ids, my_score, opp_score, opp_avg, opp_max, expected_win in (
+            (p1, 1, p2, team2, s1, s2, _avg([r3, r4] if p4 else [r3]), _max_rating([r3, r4]), expected_t1),
+            (p2, 1, p1, team2, s1, s2, _avg([r3, r4] if p4 else [r3]), _max_rating([r3, r4]), expected_t1),
+            (p3, 2, p4, team1, s2, s1, _avg([r1, r2] if p2 else [r1]), _max_rating([r1, r2]), 1.0 - expected_t1),
+            (p4, 2, p3, team1, s2, s1, _avg([r1, r2] if p2 else [r1]), _max_rating([r1, r2]), 1.0 - expected_t1),
+        ):
+            if not pid:
+                continue
+            win = winner_team == team
+            signed_delta = None
+            if delta_abs is not None:
+                signed_delta = float(delta_abs) if win else -float(delta_abs)
+            records.append(
+                {
+                    "club_id": club_id,
+                    "player_id": int(pid),
+                    "match_id": match_id,
+                    "league": league,
+                    "date_dt": date_dt,
+                    "week_key": _week_key(date_dt),
+                    "month_key": _month_key(date_dt),
+                    "season_key": _season_key(date_dt),
+                    "win": bool(win),
+                    "points_for": int(my_score),
+                    "points_against": int(opp_score),
+                    "margin": int(my_score - opp_score),
+                    "partner_id": int(partner) if partner else None,
+                    "opponent_ids": [int(x) for x in opp_ids if x],
+                    "expected_win_prob": float(expected_win),
+                    "elo_delta_signed": signed_delta,
+                    "abs_elo_delta": abs(delta_abs) if delta_abs is not None else None,
+                    "opp_max_rating": float(opp_max) if opp_max is not None else None,
+                    "lobby_avg_rating": float(lobby_avg_rating) if lobby_avg_rating is not None else None,
+                }
+            )
+
+    return pd.DataFrame.from_records(records)
+
+
+def _avg(values: Iterable[float | None]) -> float | None:
+    nums = [v for v in values if v is not None]
+    if not nums:
+        return None
+    return float(sum(nums) / len(nums))
+
+
+def _max_rating(values: Iterable[float | None]) -> float | None:
+    nums = [v for v in values if v is not None]
+    if not nums:
+        return None
+    return float(max(nums))
+
+
+def _safe_float(value) -> float | None:
+    try:
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _safe_rating(value, fallback: float | None) -> float | None:
+    v = _safe_float(value)
+    if v is not None:
+        return v
+    if fallback is not None:
+        return float(fallback)
+    return None
+
+
+def _expected_share(team_avg: float | None, opp_avg: float | None) -> float:
+    try:
+        if team_avg is None or opp_avg is None:
+            return 0.5
+        return 1.0 / (1.0 + 10 ** ((float(opp_avg) - float(team_avg)) / 400.0))
+    except Exception:
+        return 0.5
+
+
+def _week_key(date_dt: pd.Timestamp) -> str:
+    iso = date_dt.isocalendar()
+    return f"{iso.year}-W{int(iso.week):02d}"
+
+
+def _month_key(date_dt: pd.Timestamp) -> str:
+    return date_dt.strftime("%Y-%m")
+
+
+def _season_key(date_dt: pd.Timestamp) -> str:
+    return date_dt.strftime("%Y")

--- a/tests/test_match_facts.py
+++ b/tests/test_match_facts.py
@@ -1,0 +1,213 @@
+from types import SimpleNamespace
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from jupr_app.domain.gamification.match_facts import build_player_match_facts
+
+
+def test_build_player_match_facts_filters_and_outputs():
+    df_matches = pd.DataFrame(
+        [
+            {
+                "id": "m1",
+                "club_id": "club",
+                "league": "A",
+                "date": "2024-01-01",
+                "score_t1": 11,
+                "score_t2": 5,
+                "t1_p1": 1,
+                "t1_p2": None,
+                "t2_p1": 2,
+                "t2_p2": None,
+                "t1_p1_r": 1500,
+                "t2_p1_r": 1400,
+                "match_type": "League",
+                "is_valid": True,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+                "elo_delta": 10,
+            },
+            {
+                "id": "m2",
+                "club_id": "club",
+                "league": "A",
+                "date": "2024-01-02",
+                "score_t1": 11,
+                "score_t2": 9,
+                "t1_p1": 1,
+                "t1_p2": 3,
+                "t2_p1": 2,
+                "t2_p2": 4,
+                "t1_p1_r": 1500,
+                "t1_p2_r": 1550,
+                "t2_p1_r": 1400,
+                "t2_p2_r": 1450,
+                "match_type": "League",
+                "is_valid": True,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+                "elo_delta": 5,
+            },
+            {
+                "id": "m3",
+                "club_id": "club",
+                "league": "A",
+                "date": "2024-01-03",
+                "score_t1": 11,
+                "score_t2": 7,
+                "t1_p1": 1,
+                "t2_p1": 2,
+                "match_type": "PopUp",
+                "is_valid": True,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+            },
+            {
+                "id": "m4",
+                "club_id": "club",
+                "league": "A",
+                "date": "2024-01-04",
+                "score_t1": 11,
+                "score_t2": 6,
+                "t1_p1": 1,
+                "t2_p1": 2,
+                "match_type": "League",
+                "is_valid": True,
+                "context_type": "TOURNAMENT",
+                "tournament_id": None,
+            },
+            {
+                "id": "m5",
+                "club_id": "club",
+                "league": "A",
+                "date": "2024-01-05",
+                "score_t1": 11,
+                "score_t2": 8,
+                "t1_p1": 1,
+                "t2_p1": 2,
+                "match_type": "League",
+                "is_valid": False,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+            },
+            {
+                "id": "m6",
+                "club_id": "club",
+                "league": "A",
+                "date": "2024-01-06",
+                "score_t1": 11,
+                "score_t2": 3,
+                "t1_p1": 1,
+                "t2_p1": 2,
+                "match_type": "League",
+                "is_void": True,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+            },
+            {
+                "id": "m7",
+                "club_id": "club",
+                "league": "A",
+                "date": "2024-01-07",
+                "score_t1": 11,
+                "score_t2": 3,
+                "t1_p1": 1,
+                "t2_p1": 2,
+                "match_type": "League",
+                "deleted": True,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+            },
+            {
+                "id": "m8",
+                "club_id": "club",
+                "league": "A",
+                "date": "2024-01-08",
+                "score_t1": 0,
+                "score_t2": 0,
+                "t1_p1": 1,
+                "t2_p1": 2,
+                "match_type": "League",
+                "is_valid": True,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+            },
+            {
+                "id": "m9",
+                "club_id": "other",
+                "league": "A",
+                "date": "2024-01-09",
+                "score_t1": 11,
+                "score_t2": 9,
+                "t1_p1": 1,
+                "t2_p1": 2,
+                "match_type": "League",
+                "is_valid": True,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+            },
+        ]
+    )
+
+    ctx = SimpleNamespace(df_matches=df_matches, club_id="club")
+    facts = build_player_match_facts(ctx)
+
+    expected_columns = [
+        "club_id",
+        "player_id",
+        "match_id",
+        "league",
+        "date_dt",
+        "week_key",
+        "month_key",
+        "season_key",
+        "win",
+        "points_for",
+        "points_against",
+        "margin",
+        "partner_id",
+        "opponent_ids",
+        "expected_win_prob",
+        "elo_delta_signed",
+        "abs_elo_delta",
+        "opp_max_rating",
+        "lobby_avg_rating",
+    ]
+    assert list(facts.columns) == expected_columns
+    assert len(facts) == 6
+
+    m1_p1 = facts[(facts["match_id"] == "m1") & (facts["player_id"] == 1)].iloc[0]
+    assert bool(m1_p1.win) is True
+    assert m1_p1.margin == 6
+    assert m1_p1.points_for == 11
+    assert m1_p1.points_against == 5
+    assert pd.isna(m1_p1.partner_id)
+    assert m1_p1.opponent_ids == [2]
+    expected_win = 1.0 / (1.0 + 10 ** ((1400 - 1500) / 400.0))
+    assert m1_p1.expected_win_prob == pytest.approx(expected_win)
+
+    m2_p1 = facts[(facts["match_id"] == "m2") & (facts["player_id"] == 1)].iloc[0]
+    assert bool(m2_p1.win) is True
+    assert m2_p1.partner_id == 3
+    assert sorted(m2_p1.opponent_ids) == [2, 4]
+    assert m2_p1.margin == 2
+
+    week_key = pd.Timestamp("2024-01-01", tz="UTC").isocalendar()
+    assert m1_p1.week_key == f"{week_key.year}-W{int(week_key.week):02d}"
+    assert m1_p1.month_key == "2024-01"
+    assert m1_p1.season_key == "2024"
+
+
+def test_no_gamification_badge_rules_imports_in_domain_modules():
+    repo_root = Path(__file__).resolve().parents[1]
+    roots = [repo_root / "jupr_app" / "domain", repo_root / "jupr_app" / "domain" / "gamification"]
+    disallowed = "badge_rules"
+
+    for root in roots:
+        for path in root.rglob("*.py"):
+            if path.name == "badge_rules.py":
+                continue
+            contents = path.read_text(encoding="utf-8")
+            assert disallowed not in contents, f"Found '{disallowed}' in {path}"


### PR DESCRIPTION
### Motivation

- The badge engine depended on the deprecated `badge_rules.py` for core match-facts, creating two sources of truth and risking subtle behavior drift.
- The goal is to centralize match-facts generation in a non-deprecated module while keeping badge logic unchanged.
- Add regression coverage and a small guard to prevent reintroducing the deprecated import in production code.

### Description

- Added a new canonical module `jupr_app.domain.gamification.match_facts` which implements `build_player_match_facts(...)` and the helper utilities used to produce badge match-facts. 
- Updated evaluator paths to import `build_player_match_facts` from `jupr_app.domain.gamification.match_facts` instead of `badge_rules` (see `jupr_app/domain/gamification/evaluators.py`).
- Converted `jupr_app.domain.gamification.badge_rules` into a DEPRECATED shim that now delegates match-facts generation to the new `match_facts` module (removed duplicate implementation from the deprecated file). 
- Added `tests/test_match_facts.py` that (a) asserts the match-facts output and schema for synthetic matches (singles/doubles, popups excluded, tournaments excluded, invalid/void/deleted rows excluded, score normalization, etc.) and (b) asserts no production domain modules contain `badge_rules` imports (excluding the shim itself).

### Testing

- Ran the new test suite: `pytest -q tests/test_match_facts.py`, which passed (`2 passed`) with only pandas FutureWarnings reported. 
- Verified that `build_player_match_facts` is referenced from `jupr_app.domain.gamification.match_facts` in evaluator codepaths via repository search. 
- No existing badge semantics, thresholds, or filtering logic were changed; the match-facts implementation preserves prior behavior by copying the original logic into the canonical module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ec1996334832689e4373da409cfdf)