### PR TITLE
Gracefully handle missing player_badges provenance columns and retry upserts

### DIFF
--- a/docs/badges_engine.md
+++ b/docs/badges_engine.md
@@ -61,6 +61,56 @@ Each run writes a row to `badge_eval_runs` and, when updating awards, tags `play
 `awarded_by='recompute'`, a `rule_version` hash, and the `eval_run_id`. Strict mode soft-revokes
 awards by setting `revoked_at`, `revoked_by`, and `revoke_reason`.
 
+## Schema notes (player_badges provenance + revocation)
+The recompute engine expects the migrations in:
+- `migrations/20260625_badge_recompute_runs.sql`
+- `migrations/20260630_player_badges_revocation.sql`
+
+If your Supabase environment isn't applying migrations automatically, run the SQL below in the
+Supabase SQL editor to add the missing columns and grants:
+
+```sql
+create table if not exists public.badge_eval_runs (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  created_by text,
+  mode text not null,
+  scope_json jsonb not null default '{}'::jsonb,
+  status text not null default 'queued',
+  started_at timestamptz,
+  finished_at timestamptz,
+  summary_json jsonb not null default '{}'::jsonb,
+  error text
+);
+
+alter table if exists public.player_badges
+  add column if not exists awarded_by text not null default 'engine',
+  add column if not exists rule_version text,
+  add column if not exists eval_run_id uuid references public.badge_eval_runs(id),
+  add column if not exists revoked_at timestamptz,
+  add column if not exists revoked_by text,
+  add column if not exists revoke_reason text;
+
+grant select (
+  id,
+  club_id,
+  player_id,
+  badge_id,
+  earned_at,
+  context_type,
+  context_id,
+  match_id,
+  value_num,
+  value_json,
+  awarded_by,
+  rule_version,
+  eval_run_id,
+  revoked_at,
+  revoked_by,
+  revoke_reason
+) on public.player_badges to anon, authenticated;
+```
+
 ## Incremental badge evaluation
 When matches are ingested or edited, the app enqueues badge evaluation work instead of evaluating
 the full match history on every page view:

--- a/jupr_app/data/load.py
+++ b/jupr_app/data/load.py
@@ -5,14 +5,95 @@ from jupr_app.domain.player_activity import add_activity_columns
 from jupr_app.domain.gamification.badge_descriptions import BADGE_DESCRIPTIONS_MD
 from jupr_app.domain.gamification.badge_registry import badge_schema_by_id
 from jupr_app.domain.gamification.requirements import load_requirements_map
+import re
 from postgrest.exceptions import APIError
+
+
+PLAYER_BADGES_BASE_COLUMNS = [
+    "id",
+    "club_id",
+    "player_id",
+    "badge_id",
+    "earned_at",
+    "context_type",
+    "context_id",
+    "match_id",
+    "value_num",
+    "value_json",
+]
+PLAYER_BADGES_OPTIONAL_COLUMNS = [
+    "awarded_by",
+    "rule_version",
+    "eval_run_id",
+    "revoked_at",
+    "revoked_by",
+    "revoke_reason",
+]
+
+
+def _missing_player_badges_columns(exc: APIError) -> set[str]:
+    message = str(exc)
+    missing = {col for col in PLAYER_BADGES_OPTIONAL_COLUMNS if col in message}
+    if missing:
+        return missing
+    matches = re.findall(r"player_badges\\.([a-zA-Z0-9_]+)", message)
+    return {col for col in matches if col in PLAYER_BADGES_OPTIONAL_COLUMNS}
+
+
+def _ensure_player_badges_columns(df: pd.DataFrame) -> pd.DataFrame:
+    defaults = {
+        "awarded_by": "engine",
+        "rule_version": None,
+        "eval_run_id": None,
+        "revoked_at": None,
+        "revoked_by": None,
+        "revoke_reason": None,
+    }
+    for col, default in defaults.items():
+        if col not in df.columns:
+            df[col] = default
+    return df
+
+
+def _fetch_player_badges(supabase, club_id: str) -> tuple[pd.DataFrame, bool, str | None]:
+    schema_degraded = False
+    schema_degraded_reason = None
+    select_cols = ",".join(PLAYER_BADGES_BASE_COLUMNS + PLAYER_BADGES_OPTIONAL_COLUMNS)
+    try:
+        pb_resp = (
+            supabase.table("player_badges")
+            .select(select_cols)
+            .eq("club_id", club_id)
+            .execute()
+        )
+    except APIError as exc:
+        missing = _missing_player_badges_columns(exc)
+        if getattr(exc, "code", None) == "42703" and missing:
+            schema_degraded = True
+            schema_degraded_reason = (
+                "player_badges missing columns "
+                f"{', '.join(sorted(missing))}; apply migrations/20260625_badge_recompute_runs.sql and "
+                "migrations/20260630_player_badges_revocation.sql."
+            )
+            legacy_select = ",".join(PLAYER_BADGES_BASE_COLUMNS)
+            pb_resp = (
+                supabase.table("player_badges")
+                .select(legacy_select)
+                .eq("club_id", club_id)
+                .execute()
+            )
+        else:
+            raise
+    df_player_badges = pd.DataFrame(pb_resp.data or [])
+    df_player_badges = _ensure_player_badges_columns(df_player_badges)
+    return df_player_badges, schema_degraded, schema_degraded_reason
 
 
 def load_data(supabase, club_id: str, match_limit: int = 5000):
     """
     Loads club-scoped tables and returns:
       df_players_all, df_players_active, df_leagues, df_matches, df_meta, df_badges,
-      df_player_badges, name_to_id, id_to_name
+      df_player_badges, name_to_id, id_to_name, schema_degraded, schema_degraded_reason
 
     No Streamlit calls here. Raise exceptions to be handled by UI.
     """
@@ -23,6 +104,8 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
 
     for attempt in range(max_retries):
         try:
+            schema_degraded = False
+            schema_degraded_reason = None
             # Players
             p_resp = (
                 supabase.table("players")
@@ -121,33 +204,10 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
                 )
 
             # Player badges (club-scoped)
-            try:
-                pb_resp = (
-                    supabase.table("player_badges")
-                    .select(
-                        "id,club_id,player_id,badge_id,earned_at,context_type,context_id,"
-                        "match_id,value_num,value_json,awarded_by,rule_version,eval_run_id,"
-                        "revoked_at,revoked_by,revoke_reason"
-                    )
-                    .eq("club_id", club_id)
-                    .execute()
-                )
-            except APIError as exc:
-                message = str(exc)
-                if getattr(exc, "code", None) == "42703" or "player_badges.awarded_by does not exist" in message:
-                    pb_resp = (
-                        supabase.table("player_badges")
-                        .select(
-                            "id,club_id,player_id,badge_id,earned_at,context_type,context_id,"
-                            "match_id,value_num,value_json,rule_version,eval_run_id,"
-                            "revoked_at,revoked_by,revoke_reason"
-                        )
-                        .eq("club_id", club_id)
-                        .execute()
-                    )
-                else:
-                    raise
-            df_player_badges = pd.DataFrame(pb_resp.data or [])
+            df_player_badges, schema_degraded, schema_degraded_reason = _fetch_player_badges(
+                supabase,
+                club_id,
+            )
 
             # Mappings
             if (
@@ -200,6 +260,8 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
                 df_player_badges,
                 name_to_id,
                 id_to_name,
+                schema_degraded,
+                schema_degraded_reason,
             )
 
         except Exception as e:

--- a/jupr_app/domain/gamification/badge_worker.py
+++ b/jupr_app/domain/gamification/badge_worker.py
@@ -78,6 +78,8 @@ def _resolve_context(ctx: Any | None, supabase: Any, club_id: str, match_limit: 
         df_player_badges,
         name_to_id,
         id_to_name,
+        schema_degraded,
+        schema_degraded_reason,
     ) = load_data(supabase, club_id, match_limit=match_limit)
     return SimpleNamespace(
         supabase=supabase,
@@ -93,6 +95,8 @@ def _resolve_context(ctx: Any | None, supabase: Any, club_id: str, match_limit: 
         id_to_name=id_to_name,
         public_mode=False,
         admin_logged_in=True,
+        schema_degraded=schema_degraded,
+        schema_degraded_reason=schema_degraded_reason,
     )
 
 

--- a/jupr_app/domain/gamification/badges_repo.py
+++ b/jupr_app/domain/gamification/badges_repo.py
@@ -9,11 +9,13 @@ from uuid import uuid4
 
 from jupr_app.domain.gamification.badge_types import BadgeCandidate
 from jupr_app.domain.gamification.copy_pack import get_badge_copy, pick_variant, render_template
+from postgrest.exceptions import APIError
 
 
 logger = logging.getLogger(__name__)
 PLAYER_BADGES_CONFLICT_KEY = "club_id,player_id,badge_id,context_id"
 _PLAYER_BADGES_CONTRACT_CHECKED = False
+_PLAYER_BADGES_OPTIONAL_COLUMNS = ("awarded_by", "rule_version", "eval_run_id")
 
 
 def ensure_player_badges_contract(supabase: Any) -> bool:
@@ -135,11 +137,45 @@ def upsert_player_badges(
 
     chunk = 200
     for i in range(0, len(rows), chunk):
-        supabase.table("player_badges").upsert(
+        _upsert_player_badges_chunk(
+            supabase,
             rows[i : i + chunk],
+        )
+    return created
+
+
+def _upsert_player_badges_chunk(supabase: Any, rows: list[dict[str, Any]]) -> None:
+    try:
+        supabase.table("player_badges").upsert(
+            rows,
             on_conflict=PLAYER_BADGES_CONFLICT_KEY,
         ).execute()
-    return created
+    except APIError as exc:
+        if _is_missing_column_error(exc, _PLAYER_BADGES_OPTIONAL_COLUMNS):
+            logger.warning(
+                "player_badges schema missing optional columns; retrying upsert without provenance fields."
+            )
+            stripped = [_strip_optional_columns(row, _PLAYER_BADGES_OPTIONAL_COLUMNS) for row in rows]
+            supabase.table("player_badges").upsert(
+                stripped,
+                on_conflict=PLAYER_BADGES_CONFLICT_KEY,
+            ).execute()
+        else:
+            raise
+
+
+def _strip_optional_columns(row: dict[str, Any], columns: Iterable[str]) -> dict[str, Any]:
+    cleaned = dict(row)
+    for col in columns:
+        cleaned.pop(col, None)
+    return cleaned
+
+
+def _is_missing_column_error(exc: APIError, columns: Iterable[str]) -> bool:
+    if getattr(exc, "code", None) != "42703":
+        return False
+    message = str(exc)
+    return any(col in message for col in columns)
 
 
 def _fetch_existing_keys(

--- a/jupr_app/domain/gamification/recompute.py
+++ b/jupr_app/domain/gamification/recompute.py
@@ -155,6 +155,8 @@ def _load_ctx(supabase: Any, club_id: str, match_limit: int) -> Any:
         df_player_badges,
         name_to_id,
         id_to_name,
+        schema_degraded,
+        schema_degraded_reason,
     ) = load_data(supabase, club_id, match_limit=match_limit)
 
     return SimpleNamespace(
@@ -171,6 +173,8 @@ def _load_ctx(supabase: Any, club_id: str, match_limit: int) -> Any:
         id_to_name=id_to_name,
         public_mode=False,
         admin_logged_in=True,
+        schema_degraded=schema_degraded,
+        schema_degraded_reason=schema_degraded_reason,
     )
 
 

--- a/jupr_app/domain/types.py
+++ b/jupr_app/domain/types.py
@@ -17,3 +17,5 @@ class AppContext:
     id_to_name: dict
     public_mode: bool
     admin_logged_in: bool
+    schema_degraded: bool = False
+    schema_degraded_reason: str | None = None

--- a/jupr_app/ui/context.py
+++ b/jupr_app/ui/context.py
@@ -20,3 +20,5 @@ class AppContext:
     id_to_name: dict
     public_mode: bool
     admin_logged_in: bool
+    schema_degraded: bool = False
+    schema_degraded_reason: str | None = None

--- a/migrations/20260720_player_badges_provenance_grants.sql
+++ b/migrations/20260720_player_badges_provenance_grants.sql
@@ -1,0 +1,18 @@
+grant select (
+    id,
+    club_id,
+    player_id,
+    badge_id,
+    earned_at,
+    context_type,
+    context_id,
+    match_id,
+    value_num,
+    value_json,
+    awarded_by,
+    rule_version,
+    eval_run_id,
+    revoked_at,
+    revoked_by,
+    revoke_reason
+) on public.player_badges to anon, authenticated;

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -273,6 +273,8 @@ def main():
             df_player_badges,
             name_to_id,
             id_to_name,
+            schema_degraded,
+            schema_degraded_reason,
         ) = get_data(CLUB_ID)
 
         ctx = AppContext(
@@ -289,7 +291,17 @@ def main():
             id_to_name=id_to_name,
             public_mode=PUBLIC_MODE,
             admin_logged_in=admin_logged_in,
+            schema_degraded=schema_degraded,
+            schema_degraded_reason=schema_degraded_reason,
         )
+
+        if admin_logged_in and schema_degraded:
+            st.warning(
+                "Badge schema is behind the app code. Apply migrations/20260625_badge_recompute_runs.sql and "
+                "migrations/20260630_player_badges_revocation.sql to restore awarded_by/rule_version/"
+                "eval_run_id/revoked_* support. "
+                f"Details: {schema_degraded_reason}"
+            )
 
         if df_player_badges is not None and df_player_badges.empty:
             player_ids = []

--- a/tests/test_load_data_degraded_schema.py
+++ b/tests/test_load_data_degraded_schema.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pandas as pd
+from postgrest.exceptions import APIError
+
+from jupr_app.data.load import load_data
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeTableQuery:
+    def __init__(self, supabase, table_name: str):
+        self.supabase = supabase
+        self.table_name = table_name
+        self._select = ""
+
+    def select(self, cols):
+        self._select = cols
+        return self
+
+    def eq(self, *args, **kwargs):
+        return self
+
+    def order(self, *args, **kwargs):
+        return self
+
+    def limit(self, *args, **kwargs):
+        return self
+
+    def execute(self):
+        if (
+            self.table_name == "player_badges"
+            and self.supabase.raise_missing_columns
+            and "awarded_by" in self._select
+        ):
+            raise APIError(
+                {
+                    "code": "42703",
+                    "message": "column player_badges.awarded_by does not exist",
+                }
+            )
+        return _FakeResponse(self.supabase.data.get(self.table_name, []))
+
+
+class _FakeSupabase:
+    def __init__(self):
+        self.data = {
+            "players": [],
+            "league_ratings": [],
+            "matches": [],
+            "leagues_metadata": [],
+            "badges": [],
+            "player_badges": [],
+        }
+        self.raise_missing_columns = True
+
+    def table(self, name: str):
+        return _FakeTableQuery(self, name)
+
+
+def test_load_data_degrades_player_badges_schema():
+    supabase = _FakeSupabase()
+
+    (
+        df_players_all,
+        df_players_active,
+        df_leagues,
+        df_matches,
+        df_meta,
+        df_badges,
+        df_player_badges,
+        name_to_id,
+        id_to_name,
+        schema_degraded,
+        schema_degraded_reason,
+    ) = load_data(supabase, "club123", match_limit=5)
+
+    assert schema_degraded is True
+    assert schema_degraded_reason is not None
+    assert "migrations/20260625_badge_recompute_runs.sql" in schema_degraded_reason
+    assert "migrations/20260630_player_badges_revocation.sql" in schema_degraded_reason
+    assert isinstance(df_player_badges, pd.DataFrame)
+    for col in [
+        "awarded_by",
+        "rule_version",
+        "eval_run_id",
+        "revoked_at",
+        "revoked_by",
+        "revoke_reason",
+    ]:
+        assert col in df_player_badges.columns


### PR DESCRIPTION
### Motivation
- The app was crashing on startup when Supabase/PostgREST returned missing-column errors for `player_badges.awarded_by` and `player_badges.rule_version`; the DB migrations adding these columns may not have been applied. 
- Provide a two-layer fix: make the DB schema easy to apply and make the app resilient when the DB is behind so it won't crash on load.

### Description
- Added a resilient player_badges loader in `jupr_app/data/load.py` that tries the full (new) select, catches `postgrest.exceptions.APIError` 42703 for missing columns, retries with a legacy select, and then adds provenance/revocation columns with safe defaults; it returns `schema_degraded` and `schema_degraded_reason` to callers. (files: `jupr_app/data/load.py`)
- Surface an admin-facing warning in `streamlit_app.py` when `schema_degraded` is True, pointing operators to the migration files to run. (file: `streamlit_app.py`)
- Propagated `schema_degraded`/`schema_degraded_reason` through `AppContext` by adding fields to `jupr_app/ui/context.py` and `jupr_app/domain/types.py`, and passed them through call sites (`badge_worker`, `recompute`). (files: `jupr_app/ui/context.py`, `jupr_app/domain/types.py`, `jupr_app/domain/gamification/badge_worker.py`, `jupr_app/domain/gamification/recompute.py`)
- Made badge writes resilient: `jupr_app/domain/gamification/badges_repo.py` now catches `APIError` 42703 on upsert and retries the upsert without optional provenance fields (`awarded_by`, `rule_version`, `eval_run_id`) if the DB is missing them, logging a warning. (file: `jupr_app/domain/gamification/badges_repo.py`)
- Documented the canonical SQL to create `badge_eval_runs`, add the `player_badges` columns and grants, and added a migration to extend `player_badges` select grants so PostgREST will not error on column-level grants. (files: `docs/badges_engine.md`, `migrations/20260720_player_badges_provenance_grants.sql`)
- Added a small regression test that simulates a PostgREST 42703 error and asserts `load_data` returns `df_player_badges` with default provenance/revocation columns and sets `schema_degraded`. (file: `tests/test_load_data_degraded_schema.py`)

### Testing
- Ran the new smoke regression test: `python -m pytest tests/test_load_data_degraded_schema.py` and it passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f9e073bc8326ac58f81d729f295c)