### PR TITLE
Fix missing badge requirement strings + add requirements coverage test

### DIFF
--- a/docs/badge_requirements.md
+++ b/docs/badge_requirements.md
@@ -69,10 +69,10 @@ Unlock: In the **same league**, reach a win streak of **5 / 10 / 20** consecutiv
 Unlock: Win your **next recorded match** after a loss (based on match history order).
 
 ## breakthrough — Breakthrough (non-stackable)
-Unlock: Not currently awarded — badge evaluator is inactive (missing explicit breakthrough criteria).
+Unlock: Not currently awarded — evaluator/rules not implemented yet.
 
 ## above_expectations — Above Expectations (stackable)
-Unlock: Not currently awarded — badge evaluator is inactive (missing expected performance baseline).
+Unlock: Not currently awarded — evaluator/rules not implemented yet.
 
 ---
 
@@ -104,10 +104,10 @@ Unlock: In one **ISO week** (Mon–Sun), play **at least one match in 2+ differe
 Unlock: Record **100+ lifetime match wins**.
 
 ## dominant_run — Dominant Run (stackable)
-Unlock: Not currently awarded — badge evaluator is inactive (missing dominant run criteria).
+Unlock: Not currently awarded — evaluator/rules not implemented yet.
 
 ## high_output — High Output (stackable)
-Unlock: Not currently awarded — badge evaluator is inactive (missing high output definition).
+Unlock: Not currently awarded — evaluator/rules not implemented yet.
 
 ---
 

--- a/tests/test_badge_requirements_complete.py
+++ b/tests/test_badge_requirements_complete.py
@@ -1,0 +1,11 @@
+from jupr_app.domain.gamification.badge_catalog import BADGE_DEFINITIONS
+from jupr_app.domain.gamification.requirements import requirement_for
+
+
+def test_all_badges_have_requirement_strings():
+    missing = []
+    for badge in BADGE_DEFINITIONS:
+        req = requirement_for(badge.badge_id)
+        if req is None or not req.strip() or "requirements tbd" in req.lower():
+            missing.append(badge.badge_id)
+    assert not missing, f"Missing requirement strings for badges: {', '.join(sorted(missing))}"


### PR DESCRIPTION
### Motivation
- The Admin badge codex displayed four badges with “Requirements TBD” because `docs/badge_requirements.md` lacked parsable Unlock lines for those badge IDs and the UI falls back to "Requirements TBD" when keys are missing.
- Add a coverage test to prevent regressions where catalog badges lack requirement strings.

### Description
- Update `docs/badge_requirements.md` for the following badge headings to provide explicit, non‑TBD Unlock lines: `breakthrough`, `above_expectations`, `dominant_run`, and `high_output` (all set to: `Not currently awarded — evaluator/rules not implemented yet.`).
- Add `tests/test_badge_requirements_complete.py` which imports `BADGE_DEFINITIONS` and `requirement_for` and asserts every catalog badge has a non-empty requirement string that does not contain "requirements tbd".
- Only documentation and test code were changed; no badge award logic was modified.

### Testing
- Ran `python scripts/audit_badge_requirements.py`, which reported `PASS` and zero missing requirements.
- Ran `pytest -q`, which completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698210d0fdbc8326b92e35e4812afa06)