### PR TITLE
Enforce plain-text badge copy and centralize badge-card HTML rendering

### DIFF
--- a/jupr_app/domain/gamification/badge_copy.py
+++ b/jupr_app/domain/gamification/badge_copy.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_HTML_TAG_RE = re.compile(r"<[^>]*>")
+
+
+@dataclass(frozen=True)
+class BadgeCopyPlain:
+    desc_text: str | None
+    req_text: str | None
+    meta_text: str | None
+
+
+def _normalize_requirement_text(raw: Any) -> str:
+    text = str(raw or "").strip()
+    if not text:
+        return "Requirements TBD"
+    cleaned = re.sub(r"^(requirements?)\s*:\s*", "", text, flags=re.IGNORECASE)
+    cleaned = cleaned.strip()
+    return cleaned or "Requirements TBD"
+
+
+def _normalize_plain_text(raw: Any) -> str | None:
+    text = str(raw or "").strip()
+    return text or None
+
+
+def _sanitize_plain_text(field: str, text: str) -> str:
+    if "<" in text or ">" in text or "badge-card__" in text or "</" in text or "<div" in text:
+        if __debug__:
+            raise AssertionError(f"HTML detected in badge copy field {field}: {text}")
+        stripped = _HTML_TAG_RE.sub("", text)
+        stripped = stripped.replace("<", "").replace(">", "")
+        logger.warning("HTML detected in badge copy field %s; stripping tags.", field)
+        return stripped.strip()
+    return text
+
+
+def build_badge_copy_plain(
+    badge: dict[str, Any],
+    *,
+    earners_count: int | None = None,
+) -> BadgeCopyPlain:
+    desc_text = _normalize_plain_text(badge.get("description_md"))
+    req_text = _normalize_requirement_text(badge.get("requirements"))
+    meta_text = f"{earners_count} earners" if earners_count is not None else None
+
+    if desc_text:
+        desc_text = _sanitize_plain_text("desc_text", desc_text)
+    if req_text:
+        req_text = _sanitize_plain_text("req_text", req_text)
+    if meta_text:
+        meta_text = _sanitize_plain_text("meta_text", meta_text)
+
+    return BadgeCopyPlain(desc_text=desc_text, req_text=req_text, meta_text=meta_text)

--- a/jupr_app/ui/components/__init__.py
+++ b/jupr_app/ui/components/__init__.py
@@ -1,0 +1,1 @@
+"""UI component helpers."""

--- a/jupr_app/ui/components/badge_cards.py
+++ b/jupr_app/ui/components/badge_cards.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import html
+
+from markdown_it import MarkdownIt
+
+from jupr_app.domain.gamification.badge_copy import BadgeCopyPlain
+
+_INLINE_MARKDOWN = MarkdownIt("commonmark", {"html": False})
+
+
+def render_inline_badge_text(text: str | None) -> str:
+    if not text:
+        return ""
+    escaped = html.escape(str(text))
+    return _INLINE_MARKDOWN.renderInline(escaped)
+
+
+def render_badge_card_html(
+    *,
+    name: str,
+    icon: str,
+    copy_plain: BadgeCopyPlain,
+    state_label: str | None = None,
+) -> str:
+    name_text = html.escape(str(name))
+    icon_text = html.escape(str(icon))
+    desc_html = render_inline_badge_text(copy_plain.desc_text)
+    req_html = render_inline_badge_text(copy_plain.req_text)
+    meta_html = html.escape(str(copy_plain.meta_text)) if copy_plain.meta_text else ""
+    state_html = html.escape(str(state_label)) if state_label else ""
+
+    return f"""
+    <div class="badge-card">
+        <div class="badge-card__icon">{icon_text}</div>
+        <div class="badge-card__name" title="{name_text}">{name_text}</div>
+        {f'<div class="badge-card__state">{state_html}</div>' if state_html else ''}
+        {f'<div class="badge-card__desc">{desc_html}</div>' if desc_html else ''}
+        <div class="badge-card__req"><span class="label">Req:</span> {req_html}</div>
+        <div class="badge-card__meta">{meta_html}</div>
+    </div>
+    """

--- a/jupr_app/ui/pages/badge_codex.py
+++ b/jupr_app/ui/pages/badge_codex.py
@@ -4,7 +4,8 @@ import logging
 
 import streamlit as st
 
-from jupr_app.ui.helpers import render_requirement_inline_html
+from jupr_app.domain.gamification.badge_copy import build_badge_copy_plain
+from jupr_app.ui.components.badge_cards import render_badge_card_html
 from jupr_app.ui.pages.players import badge_icon
 
 logger = logging.getLogger(__name__)
@@ -93,11 +94,6 @@ def _render_badge_card(badge: dict, column, df_player_badges, df_players) -> Non
     badge_id = badge.get("badge_id", "")
     name = badge.get("name", "Badge")
     icon = badge_icon(badge_id, badge.get("category"))
-    requirements_html = render_requirement_inline_html(badge.get("requirements"))
-    description_md = badge.get("description_md")
-    description_html = (
-        render_requirement_inline_html(description_md) if description_md else ""
-    )
     earners_count = badge.get("earners_count")
     state = str(badge.get("state") or "live")
     state_label = None
@@ -112,17 +108,15 @@ def _render_badge_card(badge: dict, column, df_player_badges, df_players) -> Non
     )
 
     with column:
+        copy_plain = build_badge_copy_plain(badge, earners_count=earners_count)
+        card_html = render_badge_card_html(
+            name=name,
+            icon=icon,
+            copy_plain=copy_plain,
+            state_label=state_label,
+        )
         st.markdown(
-            f"""
-            <div class="badge-card">
-                <div class="badge-card__icon">{icon}</div>
-                <div class="badge-card__name" title="{name}">{name}</div>
-                {f"<div class='badge-card__state'>{state_label}</div>" if state_label else ""}
-                {f"<div class='badge-card__desc'>{description_html}</div>" if description_html else ""}
-                <div class="badge-card__req"><span class="label">Req:</span> {requirements_html}</div>
-                <div class="badge-card__meta">{'' if earners_count is None else f'{earners_count} earners'}</div>
-            </div>
-            """,
+            card_html,
             unsafe_allow_html=True,
         )
         if st.button(toggle_label, key=f"badge_codex_toggle_{badge_id}", use_container_width=True):

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -9,11 +9,12 @@ import streamlit as st
 import pandas as pd
 from streamlit.components.v1 import html as st_html
 
+from jupr_app.domain.gamification.badge_copy import build_badge_copy_plain
+from jupr_app.ui.components.badge_cards import render_inline_badge_text
 from jupr_app.ui.helpers import (
     qp_get,
     build_match_explorer_link,
     display_requirement_text,
-    render_requirement_inline_html,
 )
 from jupr_app.ui.layout import page_shell
 from jupr_app.domain.gamification.profile import (
@@ -1309,10 +1310,11 @@ def render(ctx):
             else:
                 featured_cards = []
                 for badge in featured:
+                    copy_plain = build_badge_copy_plain(badge)
                     icon = badge_icon(badge.get("badge_id"), badge.get("category"))
                     stack = badge.get("stack_count", 1)
                     stack_text = f" ×{stack}" if stack and stack > 1 else ""
-                    requirements_html = render_requirement_inline_html(badge.get("requirements"))
+                    requirements_html = render_inline_badge_text(copy_plain.req_text)
                     featured_cards.append(
                         f"""
                     <div class="badge-card">
@@ -1380,13 +1382,14 @@ def render(ctx):
                     card_items = []
                     for badge in visible_badges:
                         status = badge.get("status")
+                        copy_plain = build_badge_copy_plain(badge)
                         name = html.escape(str(badge.get("name", "Badge")))
                         prestige = int(badge.get("prestige", 0) or 0)
                         icon = badge_icon(badge.get("badge_id"), badge.get("category"))
                         stack = badge.get("stack_count", 1)
                         stack_text = f" ×{stack}" if stack and stack > 1 else ""
                         if status == "locked":
-                            requirements_html = render_requirement_inline_html(badge.get("requirements"))
+                            requirements_html = render_inline_badge_text(copy_plain.req_text)
                             card_items.append(
                                 f"""
                             <div class="badge-card silhouette">
@@ -1400,7 +1403,7 @@ def render(ctx):
                             """
                             )
                         else:
-                            requirements_html = render_requirement_inline_html(badge.get("requirements"))
+                            requirements_html = render_inline_badge_text(copy_plain.req_text)
                             card_items.append(
                                 f"""
                             <div class="badge-card">

--- a/tests/test_badge_copy_plain.py
+++ b/tests/test_badge_copy_plain.py
@@ -1,0 +1,24 @@
+import pytest
+
+from jupr_app.domain.gamification.badge_copy import build_badge_copy_plain
+
+
+def test_build_badge_copy_plain_keeps_text_plain():
+    badge = {
+        "requirements": "Win 10 games",
+        "description_md": "Earn *10* wins.",
+    }
+    copy = build_badge_copy_plain(badge, earners_count=7)
+
+    assert copy.req_text == "Win 10 games"
+    assert copy.desc_text == "Earn *10* wins."
+    assert copy.meta_text == "7 earners"
+
+
+def test_build_badge_copy_plain_rejects_html():
+    badge = {
+        "requirements": "<div class='badge-card__req'>Win 10 games</div>",
+        "description_md": "Plain desc",
+    }
+    with pytest.raises(AssertionError):
+        build_badge_copy_plain(badge, earners_count=1)


### PR DESCRIPTION
### Motivation
- Prevent HTML from leaking out of the domain layer so badge copy never displays raw tags, and centralize where HTML markup is constructed in the UI.
- Ensure the domain returns only plain text for descriptions, requirements, and meta lines, and provide a fail-fast guardrail for HTML leakage.
- Keep existing visual layout and behavior (badge cards, earners dropdown, player trophy room, leaderboards) while moving HTML assembly to one UI helper.

### Description
- Add a domain helper `BadgeCopyPlain` and builder with normalization and an HTML guardrail in `jupr_app/domain/gamification/badge_copy.py` to produce plain-text `desc_text`, `req_text`, and `meta_text` only.
- Introduce centralized UI helpers `render_badge_card_html` and `render_inline_badge_text` in `jupr_app/ui/components/badge_cards.py` that escape and render inline markdown, and construct the badge-card HTML string for rendering with `unsafe_allow_html=True` in a single place.
- Update UI pages to use the new plain-text flow: `jupr_app/ui/pages/badge_codex.py` and `jupr_app/ui/pages/players.py` now call `build_badge_copy_plain` and the new UI renderer instead of embedding HTML in domain outputs.
- Add tests `tests/test_badge_copy_plain.py` to assert plain-text behavior and that domain builder rejects HTML in badge copy.
- Files changed: added `jupr_app/domain/gamification/badge_copy.py`, added `jupr_app/ui/components/badge_cards.py` and `jupr_app/ui/components/__init__.py`, modified `jupr_app/ui/pages/badge_codex.py` and `jupr_app/ui/pages/players.py`, and added `tests/test_badge_copy_plain.py`.

### Testing
- Ran the new unit tests with `pytest -q tests/test_badge_copy_plain.py` and they passed (`2 passed`).
- The domain guardrail raises an assertion in debug/test mode when HTML-like content is detected and strips/logs in non-debug paths, per the unit tests which verify the assertion behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980fc5e6e2083269a0a5805f48885f0)