### PR TITLE
Clarify inactive badge unlock rules

### DIFF
--- a/docs/badge_requirements.md
+++ b/docs/badge_requirements.md
@@ -69,10 +69,10 @@ Unlock: In the **same league**, reach a win streak of **5 / 10 / 20** consecutiv
 Unlock: Win your **next recorded match** after a loss (based on match history order).
 
 ## breakthrough — Breakthrough (non-stackable)
-Unlock: Requirements TBD.
+Unlock: Not currently awarded — badge evaluator is inactive (missing explicit breakthrough criteria).
 
 ## above_expectations — Above Expectations (stackable)
-Unlock: Requirements TBD.
+Unlock: Not currently awarded — badge evaluator is inactive (missing expected performance baseline).
 
 ---
 
@@ -104,10 +104,10 @@ Unlock: In one **ISO week** (Mon–Sun), play **at least one match in 2+ differe
 Unlock: Record **100+ lifetime match wins**.
 
 ## dominant_run — Dominant Run (stackable)
-Unlock: Requirements TBD.
+Unlock: Not currently awarded — badge evaluator is inactive (missing dominant run criteria).
 
 ## high_output — High Output (stackable)
-Unlock: Requirements TBD.
+Unlock: Not currently awarded — badge evaluator is inactive (missing high output definition).
 
 ---
 


### PR DESCRIPTION
### Motivation
- Align the player-facing unlock documentation with the actual badge evaluator status for four badges that currently have no implemented award logic (`breakthrough`, `above_expectations`, `dominant_run`, `high_output`).

### Description
- Update `docs/badge_requirements.md` to replace the “Requirements TBD” lines for the four badges with explicit statements that the badges are not currently awarded because their evaluators are inactive (and include the evaluator diagnostic text).

### Testing
- Docs-only change; no automated tests were run (change committed to `docs/badge_requirements.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981875776e08326b944012d01e4fc9e)