### PR TITLE
Fix badge card HTML rendering (dedent template so Streamlit treats it as HTML)

### DIFF
--- a/jupr_app/ui/components/badge_cards.py
+++ b/jupr_app/ui/components/badge_cards.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import html
 import logging
 import re
+import textwrap
 
 from markdown_it import MarkdownIt
 
@@ -48,13 +49,16 @@ def render_badge_card_html(
     meta_html = html.escape(str(meta_text)) if meta_text else ""
     state_html = html.escape(str(state_label)) if state_label else ""
 
-    return f"""
-    <div class="badge-card">
-        <div class="badge-card__icon">{icon_text}</div>
-        <div class="badge-card__name" title="{name_text}">{name_text}</div>
-        {f'<div class="badge-card__state">{state_html}</div>' if state_html else ''}
-        {f'<div class="badge-card__desc">{desc_html}</div>' if desc_html else ''}
-        <div class="badge-card__req"><span class="label">Req:</span> {req_html}</div>
-        <div class="badge-card__meta">{meta_html}</div>
-    </div>
-    """
+    # Dedent/strip prevents Streamlit markdown from treating indented HTML as code blocks.
+    return textwrap.dedent(
+        f"""
+        <div class="badge-card">
+            <div class="badge-card__icon">{icon_text}</div>
+            <div class="badge-card__name" title="{name_text}">{name_text}</div>
+            {f'<div class="badge-card__state">{state_html}</div>' if state_html else ''}
+            {f'<div class="badge-card__desc">{desc_html}</div>' if desc_html else ''}
+            <div class="badge-card__req"><span class="label">Req:</span> {req_html}</div>
+            <div class="badge-card__meta">{meta_html}</div>
+        </div>
+        """
+    ).strip()


### PR DESCRIPTION
### Motivation
- Prevent Streamlit from displaying the badge card body as a literal code block by removing leading indentation and ensuring the template is returned as plain HTML so the existing CSS classnames (e.g. `badge-card__desc`, `badge-card__req`, `badge-card__meta`) can style the content.

### Description
- Added a `textwrap` import and changed `render_badge_card_html` in `jupr_app/ui/components/badge_cards.py` to return `textwrap.dedent(...).strip()` so the HTML template is not treated as an indented Markdown code block.  
- Kept existing `html.escape` usage and inline rendering (`render_inline_badge_text`) so interpolated content remains escaped to avoid HTML injection while preserving the structural tags for styling.  
- No other layout or `st.markdown(..., unsafe_allow_html=True)` usage was changed, so the page CSS continues to apply.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981150ff3e08326b10be408c05fbb6b)