### PR TITLE
Add admin-only read-only audit for incomplete badge requirements

### DIFF
--- a/jupr_app/ui/pages/badge_codex.py
+++ b/jupr_app/ui/pages/badge_codex.py
@@ -7,7 +7,6 @@ import streamlit as st
 import streamlit.components.v1 as components
 
 from jupr_app.domain.gamification.badge_copy import build_badge_copy_plain
-from jupr_app.domain.gamification.requirements import audit_missing_badge_requirements
 from jupr_app.ui.components import badge_cards
 from jupr_app.ui.components.badge_cards import render_badge_card_html
 from jupr_app.ui.pages.players import badge_icon
@@ -364,30 +363,13 @@ def render(ctx) -> None:
     debug_badges = st.sidebar.checkbox("Debug badge render", value=debug_env)
     admin_mode = bool(getattr(ctx, "is_admin", False) or getattr(ctx, "admin_logged_in", False))
     debug_admin_mode = admin_mode or debug_env
+    show_incomplete_audit = debug_env or bool(getattr(ctx, "is_admin", False) or getattr(ctx, "admin_logged_in", False))
 
     badge_defs = getattr(ctx, "df_badges", None)
     player_badges = getattr(ctx, "df_player_badges", None)
     if badge_defs is None:
         st.info("Badge data is still loading.")
         return
-
-    if debug_admin_mode:
-        missing_requirements = audit_missing_badge_requirements(badge_defs)
-        logger.info("Badge requirements audit: %s missing entries", len(missing_requirements))
-        with st.expander("Admin: Missing badge requirements", expanded=False):
-            if missing_requirements:
-                st.dataframe(missing_requirements, use_container_width=True)
-                st.caption("Markdown stubs for docs/badge_requirements.md")
-                stub_lines = []
-                for entry in missing_requirements:
-                    badge_id = entry.get("badge_id", "")
-                    name = entry.get("name", "Badge")
-                    stub_lines.append(f"## {badge_id} — {name}")
-                    stub_lines.append("Unlock: Requirements TBD.")
-                    stub_lines.append("")
-                st.code("\n".join(stub_lines).strip(), language="markdown")
-            else:
-                st.success("All badges have requirement strings.")
 
     include_deprecated = False
     if bool(getattr(ctx, "admin_logged_in", False)):
@@ -412,3 +394,49 @@ def render(ctx) -> None:
                 debug_badges=debug_badges,
             )
         st.markdown("<div style='height: 0.5rem'></div>", unsafe_allow_html=True)
+
+    if show_incomplete_audit:
+        audit_rows = []
+        for badge in badges:
+            copy_plain = build_badge_copy_plain(badge, earners_count=badge.get("earners_count"))
+            req_text = "" if copy_plain.req_text is None else str(copy_plain.req_text)
+            is_incomplete = not req_text.strip() or "requirements tbd" in req_text.lower()
+            if is_incomplete:
+                audit_rows.append(
+                    {
+                        "badge_id": badge.get("badge_id", ""),
+                        "name": badge.get("name", "Badge"),
+                        "category": badge.get("category") or "",
+                        "requirement_preview": req_text,
+                    }
+                )
+
+        total_checked = len(badges)
+        incomplete_count = len(audit_rows)
+        logger.info(
+            "Badge codex incomplete requirements audit: %s incomplete out of %s badges",
+            incomplete_count,
+            total_checked,
+        )
+
+        with st.expander("Admin: Incomplete Badges Audit", expanded=False):
+            st.caption("Read-only audit: does not modify badges.")
+            st.markdown(f"- Total badges checked: **{total_checked}**")
+            st.markdown(f"- Incomplete badges: **{incomplete_count}**")
+            if audit_rows:
+                st.dataframe(audit_rows, use_container_width=True)
+            else:
+                st.success("All badges have requirement strings.")
+
+            st.caption("Copy/paste stub pack for docs/badge_requirements.md")
+            if audit_rows:
+                stub_lines = []
+                for entry in audit_rows:
+                    badge_id = entry.get("badge_id", "")
+                    name = entry.get("name", "Badge")
+                    stub_lines.append(f"## {badge_id} — {name}")
+                    stub_lines.append("Unlock: Requirements TBD.")
+                    stub_lines.append("")
+                st.code("\n".join(stub_lines).strip(), language="markdown")
+            else:
+                st.text("No stubs needed.")


### PR DESCRIPTION
### Motivation
- Provide a read-only, in-UI way to identify badges whose rendered requirements are missing or showing the fallback text so maintainers can complete them later.
- Ensure the audit uses the exact same rendering pipeline the UI uses to avoid any resolver drift.

### Description
- Added an admin/debug-only expander at the bottom of `jupr_app/ui/pages/badge_codex.py` named `Admin: Incomplete Badges Audit` that lists incomplete badges without modifying any data.  
- The audit iterates the canonical badge list returned by `get_all_badges(...)` and derives the requirement text by calling the same pipeline function `build_badge_copy_plain(...)` used by the badge card renderer.  
- A badge is flagged incomplete when the produced `req_text` is empty/whitespace or contains `Requirements TBD` (case-insensitive).  
- The expander shows total badges checked, the incomplete count, a table with `badge_id`, `name`, `category`, and `requirement_preview`, and a copy/paste stub pack for `docs/badge_requirements.md`.  
- The audit is gated and visible only when `JUPR_DEBUG_BADGES=1` or the user is an admin (`ctx.is_admin` / `ctx.admin_logged_in`).  
- Only `jupr_app/ui/pages/badge_codex.py` was modified; the audit is explicitly labeled `Read-only audit: does not modify badges.`

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698186383d8c8326aeb0411c203c1c15)