### PR TITLE
Add badge render debug instrumentation and flatten HTML output

### DIFF
--- a/jupr_app/ui/components/badge_cards.py
+++ b/jupr_app/ui/components/badge_cards.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import html
 import logging
 import re
-import textwrap
-
 from markdown_it import MarkdownIt
 
 from jupr_app.domain.gamification.badge_copy import BadgeCopyPlain
 
 logger = logging.getLogger(__name__)
+
+BADGE_RENDER_REV = "2026-02-02a"
 
 _INLINE_MARKDOWN = MarkdownIt("commonmark", {"html": False})
 _HTML_TAG_RE = re.compile(r"<[^>]*>")
@@ -53,16 +53,17 @@ def render_badge_card_html(
     meta_html = html.escape(str(meta_text)) if meta_text else ""
     state_html = html.escape(str(state_label)) if state_label else ""
 
-    # Dedent/strip prevents Streamlit markdown from treating indented HTML as code blocks.
-    return textwrap.dedent(
-        f"""
-        <div class="badge-card">
-            <div class="badge-card__icon">{icon_text}</div>
-            <div class="badge-card__name" title="{name_text}">{name_text}</div>
-            {f'<div class="badge-card__state">{state_html}</div>' if state_html else ''}
-            {f'<div class="badge-card__desc">{desc_html}</div>' if desc_html else ''}
-            <div class="badge-card__req"><span class="label">Req:</span> {req_html}</div>
-            <div class="badge-card__meta">{meta_html}</div>
-        </div>
-        """
-    ).strip()
+    lines = [
+        '<div class="badge-card">',
+        f'<div class="badge-card__icon">{icon_text}</div>',
+        f'<div class="badge-card__name" title="{name_text}">{name_text}</div>',
+    ]
+    if state_html:
+        lines.append(f'<div class="badge-card__state">{state_html}</div>')
+    if desc_html:
+        lines.append(f'<div class="badge-card__desc">{desc_html}</div>')
+    lines.append(f'<div class="badge-card__req"><span class="label">Req:</span> {req_html}</div>')
+    if meta_html:
+        lines.append(f'<div class="badge-card__meta">{meta_html}</div>')
+    lines.append("</div>")
+    return "\n".join(lines)

--- a/jupr_app/ui/pages/badge_codex.py
+++ b/jupr_app/ui/pages/badge_codex.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import logging
-import textwrap
+import os
 
 import streamlit as st
+import streamlit.components.v1 as components
 
 from jupr_app.domain.gamification.badge_copy import build_badge_copy_plain
+from jupr_app.ui.components import badge_cards
 from jupr_app.ui.components.badge_cards import render_badge_card_html
 from jupr_app.ui.pages.players import badge_icon
 
@@ -91,7 +93,14 @@ def _group_badges(badges: list[dict]) -> list[tuple[str, list[dict]]]:
     return [(section, sorted(items, key=lambda item: item["name"].lower())) for section, items in ordered_sections]
 
 
-def _render_badge_card(badge: dict, column, df_player_badges, df_players) -> None:
+def _render_badge_card(
+    badge: dict,
+    column,
+    df_player_badges,
+    df_players,
+    *,
+    debug_badges: bool = False,
+) -> None:
     badge_id = badge.get("badge_id", "")
     name = badge.get("name", "Badge")
     icon = badge_icon(badge_id, badge.get("category"))
@@ -116,7 +125,44 @@ def _render_badge_card(badge: dict, column, df_player_badges, df_players) -> Non
             copy_plain=copy_plain,
             state_label=state_label,
         )
-        st.markdown(textwrap.dedent(card_html).strip(), unsafe_allow_html=True)
+        final_md = card_html
+        if debug_badges and not st.session_state.get("badge_codex_debug_shown"):
+            st.session_state["badge_codex_debug_shown"] = True
+            lines = final_md.splitlines()
+            has_blank_line = any(line.strip() == "" for line in lines)
+            has_4space_lines = any(
+                line.startswith("    ") or line.startswith("\t") for line in lines if line.strip()
+            )
+            blank_then_4space = any(
+                lines[idx].strip() == "" and (lines[idx + 1].startswith("    ") or lines[idx + 1].startswith("\t"))
+                for idx in range(len(lines) - 1)
+            )
+            first_nonblank = next((line for line in lines if line.strip()), "")
+            leading_ws = len(first_nonblank) - len(first_nonblank.lstrip(" \t")) if first_nonblank else 0
+            starts_with_div_at_col0 = first_nonblank.lstrip(" \t").startswith("<div") and leading_ws <= 3
+            contains_escaped_lt = "&lt;" in final_md or "&#60;" in final_md or "&#x3c;" in final_md
+            analysis_lines = ["line | lead_ws | blank | preview", "-" * 78]
+            for idx, line in enumerate(lines, start=1):
+                lead = len(line) - len(line.lstrip(" \t"))
+                is_blank = line.strip() == ""
+                analysis_lines.append(f"{idx:>4} | {lead:>7} | {str(is_blank):<5} | {line[:60]}")
+            st.caption("Badge render debug (first card only).")
+            st.text(f"badge_cards.__file__ = {badge_cards.__file__}")
+            st.text(f"BADGE_RENDER_REV = {badge_cards.BADGE_RENDER_REV}")
+            st.code(final_md, language="html")
+            st.text("\n".join(analysis_lines))
+            st.text(
+                "Flags: "
+                f"has_blank_line={has_blank_line}, "
+                f"has_4space_lines={has_4space_lines}, "
+                f"blank_then_4space={blank_then_4space}, "
+                f"starts_with_div_at_col0={starts_with_div_at_col0}, "
+                f"contains_escaped_lt={contains_escaped_lt}"
+            )
+            if blank_then_4space:
+                st.warning("Debug guard: blank line followed by 4-space indentation detected.")
+            components.html(final_md, height=260, scrolling=True)
+        st.markdown(final_md, unsafe_allow_html=True)
         if st.button(toggle_label, key=f"badge_codex_toggle_{badge_id}", use_container_width=True):
             open_state = not open_state
             st.session_state[open_key] = open_state
@@ -313,6 +359,8 @@ def render(ctx) -> None:
     )
 
     df_players = getattr(ctx, "df_players_all", None)
+    debug_env = os.getenv("JUPR_DEBUG_BADGES") == "1"
+    debug_badges = st.sidebar.checkbox("Debug badge render", value=debug_env)
 
     badge_defs = getattr(ctx, "df_badges", None)
     player_badges = getattr(ctx, "df_player_badges", None)
@@ -340,5 +388,6 @@ def render(ctx) -> None:
                 columns[idx % 3],
                 player_badges,
                 df_players,
+                debug_badges=debug_badges,
             )
         st.markdown("<div style='height: 0.5rem'></div>", unsafe_allow_html=True)

--- a/tests/test_badge_ui_rendering.py
+++ b/tests/test_badge_ui_rendering.py
@@ -1,5 +1,8 @@
-from pathlib import Path
 import re
+from pathlib import Path
+
+from jupr_app.domain.gamification.badge_copy import BadgeCopyPlain
+from jupr_app.ui.components.badge_cards import render_badge_card_html
 
 
 BADGE_RENDER_FILES = [
@@ -30,3 +33,10 @@ def test_badge_renderers_do_not_use_lore_or_hint_fields():
         content = _read(path)
         for pattern in patterns:
             assert re.search(pattern, content) is None, f"Unexpected lore/hint usage in {path}: {pattern}"
+
+
+def test_badge_card_html_has_no_blank_lines():
+    copy_plain = BadgeCopyPlain(desc_text="Desc", req_text="Do thing", meta_text="Meta")
+    html = render_badge_card_html(name="Test Badge", icon="🏆", copy_plain=copy_plain, state_label="Live")
+    lines = html.splitlines()
+    assert all(line.strip() for line in lines), f"Found blank lines in badge card HTML: {lines}"


### PR DESCRIPTION
### Motivation
- Badge cards were appearing as literal HTML inside a gray code block due to CommonMark treating a blank line followed by 4-space-indented HTML as an indented code block.  
- We need runtime proof of the exact markdown/html shape being passed to Streamlit so we can reliably detect and fix the parsing trigger.  
- Implement a minimal, safe fix that guarantees badge HTML output contains no blank lines or 4-space-indented lines to avoid CommonMark mis-parsing.

### Description
- Add debug instrumentation to the Badge Codex page controlled by `JUPR_DEBUG_BADGES=1` or a sidebar checkbox that, for the first rendered badge card, shows the exact `final_md`, a line-by-line analysis (line number, leading whitespace count, blank flag, preview), boolean parsing flags, provenance (`badge_cards.__file__`) and a `BADGE_RENDER_REV` marker, and a debug `components.html` rendering to disambiguate parsing vs escaping.  
- Refactor `render_badge_card_html` to build HTML as a list of lines and `"\n".join(lines)` to ensure zero/controlled indentation and no blank lines instead of using a triple-quoted indented template and `textwrap.dedent`.  
- Wire the debug switch into `jupr_app/ui/pages/badge_codex.py` and show a one-time debug report for the first card when enabled.  
- Add a regression unit test `test_badge_card_html_has_no_blank_lines` to assert generated badge card HTML contains no blank lines.

### Testing
- Ran the focused test file with `pytest -q tests/test_badge_ui_rendering.py` and observed `3 passed` indicating the new regression test and existing checks succeeded.  
- The debug instrumentation was exercised locally in the code paths (one-time display gated by session state) and will surface `blank_then_4space` and related flags when `JUPR_DEBUG_BADGES` is enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69812311988c8326a75c3972cf28d6ff)