### PR TITLE
Harden badge copy plain-text boundaries

### DIFF
--- a/jupr_app/domain/gamification/badge_copy.py
+++ b/jupr_app/domain/gamification/badge_copy.py
@@ -10,6 +10,15 @@ logger = logging.getLogger(__name__)
 _HTML_TAG_RE = re.compile(r"<[^>]*>")
 
 
+def _strip_html(text: str) -> str:
+    stripped = _HTML_TAG_RE.sub("", text)
+    return stripped.replace("<", "").replace(">", "").strip()
+
+
+def _contains_html(text: str) -> bool:
+    return "<" in text or "badge-card__" in text or "</" in text or "<div" in text
+
+
 @dataclass(frozen=True)
 class BadgeCopyPlain:
     desc_text: str | None
@@ -21,25 +30,48 @@ def _normalize_requirement_text(raw: Any) -> str:
     text = str(raw or "").strip()
     if not text:
         return "Requirements TBD"
-    cleaned = re.sub(r"^(requirements?)\s*:\s*", "", text, flags=re.IGNORECASE)
+    sanitized = _sanitize_plain_text("req_text", text, context="normalize_requirement")
+    cleaned = re.sub(r"^(requirements?)\s*:\s*", "", sanitized, flags=re.IGNORECASE)
     cleaned = cleaned.strip()
     return cleaned or "Requirements TBD"
 
 
-def _normalize_plain_text(raw: Any) -> str | None:
+def _normalize_plain_text(raw: Any, *, field: str) -> str | None:
     text = str(raw or "").strip()
-    return text or None
+    if not text:
+        return None
+    sanitized = _sanitize_plain_text(field, text, context="normalize_plain")
+    return sanitized or None
 
 
-def _sanitize_plain_text(field: str, text: str) -> str:
-    if "<" in text or ">" in text or "badge-card__" in text or "</" in text or "<div" in text:
+def _sanitize_plain_text(field: str, text: str, *, context: str | None = None) -> str:
+    if _contains_html(text):
+        message = f"HTML detected in badge copy field {field}"
+        if context:
+            message = f"{message} ({context})"
         if __debug__:
-            raise AssertionError(f"HTML detected in badge copy field {field}: {text}")
-        stripped = _HTML_TAG_RE.sub("", text)
-        stripped = stripped.replace("<", "").replace(">", "")
-        logger.warning("HTML detected in badge copy field %s; stripping tags.", field)
-        return stripped.strip()
+            raise AssertionError(f"{message}: {text}")
+        logger.error("%s; stripping tags.", message)
+        return _strip_html(text)
     return text
+
+
+def validate_badge_copy_plain(
+    copy: BadgeCopyPlain,
+    *,
+    context: str | None = None,
+) -> BadgeCopyPlain:
+    return BadgeCopyPlain(
+        desc_text=_sanitize_plain_text("desc_text", copy.desc_text, context=context)
+        if copy.desc_text
+        else None,
+        req_text=_sanitize_plain_text("req_text", copy.req_text, context=context)
+        if copy.req_text
+        else None,
+        meta_text=_sanitize_plain_text("meta_text", copy.meta_text, context=context)
+        if copy.meta_text
+        else None,
+    )
 
 
 def build_badge_copy_plain(
@@ -47,15 +79,9 @@ def build_badge_copy_plain(
     *,
     earners_count: int | None = None,
 ) -> BadgeCopyPlain:
-    desc_text = _normalize_plain_text(badge.get("description_md"))
+    desc_text = _normalize_plain_text(badge.get("description_md"), field="desc_text")
     req_text = _normalize_requirement_text(badge.get("requirements"))
     meta_text = f"{earners_count} earners" if earners_count is not None else None
 
-    if desc_text:
-        desc_text = _sanitize_plain_text("desc_text", desc_text)
-    if req_text:
-        req_text = _sanitize_plain_text("req_text", req_text)
-    if meta_text:
-        meta_text = _sanitize_plain_text("meta_text", meta_text)
-
-    return BadgeCopyPlain(desc_text=desc_text, req_text=req_text, meta_text=meta_text)
+    copy = BadgeCopyPlain(desc_text=desc_text, req_text=req_text, meta_text=meta_text)
+    return validate_badge_copy_plain(copy, context="build_badge_copy_plain")

--- a/jupr_app/ui/components/badge_cards.py
+++ b/jupr_app/ui/components/badge_cards.py
@@ -1,18 +1,35 @@
 from __future__ import annotations
 
 import html
+import logging
+import re
 
 from markdown_it import MarkdownIt
 
 from jupr_app.domain.gamification.badge_copy import BadgeCopyPlain
 
+logger = logging.getLogger(__name__)
+
 _INLINE_MARKDOWN = MarkdownIt("commonmark", {"html": False})
+_HTML_TAG_RE = re.compile(r"<[^>]*>")
+
+
+def _tripwire_plain_text(text: str | None, *, field: str) -> str | None:
+    if not text:
+        return None
+    if "<div" in text or "badge-card__" in text or "<" in text:
+        logger.error("HTML detected at UI boundary for badge %s; stripping tags.", field)
+        stripped = _HTML_TAG_RE.sub("", text)
+        stripped = stripped.replace("<", "").replace(">", "")
+        return stripped.strip()
+    return text
 
 
 def render_inline_badge_text(text: str | None) -> str:
     if not text:
         return ""
-    escaped = html.escape(str(text))
+    cleaned = _tripwire_plain_text(str(text), field="copy")
+    escaped = html.escape(str(cleaned))
     return _INLINE_MARKDOWN.renderInline(escaped)
 
 
@@ -25,9 +42,10 @@ def render_badge_card_html(
 ) -> str:
     name_text = html.escape(str(name))
     icon_text = html.escape(str(icon))
-    desc_html = render_inline_badge_text(copy_plain.desc_text)
-    req_html = render_inline_badge_text(copy_plain.req_text)
-    meta_html = html.escape(str(copy_plain.meta_text)) if copy_plain.meta_text else ""
+    desc_html = render_inline_badge_text(_tripwire_plain_text(copy_plain.desc_text, field="desc_text"))
+    req_html = render_inline_badge_text(_tripwire_plain_text(copy_plain.req_text, field="req_text"))
+    meta_text = _tripwire_plain_text(copy_plain.meta_text, field="meta_text")
+    meta_html = html.escape(str(meta_text)) if meta_text else ""
     state_html = html.escape(str(state_label)) if state_label else ""
 
     return f"""


### PR DESCRIPTION
### Motivation

- Ensure the domain layer only returns plain text for badge copy so no HTML leaks into downstream logic or storage.
- Centralize sanitization and validation at the domain boundary and provide a UI-side tripwire to catch any future regressions.

### Description

- Add domain helpers in `jupr_app/domain/gamification/badge_copy.py`: `_strip_html`, `_contains_html`, `_sanitize_plain_text`, and `validate_badge_copy_plain`, and update `build_badge_copy_plain` to produce and validate a `BadgeCopyPlain` instance. 
- Tighten normalization by having `_normalize_plain_text` and `_normalize_requirement_text` call the sanitizer and by raising an `AssertionError` in debug mode if HTML is detected. 
- Add a UI safety tripwire in `jupr_app/ui/components/badge_cards.py` via `_tripwire_plain_text` that logs and strips any leaked tags just before rendering, and ensure all rendered badge card fragments are escaped and rendered via `MarkdownIt` with HTML disabled.

### Testing

- Ran `pytest tests/test_badge_copy_plain.py` which succeeded (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980fec995208326ae2f5db2a49bce13)