### PR TITLE
Fix requirements cache invalidation and wire admin refresh + tests

### DIFF
--- a/jupr_app/domain/gamification/requirements.py
+++ b/jupr_app/domain/gamification/requirements.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import re
 
 _REQUIREMENTS_CACHE: dict[str, str] | None = None
+_REQUIREMENTS_CACHE_MTIME: float | None = None
+_REQUIREMENTS_CACHE_PATH: str | None = None
 
 _HEADING_RE = re.compile(r"^#{2,3}\s+(.+)$")
 _REQ_RE = re.compile(r"^(Unlock|Status):\s*(.+)$", re.IGNORECASE)
@@ -71,15 +73,37 @@ def _parse_requirements(text: str) -> dict[str, str]:
 
 
 def load_requirements_map() -> dict[str, str]:
-    global _REQUIREMENTS_CACHE
-    if _REQUIREMENTS_CACHE is not None:
-        return _REQUIREMENTS_CACHE
-    requirements: dict[str, str] = {}
+    global _REQUIREMENTS_CACHE, _REQUIREMENTS_CACHE_MTIME, _REQUIREMENTS_CACHE_PATH
     requirements_path = _requirements_path()
-    if requirements_path and requirements_path.exists():
-        requirements = _parse_requirements(requirements_path.read_text(encoding="utf-8"))
+    if not requirements_path or not requirements_path.exists():
+        if _REQUIREMENTS_CACHE is None:
+            _REQUIREMENTS_CACHE = {}
+            _REQUIREMENTS_CACHE_MTIME = None
+            _REQUIREMENTS_CACHE_PATH = None
+        return _REQUIREMENTS_CACHE
+
+    path_str = str(requirements_path)
+    mtime = requirements_path.stat().st_mtime
+
+    if (
+        _REQUIREMENTS_CACHE is not None
+        and _REQUIREMENTS_CACHE_MTIME == mtime
+        and _REQUIREMENTS_CACHE_PATH == path_str
+    ):
+        return _REQUIREMENTS_CACHE
+
+    requirements = _parse_requirements(requirements_path.read_text(encoding="utf-8"))
     _REQUIREMENTS_CACHE = requirements
+    _REQUIREMENTS_CACHE_MTIME = mtime
+    _REQUIREMENTS_CACHE_PATH = path_str
     return requirements
+
+
+def clear_requirements_cache() -> None:
+    global _REQUIREMENTS_CACHE, _REQUIREMENTS_CACHE_MTIME, _REQUIREMENTS_CACHE_PATH
+    _REQUIREMENTS_CACHE = None
+    _REQUIREMENTS_CACHE_MTIME = None
+    _REQUIREMENTS_CACHE_PATH = None
 
 
 def load_requirements() -> dict[str, str]:

--- a/jupr_app/ui/pages/badge_codex.py
+++ b/jupr_app/ui/pages/badge_codex.py
@@ -7,6 +7,7 @@ import streamlit as st
 import streamlit.components.v1 as components
 
 from jupr_app.domain.gamification.badge_copy import build_badge_copy_plain
+from jupr_app.domain.gamification.requirements import load_requirements_map, requirement_for
 from jupr_app.ui.components import badge_cards
 from jupr_app.ui.components.badge_cards import render_badge_card_html
 from jupr_app.ui.pages.players import badge_icon
@@ -440,3 +441,20 @@ def render(ctx) -> None:
                 st.code("\n".join(stub_lines).strip(), language="markdown")
             else:
                 st.text("No stubs needed.")
+
+        with st.expander("Admin: Requirement resolver debug", expanded=False):
+            debug_badge_ids = [
+                "above_expectations",
+                "breakthrough",
+                "dominant_run",
+                "high_output",
+            ]
+            req_map = load_requirements_map()
+            st.caption("Live resolver output for select badge IDs.")
+            st.markdown(f"- Total requirements loaded: **{len(req_map)}**")
+            for badge_id in debug_badge_ids:
+                resolved = requirement_for(badge_id)
+                exists = badge_id in req_map
+                st.markdown(
+                    f"- `{badge_id}`: exists={exists} · resolved: {resolved}",
+                )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -454,6 +454,12 @@ def main():
 
             if admin_logged_in and st.sidebar.button("🔄 Refresh data"):
                 get_data.clear()
+                try:
+                    from jupr_app.domain.gamification.requirements import clear_requirements_cache
+
+                    clear_requirements_cache()
+                except Exception:
+                    pass
                 st.rerun()
 
             sel = st.sidebar.radio("Go to:", visible_labels, key="main_nav")

--- a/tests/test_badge_requirements_complete.py
+++ b/tests/test_badge_requirements_complete.py
@@ -1,0 +1,19 @@
+from jupr_app.domain.gamification.badge_catalog import BADGE_DEFINITIONS
+from jupr_app.domain.gamification.requirements import (
+    clear_requirements_cache,
+    requirement_for,
+)
+
+
+def test_badge_requirements_are_complete() -> None:
+    clear_requirements_cache()
+    missing = []
+    for badge in BADGE_DEFINITIONS:
+        req = requirement_for(badge.badge_id)
+        cleaned = str(req or "").strip()
+        if not cleaned or "requirements tbd" in cleaned.lower():
+            missing.append(badge.badge_id)
+    assert missing == [], (
+        "Expected all badge requirements to be resolved; missing or TBD for: "
+        f"{', '.join(missing)}"
+    )


### PR DESCRIPTION
### Motivation
- The requirements loader cached parsed badge requirements in a module-global and never invalidated it, causing the UI to continue showing stale "Requirements TBD" values after `docs/badge_requirements.md` changed.

### Description
- Make the requirements cache mtime-aware by adding `_REQUIREMENTS_CACHE_MTIME` and `_REQUIREMENTS_CACHE_PATH` and comparing file `mtime` in `load_requirements_map()` so file changes reload automatically (`jupr_app/domain/gamification/requirements.py`).
- Add a manual `clear_requirements_cache()` function to invalidate the cache programmatically (`jupr_app/domain/gamification/requirements.py`).
- Wire the manual cache clear into the admin "🔄 Refresh data" button so clicking it also clears requirements cache before `st.rerun()` (`streamlit_app.py`).
- Add an admin debug expander in the Badge Codex that shows `load_requirements_map()` and `requirement_for()` outputs for the four target badges so resolver state is visible in the UI (`jupr_app/ui/pages/badge_codex.py`).
- Add a regression test `tests/test_badge_requirements_complete.py` that clears the cache and asserts no `BADGE_DEFINITIONS` entry resolves to "Requirements TBD".

### Testing
- Ran `python scripts/audit_badge_requirements.py` which reported `Badges missing requirements: 0` and `Result: PASS`.
- Ran `pytest -q` and all tests passed (`112 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821388a2f88326ba2cbf372d8f9161)