### PR TITLE
Strip escaped badge HTML and dedent badge card HTML

### DIFF
--- a/jupr_app/ui/components/badge_cards.py
+++ b/jupr_app/ui/components/badge_cards.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import html
 import logging
 import re
+import textwrap
 
 from markdown_it import MarkdownIt
 
@@ -17,12 +18,16 @@ _HTML_TAG_RE = re.compile(r"<[^>]*>")
 def _tripwire_plain_text(text: str | None, *, field: str) -> str | None:
     if not text:
         return None
-    if "<div" in text or "badge-card__" in text or "<" in text:
+    raw_text = str(text)
+    probe_text = raw_text
+    if "&lt;" in raw_text or "&#60;" in raw_text or "&#x3c;" in raw_text:
+        probe_text = html.unescape(raw_text)
+    if "badge-card__" in probe_text or "<div" in probe_text or _HTML_TAG_RE.search(probe_text):
         logger.error("HTML detected at UI boundary for badge %s; stripping tags.", field)
-        stripped = _HTML_TAG_RE.sub("", text)
+        stripped = _HTML_TAG_RE.sub("", probe_text)
         stripped = stripped.replace("<", "").replace(">", "")
         return stripped.strip()
-    return text
+    return raw_text
 
 
 def render_inline_badge_text(text: str | None) -> str:
@@ -48,13 +53,16 @@ def render_badge_card_html(
     meta_html = html.escape(str(meta_text)) if meta_text else ""
     state_html = html.escape(str(state_label)) if state_label else ""
 
-    return f"""
-    <div class="badge-card">
-        <div class="badge-card__icon">{icon_text}</div>
-        <div class="badge-card__name" title="{name_text}">{name_text}</div>
-        {f'<div class="badge-card__state">{state_html}</div>' if state_html else ''}
-        {f'<div class="badge-card__desc">{desc_html}</div>' if desc_html else ''}
-        <div class="badge-card__req"><span class="label">Req:</span> {req_html}</div>
-        <div class="badge-card__meta">{meta_html}</div>
-    </div>
-    """
+    # Dedent/strip prevents Streamlit markdown from treating indented HTML as code blocks.
+    return textwrap.dedent(
+        f"""
+        <div class="badge-card">
+            <div class="badge-card__icon">{icon_text}</div>
+            <div class="badge-card__name" title="{name_text}">{name_text}</div>
+            {f'<div class="badge-card__state">{state_html}</div>' if state_html else ''}
+            {f'<div class="badge-card__desc">{desc_html}</div>' if desc_html else ''}
+            <div class="badge-card__req"><span class="label">Req:</span> {req_html}</div>
+            <div class="badge-card__meta">{meta_html}</div>
+        </div>
+        """
+    ).strip()


### PR DESCRIPTION
### Motivation
- Prevent raw or HTML-escaped badge markup from showing up in the UI and ensure the badge card template is treated as HTML by Streamlit rather than an indented code block.
- Preserve plain text badge copy when no markup is present while safely stripping any injected or escaped HTML.

### Description
- Update `_tripwire_plain_text` in `jupr_app/ui/components/badge_cards.py` to detect HTML entity escapes (`&lt;`, `&#60;`, `&#x3c;`), unescape them, and strip tags when `badge-card__` or other HTML tags are present, otherwise return the raw text.
- Use `textwrap.dedent(...).strip()` to return the badge card template from `render_badge_card_html` so Streamlit does not render the template as an indented Markdown code block.
- Keep inline rendering behavior in `render_inline_badge_text` which calls `_tripwire_plain_text`, escapes the cleaned text with `html.escape`, and renders inline Markdown with `MarkdownIt`.
- Adjust imports to include `textwrap` and rely on `html` for unescaping and escaping.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981150ff3e08326b10be408c05fbb6b)