### PR TITLE
Escape leaderboard story text in Story View

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -23,6 +23,13 @@ logger = logging.getLogger(__name__)
 MAX_STORY_BADGES = 2
 
 
+def _safe_text(value: object) -> str:
+    text = "" if value is None else str(value)
+    if ("&lt;" in text or "&gt;" in text or "&amp;" in text) and "<" not in text and ">" not in text:
+        return text
+    return html.escape(text)
+
+
 def _delta_color(delta, up_color, flat_color, down_color):
     try:
         if pd.isna(delta):
@@ -96,7 +103,7 @@ def _player_profile_url(pid, public_mode, ctx):
 
 
 def _build_player_link(pid, name, public_mode, ctx):
-    safe_name = html.escape(str(name))
+    safe_name = _safe_text(name)
     url = _player_profile_url(pid, public_mode, ctx)
     if not url:
         return safe_name
@@ -1253,8 +1260,8 @@ def render(ctx):
                         title_parts.append(f"Prestige {int(prestige)}")
                     title = " • ".join(title_parts)
                     badge_parts.append(
-                        f'<span class="lb-story-badge" title="{html.escape(title)}">'
-                        f"{html.escape(str(icon))}</span>"
+                        f'<span class="lb-story-badge" title="{_safe_text(title)}">'
+                        f"{_safe_text(icon)}</span>"
                     )
                 story_badges_html = f'<div class="lb-badge-strip">{"".join(badge_parts)}</div>'
             elif row.get("matches_played", 0) == 0:
@@ -1279,7 +1286,7 @@ def render(ctx):
                         inserts.append(_build_partner_story(partner, id_to_name))
                 if inserts:
                     story_text = f"{story_text} {' '.join(inserts)}".strip()
-            story_text_html = f'<div class="lb-story-text">{html.escape(story_text)}</div>'
+            story_text_html = f'<div class="lb-story-text">{_safe_text(story_text)}</div>'
             st.markdown(
                 f"""
                 <div class="lb-standings-card">

--- a/tests/test_leaderboards_story_escape.py
+++ b/tests/test_leaderboards_story_escape.py
@@ -1,0 +1,11 @@
+from jupr_app.ui.pages import leaderboards
+
+
+def test_safe_text_escapes_html_story():
+    raw_story = "<b>Hi</b> & stuff"
+    assert leaderboards._safe_text(raw_story) == "&lt;b&gt;Hi&lt;/b&gt; &amp; stuff"
+
+
+def test_safe_text_preserves_preescaped_text():
+    escaped_story = "&lt;div&gt;Already escaped&lt;/div&gt;"
+    assert leaderboards._safe_text(escaped_story) == escaped_story


### PR DESCRIPTION
### Motivation
- Prevent raw HTML from user/db-derived story text and badge metadata from being rendered in the Leaderboards Story View while keeping the existing HTML layout and styling intact.

### Description
- Add a `_safe_text` helper that returns already-escaped text as-is or otherwise returns `html.escape(...)` for safety and readability.
- Apply `_safe_text` to player name links, badge tooltip/title, badge icon rendering, and the story text before injecting into the HTML template in `jupr_app/ui/pages/leaderboards.py`.
- Preserve the use of `unsafe_allow_html=True` for layout HTML while ensuring all user/db-derived strings inserted into templates are escaped.
- Add unit tests `tests/test_leaderboards_story_escape.py` to verify escaping of raw HTML and preservation of pre-escaped input.

### Testing
- Ran `pytest -q tests/test_leaderboards_story_escape.py` and the test suite for the new tests passed (2 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983b56b8d488326bff57d29f23b6c3b)