### PR TITLE
Handle legacy badges schema in load_data

### DIFF
--- a/jupr_app/data/load.py
+++ b/jupr_app/data/load.py
@@ -4,6 +4,7 @@ import pandas as pd
 from jupr_app.domain.player_activity import add_activity_columns
 from jupr_app.domain.gamification.badge_registry import badge_schema_by_id
 from jupr_app.domain.gamification.requirements import load_requirements_map
+from postgrest.exceptions import APIError
 
 
 def load_data(supabase, club_id: str, match_limit: int = 5000):
@@ -71,14 +72,29 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
             df_meta = pd.DataFrame(meta_resp.data or [])
 
             # Badges (global definitions)
-            badges_resp = (
-                supabase.table("badges")
-                .select(
-                    "badge_id,name,prestige,category,is_stackable,is_active,rarity,"
-                    "tier,icon_key,scope,state,state_changed_at,state_change_reason,eval_triggers,created_at"
+            try:
+                # Support older badge schema variants that lack state-related columns.
+                badges_resp = (
+                    supabase.table("badges")
+                    .select(
+                        "badge_id,name,prestige,category,is_stackable,is_active,rarity,"
+                        "tier,icon_key,scope,state,state_changed_at,state_change_reason,eval_triggers,created_at"
+                    )
+                    .execute()
                 )
-                .execute()
-            )
+            except APIError as exc:
+                message = str(exc)
+                if getattr(exc, "code", None) == "42703" or "badges.state does not exist" in message:
+                    badges_resp = (
+                        supabase.table("badges")
+                        .select(
+                            "badge_id,name,prestige,category,is_stackable,is_active,rarity,"
+                            "tier,icon_key,scope,created_at"
+                        )
+                        .execute()
+                    )
+                else:
+                    raise
             df_badges = pd.DataFrame(badges_resp.data or [])
             if not df_badges.empty and "badge_id" in df_badges.columns:
                 if "state" not in df_badges.columns:


### PR DESCRIPTION
### Motivation
- Streamlit crashes when the Supabase `badges` table lacks newer columns like `state`/`eval_triggers`, raising PostgREST 42703 errors and preventing the app from loading badges.

### Description
- Import `APIError` and wrap the `badges` query in a `try/except` to catch PostgREST missing-column errors and retry a legacy `select` that omits `state`-related columns when the error code is `42703` (or the message contains `badges.state does not exist`).
- Preserve existing downstream behavior to set `df_badges["state"] = "live"` and `df_badges["eval_triggers"] = [["match_recorded","match_updated"]]` when those columns are absent, and keep requirements/schema mapping via `load_requirements_map()` and `badge_schema_by_id()`.
- Add a short comment explaining the schema compatibility fallback and update `jupr_app/data/load.py` accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f64b40b08326be650e3fac818f47)