### PR TITLE
Replace per-tier tabs with four-column ladder layout and global search

### DIFF
--- a/jupr_app/ui/pages/challenge_ladder.py
+++ b/jupr_app/ui/pages/challenge_ladder.py
@@ -163,10 +163,12 @@ def render(ctx):
                 id_to_name=ctx.id_to_name,
             )
 
-            t_tabs = st.tabs([tier_title(tid) for tid in TIER_ORDER])
+            q_all = st.text_input("Search ladder (all tiers)", value="", key="challenge_ladder_search_all")
 
-            for i, tid in enumerate(TIER_ORDER):
-                with t_tabs[i]:
+            cols = st.columns(4)
+            for col, tid in zip(cols, TIER_ORDER):
+                with col:
+                    st.subheader(tier_title(tid))
                     # Defensive filtering (pandas can hold bools as object)
                     sub = df_roster.copy()
                     if "is_active" in sub.columns:
@@ -187,9 +189,8 @@ def render(ctx):
                     sub["status"] = sub["player_id"].apply(lambda pid: status_map.get(int(pid), {}).get("status", "Ready to Defend"))
                     sub["detail"] = sub["player_id"].apply(lambda pid: status_map.get(int(pid), {}).get("detail", ""))
 
-                    q = st.text_input(f"Search ({tier_title(tid)})", value="", key=f"challenge_ladder_search_{tid}")
-                    if q.strip():
-                        sub = sub[sub["name"].str.contains(q.strip(), case=False, na=False)].copy()
+                    if q_all.strip():
+                        sub = sub[sub["name"].str.contains(q_all.strip(), case=False, na=False)].copy()
 
                     if "rank" in sub.columns:
                         sub = sub.sort_values("rank", ascending=True).copy()
@@ -205,9 +206,33 @@ def render(ctx):
                             return str(r)
 
                         sub["Rank"] = sub["rank"].astype(int).apply(rank_badge)
-                        st.dataframe(sub[["Rank", "name", "status", "detail"]], use_container_width=True, hide_index=True)
+                        st.dataframe(
+                            sub[["Rank", "name", "status"]],
+                            use_container_width=True,
+                            hide_index=True,
+                            height=520,
+                        )
+                        with st.expander("Show details", expanded=False):
+                            st.dataframe(
+                                sub[["Rank", "name", "status", "detail"]],
+                                use_container_width=True,
+                                hide_index=True,
+                                height=520,
+                            )
                     else:
-                        st.dataframe(sub[["name", "status", "detail"]], use_container_width=True, hide_index=True)
+                        st.dataframe(
+                            sub[["name", "status"]],
+                            use_container_width=True,
+                            hide_index=True,
+                            height=520,
+                        )
+                        with st.expander("Show details", expanded=False):
+                            st.dataframe(
+                                sub[["name", "status", "detail"]],
+                                use_container_width=True,
+                                hide_index=True,
+                                height=520,
+                            )
 
     # -------------------------
     # TAB 2: ACTIVE CHALLENGES


### PR DESCRIPTION
### Motivation
- Show all four ladder tiers side-by-side with a single global search so users can compare tiers at a glance while preserving existing behavior.

### Description
- Removed the per-tier `st.tabs(...)` block and added a global `q_all = st.text_input(...)` with a `cols = st.columns(4)` loop rendering each tier in its own column and `st.subheader` for titles.
- Preserved the defensive filtering logic for `is_active`, `active_ids`, and `tier_id`, and kept the existing `status_map` usage and `rank_badge` medal logic exactly as before.
- Rendered compact tables showing `Rank`, `name`, and `status` by default and used `st.dataframe(..., use_container_width=True, hide_index=True, height=520)` to keep tables readable in columns.
- Added a per-tier `st.expander("Show details")` that exposes the `detail` column while removing the previous per-tier search inputs in favor of the global search.

### Testing
- Attempted automated UI render and screenshot via Playwright, but the Streamlit server returned `net::ERR_EMPTY_RESPONSE` and the capture failed.
- No unit or integration tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982c88eb15c8326b27d3495fa02d1eb)