### PR TITLE
Add DB migration runner and schema preflight for badge provenance and revocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: db-migrate
+
+db-migrate: ## Apply pending SQL migrations (requires DATABASE_URL)
+	@bash scripts/db_migrate.sh

--- a/docs/badges_engine.md
+++ b/docs/badges_engine.md
@@ -111,6 +111,13 @@ grant select (
 ) on public.player_badges to anon, authenticated;
 ```
 
+### Applying migrations from the repo
+If you have direct Postgres access, apply migrations in order with:
+
+```bash
+DATABASE_URL="postgres://USER:PASSWORD@HOST:5432/dbname" make db-migrate
+```
+
 ## Incremental badge evaluation
 When matches are ingested or edited, the app enqueues badge evaluation work instead of evaluating
 the full match history on every page view:

--- a/jupr_app/data/load.py
+++ b/jupr_app/data/load.py
@@ -5,6 +5,7 @@ from jupr_app.domain.player_activity import add_activity_columns
 from jupr_app.domain.gamification.badge_descriptions import BADGE_DESCRIPTIONS_MD
 from jupr_app.domain.gamification.badge_registry import badge_schema_by_id
 from jupr_app.domain.gamification.requirements import load_requirements_map
+from jupr_app.data.schema_preflight import ensure_badge_schema_preflight
 import re
 from postgrest.exceptions import APIError
 
@@ -98,6 +99,7 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
     No Streamlit calls here. Raise exceptions to be handled by UI.
     """
     club_id = str(club_id)
+    ensure_badge_schema_preflight(supabase)
 
     max_retries = 3
     last_err = None

--- a/jupr_app/data/schema_preflight.py
+++ b/jupr_app/data/schema_preflight.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+REQUIRED_PLAYER_BADGES_COLUMNS = {
+    "awarded_by",
+    "rule_version",
+    "eval_run_id",
+}
+REQUIRED_REVOKED_COLUMNS = {
+    "revoked_at",
+    "revoked_by",
+    "revoke_reason",
+}
+MIGRATION_HINT = (
+    "DB schema out of date. Apply migrations/20260625_badge_recompute_runs.sql and "
+    "migrations/20260630_player_badges_revocation.sql"
+)
+
+
+def ensure_badge_schema_preflight(supabase: Any) -> bool:
+    if _should_skip_preflight():
+        return True
+    columns = _fetch_player_badges_columns(supabase)
+    missing = sorted(REQUIRED_PLAYER_BADGES_COLUMNS - columns)
+    missing_revoked = sorted(REQUIRED_REVOKED_COLUMNS - columns)
+    if missing or missing_revoked:
+        missing_all = ", ".join(sorted(set(missing + missing_revoked)))
+        raise RuntimeError(
+            f"{MIGRATION_HINT}. Missing player_badges columns: {missing_all}."
+        )
+    return True
+
+
+def _fetch_player_badges_columns(supabase: Any) -> set[str]:
+    resp = (
+        supabase.schema("information_schema")
+        .table("columns")
+        .select("column_name")
+        .eq("table_schema", "public")
+        .eq("table_name", "player_badges")
+        .execute()
+    )
+    return {row.get("column_name") for row in (resp.data or []) if row.get("column_name")}
+
+
+def _should_skip_preflight() -> bool:
+    return os.getenv("JUPR_SKIP_DB_PREFLIGHT", "0") == "1"

--- a/scripts/db_migrate.sh
+++ b/scripts/db_migrate.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATIONS_DIR="${ROOT_DIR}/migrations"
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL is required (Postgres connection string)." >&2
+  exit 1
+fi
+
+if [[ ! -d "${MIGRATIONS_DIR}" ]]; then
+  echo "Migrations directory not found: ${MIGRATIONS_DIR}" >&2
+  exit 1
+fi
+
+psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 <<'SQL'
+create table if not exists public.schema_migrations (
+  filename text primary key,
+  applied_at timestamptz not null default now()
+);
+SQL
+
+applied=$(
+  psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 -t -A \
+    -c "select filename from public.schema_migrations order by filename;"
+)
+
+mapfile -t migration_files < <(ls -1 "${MIGRATIONS_DIR}"/*.sql 2>/dev/null | sort)
+
+if [[ ${#migration_files[@]} -eq 0 ]]; then
+  echo "No migrations found in ${MIGRATIONS_DIR}."
+  exit 0
+fi
+
+for file in "${migration_files[@]}"; do
+  filename="$(basename "${file}")"
+  if echo "${applied}" | grep -Fxq "${filename}"; then
+    echo "Skipping ${filename} (already applied)."
+    continue
+  fi
+  echo "Applying ${filename}..."
+  psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 <<SQL
+begin;
+\\i ${file}
+insert into public.schema_migrations (filename) values ('${filename}');
+commit;
+SQL
+done
+
+echo "Migrations complete."

--- a/tests/test_load_data_degraded_schema.py
+++ b/tests/test_load_data_degraded_schema.py
@@ -61,7 +61,8 @@ class _FakeSupabase:
         return _FakeTableQuery(self, name)
 
 
-def test_load_data_degrades_player_badges_schema():
+def test_load_data_degrades_player_badges_schema(monkeypatch):
+    monkeypatch.setenv("JUPR_SKIP_DB_PREFLIGHT", "1")
     supabase = _FakeSupabase()
 
     (

--- a/tests/test_schema_preflight.py
+++ b/tests/test_schema_preflight.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from jupr_app.data.schema_preflight import ensure_badge_schema_preflight
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeColumnsQuery:
+    def __init__(self, supabase):
+        self.supabase = supabase
+        self.filters = {}
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, key, value):
+        self.filters[key] = value
+        return self
+
+    def execute(self):
+        if (
+            self.filters.get("table_schema") == "public"
+            and self.filters.get("table_name") == "player_badges"
+        ):
+            return _FakeResponse([{"column_name": col} for col in self.supabase.columns])
+        return _FakeResponse([])
+
+
+class _FakeSchema:
+    def __init__(self, supabase):
+        self.supabase = supabase
+
+    def table(self, _name):
+        return _FakeColumnsQuery(self.supabase)
+
+
+class _FakeSupabase:
+    def __init__(self, columns):
+        self.columns = columns
+
+    def schema(self, _name):
+        return _FakeSchema(self)
+
+
+def test_preflight_passes_with_required_columns():
+    supabase = _FakeSupabase(
+        [
+            "awarded_by",
+            "rule_version",
+            "eval_run_id",
+            "revoked_at",
+            "revoked_by",
+            "revoke_reason",
+        ]
+    )
+    assert ensure_badge_schema_preflight(supabase) is True
+
+
+def test_preflight_raises_when_columns_missing(monkeypatch):
+    monkeypatch.delenv("JUPR_SKIP_DB_PREFLIGHT", raising=False)
+    supabase = _FakeSupabase(["awarded_by"])
+    with pytest.raises(RuntimeError) as excinfo:
+        ensure_badge_schema_preflight(supabase)
+    assert "migrations/20260625_badge_recompute_runs.sql" in str(excinfo.value)
+    assert "migrations/20260630_player_badges_revocation.sql" in str(excinfo.value)


### PR DESCRIPTION
### Motivation
- The app expects provenance and revocation columns on `player_badges` (awarded_by, rule_version, eval_run_id, revoked_at, revoked_by, revoke_reason) but some databases were missing the two SQL migrations that add them.
- Missing columns cause runtime failures deep in badge logic and make debugging unclear. The intent is to ensure migrations are applied in order and the app fails fast with a clear remediation message when the schema is behind.

### Description
- Add `jupr_app/data/schema_preflight.py` which checks `information_schema.columns` for `player_badges` and ensures `awarded_by`, `rule_version`, `eval_run_id` and the revoked columns `revoked_at`, `revoked_by`, `revoke_reason` are present, raising a clear `RuntimeError` that points to `migrations/20260625_badge_recompute_runs.sql` and `migrations/20260630_player_badges_revocation.sql` if not present.
- Wire the preflight into early data loading by calling `ensure_badge_schema_preflight` from `load_data` so the app fails fast by default; the check can be skipped by setting `JUPR_SKIP_DB_PREFLIGHT=1` for tests or special environments.
- Add a simple, deterministic migration runner `scripts/db_migrate.sh` plus a `Makefile` target `db-migrate` which applies `.sql` files from `migrations/` in sorted order, records applied files in `public.schema_migrations` for idempotence, and aborts on error. The runner will therefore apply `20260625_badge_recompute_runs.sql` before `20260630_player_badges_revocation.sql` when ordered by filename.
- Add unit tests `tests/test_schema_preflight.py` for the preflight and update `tests/test_load_data_degraded_schema.py` to opt-in to the degraded-path by setting `JUPR_SKIP_DB_PREFLIGHT=1`. The docs `docs/badges_engine.md` were extended with a Makefile usage snippet.
- The two migrations do the following: `migrations/20260625_badge_recompute_runs.sql` creates `public.badge_eval_runs` and adds `awarded_by text not null default 'engine'`, `rule_version text`, and `eval_run_id uuid references public.badge_eval_runs(id)` to `player_badges`; `migrations/20260630_player_badges_revocation.sql` adds `revoked_at timestamptz`, `revoked_by text`, and `revoke_reason text` to `player_badges`.

### Testing
- Ran `pytest -q tests/test_schema_preflight.py tests/test_load_data_degraded_schema.py` and observed that all tests passed. (3 passed)
- Added `tests/test_schema_preflight.py` which asserts the preflight succeeds when all columns are present and raises with the migration hints when columns are missing.
- Updated `tests/test_load_data_degraded_schema.py` to set `JUPR_SKIP_DB_PREFLIGHT=1` so the existing degraded-schema behavior is still covered in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698126830e208326b2572d455b337ec0)