### PR TITLE
Merge Emerging into Developing ladder tier

### DIFF
--- a/jupr_app/domain/challenge_ladder.py
+++ b/jupr_app/domain/challenge_ladder.py
@@ -54,15 +54,21 @@ def ladder_nm(pid: int, id_to_name: Dict[int, str]) -> str:
 # -------------------------
 # Tier definitions (Option A, range-labeled)
 # -------------------------
-TIER_ORDER = ["PREM", "ADV", "INT", "DEV", "EMER"]
+TIER_ORDER = ["PREM", "ADV", "INT", "DEV"]
 
 TIER_DEFS = {
     "PREM": {"label": "Premier",       "min": 4.25, "max": None, "range": "4.25+"},
     "ADV":  {"label": "Advanced",      "min": 3.75, "max": 4.25, "range": "3.75–4.25"},
     "INT":  {"label": "Intermediate",  "min": 3.25, "max": 3.75, "range": "3.25–3.75"},
-    "DEV":  {"label": "Developing",    "min": 3.0,  "max": 3.25, "range": "3.0–3.25"},
-    "EMER": {"label": "Emerging",      "min": None, "max": 3.0,  "range": "< 3.0"},
+    "DEV":  {"label": "Developing",    "min": None, "max": 3.25, "range": "< 3.25"},
 }
+
+
+def normalize_tier_id(tier_id: str) -> str:
+    tid = str(tier_id or "").strip().upper()
+    if tid == "EMER":
+        return "DEV"
+    return tid or "DEV"
 
 
 def tier_for_jupr(jupr: float) -> str:
@@ -70,8 +76,6 @@ def tier_for_jupr(jupr: float) -> str:
         x = float(jupr)
     except Exception:
         return "INT"
-    if x < 3.0:
-        return "EMER"
     if x < 3.25:
         return "DEV"
     if x < 3.75:
@@ -82,13 +86,14 @@ def tier_for_jupr(jupr: float) -> str:
 
 
 def tier_title(tier_id: str) -> str:
-    t = TIER_DEFS.get(str(tier_id), {"label": str(tier_id), "range": ""})
+    tid = normalize_tier_id(tier_id)
+    t = TIER_DEFS.get(tid, {"label": tid, "range": ""})
     rng = t.get("range", "")
     return f"{t.get('label','Tier')} — {rng}".strip(" —")
 
 
 def tier_idx(tier_id: str) -> int:
-    tid = str(tier_id)
+    tid = normalize_tier_id(tier_id)
     return TIER_ORDER.index(tid) if tid in TIER_ORDER else 999
 
 
@@ -103,8 +108,8 @@ def is_demotion(from_tier: str, to_tier: str) -> bool:
 def sorted_tiers(tiers: list[str]) -> list[str]:
     """Return tiers sorted by TIER_ORDER (highest -> lowest).
 
-    >>> sorted_tiers(["DEV", "PREM", "EMER"])
-    ['PREM', 'DEV', 'EMER']
+    >>> sorted_tiers(["DEV", "PREM"])
+    ['PREM', 'DEV']
     """
     seen = set()
     input_set = {str(t) for t in tiers}

--- a/jupr_app/ui/pages/challenge_ladder.py
+++ b/jupr_app/ui/pages/challenge_ladder.py
@@ -9,6 +9,7 @@ import streamlit as st
 
 from jupr_app.domain.challenge_ladder import (
     TIER_ORDER,
+    normalize_tier_id,
     tier_title,
     ladder_nm,
     ladder_bucket_challenge,
@@ -136,6 +137,8 @@ def render(ctx):
 
     settings = ladder_fetch_settings(ctx.supabase, ctx.club_id)
     df_roster, df_flags, df_ch, df_pass = ladder_load_core(ctx.supabase, ctx.club_id)
+    if df_roster is not None and not df_roster.empty and "tier_id" in df_roster.columns:
+        df_roster["tier_id"] = df_roster["tier_id"].astype(str).apply(normalize_tier_id)
     active_ids = None
     if getattr(ctx, "df_players_active", None) is not None and not ctx.df_players_active.empty:
         if "id" in ctx.df_players_active.columns:

--- a/jupr_app/ui/pages/challenge_ladder_admin.py
+++ b/jupr_app/ui/pages/challenge_ladder_admin.py
@@ -11,6 +11,7 @@ from jupr_app.domain.tier_movement import compute_out_of_tier_streak
 
 from jupr_app.domain.challenge_ladder import (
     TIER_ORDER,
+    normalize_tier_id,
     tier_title,
     tier_for_jupr,
     tier_idx,
@@ -176,6 +177,8 @@ def render(ctx):
 
     settings = ladder_fetch_settings(supabase, club_id)
     df_roster, df_flags, df_ch, df_pass = ladder_load_core(supabase, club_id)
+    if df_roster is not None and not df_roster.empty and "tier_id" in df_roster.columns:
+        df_roster["tier_id"] = df_roster["tier_id"].astype(str).apply(normalize_tier_id)
 
     tabs = st.tabs(["📊 Dashboard", "🧾 Intake", "🗂 Challenge Detail", "👥 Roster", "⬆️⬇️ Tier Movement", "🏖 Overrides", "📜 Audit"])
 


### PR DESCRIPTION
### Motivation
- Consolidate the bottom two ladder tiers so Emerging and Developing become a single "Developing (< 3.25)" tier while preserving backward compatibility for existing EMER rows.
- Prevent UI/logic regressions by ensuring old `EMER` tier_ids still render under the merged bottom tier and do not cause crashes from the removed `EMER` entry.

### Description
- Remove `EMER` from `TIER_ORDER` and update `TIER_DEFS` so `DEV` represents the merged bottom tier with `"min": None, "max": 3.25, "range": "< 3.25"` in `jupr_app/domain/challenge_ladder.py`.
- Change `tier_for_jupr()` to map `x < 3.25` to `"DEV"` (keeping higher-tier thresholds unchanged).
- Add `normalize_tier_id(tier_id: str) -> str` to map legacy `"EMER"` to `"DEV"` and use it in `tier_title()` and `tier_idx()` so older values render correctly.
- Normalize roster tier IDs in the UI by importing `normalize_tier_id` and applying it to `df_roster["tier_id"]` in both `jupr_app/ui/pages/challenge_ladder.py` and `jupr_app/ui/pages/challenge_ladder_admin.py` so EMER rows continue to appear under Developing.
- Optional SQL cleanup recommended for Supabase (run manually):
```sql
update ladder_roster set tier_id='DEV' where tier_id='EMER';
update ladder_challenges set tier_id='DEV' where tier_id='EMER';
update ladder_player_flags set tier_move_dest_tier='DEV' where tier_move_dest_tier='EMER';
```

### Testing
- Ran the test suite with `pytest -q` and all tests passed (`112 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821befaa4083269ff64768c25dc1e5)