### PR TITLE
Add CLI audit script for incomplete badge requirements and copy

### DIFF
--- a/scripts/audit_incomplete_badges.py
+++ b/scripts/audit_incomplete_badges.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# How to run it:
+#   python scripts/audit_incomplete_badges.py
+#   JUPR_AUDIT_VERBOSE=1 python scripts/audit_incomplete_badges.py
+"""Audit the Badge Codex for incomplete badges (requirements + copy + optional DB rules)."""
+from __future__ import annotations
+
+import os
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FALLBACK_TEXT = "Requirements TBD"
+
+
+@dataclass(frozen=True)
+class BadgeAuditRow:
+    badge_id: str
+    name: str
+    category: str
+    requirement_preview: str
+    missing_req: bool
+    missing_desc: bool
+    missing_meta: bool
+    db_rules_total: str
+    db_rules_enabled: str
+
+
+def _bootstrap_repo_root() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+
+def _missing_requirement(text: str | None) -> bool:
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return True
+    return FALLBACK_TEXT.lower() in cleaned.lower()
+
+
+def _normalize_preview(text: str | None, *, limit: int = 120) -> str:
+    compact = " ".join(str(text or "").split())
+    if len(compact) <= limit:
+        return compact
+    return compact[:limit]
+
+
+def _load_badges():
+    from jupr_app.domain.gamification.badge_catalog import BADGE_DEFINITIONS
+
+    return BADGE_DEFINITIONS
+
+
+def _load_badge_copy_sources():
+    from jupr_app.domain.gamification.badge_descriptions import BADGE_DESCRIPTIONS_MD
+    from jupr_app.domain.gamification.badge_copy import build_badge_copy_plain
+    from jupr_app.domain.gamification.requirements import load_requirements_map
+
+    requirements = load_requirements_map()
+    return BADGE_DESCRIPTIONS_MD, build_badge_copy_plain, requirements
+
+
+def _load_rules_counts() -> tuple[dict[str, int] | None, dict[str, int] | None]:
+    supabase_url = os.getenv("SUPABASE_URL")
+    supabase_key = os.getenv("SUPABASE_KEY")
+    if not supabase_url or not supabase_key:
+        return None, None
+
+    try:
+        from jupr_app.data.client import make_supabase
+    except Exception:
+        return None, None
+
+    supabase = make_supabase(supabase_url, supabase_key)
+    try:
+        response = supabase.table("badge_rules_v2").select("badge_id,enabled").execute()
+    except Exception:
+        return None, None
+
+    totals: dict[str, int] = defaultdict(int)
+    enabled: dict[str, int] = defaultdict(int)
+    for row in response.data or []:
+        badge_id = str(row.get("badge_id") or "")
+        if not badge_id:
+            continue
+        totals[badge_id] += 1
+        if row.get("enabled") is True:
+            enabled[badge_id] += 1
+    return totals, enabled
+
+
+def main() -> int:
+    _bootstrap_repo_root()
+    try:
+        badges = _load_badges()
+        descriptions_map, build_badge_copy_plain, requirements_map = _load_badge_copy_sources()
+    except Exception as exc:  # pragma: no cover - defensive CLI
+        print("[audit_incomplete_badges] Badge audit")
+        print(f"[audit_incomplete_badges] import error: {exc}")
+        print("Run this script from the repo root with dependencies installed.")
+        return 1
+
+    try:
+        verbose = os.getenv("JUPR_AUDIT_VERBOSE") == "1"
+        rules_totals, rules_enabled = _load_rules_counts()
+        db_available = rules_totals is not None and rules_enabled is not None
+        rows: list[BadgeAuditRow] = []
+        incomplete: list[BadgeAuditRow] = []
+
+        for badge in badges:
+            badge_id = str(getattr(badge, "badge_id", "") or "")
+            if not badge_id:
+                continue
+            name = str(getattr(badge, "name", "Badge") or "Badge")
+            category = str(getattr(badge, "category", "") or "")
+            description_md = descriptions_map.get(badge_id, "")
+            requirements_raw = requirements_map.get(badge_id)
+
+            copy_plain = build_badge_copy_plain(
+                {
+                    "badge_id": badge_id,
+                    "name": name,
+                    "category": category,
+                    "requirements": requirements_raw,
+                    "description_md": description_md,
+                }
+            )
+
+            requirement_text = copy_plain.req_text
+            missing_req = _missing_requirement(requirement_text)
+            missing_desc = badge_id in descriptions_map and not (copy_plain.desc_text or "").strip()
+            missing_meta = False
+
+            total_rules = rules_totals.get(badge_id, 0) if db_available else None
+            enabled_rules = rules_enabled.get(badge_id, 0) if db_available else None
+            rules_flag = False
+            if db_available:
+                rules_flag = total_rules == 0 or enabled_rules == 0
+
+            row = BadgeAuditRow(
+                badge_id=badge_id,
+                name=name,
+                category=category,
+                requirement_preview=_normalize_preview(requirement_text),
+                missing_req=missing_req,
+                missing_desc=missing_desc,
+                missing_meta=missing_meta,
+                db_rules_total=str(total_rules) if db_available else "N/A",
+                db_rules_enabled=str(enabled_rules) if db_available else "N/A",
+            )
+            rows.append(row)
+
+            if missing_req or missing_desc or missing_meta or rules_flag:
+                incomplete.append(row)
+
+            if verbose:
+                print(
+                    "[audit_incomplete_badges][verbose] "
+                    f"{badge_id} | req_missing={missing_req} | desc_missing={missing_desc} "
+                    f"| meta_missing={missing_meta} | rules_total={row.db_rules_total} "
+                    f"| rules_enabled={row.db_rules_enabled}"
+                )
+
+        print("[audit_incomplete_badges] Badge audit")
+        print(f"Badges checked: {len(rows)}")
+        print(f"Incomplete badges: {len(incomplete)}")
+        if db_available:
+            print("DB rules check: enabled (badge_rules_v2).")
+        else:
+            print("DB rules check: skipped (SUPABASE_URL/SUPABASE_KEY not set).")
+
+        if incomplete:
+            print("\nIncomplete badge list (tab-separated):")
+            print(
+                "badge_id\tname\tcategory\trequirement_preview\tmissing_req\tmissing_desc\tmissing_meta\t"
+                "db_rules_total\tdb_rules_enabled"
+            )
+            for row in sorted(incomplete, key=lambda item: item.badge_id):
+                print(
+                    f"{row.badge_id}\t{row.name}\t{row.category}\t{row.requirement_preview}\t"
+                    f"{row.missing_req}\t{row.missing_desc}\t{row.missing_meta}\t"
+                    f"{row.db_rules_total}\t{row.db_rules_enabled}"
+                )
+
+            missing_req_rows = sorted(
+                (row for row in incomplete if row.missing_req),
+                key=lambda item: item.badge_id,
+            )
+            if missing_req_rows:
+                print("\nFix pack: markdown stubs for docs/badge_requirements.md")
+                for row in missing_req_rows:
+                    print(f"## {row.badge_id} — {row.name}")
+                    print("Unlock: Requirements TBD.")
+                    print("")
+
+            return 2
+
+        print("Result: PASS (no incomplete badges found). ✅")
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive CLI
+        print("[audit_incomplete_badges] Badge audit")
+        print(f"[audit_incomplete_badges] unexpected error: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide a server-side audit that reliably finds badges rendering the fallback requirement text and other missing copy wiring using the exact same resolver pipeline the UI uses.
- Make it easy to run locally or in CI/maintenance contexts and optionally surface DB signals from `badge_rules_v2` when Supabase credentials are available.

### Description
- Add `scripts/audit_incomplete_badges.py`, a CLI that loads the canonical badge list (`BADGE_DEFINITIONS`) and uses the same copy/resolver pipeline (`build_badge_copy_plain` / `load_requirements_map`) to detect fallback requirement text.
- The script optionally connects to Supabase using `jupr_app.data.client.make_supabase` when `SUPABASE_URL`/`SUPABASE_KEY` are present and summarizes `badge_rules_v2` totals and enabled counts.
- Output includes `badge_id`, `name`, `category`, `requirement_text_preview` (first 120 chars), flags `missing_req`, `missing_desc`, `missing_meta`, and `db_rules_total`/`db_rules_enabled`, and it prints a copy/paste-ready fix pack of markdown stubs for missing requirements.
- Implements usage instructions, `JUPR_AUDIT_VERBOSE` for verbose per-badge logging, and exit codes `0` (none incomplete), `2` (incomplete found), and `1` (crash/import error).

### Testing
- Ran `python scripts/audit_incomplete_badges.py` in the repo root, which exited with code `2` indicating incomplete badges were detected and printed the following sample output:
```
[audit_incomplete_badges] Badge audit
Badges checked: 55
Incomplete badges: 4
DB rules check: skipped (SUPABASE_URL/SUPABASE_KEY not set).

Incomplete badge list (tab-separated):
badge_id	name	category	requirement_preview	missing_req	missing_desc	missing_meta	db_rules_total	db_rules_enabled
above_expectations	Above Expectations	Skill Growth & Momentum	Requirements TBD.	True	False	False	N/A	N/A
breakthrough	Breakthrough	Skill Growth & Momentum	Requirements TBD.	True	False	False	N/A	N/A
dominant_run	Dominant Run	Dominance & Quality	Requirements TBD.	True	False	False	N/A	N/A
high_output	High Output	Dominance & Quality	Requirements TBD.	True	False	False	N/A	N/A

Fix pack: markdown stubs for docs/badge_requirements.md
## above_expectations — Above Expectations
Unlock: Requirements TBD.

## breakthrough — Breakthrough
Unlock: Requirements TBD.

## dominant_run — Dominant Run
Unlock: Requirements TBD.

## high_output — High Output
Unlock: Requirements TBD.
```
- The DB rules check was skipped in this run because `SUPABASE_URL`/`SUPABASE_KEY` were not set, and the script reports `N/A` for DB counts in that case.
- Verbose mode can be enabled with `JUPR_AUDIT_VERBOSE=1` to print per-badge diagnostics during the audit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698183428bb0832689fc4ac73dae657d)