### PR TITLE
Handle missing badge_eval_queue table gracefully

### DIFF
--- a/jupr_app/data/schema_preflight.py
+++ b/jupr_app/data/schema_preflight.py
@@ -24,6 +24,7 @@ MIGRATION_HINT = (
     "PostgREST schema cache"
 )
 REQUIRED_BADGE_TABLES = {"badge_eval_runs"}
+OPTIONAL_BADGE_TABLES = {"badge_eval_queue"}
 SKIP_PREFLIGHT_ENV = "JUPR_SKIP_BADGE_SCHEMA_PREFLIGHT"
 _MISSING_COLUMN_CODES = {"PGRST204"}
 _MISSING_TABLE_CODES = {"PGRST205", "42P01"}
@@ -35,7 +36,8 @@ def ensure_badge_schema_preflight(supabase: Any) -> bool:
     if _should_skip_preflight():
         return True
     missing_columns = _find_missing_player_badges_columns(supabase)
-    missing_tables = _find_missing_tables(supabase)
+    missing_tables = _find_missing_tables(supabase, REQUIRED_BADGE_TABLES)
+    missing_optional_tables = _find_missing_tables(supabase, OPTIONAL_BADGE_TABLES)
     if missing_columns or missing_tables:
         message_parts = [MIGRATION_HINT + "."]
         if missing_columns:
@@ -45,6 +47,11 @@ def ensure_badge_schema_preflight(supabase: Any) -> bool:
             missing_tables_list = ", ".join(sorted(missing_tables))
             message_parts.append(f"Missing tables: {missing_tables_list}.")
         raise RuntimeError(" ".join(message_parts))
+    if missing_optional_tables:
+        logger.warning(
+            "Optional badge tables missing: %s. Badge queue processing will be disabled until applied.",
+            ", ".join(sorted(missing_optional_tables)),
+        )
     return True
 
 
@@ -56,9 +63,9 @@ def _find_missing_player_badges_columns(supabase: Any) -> set[str]:
     return missing
 
 
-def _find_missing_tables(supabase: Any) -> set[str]:
+def _find_missing_tables(supabase: Any, tables: set[str]) -> set[str]:
     missing = set()
-    for table in sorted(REQUIRED_BADGE_TABLES):
+    for table in sorted(tables):
         if not _probe_table(supabase, table):
             missing.add(table)
     return missing

--- a/jupr_app/domain/gamification/badge_queue.py
+++ b/jupr_app/domain/gamification/badge_queue.py
@@ -67,25 +67,39 @@ def enqueue_badge_eval(
 def dequeue_badge_eval(supabase: Any) -> dict[str, Any] | None:
     if supabase is None:
         return None
-    resp = (
-        supabase.table(BADGE_QUEUE_TABLE)
-        .select("*")
-        .eq("status", "pending")
-        .order("created_at", desc=False)
-        .limit(1)
-        .execute()
-    )
-    rows = resp.data or []
-    if not rows:
-        return None
-    job = rows[0]
-    attempts = int(job.get("attempts") or 0) + 1
-    supabase.table(BADGE_QUEUE_TABLE).update(
-        {"status": "processing", "attempts": attempts}
-    ).eq("id", job.get("id")).execute()
-    job["attempts"] = attempts
-    job["status"] = "processing"
-    return job
+    try:
+        resp = (
+            supabase.table(BADGE_QUEUE_TABLE)
+            .select("*")
+            .eq("status", "pending")
+            .order("created_at", desc=False)
+            .limit(1)
+            .execute()
+        )
+        rows = resp.data or []
+        if not rows:
+            return None
+        job = rows[0]
+        attempts = int(job.get("attempts") or 0) + 1
+        supabase.table(BADGE_QUEUE_TABLE).update(
+            {"status": "processing", "attempts": attempts}
+        ).eq("id", job.get("id")).execute()
+        job["attempts"] = attempts
+        job["status"] = "processing"
+        return job
+    except APIError as exc:
+        code = _get_api_error_code(exc)
+        message = _get_api_error_message(exc)
+        if code in _MISSING_TABLE_CODES:
+            logger.warning(
+                "Badge queue table %s missing in PostgREST schema cache (code=%s message=%s). "
+                "Skipping badge dequeue.",
+                BADGE_QUEUE_TABLE,
+                code,
+                message,
+            )
+            return None
+        raise
 
 
 def ack_badge_eval(

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -4,6 +4,7 @@ import time
 from datetime import datetime, timezone
 from jupr_app.domain.replay_history import replay_history
 
+from postgrest.exceptions import APIError
 
 from jupr_app.domain.ratings import calculate_hybrid_elo
 from jupr_app.domain.constants import DEFAULT_K_FACTOR
@@ -11,6 +12,16 @@ from jupr_app.domain.gamification.ensure_badges import ensure_badges
 from jupr_app.domain.gamification.badge_state import ALLOWED_BADGE_STATES, can_transition_badge_state
 from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
 from jupr_app.ui.layout import page_shell
+
+
+def _get_api_error_code(exc: APIError) -> str | None:
+    code = getattr(exc, "code", None)
+    if code:
+        return code
+    if exc.args and isinstance(exc.args[0], dict):
+        return exc.args[0].get("code")
+    return None
+
 
 def render(ctx):
     mode_label = "Public" if bool(ctx.public_mode) else "Admin"
@@ -68,8 +79,27 @@ def render(ctx):
     st.caption("Process queued badge evaluations without blocking the UI (short time budget).")
     if st.button("Process queued badge evaluations", key="badge_eval_queue_process"):
         with st.spinner("Processing queued badge evaluations..."):
-            result = process_badge_eval_queue(supabase, max_jobs=5, time_budget_seconds=2)
-        st.success(f"Processed {result['processed']} job(s); {result['errored']} error(s).")
+            try:
+                result = process_badge_eval_queue(supabase, max_jobs=5, time_budget_seconds=2)
+            except APIError as exc:
+                code = _get_api_error_code(exc)
+                if code in {"PGRST205", "42P01"}:
+                    st.error(
+                        "Missing table badge_eval_queue; apply migrations/20260705_badge_eval_queue.sql and "
+                        "run NOTIFY pgrst, 'reload schema';"
+                    )
+                    st.code(
+                        "-- Apply migrations/20260705_badge_eval_queue.sql\nNOTIFY pgrst, 'reload schema';",
+                        language="sql",
+                    )
+                else:
+                    st.error("Failed to process queued badge evaluations.")
+                    st.exception(exc)
+            except Exception as exc:  # noqa: BLE001 - UI should not crash
+                st.error("Failed to process queued badge evaluations.")
+                st.exception(exc)
+            else:
+                st.success(f"Processed {result['processed']} job(s); {result['errored']} error(s).")
 
     # -------------------------
     # Replay History


### PR DESCRIPTION
### Motivation
- Prevent the Admin Tools UI from crashing when the `badge_eval_queue` table is not present in production PostgREST schema cache.
- Make badge queue operations tolerant of missing-table PostgREST errors so match ingestion and background workers do not fail.
- Report optional schema issues in preflight checks without blocking startup, and provide clear remediation steps to operators.

### Description
- UI: Wrap the call to `process_badge_eval_queue` in `jupr_app/ui/pages/admin_tools.py` with `try/except` to catch `postgrest.exceptions.APIError` and render a clear `st.error` plus the SQL remediation (`NOTIFY pgrst, 'reload schema';`) instead of raising; also added a small helper `_get_api_error_code`.
- Queue dequeue: Updated `jupr_app/domain/gamification/badge_queue.py` to catch `APIError` during `dequeue_badge_eval` and return `None` (no job) while logging a warning when the error code is `PGRST205` or `42P01`.
- Schema preflight: Marked `badge_eval_queue` as optional in `jupr_app/data/schema_preflight.py` by adding `OPTIONAL_BADGE_TABLES`, changed `_find_missing_tables` to accept a table set, and log a warning when optional tables are missing instead of failing.
- No changes to `badge_worker.py` logic were necessary because `process_badge_eval_queue` already handles a `None` return from `dequeue_badge_eval` by ending the work loop and returning `processed=0`.

### Testing
- No automated tests were run as part of this change.
- No unit tests were added in this patch (a unit test for missing-table behavior was recommended but not included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983b9cee8f8832683fc6ea7a96b99ce)