### PR TITLE
Enforce canonical player_badges uniqueness contract

### DIFF
--- a/docs/badges_engine.md
+++ b/docs/badges_engine.md
@@ -14,6 +14,12 @@ The engine computes `BadgeCandidate` objects via the registry/evaluators and per
 `badges_repo.upsert_player_badges`, which enforces idempotency using the
 `club_id,player_id,badge_id,context_id` unique key.
 
+## Player badge uniqueness contract
+- **Uniqueness key:** `(club_id, player_id, badge_id, context_id)`
+- `context_id` encodes the award scope (overall / league / season / day) and **must always be set**.
+- `context_type` is informational only and does **not** participate in uniqueness.
+- A badge can be earned multiple times only if the `context_id` differs.
+
 ## How to run backfill
 ### Streamlit admin tool
 Use **Admin Tools → Badge Backfill**. This calls `ensure_badges()` with optional league and as-of

--- a/jupr_app/domain/gamification/badges_repo.py
+++ b/jupr_app/domain/gamification/badges_repo.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import logging
+import os
+import re
 from typing import Any, Iterable
 from uuid import uuid4
 
@@ -10,6 +12,66 @@ from jupr_app.domain.gamification.copy_pack import get_badge_copy, pick_variant,
 
 
 logger = logging.getLogger(__name__)
+PLAYER_BADGES_CONFLICT_KEY = "club_id,player_id,badge_id,context_id"
+_PLAYER_BADGES_CONTRACT_CHECKED = False
+
+
+def ensure_player_badges_contract(supabase: Any) -> bool:
+    expected_columns = ["club_id", "player_id", "badge_id", "context_id"]
+    try:
+        resp = (
+            supabase.table("pg_indexes")
+            .select("schemaname,tablename,indexname,indexdef")
+            .eq("schemaname", "public")
+            .eq("tablename", "player_badges")
+            .execute()
+        )
+    except Exception:
+        logger.exception("Failed to verify player_badges unique index; skipping contract check")
+        return False
+
+    rows = resp.data or []
+    if _has_unique_index_on_columns(rows, expected_columns):
+        return True
+
+    logger.error(
+        "player_badges unique contract missing or mismatched. Expected unique index on (%s).",
+        ", ".join(expected_columns),
+    )
+    if _should_raise_on_schema_mismatch():
+        raise RuntimeError("player_badges unique index contract missing")
+    return False
+
+
+def _has_unique_index_on_columns(rows: Iterable[dict[str, Any]], expected: list[str]) -> bool:
+    expected_normalized = [col.strip().lower() for col in expected]
+    for row in rows:
+        indexdef = str(row.get("indexdef") or "")
+        if "UNIQUE" not in indexdef.upper():
+            continue
+        columns = _extract_index_columns(indexdef)
+        if columns == expected_normalized:
+            return True
+    return False
+
+
+def _extract_index_columns(indexdef: str) -> list[str]:
+    match = re.search(r"\(([^)]+)\)", indexdef)
+    if not match:
+        return []
+    columns = []
+    for col in match.group(1).split(","):
+        col = col.strip().strip('"')
+        if col:
+            columns.append(col.lower())
+    return columns
+
+
+def _should_raise_on_schema_mismatch() -> bool:
+    env = os.getenv("JUPR_ENV", "").lower()
+    if env in {"dev", "development", "local"}:
+        return True
+    return os.getenv("BADGE_DEBUG") == "1" or os.getenv("JUPR_ADMIN") == "1"
 
 
 def upsert_player_badges(
@@ -17,9 +79,14 @@ def upsert_player_badges(
     club_id: str,
     candidates: Iterable[BadgeCandidate],
 ) -> list[BadgeCandidate]:
+    global _PLAYER_BADGES_CONTRACT_CHECKED
     candidate_list = list(candidates)
     if not candidate_list:
         return []
+
+    if not _PLAYER_BADGES_CONTRACT_CHECKED:
+        ensure_player_badges_contract(supabase)
+        _PLAYER_BADGES_CONTRACT_CHECKED = True
 
     existing = _fetch_existing_keys(supabase, club_id, candidate_list)
     now = datetime.now(timezone.utc).isoformat()
@@ -27,9 +94,9 @@ def upsert_player_badges(
     created: list[BadgeCandidate] = []
 
     for candidate in candidate_list:
-        context_id = candidate.context_id
-        if context_id is None:
-            context_id = str(candidate.badge_id)
+        if candidate.context_id is None or str(candidate.context_id).strip() == "":
+            raise ValueError(f"Missing context_id for badge {candidate.badge_id} (player {candidate.player_id})")
+        context_id = str(candidate.context_id)
         key = (int(candidate.player_id), str(candidate.badge_id), str(context_id))
         if key in existing:
             continue
@@ -63,7 +130,7 @@ def upsert_player_badges(
     for i in range(0, len(rows), chunk):
         supabase.table("player_badges").upsert(
             rows[i : i + chunk],
-            on_conflict="club_id,player_id,badge_id,context_id",
+            on_conflict=PLAYER_BADGES_CONFLICT_KEY,
         ).execute()
     return created
 
@@ -93,8 +160,10 @@ def _fetch_existing_keys(
         except Exception:
             continue
         badge_id = str(row.get("badge_id"))
-        context_id = str(row.get("context_id") or badge_id)
-        existing.add((player_id, badge_id, context_id))
+        context_id = row.get("context_id")
+        if context_id is None:
+            continue
+        existing.add((player_id, badge_id, str(context_id)))
     return existing
 
 

--- a/jupr_app/domain/gamification/evaluators.py
+++ b/jupr_app/domain/gamification/evaluators.py
@@ -57,7 +57,7 @@ def _participant_candidates(ctx: BadgeEvaluationContext, badge_id: str, threshol
                 player_id=int(player_id),
                 club_id=ctx.club_id,
                 context_type="overall",
-                context_id=None,
+                context_id="overall",
                 match_id=None,
                 value_json={"games": int(games)},
                 value_num=float(games),

--- a/migrations/20260615_player_badges_unique_contract.sql
+++ b/migrations/20260615_player_badges_unique_contract.sql
@@ -1,0 +1,55 @@
+-- Canonical player_badges uniqueness contract:
+-- (club_id, player_id, badge_id, context_id)
+-- context_id encodes scope; context_type is informational only.
+
+with ranked as (
+    select
+        id,
+        row_number() over (
+            partition by club_id, player_id, badge_id, context_id
+            order by earned_at asc nulls last, id asc
+        ) as rn
+    from player_badges
+)
+delete from player_badges
+where id in (select id from ranked where rn > 1);
+
+do $$
+declare
+    constraint_name text;
+begin
+    for constraint_name in
+        select con.conname
+        from pg_constraint con
+        join pg_class rel on rel.oid = con.conrelid
+        join pg_namespace nsp on nsp.oid = rel.relnamespace
+        join unnest(con.conkey) with ordinality as cols(attnum, ord) on true
+        join pg_attribute att on att.attrelid = rel.oid and att.attnum = cols.attnum
+        where con.contype = 'u'
+          and nsp.nspname = 'public'
+          and rel.relname = 'player_badges'
+        group by con.conname
+        having bool_or(att.attname = 'context_type')
+    loop
+        execute format('alter table public.player_badges drop constraint if exists %I', constraint_name);
+    end loop;
+
+    execute 'alter table public.player_badges drop constraint if exists player_badges_unique_context';
+    execute 'alter table public.player_badges drop constraint if exists player_badges_club_id_player_id_badge_id_context_id_key';
+    execute 'alter table public.player_badges drop constraint if exists player_badges_unique_context_type';
+
+    if not exists (
+        select 1
+        from pg_constraint con
+        join pg_class rel on rel.oid = con.conrelid
+        join pg_namespace nsp on nsp.oid = rel.relnamespace
+        where con.contype = 'u'
+          and nsp.nspname = 'public'
+          and rel.relname = 'player_badges'
+          and con.conname = 'player_badges_unique_context'
+    ) then
+        alter table public.player_badges
+            add constraint player_badges_unique_context
+            unique (club_id, player_id, badge_id, context_id);
+    end if;
+end $$;

--- a/tests/test_badge_engine.py
+++ b/tests/test_badge_engine.py
@@ -110,7 +110,7 @@ def test_badge_upsert_adds_tape_excerpt_and_is_idempotent():
         player_id=1,
         club_id="club",
         context_type="overall",
-        context_id=None,
+        context_id="overall",
         match_id=None,
         value_json={"games": 1},
     )

--- a/tests/test_badge_integrity.py
+++ b/tests/test_badge_integrity.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pandas as pd
+import pytest
 
 from jupr_app.domain.gamification.badge_integrity import dedupe_player_badges_rows
 from jupr_app.domain.gamification.badge_types import BadgeCandidate
@@ -104,10 +105,27 @@ def test_participation_insert_uses_upsert_conflict():
             player_id=1,
             club_id="club",
             context_type="overall",
-            context_id=None,
+            context_id="overall",
             match_id=None,
             value_num=5,
         )
     ]
     upsert_player_badges(supabase, "club", candidates)
     assert supabase.table_ref.on_conflict == "club_id,player_id,badge_id,context_id"
+
+
+def test_upsert_rejects_missing_context_id():
+    supabase = CaptureSupabase()
+    candidates = [
+        BadgeCandidate(
+            badge_id="participant",
+            player_id=1,
+            club_id="club",
+            context_type="overall",
+            context_id=None,
+            match_id=None,
+            value_num=5,
+        )
+    ]
+    with pytest.raises(ValueError):
+        upsert_player_badges(supabase, "club", candidates)

--- a/tests/test_player_badges_contract.py
+++ b/tests/test_player_badges_contract.py
@@ -1,0 +1,128 @@
+from types import SimpleNamespace
+
+import pytest
+
+from jupr_app.domain.gamification.badge_types import BadgeCandidate
+from jupr_app.domain.gamification.badges_repo import ensure_player_badges_contract, upsert_player_badges
+
+
+class FakeTable:
+    def __init__(self, storage, name):
+        self.storage = storage
+        self.name = name
+        self.filters = []
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, column, value):
+        self.filters.append(("eq", column, value))
+        return self
+
+    def in_(self, column, values):
+        self.filters.append(("in", column, set(values)))
+        return self
+
+    def upsert(self, rows, on_conflict=None):
+        existing = self.storage.setdefault(self.name, [])
+        keys = [c.strip() for c in str(on_conflict or "").split(",") if c.strip()]
+        existing_keys = {tuple(row.get(k) for k in keys) for row in existing} if keys else set()
+        for row in rows:
+            key = tuple(row.get(k) for k in keys) if keys else None
+            if key is not None and key in existing_keys:
+                continue
+            existing.append(row)
+            if key is not None:
+                existing_keys.add(key)
+        return self
+
+    def execute(self):
+        data = list(self.storage.get(self.name, []))
+        for op, column, value in self.filters:
+            if op == "eq":
+                data = [row for row in data if str(row.get(column)) == str(value)]
+            elif op == "in":
+                data = [row for row in data if row.get(column) in value]
+        return SimpleNamespace(data=data)
+
+
+class FakeSupabase:
+    def __init__(self, storage=None):
+        self.storage = storage if storage is not None else {}
+
+    def table(self, name):
+        return FakeTable(self.storage, name)
+
+
+def _default_indexes():
+    return [
+        {
+            "schemaname": "public",
+            "tablename": "player_badges",
+            "indexname": "player_badges_unique_context",
+            "indexdef": (
+                "CREATE UNIQUE INDEX player_badges_unique_context "
+                "ON public.player_badges USING btree (club_id, player_id, badge_id, context_id)"
+            ),
+        }
+    ]
+
+
+def test_player_badges_idempotent_upsert():
+    storage = {"pg_indexes": _default_indexes()}
+    supabase = FakeSupabase(storage)
+    candidate = BadgeCandidate(
+        badge_id="participant",
+        player_id=1,
+        club_id="club",
+        context_type="overall",
+        context_id="overall",
+        match_id=None,
+        value_json={"games": 1},
+    )
+    upsert_player_badges(supabase, "club", [candidate])
+    upsert_player_badges(supabase, "club", [candidate])
+    assert len(storage["player_badges"]) == 1
+
+
+def test_player_badges_multi_context_allowed():
+    storage = {"pg_indexes": _default_indexes()}
+    supabase = FakeSupabase(storage)
+    base = dict(
+        badge_id="mountain_climber",
+        player_id=1,
+        club_id="club",
+        context_type="league",
+        match_id=None,
+    )
+    upsert_player_badges(
+        supabase,
+        "club",
+        [BadgeCandidate(context_id="league:alpha", value_json={"games": 1}, **base)],
+    )
+    upsert_player_badges(
+        supabase,
+        "club",
+        [BadgeCandidate(context_id="league:beta", value_json={"games": 2}, **base)],
+    )
+    assert len(storage["player_badges"]) == 2
+
+
+def test_player_badges_contract_check_rejects_wrong_index(monkeypatch):
+    storage = {
+        "pg_indexes": [
+            {
+                "schemaname": "public",
+                "tablename": "player_badges",
+                "indexname": "player_badges_unique_context_type",
+                "indexdef": (
+                    "CREATE UNIQUE INDEX player_badges_unique_context_type "
+                    "ON public.player_badges USING btree (club_id, player_id, badge_id, context_type, context_id)"
+                ),
+            }
+        ]
+    }
+    supabase = FakeSupabase(storage)
+    monkeypatch.setenv("BADGE_DEBUG", "1")
+    with pytest.raises(RuntimeError):
+        ensure_player_badges_contract(supabase)


### PR DESCRIPTION
### Motivation
- Establish a single, provable uniqueness contract for `player_badges` to eliminate ON CONFLICT errors, silent duplicates, and environment drift.
- `context_id` must encode award scope and participate in uniqueness while `context_type` remains informational only.
- Changes must be safe, idempotent across runs, and surface future schema drift loudly.

### Description
- Add an idempotent migration `migrations/20260615_player_badges_unique_contract.sql` that deduplicates existing rows (keeping earliest `earned_at` / lowest `id`), drops legacy `context_type`-based unique constraints, and creates the canonical unique constraint on `(club_id, player_id, badge_id, context_id)`.
- Harden persistence in `jupr_app/domain/gamification/badges_repo.py` by requiring non-null `context_id`, switching to a single `PLAYER_BADGES_CONFLICT_KEY = "club_id,player_id,badge_id,context_id"`, and consulting a runtime schema health check `ensure_player_badges_contract()` that validates the exact unique index via `pg_indexes` and optionally raises on mismatch in dev/debug/admin modes.
- Update evaluators to populate `context_id` for participant-style badges (`context_id="overall"`) so stackable badges never write null `context_id` by default.
- Add documentation to `docs/badges_engine.md` describing the canonical uniqueness contract and add tests under `tests/test_player_badges_contract.py` plus small adjustments to existing tests to reflect the contract and to assert rejection of missing `context_id`.

### Testing
- Added unit tests verifying idempotent upserts, legitimate multi-context awards, and schema-contract rejection in `tests/test_player_badges_contract.py` and adjusted existing tests in `tests/test_badge_engine.py` and `tests/test_badge_integrity.py` to the new contract.
- Ran `pytest tests/test_badge_engine.py tests/test_badge_integrity.py tests/test_player_badges_contract.py` and all tests passed (`12 passed`).
- The migration is written defensively (uses `IF EXISTS` / `IF NOT EXISTS` patterns and safe deletes) to be safe to re-run in production environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fa7df5e308326b3d345b24a1d243a)