### PR TITLE
Improve badge audit script output

### DIFF
--- a/scripts/audit_badge_requirements.py
+++ b/scripts/audit_badge_requirements.py
@@ -1,7 +1,24 @@
 #!/usr/bin/env python3
+# How to run it:
+#   python scripts/audit_badge_requirements.py
+# What success output looks like:
+#   [audit_badge_requirements] Badge requirement audit
+#   Badges checked: 42
+#   Badges missing requirements: 0
+#   Result: PASS
+#   What to do next: No missing requirements detected. ✅
+# What failure output looks like:
+#   [audit_badge_requirements] Badge requirement audit
+#   Badges checked: 42
+#   Badges missing requirements: 3
+#   Result: FAIL
+#   What to do next: Fill in the missing requirement text and re-run the audit.
+# How to check exit code (echo $?):
+#   echo $?
 """Audit badge requirement text coverage for the Badge Codex badge catalog."""
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -36,40 +53,71 @@ def main() -> int:
         badges = _load_badges()
         from jupr_app.domain.gamification.requirements import requirement_for
     except Exception as exc:  # pragma: no cover - defensive CLI
+        print("[audit_badge_requirements] Badge requirement audit")
         print(f"[audit_badge_requirements] import error: {exc}")
         print("Run this script from the repo root with dependencies installed.")
         return 1
 
-    missing = []
-    for badge in badges:
-        badge_id = str(getattr(badge, "badge_id", "") or "")
-        if not badge_id:
-            continue
-        name = str(getattr(badge, "name", "Badge") or "Badge")
-        category = getattr(badge, "category", None)
-        requirement_text = requirement_for(badge_id)
-        if _missing_requirement(requirement_text):
-            missing.append(
-                {
-                    "badge_id": badge_id,
-                    "name": name,
-                    "category": str(category or ""),
-                }
+    try:
+        verbose = os.getenv("JUPR_AUDIT_VERBOSE") == "1"
+        missing = []
+        badges_checked = 0
+        for badge in badges:
+            badge_id = str(getattr(badge, "badge_id", "") or "")
+            if not badge_id:
+                continue
+            badges_checked += 1
+            name = str(getattr(badge, "name", "Badge") or "Badge")
+            category = getattr(badge, "category", None)
+            requirement_text = requirement_for(badge_id)
+            is_missing = _missing_requirement(requirement_text)
+            if verbose:
+                preview = " ".join(str(requirement_text or "").split())
+                preview = preview[:80]
+                missing_flag = "Y" if is_missing else "N"
+                print(
+                    "[audit_badge_requirements][verbose] "
+                    f"{badge_id} | {name} | {preview} | missing={missing_flag}"
+                )
+            if is_missing:
+                missing.append(
+                    {
+                        "badge_id": badge_id,
+                        "name": name,
+                        "category": str(category or ""),
+                    }
+                )
+
+        missing.sort(key=lambda row: row["badge_id"])
+        print("[audit_badge_requirements] Badge requirement audit")
+        print(f"Badges checked: {badges_checked}")
+        print(f"Badges missing requirements: {len(missing)}")
+        print(f"Result: {'FAIL' if missing else 'PASS'}")
+
+        if missing:
+            print("What to do next: Fill in the missing requirement text and re-run the audit.")
+            print("\nMissing badge requirements:")
+            for entry in missing:
+                print(f"{entry['badge_id']}\t{entry['name']}\t{entry['category']}")
+
+            print("\nMarkdown stub pack:")
+            for entry in missing:
+                print(f"## {entry['badge_id']} — {entry['name']}")
+                print(f"Unlock: {FALLBACK_TEXT}.")
+                print("")
+        else:
+            print("What to do next: No missing requirements detected. ✅")
+            print(
+                "Troubleshooting: If you still see TBD in the UI, the audit may not "
+                "be using the same resolver. Re-run with JUPR_AUDIT_VERBOSE=1 and paste "
+                "the output in your report."
             )
 
-    missing.sort(key=lambda row: row["badge_id"])
-    print(f"Missing badge requirements: {len(missing)}")
-    for entry in missing:
-        print(f"{entry['badge_id']}\t{entry['name']}\t{entry['category']}")
-
-    if missing:
-        print("\nMarkdown stub pack:")
-        for entry in missing:
-            print(f"## {entry['badge_id']} — {entry['name']}")
-            print(f"Unlock: {FALLBACK_TEXT}.")
-            print("")
-
-    return 2 if missing else 0
+        return 2 if missing else 0
+    except Exception as exc:  # pragma: no cover - defensive CLI
+        print("[audit_badge_requirements] Badge requirement audit")
+        print(f"[audit_badge_requirements] unexpected error: {exc}")
+        return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Make `scripts/audit_badge_requirements.py` produce an unmissable, human-friendly summary so running the audit clearly shows pass/fail and next steps.
- Provide a lightweight per-badge sanity mode to help diagnose resolver differences when the UI still shows "TBD".

### Description
- Add a README-style comment header with `How to run it`, expected success/failure output examples, and how to check the exit code (`echo $?`).
- Print a clear audit header plus `Badges checked`, `Badges missing requirements`, `Result: PASS/FAIL`, and a short `What to do next` note, and emit a markdown stub pack when missing items exist.
- Add a verbose sanity mode toggled by `JUPR_AUDIT_VERBOSE=1` that prints `badge_id | name | first 80 chars of requirement | missing=Y/N` for each badge while keeping the default concise.
- Make exit codes explicit and robust: return `0` when `missing == 0`, `2` when `missing > 0`, and `1` on import or unexpected errors, with defensive error handling.

### Testing
- Ran the normal audit with `python scripts/audit_badge_requirements.py`, which exited with code `2` (missing items) and produced the following output:
```
[audit_badge_requirements] Badge requirement audit
Badges checked: 55
Badges missing requirements: 4
Result: FAIL
What to do next: Fill in the missing requirement text and re-run the audit.

Missing badge requirements:
above_expectations	Above Expectations	Skill Growth & Momentum
breakthrough	Breakthrough	Skill Growth & Momentum
dominant_run	Dominant Run	Dominance & Quality
high_output	High Output	Dominance & Quality

Markdown stub pack:
## above_expectations — Above Expectations
Unlock: Requirements TBD.

## breakthrough — Breakthrough
Unlock: Requirements TBD.

## dominant_run — Dominant Run
Unlock: Requirements TBD.

## high_output — High Output
Unlock: Requirements TBD.
```
- Ran the verbose sanity check with `JUPR_AUDIT_VERBOSE=1 python scripts/audit_badge_requirements.py`, which exited with code `2` and produced per-badge previews followed by the same summary; an excerpt of the verbose lines and final summary is below:
```
[audit_badge_requirements][verbose] participant | Participant | Play **1 recorded match** (lifetime). | missing=N
[audit_badge_requirements][verbose] dedicated_participant_50 | Dedicated Participant | Play **50 recorded matches** (lifetime). | missing=N
...
[audit_badge_requirements][verbose] breakthrough | Breakthrough | Requirements TBD. | missing=Y
[audit_badge_requirements][verbose] above_expectations | Above Expectations | Requirements TBD. | missing=Y
[audit_badge_requirements] Badge requirement audit
Badges checked: 55
Badges missing requirements: 4
Result: FAIL
What to do next: Fill in the missing requirement text and re-run the audit.
```
- Both automated runs behaved as designed (exit codes `2` when missing items were found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69817fc67be083269cd376f223a9c969)