### PR TITLE
Merge EMER into DEV (collapse Emerging tier into Developing)

### DIFF
--- a/jupr_app/domain/challenge_ladder.py
+++ b/jupr_app/domain/challenge_ladder.py
@@ -68,7 +68,9 @@ def normalize_tier_id(tier_id: str) -> str:
     tid = str(tier_id or "").strip().upper()
     if tid == "EMER":
         return "DEV"
-    return tid or "DEV"
+    if tid == "":
+        return "DEV"
+    return tid
 
 
 def tier_for_jupr(jupr: float) -> str:
@@ -116,6 +118,8 @@ def sorted_tiers(tiers: list[str]) -> list[str]:
     ordered = [tid for tid in TIER_ORDER if tid in input_set and not (tid in seen or seen.add(tid))]
     extras = [str(t) for t in tiers if str(t) not in TIER_ORDER and str(t) not in seen and not seen.add(str(t))]
     return ordered + extras
+
+
 
 
 # -------------------------
@@ -420,3 +424,9 @@ def ladder_compute_challenge_outcome(df_match_rows: pd.DataFrame) -> Optional[Di
         "points_chal": pts_chal,
         "point_diff_def": pdiff,
     }
+
+
+# Optional cleanup:
+# update ladder_roster set tier_id='DEV' where tier_id='EMER';
+# update ladder_challenges set tier_id='DEV' where tier_id='EMER';
+# update ladder_player_flags set tier_move_dest_tier='DEV' where tier_move_dest_tier='EMER';

--- a/jupr_app/ui/pages/challenge_ladder.py
+++ b/jupr_app/ui/pages/challenge_ladder.py
@@ -88,6 +88,9 @@ def ladder_load_core(supabase, club_id: str) -> Tuple[pd.DataFrame, pd.DataFrame
         .execute()
     ))
     df_roster = _df_from_resp(roster)
+    if df_roster is not None and not df_roster.empty and "tier_id" in df_roster.columns:
+        df_roster = df_roster.copy()
+        df_roster["tier_id"] = df_roster["tier_id"].astype(str).apply(normalize_tier_id)
 
     # Flags
     flags = sb_retry(lambda: (
@@ -137,8 +140,6 @@ def render(ctx):
 
     settings = ladder_fetch_settings(ctx.supabase, ctx.club_id)
     df_roster, df_flags, df_ch, df_pass = ladder_load_core(ctx.supabase, ctx.club_id)
-    if df_roster is not None and not df_roster.empty and "tier_id" in df_roster.columns:
-        df_roster["tier_id"] = df_roster["tier_id"].astype(str).apply(normalize_tier_id)
     active_ids = None
     if getattr(ctx, "df_players_active", None) is not None and not ctx.df_players_active.empty:
         if "id" in ctx.df_players_active.columns:

--- a/jupr_app/ui/pages/challenge_ladder_admin.py
+++ b/jupr_app/ui/pages/challenge_ladder_admin.py
@@ -499,6 +499,7 @@ def render(ctx):
             r0["player_id"] = r0["player_id"].astype(int)
         if "tier_id" in r0.columns:
             r0["tier_id"] = r0["tier_id"].astype(str)
+            r0["tier_id"] = r0["tier_id"].apply(normalize_tier_id)
         if "is_active" in r0.columns:
             # Supabase booleans come back as bool; keep as-is
             pass


### PR DESCRIPTION
### Motivation
- Simplify the ladder tiers by removing the EMER (Emerging) tier and treating those players as DEV (Developing) so the UI shows one bottom tier: "< 3.25".
- Keep backwards compatibility so existing rows with `tier_id='EMER'` continue to appear and filter correctly in both public and admin views.

### Description
- Removed EMER from `TIER_ORDER` and updated `TIER_DEFS` so `DEV` is labeled "Developing" with `max: 3.25` and `range: "< 3.25"` in `jupr_app/domain/challenge_ladder.py`.
- Added `normalize_tier_id()` compatibility mapping in `jupr_app/domain/challenge_ladder.py` to map `"EMER"` (and empty ids) to `"DEV"`, and updated `tier_title()` and `tier_idx()` to use the normalized id.
- Moved roster tier normalization into `ladder_load_core()` in `jupr_app/ui/pages/challenge_ladder.py` so data loaded for the public ladder view has `tier_id` normalized (EMER → DEV) before rendering tabs.
- Normalized `r0["tier_id"]` in `jupr_app/ui/pages/challenge_ladder_admin.py` to apply `normalize_tier_id()` so admin roster filtering treats EMER rows as DEV.
- Added an optional (commented) Supabase cleanup SQL block at the bottom of `jupr_app/domain/challenge_ladder.py` to convert existing `EMER` values to `DEV` in backend tables.

### Testing
- Ran `rg 'TIER_ORDER.*EMER' -n jupr_app` to verify EMER was removed from tier ordering and found no matches (success).
- Ran `rg '"EMER"' -n jupr_app/domain/challenge_ladder.py` to confirm the only remaining literal EMER mention is the compatibility mapping, and found the mapping in `normalize_tier_id()` (success).
- Ran `rg 'Emerging' -n jupr_app/domain/challenge_ladder.py jupr_app/ui/pages/challenge_ladder.py` to confirm there is no lingering "Emerging" label and found no matches (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821e775fb083268bad1511439ae446)