### PR TITLE
Make Pop-Up Round Robins first-class Events; add events table and wire uploader

### DIFF
--- a/jupr_app/domain/events.py
+++ b/jupr_app/domain/events.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+
+def upsert_or_get_active_event(
+    supabase: Any,
+    club_id: str,
+    name: str,
+    event_type: str = "popup_rr",
+) -> str:
+    if supabase is None:
+        raise ValueError("Supabase client is required to upsert events.")
+    if not club_id:
+        raise ValueError("club_id is required to upsert events.")
+    if not name:
+        raise ValueError("name is required to upsert events.")
+
+    lookup = (
+        supabase.table("events")
+        .select("id")
+        .eq("club_id", club_id)
+        .eq("name", name)
+        .eq("event_type", event_type)
+        .eq("is_active", True)
+        .limit(1)
+        .execute()
+    )
+    if lookup.data:
+        return str(lookup.data[0]["id"])
+
+    payload = {
+        "club_id": club_id,
+        "name": name,
+        "event_type": event_type,
+        "is_active": True,
+    }
+    inserted = supabase.table("events").insert(payload).execute()
+    if not inserted.data:
+        raise RuntimeError("Failed to insert event record.")
+    return str(inserted.data[0]["id"])

--- a/jupr_app/ui/pages/match_uploader.py
+++ b/jupr_app/ui/pages/match_uploader.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import pandas as pd
 import streamlit as st
 
+from jupr_app.domain.events import upsert_or_get_active_event
 from jupr_app.domain.schedule import get_match_schedule
 from jupr_app.domain.match_processing import process_matches
 from jupr_app.ui.layout import page_shell
@@ -52,14 +53,19 @@ def render(ctx):
         selected_league = c2.selectbox("Select League", opts, key="mu_selected_league")
         match_type_db = "Live Match"
         is_popup = False
+        popup_event_name = None
     else:
-        selected_league = c2.text_input("Event Name", "Saturday Social", key="mu_event_name")
+        popup_event_name = c2.text_input("Event Name", "Saturday Social", key="mu_event_name")
         match_type_db = "PopUp"
         is_popup = True
 
     if is_popup:
-        selected_league = (selected_league or "").strip() or "Pop-Up Event"
-        selected_league = f"POPUP::{selected_league}"
+        popup_event_name = (popup_event_name or "").strip() or "Pop-Up Event"
+        selected_league = "POPUP"
+        if st.session_state.get("mu_event_id_name") != popup_event_name:
+            st.session_state.mu_event_id = None
+        if st.session_state.get("mu_event_id"):
+            st.caption(f"Event ID: {st.session_state.mu_event_id}")
 
     week_tag = c3.selectbox(
         "Week / Session",
@@ -119,6 +125,15 @@ def render(ctx):
         st.session_state.mu_batch_df = edited_batch.copy()
 
         if st.button("Submit Batch", key="mu_submit_batch"):
+            event_id = None
+            if is_popup:
+                event_id = upsert_or_get_active_event(
+                    supabase,
+                    club_id=str(club_id),
+                    name=popup_event_name,
+                )
+                st.session_state.mu_event_id = event_id
+                st.session_state.mu_event_id_name = popup_event_name
             valid_batch = []
             for _, row in edited_batch.iterrows():
                 try:
@@ -141,6 +156,8 @@ def render(ctx):
                             "match_type": match_type_db,
                             "week_tag": week_tag,
                             "is_popup": is_popup,
+                            "context_type": "event" if is_popup else None,
+                            "context_id": event_id if is_popup else None,
                         }
                     )
 
@@ -200,6 +217,14 @@ def render(ctx):
             )
 
             if st.form_submit_button("Generate"):
+                if is_popup:
+                    event_id = upsert_or_get_active_event(
+                        supabase,
+                        club_id=str(club_id),
+                        name=popup_event_name,
+                    )
+                    st.session_state.mu_event_id = event_id
+                    st.session_state.mu_event_id_name = popup_event_name
                 st.session_state.mu_lc_schedule = []
                 st.session_state.mu_active_lg = selected_league
                 st.session_state.mu_active_wk = week_tag
@@ -243,6 +268,10 @@ def render(ctx):
                                 "match_type": st.session_state.mu_active_mt,
                                 "week_tag": st.session_state.mu_active_wk,
                                 "is_popup": bool(st.session_state.mu_active_is_popup),
+                                "context_type": "event" if st.session_state.mu_active_is_popup else None,
+                                "context_id": st.session_state.get("mu_event_id")
+                                if st.session_state.mu_active_is_popup
+                                else None,
                             }
                         )
 

--- a/migrations/20260725_events.sql
+++ b/migrations/20260725_events.sql
@@ -1,0 +1,16 @@
+-- Events table for popup round robins and other club events
+
+CREATE TABLE IF NOT EXISTS public.events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  club_id text NOT NULL,
+  name text NOT NULL,
+  event_type text NOT NULL DEFAULT 'popup_rr',
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  starts_at timestamptz NULL,
+  ends_at timestamptz NULL,
+  notes text NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_club_active ON public.events (club_id, is_active);
+CREATE INDEX IF NOT EXISTS idx_events_club_name ON public.events (club_id, name);


### PR DESCRIPTION
### Motivation
- Pop-Up uploads should create and attach to a canonical `event_id` and stop relying on `league_name` as the primary Pop-Up identifier. 
- Expose an admin-friendly event id in the UI so Pop-Up debugging and match attribution are straightforward.

### Description
- Add a migration `migrations/20260725_events.sql` that creates `public.events` with the requested columns and indexes on `(club_id, is_active)` and `(club_id, name)`. 
- Add `jupr_app/domain/events.py` with `upsert_or_get_active_event(supabase, club_id, name, event_type='popup_rr')` which looks up an active event by `club_id+name+event_type` and inserts one if none exists. 
- Update `jupr_app/ui/pages/match_uploader.py` to call the helper in both Batch and Single RR flows, persist the resulting id in `st.session_state.mu_event_id`, show the `Event ID` via `st.caption`, set Pop-Up matches to use `league = "POPUP"`, and include `context_type: "event"` and `context_id: st.session_state.mu_event_id` on Pop-Up match payloads. 
- Confirmed `jupr_app/domain/match_processing.py` already accepts and writes `context_type` and `context_id` into inserted match rows so the change wires end-to-end without altering non-Pop-Up uploads. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698265b6afd083269c7098d105122574)