### PR TITLE
Add badge requirements audit CLI script

### DIFF
--- a/scripts/audit_badge_requirements.py
+++ b/scripts/audit_badge_requirements.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Audit badge requirements and report which badges still use placeholder text."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+FALLBACK_REQUIREMENTS = "Requirements TBD"
+
+
+def _bootstrap_repo_root() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+
+
+def _is_missing_requirement(text: str | None) -> bool:
+    if text is None:
+        return True
+    cleaned = str(text).strip()
+    if not cleaned:
+        return True
+    if cleaned == FALLBACK_REQUIREMENTS:
+        return True
+    return "requirements tbd" in cleaned.lower()
+
+
+def main() -> int:
+    _bootstrap_repo_root()
+    try:
+        from jupr_app.domain.gamification.badge_catalog import BADGE_DEFINITIONS
+        from jupr_app.domain.gamification.requirements import requirement_for
+    except Exception as exc:  # pragma: no cover - import guard for CLI usage
+        print(
+            "Unable to import JUPR badge modules. Run from the repo root with "
+            "`python scripts/audit_badge_requirements.py`.",
+            file=sys.stderr,
+        )
+        print(f"Import error: {exc}", file=sys.stderr)
+        return 1
+
+    missing = []
+    for badge in BADGE_DEFINITIONS:
+        requirements_text = requirement_for(badge.badge_id)
+        if _is_missing_requirement(requirements_text):
+            missing.append(
+                {
+                    "badge_id": badge.badge_id,
+                    "name": badge.name,
+                    "category": badge.category,
+                }
+            )
+
+    total = len(BADGE_DEFINITIONS)
+    print(f"Missing badge requirements: {len(missing)} of {total}")
+    for entry in missing:
+        print(f"{entry['badge_id']}\t{entry['name']}\t{entry['category']}")
+
+    if missing:
+        print("\nMarkdown stub pack:")
+        for entry in missing:
+            print(f"## {entry['badge_id']} — {entry['name']}")
+            print("Unlock: Requirements TBD.")
+            print()
+
+    return 2 if missing else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Add a small CLI audit tool to detect badges whose requirements text is missing or still using the placeholder so docs/CI can be updated quickly.

### Description
- Add `scripts/audit_badge_requirements.py` which loads the canonical `BADGE_DEFINITIONS` and calls the same `requirement_for` lookup used by the UI.
- The script treats a requirement as missing when it is `None`/empty/whitespace, equals the fallback `Requirements TBD`, or contains the phrase “Requirements TBD” case-insensitive.
- It prints a summary count, one badge per line as `<badge_id>\t<badge_name>\t<category>`, followed by a "Markdown stub pack" using the exact heading key format the loader expects, and returns exit code `0` (none missing) or `2` (any missing).
- The CLI includes a repo-root `sys.path` bootstrap and a friendly import-error message for running from the repository root.

### Testing
- Ran `python scripts/audit_badge_requirements.py`; it exited with code `2` and reported 4 missing badges including `breakthrough`, `above_expectations`, `dominant_run`, and `high_output`.
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69817c338a2c83268a8e4adf4755a61a)