### PR TITLE
Harden pop-up match uploader flow

### DIFF
--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -52,6 +52,7 @@ def process_matches(
 
     skipped_incomplete = 0
     skipped_empty = 0
+    has_non_popup_match = False
 
     def get_k(league_name: str) -> int:
         if df_meta is None or getattr(df_meta, "empty", True):
@@ -185,6 +186,8 @@ def process_matches(
         week_tag = str(m.get("week_tag", "") or "")
         match_type = str(m.get("match_type", "") or "")
         is_popup = bool(m.get("is_popup", False)) or (match_type == "PopUp")
+        if not is_popup:
+            has_non_popup_match = True
 
         dt_val = m.get("date", None)
         match_dt = coerce_utc_datetime(dt_val)
@@ -280,7 +283,7 @@ def process_matches(
             chunk = db_matches[i : i + CHUNK_M]
             sb_retry(lambda chunk=chunk: supabase.table("matches").insert(chunk).execute())
 
-        if supabase is not None:
+        if supabase is not None and has_non_popup_match:
             enqueue_badge_eval(
                 supabase,
                 club_id=str(club_id),

--- a/jupr_app/ui/pages/match_uploader.py
+++ b/jupr_app/ui/pages/match_uploader.py
@@ -57,6 +57,10 @@ def render(ctx):
         match_type_db = "PopUp"
         is_popup = True
 
+    if is_popup:
+        selected_league = (selected_league or "").strip() or "Pop-Up Event"
+        selected_league = f"POPUP::{selected_league}"
+
     week_tag = c3.selectbox(
         "Week / Session",
         [f"Week {i}" for i in range(1, 13)] + ["Playoffs", "Finals", "Event"],
@@ -245,15 +249,20 @@ def render(ctx):
                 if st.form_submit_button("Submit"):
                     payload = [x for x in all_res if (x["s1"] > 0 or x["s2"] > 0)]
                     if payload:
-                        process_matches(
-                            payload,
-                            supabase=supabase,
-                            club_id=str(club_id),
-                            name_to_id=name_to_id,
-                            df_players_all=df_players_all,
-                            df_leagues=df_leagues,
-                            df_meta=df_meta,
-                        )
+                        try:
+                            process_matches(
+                                payload,
+                                supabase=supabase,
+                                club_id=str(club_id),
+                                name_to_id=name_to_id,
+                                df_players_all=df_players_all,
+                                df_leagues=df_leagues,
+                                df_meta=df_meta,
+                            )
+                        except Exception as e:
+                            st.error("Failed to submit matches.")
+                            st.exception(e)
+                            st.stop()
 
                     st.success("✅ Done!")
                     if "mu_lc_schedule" in st.session_state:


### PR DESCRIPTION
### Motivation
- Prevent silent Streamlit crashes during Single Round Robin submissions and make Pop-Up league names deterministic to avoid collisions.
- Avoid running badge evaluation for batches that only contain Pop-Up matches while keeping rating and DB behavior unchanged.

### Description
- Wrap the `process_matches()` call in the Single Round Robin `Submit` handler with a `try/except` that calls `st.error()`, `st.exception(e)`, and `st.stop()` on exception to surface errors and halt execution.
- Normalize Pop-Up league names by defaulting empty/whitespace names to `"Pop-Up Event"` and prefixing them with `"POPUP::"` to avoid name collisions.
- Update `process_matches()` to track whether any non-Pop-Up matches exist and skip calling `enqueue_badge_eval()` when the entire batch is Pop-Up matches, leaving rating logic and DB schemas unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982643921e88326aff0e1e4ae71ef4e)