### PR TITLE
Add admin audit for missing badge requirements

### DIFF
--- a/jupr_app/domain/gamification/requirements.py
+++ b/jupr_app/domain/gamification/requirements.py
@@ -91,6 +91,57 @@ def requirement_for(badge_id: str) -> str:
     return requirements.get(str(badge_id), "Requirements TBD")
 
 
+def audit_missing_badge_requirements(badge_defs) -> list[dict]:
+    """Return missing requirement entries for the badge catalog.
+
+    To resolve missing entries, add or update the badge heading in docs/badge_requirements.md:
+    "## <badge_id> — <Badge Name>" followed by an "Unlock:" line with the requirement text.
+    """
+
+    def _get_field(row, *fields):
+        for field in fields:
+            if isinstance(row, dict) and field in row:
+                return row.get(field)
+            if hasattr(row, field):
+                return getattr(row, field)
+        return None
+
+    def _iter_badges(defs):
+        if defs is None:
+            return []
+        if hasattr(defs, "itertuples"):
+            return list(defs.itertuples(index=False))
+        return list(defs)
+
+    def _first_value(row, *fields):
+        for field in fields:
+            value = _get_field(row, field)
+            if value is not None and str(value).strip() != "":
+                return value
+        return None
+
+    missing: list[dict] = []
+    for row in _iter_badges(badge_defs):
+        badge_id = _first_value(row, "badge_id", "slug", "id")
+        if badge_id is None:
+            continue
+        badge_id_str = str(badge_id)
+        returned_text = requirement_for(badge_id_str)
+        cleaned = str(returned_text or "").strip()
+        if not cleaned or cleaned == "Requirements TBD":
+            missing.append(
+                {
+                    "badge_id": badge_id_str,
+                    "slug": _first_value(row, "slug"),
+                    "name": str(_get_field(row, "name") or "Badge"),
+                    "category": _get_field(row, "category"),
+                    "source_hint": _first_value(row, "source_hint", "source"),
+                    "returned_text": cleaned or "Requirements TBD",
+                }
+            )
+    return missing
+
+
 def missing_badge_ids(all_badge_ids: list[str]) -> list[str]:
     requirements = load_requirements_map()
     return [str(badge_id) for badge_id in all_badge_ids if str(badge_id) not in requirements]

--- a/jupr_app/ui/pages/badge_codex.py
+++ b/jupr_app/ui/pages/badge_codex.py
@@ -7,6 +7,7 @@ import streamlit as st
 import streamlit.components.v1 as components
 
 from jupr_app.domain.gamification.badge_copy import build_badge_copy_plain
+from jupr_app.domain.gamification.requirements import audit_missing_badge_requirements
 from jupr_app.ui.components import badge_cards
 from jupr_app.ui.components.badge_cards import render_badge_card_html
 from jupr_app.ui.pages.players import badge_icon
@@ -361,12 +362,32 @@ def render(ctx) -> None:
     df_players = getattr(ctx, "df_players_all", None)
     debug_env = os.getenv("JUPR_DEBUG_BADGES") == "1"
     debug_badges = st.sidebar.checkbox("Debug badge render", value=debug_env)
+    admin_mode = bool(getattr(ctx, "is_admin", False) or getattr(ctx, "admin_logged_in", False))
+    debug_admin_mode = admin_mode or debug_env
 
     badge_defs = getattr(ctx, "df_badges", None)
     player_badges = getattr(ctx, "df_player_badges", None)
     if badge_defs is None:
         st.info("Badge data is still loading.")
         return
+
+    if debug_admin_mode:
+        missing_requirements = audit_missing_badge_requirements(badge_defs)
+        logger.info("Badge requirements audit: %s missing entries", len(missing_requirements))
+        with st.expander("Admin: Missing badge requirements", expanded=False):
+            if missing_requirements:
+                st.dataframe(missing_requirements, use_container_width=True)
+                st.caption("Markdown stubs for docs/badge_requirements.md")
+                stub_lines = []
+                for entry in missing_requirements:
+                    badge_id = entry.get("badge_id", "")
+                    name = entry.get("name", "Badge")
+                    stub_lines.append(f"## {badge_id} — {name}")
+                    stub_lines.append("Unlock: Requirements TBD.")
+                    stub_lines.append("")
+                st.code("\n".join(stub_lines).strip(), language="markdown")
+            else:
+                st.success("All badges have requirement strings.")
 
     include_deprecated = False
     if bool(getattr(ctx, "admin_logged_in", False)):


### PR DESCRIPTION
### Motivation
- Provide a deterministic way to find which badges fall back to the UI placeholder `"Requirements TBD"` so maintainers can populate `docs/badge_requirements.md`. 
- Surface this information in the Badge Codex UI for admins/debug to make it easy to copy/paste markdown stubs and prioritize documentation fixes.

### Description
- Add `audit_missing_badge_requirements(badge_defs)` in `jupr_app/domain/gamification/requirements.py` which iterates the canonical badge catalog, calls the existing `requirement_for` lookup, and returns entries for badges whose requirement text is empty or equals `"Requirements TBD"`, with fields `badge_id`, `slug`, `name`, `category`, `source_hint`, and `returned_text` and an in-code docstring describing how to add entries to `docs/badge_requirements.md`.
- Wire the audit into the Badge Codex UI (`jupr_app/ui/pages/badge_codex.py`) behind an admin/debug gate (visible when `ctx.is_admin` or `ctx.admin_logged_in` or when `JUPR_DEBUG_BADGES=1`), rendering a collapsible expander that shows a dataframe of missing entries, logs the missing count, and presents copy/paste-ready markdown stubs for `docs/badge_requirements.md`.
- Keep behavior deterministic by using the same requirement lookup (`requirement_for` / `load_requirements_map`) that the rest of the app uses so the audit matches the UI fallback logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69812f8a4d648326b72cec31d83c8dcb)