### PR TITLE
Add CLI script to audit missing badge requirements

### DIFF
--- a/scripts/audit_badge_requirements.py
+++ b/scripts/audit_badge_requirements.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Audit badge requirement text coverage for the Badge Codex badge catalog."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+FALLBACK_TEXT = "Requirements TBD"
+
+
+def _bootstrap_repo_root() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+
+def _load_badges():
+    from jupr_app.domain.gamification.badge_catalog import BADGE_DEFINITIONS
+
+    return BADGE_DEFINITIONS
+
+
+def _missing_requirement(raw: str | None) -> bool:
+    cleaned = str(raw or "").strip()
+    if not cleaned:
+        return True
+    if cleaned == FALLBACK_TEXT:
+        return True
+    return FALLBACK_TEXT.lower() in cleaned.lower()
+
+
+def main() -> int:
+    _bootstrap_repo_root()
+    try:
+        badges = _load_badges()
+        from jupr_app.domain.gamification.requirements import requirement_for
+    except Exception as exc:  # pragma: no cover - defensive CLI
+        print(f"[audit_badge_requirements] import error: {exc}")
+        print("Run this script from the repo root with dependencies installed.")
+        return 1
+
+    missing = []
+    for badge in badges:
+        badge_id = str(getattr(badge, "badge_id", "") or "")
+        if not badge_id:
+            continue
+        name = str(getattr(badge, "name", "Badge") or "Badge")
+        category = getattr(badge, "category", None)
+        requirement_text = requirement_for(badge_id)
+        if _missing_requirement(requirement_text):
+            missing.append(
+                {
+                    "badge_id": badge_id,
+                    "name": name,
+                    "category": str(category or ""),
+                }
+            )
+
+    missing.sort(key=lambda row: row["badge_id"])
+    print(f"Missing badge requirements: {len(missing)}")
+    for entry in missing:
+        print(f"{entry['badge_id']}\t{entry['name']}\t{entry['category']}")
+
+    if missing:
+        print("\nMarkdown stub pack:")
+        for entry in missing:
+            print(f"## {entry['badge_id']} — {entry['name']}")
+            print(f"Unlock: {FALLBACK_TEXT}.")
+            print("")
+
+    return 2 if missing else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide a small CLI utility to deterministically report badges whose requirement lookup returns the fallback placeholder or is empty so maintainers can quickly find and fix missing requirement text.
- Ensure the script uses the same canonical badge definitions and the same requirement lookup used by the app so audit results match the UI behavior.

### Description
- Add `scripts/audit_badge_requirements.py`, a standalone CLI that bootstraps the repo path, imports `BADGE_DEFINITIONS` from `jupr_app.domain.gamification.badge_catalog`, and calls `requirement_for` from `jupr_app.domain.gamification.requirements` for each badge.
- Detects missing requirement text when it is empty/whitespace, equals the fallback `"Requirements TBD"`, or contains that phrase case-insensitively, and prints a sorted list of missing badges as `<badge_id>\t<badge_name>\t<category>`.
- Prints a CI-friendly summary count, a `Markdown stub pack` with headers matching the requirements loader format (e.g. `## <badge_id> — <Badge Name>` and `Unlock: Requirements TBD.`), and exits with code `0` when none missing or `2` when any are missing.
- Does not modify any Streamlit UI files and reuses the same loaders/parsers as the app to guarantee consistent results.

### Testing
- Ran `python scripts/audit_badge_requirements.py` from the repository root and the script executed and returned the expected exit code `2` when missing entries exist.
- Sample output from the run (script exit code `2`):
```
Missing badge requirements: 4
above_expectations	Above Expectations	Skill Growth & Momentum
breakthrough	Breakthrough	Skill Growth & Momentum
dominant_run	Dominant Run	Dominance & Quality
high_output	High Output	Dominance & Quality

Markdown stub pack:
## above_expectations — Above Expectations
Unlock: Requirements TBD.

## breakthrough — Breakthrough
Unlock: Requirements TBD.

## dominant_run — Dominant Run
Unlock: Requirements TBD.

## high_output — High Output
Unlock: Requirements TBD.
```
- The run demonstrates the script imports the canonical badge catalog and requirements loader successfully and reports missing requirement text as designed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69817a52a62c8326848f38d5e2df8f51)