### PR TITLE
Fix badge card HTML rendering in Badge Codex

### DIFF
--- a/jupr_app/ui/pages/badge_codex.py
+++ b/jupr_app/ui/pages/badge_codex.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import textwrap
 
 import streamlit as st
 
@@ -115,10 +116,7 @@ def _render_badge_card(badge: dict, column, df_player_badges, df_players) -> Non
             copy_plain=copy_plain,
             state_label=state_label,
         )
-        st.markdown(
-            card_html,
-            unsafe_allow_html=True,
-        )
+        st.markdown(textwrap.dedent(card_html).strip(), unsafe_allow_html=True)
         if st.button(toggle_label, key=f"badge_codex_toggle_{badge_id}", use_container_width=True):
             open_state = not open_state
             st.session_state[open_key] = open_state


### PR DESCRIPTION
### Motivation
- Badge card HTML was being rendered verbatim as a Markdown code block in the Badge Codex because leading indentation in the final string caused Streamlit to treat it as a code block.

### Description
- Add a `textwrap` import and wrap the `card_html` passed to `st.markdown` with `textwrap.dedent(card_html).strip()` in `_render_badge_card` in `jupr_app/ui/pages/badge_codex.py`, keeping `unsafe_allow_html=True` and all existing CSS class names unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69811a8174f88326b8de7541b45d8618)