### PR TITLE
Implement dominant_run, high_output, breakthrough, and above_expectations evaluators with tests and docs

### DIFF
--- a/docs/badge_requirements.md
+++ b/docs/badge_requirements.md
@@ -68,11 +68,11 @@ Unlock: In the **same league**, reach a win streak of **5 / 10 / 20** consecutiv
 ## bounce_back — Bounce Back (stackable)
 Unlock: Win your **next recorded match** after a loss (based on match history order).
 
-## breakthrough — Breakthrough (non-stackable)
-Unlock: Not currently awarded — badge evaluator is inactive (missing explicit breakthrough criteria).
+## breakthrough — Breakthrough (stackable)
+Unlock: In a league, play **10+ matches** and move from **outside the top 25 / top 10** (starting rank) into the **current top 25 / top 10** (by JUPR rating). Earn each tier separately.
 
 ## above_expectations — Above Expectations (stackable)
-Unlock: Not currently awarded — badge evaluator is inactive (missing expected performance baseline).
+Unlock: Win with **expected win chance ≤ 40%** and a **4+ point margin**. If rating deltas are available, the match must be at or above the **75th percentile** of absolute rating delta within that league.
 
 ---
 
@@ -104,10 +104,10 @@ Unlock: In one **ISO week** (Mon–Sun), play **at least one match in 2+ differe
 Unlock: Record **100+ lifetime match wins**.
 
 ## dominant_run — Dominant Run (stackable)
-Unlock: Not currently awarded — badge evaluator is inactive (missing dominant run criteria).
+Unlock: Across all leagues, reach a **10+ match win streak** with **average win margin ≥ 5** across the current streak. Earn it again for each additional win while the streak and average margin stay at or above the threshold.
 
 ## high_output — High Output (stackable)
-Unlock: Not currently awarded — badge evaluator is inactive (missing high output definition).
+Unlock: Across all leagues, in your **last 25 matches**, record **20+ wins** with **average margin ≥ 4**.
 
 ---
 

--- a/jupr_app/domain/gamification/evaluators.py
+++ b/jupr_app/domain/gamification/evaluators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Iterable
 from datetime import datetime
 import logging
@@ -739,19 +740,169 @@ def evaluate_mentor(ctx: BadgeEvaluationContext) -> Iterable[BadgeCandidate]:
 
 
 def evaluate_breakthrough(ctx: BadgeEvaluationContext) -> Iterable[BadgeCandidate]:
-    return _inactive("breakthrough", "missing explicit breakthrough criteria")
+    df_leagues = getattr(ctx.ctx, "df_leagues", None)
+    if df_leagues is None or df_leagues.empty:
+        return []
+    if "league_name" not in df_leagues.columns or "player_id" not in df_leagues.columns:
+        return []
+    df = df_leagues.copy()
+    df["league_name"] = df["league_name"].fillna("").astype(str).str.strip()
+    df["rating"] = pd.to_numeric(df.get("rating", 1200.0), errors="coerce").fillna(1200.0)
+    df["starting_rating"] = pd.to_numeric(df.get("starting_rating", df["rating"]), errors="coerce").fillna(df["rating"])
+    df["matches_played"] = pd.to_numeric(df.get("matches_played", 0), errors="coerce").fillna(0).astype(int)
+    candidates: list[BadgeCandidate] = []
+    for league_name, league_df in df.groupby("league_name"):
+        if not league_name:
+            continue
+        if ctx.league_id and str(league_name) != str(ctx.league_id):
+            continue
+        start_sorted = league_df.sort_values("starting_rating", ascending=False).reset_index(drop=True)
+        start_sorted["start_rank"] = start_sorted.index + 1
+        current_sorted = league_df.sort_values("rating", ascending=False).reset_index(drop=True)
+        current_sorted["current_rank"] = current_sorted.index + 1
+        ranks = start_sorted[["player_id", "start_rank"]].merge(
+            current_sorted[["player_id", "current_rank"]], on="player_id", how="inner"
+        )
+        ranks = ranks.merge(league_df[["player_id", "matches_played"]], on="player_id", how="left")
+        for _, row in ranks.iterrows():
+            matches_played = int(row.get("matches_played", 0) or 0)
+            if matches_played < 10:
+                continue
+            start_rank = int(row["start_rank"])
+            current_rank = int(row["current_rank"])
+            for tier in (25, 10):
+                if start_rank > tier and current_rank <= tier:
+                    candidates.append(
+                        BadgeCandidate(
+                            badge_id="breakthrough",
+                            player_id=int(row["player_id"]),
+                            club_id=ctx.club_id,
+                            context_type="league",
+                            context_id=f"{league_name}:breakthrough:top{tier}",
+                            match_id=None,
+                            value_json={
+                                "league": league_name,
+                                "tier": tier,
+                                "start_rank": start_rank,
+                                "current_rank": current_rank,
+                                "matches_played": matches_played,
+                            },
+                        )
+                    )
+    return candidates
 
 
 def evaluate_above_expectations(ctx: BadgeEvaluationContext) -> Iterable[BadgeCandidate]:
-    return _inactive("above_expectations", "missing expected performance baseline")
+    facts = _as_of_filter(ctx.facts, ctx.as_of)
+    facts = _league_filter(facts, ctx.league_id)
+    if facts.empty:
+        return []
+    facts = facts.copy()
+    if "league" not in facts.columns:
+        facts["league"] = "OVERALL"
+    thresholds: dict[str, float] = {}
+    if "abs_elo_delta" in facts.columns:
+        non_null = facts["abs_elo_delta"].dropna()
+        if not non_null.empty:
+            thresholds = (
+                facts.groupby("league")["abs_elo_delta"]
+                .quantile(0.75, interpolation="linear")
+                .dropna()
+                .astype(float)
+                .to_dict()
+            )
+    candidates: list[BadgeCandidate] = []
+    for row in facts.itertuples(index=False):
+        if not bool(getattr(row, "win", False)):
+            continue
+        expected_win_prob = getattr(row, "expected_win_prob", None)
+        if expected_win_prob is None or float(expected_win_prob) > 0.40:
+            continue
+        margin = getattr(row, "margin", None)
+        if margin is None or float(margin) < 4:
+            continue
+        abs_elo_delta = getattr(row, "abs_elo_delta", None)
+        league = getattr(row, "league", "OVERALL")
+        threshold = thresholds.get(str(league))
+        if abs_elo_delta is not None and threshold is not None:
+            if float(abs_elo_delta) < float(threshold):
+                continue
+        candidates.append(
+            BadgeCandidate(
+                badge_id="above_expectations",
+                player_id=int(row.player_id),
+                club_id=ctx.club_id,
+                context_type="match",
+                context_id=f"{row.match_id}:above_expectations",
+                match_id=str(row.match_id),
+                value_json={
+                    "expected_win_prob": float(expected_win_prob),
+                    "margin": float(margin),
+                    "abs_elo_delta": float(abs_elo_delta) if abs_elo_delta is not None else None,
+                },
+            )
+        )
+    return candidates
 
 
 def evaluate_dominant_run(ctx: BadgeEvaluationContext) -> Iterable[BadgeCandidate]:
-    return _inactive("dominant_run", "missing dominant run criteria")
+    facts = _as_of_filter(ctx.facts, ctx.as_of).sort_values(["date_dt", "match_id"])
+    if facts.empty:
+        return []
+    candidates: list[BadgeCandidate] = []
+    for player_id, group in facts.groupby("player_id"):
+        streak = 0
+        margin_sum = 0.0
+        for row in group.itertuples(index=False):
+            if row.win:
+                streak += 1
+                margin_sum += float(row.margin)
+                avg_margin = margin_sum / streak
+                if streak >= 10 and avg_margin >= 5.0:
+                    candidates.append(
+                        BadgeCandidate(
+                            badge_id="dominant_run",
+                            player_id=int(player_id),
+                            club_id=ctx.club_id,
+                            context_type="overall",
+                            context_id=f"dominant_run:streak:{streak}:end:{row.match_id}",
+                            match_id=str(row.match_id),
+                            value_json={"streak": streak, "avg_margin": avg_margin},
+                        )
+                    )
+            else:
+                streak = 0
+                margin_sum = 0.0
+    return candidates
 
 
 def evaluate_high_output(ctx: BadgeEvaluationContext) -> Iterable[BadgeCandidate]:
-    return _inactive("high_output", "missing high output definition")
+    facts = _as_of_filter(ctx.facts, ctx.as_of).sort_values(["date_dt", "match_id"])
+    if facts.empty:
+        return []
+    candidates: list[BadgeCandidate] = []
+    for player_id, group in facts.groupby("player_id"):
+        window = deque(maxlen=25)
+        for row in group.itertuples(index=False):
+            window.append(row)
+            if len(window) < 25:
+                continue
+            wins = int(sum(1 for item in window if item.win))
+            avg_margin = float(sum(float(item.margin) for item in window) / len(window))
+            if wins >= 20 and avg_margin >= 4.0:
+                end_match_id = window[-1].match_id
+                candidates.append(
+                    BadgeCandidate(
+                        badge_id="high_output",
+                        player_id=int(player_id),
+                        club_id=ctx.club_id,
+                        context_type="overall",
+                        context_id=f"high_output:window25:end:{end_match_id}",
+                        match_id=str(end_match_id),
+                        value_json={"window": 25, "wins": wins, "avg_margin": avg_margin},
+                    )
+                )
+    return candidates
 
 
 def evaluate_battle_tested(ctx: BadgeEvaluationContext) -> Iterable[BadgeCandidate]:

--- a/tests/test_new_badges_output_dominance_breakthrough.py
+++ b/tests/test_new_badges_output_dominance_breakthrough.py
@@ -1,0 +1,146 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from jupr_app.domain.gamification.badge_types import BadgeEvaluationContext
+from jupr_app.domain.gamification.evaluators import (
+    evaluate_above_expectations,
+    evaluate_breakthrough,
+    evaluate_dominant_run,
+    evaluate_high_output,
+)
+
+
+def _context_with_facts(facts: pd.DataFrame, df_leagues: pd.DataFrame | None = None) -> BadgeEvaluationContext:
+    ctx = SimpleNamespace(df_leagues=df_leagues)
+    return BadgeEvaluationContext(
+        club_id="club",
+        league_id=None,
+        as_of=None,
+        ctx=ctx,
+        facts=facts,
+        matches=facts,
+    )
+
+
+def test_dominant_run_awards_at_10th_win():
+    rows = []
+    for idx in range(10):
+        rows.append(
+            {
+                "player_id": 1,
+                "match_id": idx + 1,
+                "league": "A" if idx % 2 == 0 else "B",
+                "date_dt": pd.Timestamp(2024, 1, idx + 1, tz="UTC"),
+                "win": True,
+                "margin": 5,
+            }
+        )
+    facts = pd.DataFrame(rows)
+    ctx = _context_with_facts(facts)
+
+    candidates = list(evaluate_dominant_run(ctx))
+
+    assert any(
+        candidate.badge_id == "dominant_run" and candidate.match_id == "10"
+        for candidate in candidates
+    )
+
+
+def test_high_output_awards_on_window_end():
+    rows = []
+    for idx in range(25):
+        rows.append(
+            {
+                "player_id": 2,
+                "match_id": f"m{idx + 1}",
+                "league": "L1",
+                "date_dt": pd.Timestamp(2024, 2, idx + 1, tz="UTC"),
+                "win": idx < 20,
+                "margin": 4,
+            }
+        )
+    facts = pd.DataFrame(rows)
+    ctx = _context_with_facts(facts)
+
+    candidates = list(evaluate_high_output(ctx))
+
+    assert any(
+        candidate.badge_id == "high_output" and candidate.match_id == "m25"
+        for candidate in candidates
+    )
+
+
+def test_breakthrough_awards_top25_and_top10():
+    players = []
+    for pid in range(1, 31):
+        players.append(
+            {
+                "player_id": pid,
+                "league_name": "Premier",
+                "starting_rating": 2000 - pid,
+                "rating": 2000 - pid,
+                "matches_played": 12,
+            }
+        )
+    players[-1]["player_id"] = 99
+    players[-1]["starting_rating"] = 1700
+    players[-1]["rating"] = 2600
+    df_leagues = pd.DataFrame(players)
+    ctx = _context_with_facts(pd.DataFrame(), df_leagues=df_leagues)
+
+    candidates = [c for c in evaluate_breakthrough(ctx) if c.player_id == 99]
+    tiers = sorted(c.value_json["tier"] for c in candidates)
+
+    assert tiers == [10, 25]
+
+
+def test_above_expectations_awards_with_quality_filter():
+    rows = [
+        {
+            "player_id": 5,
+            "match_id": "m1",
+            "league": "L1",
+            "date_dt": pd.Timestamp(2024, 3, 1, tz="UTC"),
+            "win": True,
+            "margin": 4,
+            "expected_win_prob": 0.35,
+            "abs_elo_delta": 10.0,
+        },
+        {
+            "player_id": 6,
+            "match_id": "m2",
+            "league": "L1",
+            "date_dt": pd.Timestamp(2024, 3, 2, tz="UTC"),
+            "win": True,
+            "margin": 1,
+            "expected_win_prob": 0.6,
+            "abs_elo_delta": 1.0,
+        },
+        {
+            "player_id": 7,
+            "match_id": "m3",
+            "league": "L1",
+            "date_dt": pd.Timestamp(2024, 3, 3, tz="UTC"),
+            "win": False,
+            "margin": -2,
+            "expected_win_prob": 0.2,
+            "abs_elo_delta": 2.0,
+        },
+        {
+            "player_id": 8,
+            "match_id": "m4",
+            "league": "L1",
+            "date_dt": pd.Timestamp(2024, 3, 4, tz="UTC"),
+            "win": True,
+            "margin": 4,
+            "expected_win_prob": 0.45,
+            "abs_elo_delta": 3.0,
+        },
+    ]
+    facts = pd.DataFrame(rows)
+    ctx = _context_with_facts(facts)
+
+    candidates = list(evaluate_above_expectations(ctx))
+
+    assert any(candidate.match_id == "m1" for candidate in candidates)


### PR DESCRIPTION
### Motivation

- Make the previously inactive badges `dominant_run`, `high_output`, `breakthrough`, and `above_expectations` awardable using existing match facts without any DB/schema changes. 
- Use the canonical match facts (`ctx.facts` via `build_player_match_facts` / `_as_of_filter`) and deterministic logic so badges are reproducible across clubs and leagues.

### Description

- Implemented `evaluate_dominant_run` to award stackable streak badges across all leagues by scanning per-`player_id` win streaks, tracking running average margin, and emitting a `dominant_run` candidate when the streak reaches `>=10` wins with `avg_margin >= 5`, and again for each subsequent qualifying win. 
- Implemented `evaluate_high_output` to maintain a rolling deque of the last 25 matches per `player_id` and emit `high_output` when the 25-match window has `wins >= 20` and `avg_margin >= 4`. 
- Implemented `evaluate_breakthrough` to compute per-league `start_rank` and `current_rank` from `ctx.ctx.df_leagues`, require `matches_played >= 10`, and award stackable `breakthrough` candidates for crossing into top25 and/or top10. 
- Implemented `evaluate_above_expectations` to emit match-level `above_expectations` candidates for wins with `expected_win_prob <= 0.40` and `margin >= 4`, optionally filtering by per-league 75th-percentile absolute rating delta when `abs_elo_delta` is present. 
- Updated `docs/badge_requirements.md` to reflect the new, concrete unlock criteria for the four badges (reworded to avoid forbidden terminology in schema validation). 
- Added deterministic unit tests in `tests/test_new_badges_output_dominance_breakthrough.py` that build small synthetic `facts` and `df_leagues` DataFrames and exercise each evaluator (`dominant_run`, `high_output`, `breakthrough`, `above_expectations`). 

### Testing

- Ran the full test suite with `pytest -q`; after a small docs wording fix the suite completed successfully. 
- Final test run: all tests passed (`116 passed`, `17 warnings`). 
- The new deterministic tests for the four badges were included and passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821ad0bb00832697088cad9b08a8f6)