### PR TITLE
Fix badge schema preflight to use PostgREST-safe probes

### DIFF
--- a/jupr_app/data/schema_preflight.py
+++ b/jupr_app/data/schema_preflight.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any
+
+from postgrest.exceptions import APIError
 
 
 REQUIRED_PLAYER_BADGES_COLUMNS = {
@@ -16,35 +19,112 @@ REQUIRED_REVOKED_COLUMNS = {
 }
 MIGRATION_HINT = (
     "DB schema out of date. Apply migrations/20260625_badge_recompute_runs.sql and "
-    "migrations/20260630_player_badges_revocation.sql"
+    "migrations/20260630_player_badges_revocation.sql. If you just applied them in "
+    "Supabase, run \"NOTIFY pgrst, 'reload schema';\" in the SQL editor to refresh the "
+    "PostgREST schema cache"
 )
+REQUIRED_BADGE_TABLES = {"badge_eval_runs"}
+SKIP_PREFLIGHT_ENV = "JUPR_SKIP_BADGE_SCHEMA_PREFLIGHT"
+_MISSING_COLUMN_CODES = {"PGRST204"}
+_MISSING_TABLE_CODES = {"PGRST205", "42P01"}
+
+logger = logging.getLogger(__name__)
 
 
 def ensure_badge_schema_preflight(supabase: Any) -> bool:
     if _should_skip_preflight():
         return True
-    columns = _fetch_player_badges_columns(supabase)
-    missing = sorted(REQUIRED_PLAYER_BADGES_COLUMNS - columns)
-    missing_revoked = sorted(REQUIRED_REVOKED_COLUMNS - columns)
-    if missing or missing_revoked:
-        missing_all = ", ".join(sorted(set(missing + missing_revoked)))
-        raise RuntimeError(
-            f"{MIGRATION_HINT}. Missing player_badges columns: {missing_all}."
-        )
+    missing_columns = _find_missing_player_badges_columns(supabase)
+    missing_tables = _find_missing_tables(supabase)
+    if missing_columns or missing_tables:
+        message_parts = [MIGRATION_HINT + "."]
+        if missing_columns:
+            missing_all = ", ".join(sorted(missing_columns))
+            message_parts.append(f"Missing player_badges columns: {missing_all}.")
+        if missing_tables:
+            missing_tables_list = ", ".join(sorted(missing_tables))
+            message_parts.append(f"Missing tables: {missing_tables_list}.")
+        raise RuntimeError(" ".join(message_parts))
     return True
 
 
-def _fetch_player_badges_columns(supabase: Any) -> set[str]:
-    resp = (
-        supabase.schema("information_schema")
-        .table("columns")
-        .select("column_name")
-        .eq("table_schema", "public")
-        .eq("table_name", "player_badges")
-        .execute()
-    )
-    return {row.get("column_name") for row in (resp.data or []) if row.get("column_name")}
+def _find_missing_player_badges_columns(supabase: Any) -> set[str]:
+    missing = set()
+    for column in sorted(REQUIRED_PLAYER_BADGES_COLUMNS | REQUIRED_REVOKED_COLUMNS):
+        if not _probe_column(supabase, "player_badges", column):
+            missing.add(column)
+    return missing
+
+
+def _find_missing_tables(supabase: Any) -> set[str]:
+    missing = set()
+    for table in sorted(REQUIRED_BADGE_TABLES):
+        if not _probe_table(supabase, table):
+            missing.add(table)
+    return missing
+
+
+def _probe_column(supabase: Any, table: str, column: str) -> bool:
+    try:
+        supabase.table(table).select(column).limit(1).execute()
+    except APIError as exc:
+        code = _get_api_error_code(exc)
+        message = _get_api_error_message(exc)
+        logger.warning(
+            "PostgREST error while checking %s.%s (code=%s message=%s)",
+            table,
+            column,
+            code,
+            message,
+        )
+        if code in _MISSING_COLUMN_CODES:
+            return False
+        raise RuntimeError(
+            f"PostgREST error while checking {table}.{column} (code={code} message={message})."
+        ) from exc
+    return True
+
+
+def _probe_table(supabase: Any, table: str) -> bool:
+    try:
+        supabase.table(table).select("id").limit(1).execute()
+    except APIError as exc:
+        code = _get_api_error_code(exc)
+        message = _get_api_error_message(exc)
+        logger.warning(
+            "PostgREST error while checking %s table (code=%s message=%s)",
+            table,
+            code,
+            message,
+        )
+        if code in _MISSING_TABLE_CODES:
+            return False
+        raise RuntimeError(
+            f"PostgREST error while checking table {table} (code={code} message={message})."
+        ) from exc
+    return True
+
+
+def _get_api_error_code(exc: APIError) -> str | None:
+    code = getattr(exc, "code", None)
+    if code:
+        return code
+    if exc.args and isinstance(exc.args[0], dict):
+        return exc.args[0].get("code")
+    return None
+
+
+def _get_api_error_message(exc: APIError) -> str:
+    message = getattr(exc, "message", None)
+    if message:
+        return message
+    if exc.args and isinstance(exc.args[0], dict):
+        return exc.args[0].get("message", str(exc))
+    return str(exc)
 
 
 def _should_skip_preflight() -> bool:
-    return os.getenv("JUPR_SKIP_DB_PREFLIGHT", "0") == "1"
+    return (
+        os.getenv(SKIP_PREFLIGHT_ENV, "0") == "1"
+        or os.getenv("JUPR_SKIP_DB_PREFLIGHT", "0") == "1"
+    )

--- a/tests/test_load_data_degraded_schema.py
+++ b/tests/test_load_data_degraded_schema.py
@@ -62,7 +62,7 @@ class _FakeSupabase:
 
 
 def test_load_data_degrades_player_badges_schema(monkeypatch):
-    monkeypatch.setenv("JUPR_SKIP_DB_PREFLIGHT", "1")
+    monkeypatch.setenv("JUPR_SKIP_BADGE_SCHEMA_PREFLIGHT", "1")
     supabase = _FakeSupabase()
 
     (

--- a/tests/test_schema_preflight.py
+++ b/tests/test_schema_preflight.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import os
-
 import pytest
+from postgrest.exceptions import APIError
 
 from jupr_app.data.schema_preflight import ensure_badge_schema_preflight
 
@@ -12,61 +11,69 @@ class _FakeResponse:
         self.data = data
 
 
-class _FakeColumnsQuery:
-    def __init__(self, supabase):
+class _FakeTableQuery:
+    def __init__(self, supabase, table_name: str):
         self.supabase = supabase
-        self.filters = {}
+        self.table_name = table_name
+        self.selected = None
 
-    def select(self, _cols):
+    def select(self, cols):
+        self.selected = cols
         return self
 
-    def eq(self, key, value):
-        self.filters[key] = value
+    def limit(self, _):
         return self
 
     def execute(self):
-        if (
-            self.filters.get("table_schema") == "public"
-            and self.filters.get("table_name") == "player_badges"
-        ):
-            return _FakeResponse([{"column_name": col} for col in self.supabase.columns])
-        return _FakeResponse([])
-
-
-class _FakeSchema:
-    def __init__(self, supabase):
-        self.supabase = supabase
-
-    def table(self, _name):
-        return _FakeColumnsQuery(self.supabase)
+        if self.table_name not in self.supabase.tables:
+            raise APIError(
+                {
+                    "code": "PGRST205",
+                    "message": f"Could not find the table '{self.table_name}'",
+                }
+            )
+        if self.selected:
+            column = self.selected.split(",")[0].strip()
+            if column not in self.supabase.tables[self.table_name]:
+                raise APIError(
+                    {
+                        "code": "PGRST204",
+                        "message": f"column {self.table_name}.{column} does not exist",
+                    }
+                )
+        return _FakeResponse([{}])
 
 
 class _FakeSupabase:
-    def __init__(self, columns):
-        self.columns = columns
+    def __init__(self, tables):
+        self.tables = tables
 
-    def schema(self, _name):
-        return _FakeSchema(self)
+    def table(self, name: str):
+        return _FakeTableQuery(self, name)
 
 
 def test_preflight_passes_with_required_columns():
     supabase = _FakeSupabase(
-        [
-            "awarded_by",
-            "rule_version",
-            "eval_run_id",
-            "revoked_at",
-            "revoked_by",
-            "revoke_reason",
-        ]
+        {
+            "player_badges": {
+                "awarded_by",
+                "rule_version",
+                "eval_run_id",
+                "revoked_at",
+                "revoked_by",
+                "revoke_reason",
+            },
+            "badge_eval_runs": {"id"},
+        }
     )
     assert ensure_badge_schema_preflight(supabase) is True
 
 
 def test_preflight_raises_when_columns_missing(monkeypatch):
-    monkeypatch.delenv("JUPR_SKIP_DB_PREFLIGHT", raising=False)
-    supabase = _FakeSupabase(["awarded_by"])
+    monkeypatch.delenv("JUPR_SKIP_BADGE_SCHEMA_PREFLIGHT", raising=False)
+    supabase = _FakeSupabase({"player_badges": {"awarded_by"}})
     with pytest.raises(RuntimeError) as excinfo:
         ensure_badge_schema_preflight(supabase)
     assert "migrations/20260625_badge_recompute_runs.sql" in str(excinfo.value)
     assert "migrations/20260630_player_badges_revocation.sql" in str(excinfo.value)
+    assert "badge_eval_runs" in str(excinfo.value)


### PR DESCRIPTION
### Motivation

- Avoid querying `information_schema` via PostgREST because Supabase does not expose it and PostgREST will raise `APIError` for unauthorized schemas.  The preflight must work over the PostgREST REST API.

### Description

- Replace the `information_schema` query in `jupr_app/data/schema_preflight.py` with PostgREST-safe probes that perform lightweight selects against public tables via `supabase.table(...).select(...).limit(1).execute()` to detect missing columns and tables.
- Add table existence probing for migration-created table `badge_eval_runs` and column probing for `player_badges` required columns (`awarded_by`, `rule_version`, `eval_run_id`) and revoked columns (`revoked_at`, `revoked_by`, `revoke_reason`).
- Map PostgREST error codes to missing-column/table detection (`PGRST204` for missing column, `PGRST205`/`42P01` for missing table), log API error code/message, and re-raise other errors with context.
- Add optional environment variable `JUPR_SKIP_BADGE_SCHEMA_PREFLIGHT` (and preserve legacy `JUPR_SKIP_DB_PREFLIGHT`) to bypass the preflight when needed.
- Improve `MIGRATION_HINT` to include a note about running `NOTIFY pgrst, 'reload schema';` in Supabase after applying migrations.
- Update tests (`tests/test_schema_preflight.py`, `tests/test_load_data_degraded_schema.py`) to exercise the new probing logic and env var name.

### Testing

- Ran `pytest tests/test_schema_preflight.py tests/test_load_data_degraded_schema.py` and both tests passed (`3 passed`).
- Unit tests exercise both the success path when required columns/tables exist and the failure path reporting missing columns and tables.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981298ed4248326a6c7a358036361e3)