### PR TITLE
Add 9-player round robin schedule template

### DIFF
--- a/jupr_app/domain/schedule.py
+++ b/jupr_app/domain/schedule.py
@@ -94,6 +94,29 @@ def get_match_schedule(format_type: str, players: list[Any], custom_text: str | 
             {"t1": [p[0], p[2]], "t2": [p[4], p[6]], "desc": "Rnd 7 (Ct 2)"},
         ]
 
+    if format_type == "9-Player":
+        # Expected games: 18
+        return [
+            {"t1": [p[1], p[2]], "t2": [p[3], p[6]], "desc": "Rnd 1 (Ct 1)"},
+            {"t1": [p[4], p[8]], "t2": [p[5], p[7]], "desc": "Rnd 1 (Ct 2)"},
+            {"t1": [p[2], p[0]], "t2": [p[4], p[7]], "desc": "Rnd 2 (Ct 1)"},
+            {"t1": [p[5], p[6]], "t2": [p[3], p[8]], "desc": "Rnd 2 (Ct 2)"},
+            {"t1": [p[0], p[1]], "t2": [p[5], p[8]], "desc": "Rnd 3 (Ct 1)"},
+            {"t1": [p[3], p[7]], "t2": [p[4], p[6]], "desc": "Rnd 3 (Ct 2)"},
+            {"t1": [p[4], p[5]], "t2": [p[6], p[0]], "desc": "Rnd 4 (Ct 1)"},
+            {"t1": [p[7], p[2]], "t2": [p[8], p[1]], "desc": "Rnd 4 (Ct 2)"},
+            {"t1": [p[5], p[3]], "t2": [p[7], p[1]], "desc": "Rnd 5 (Ct 1)"},
+            {"t1": [p[8], p[0]], "t2": [p[6], p[2]], "desc": "Rnd 5 (Ct 2)"},
+            {"t1": [p[3], p[4]], "t2": [p[8], p[2]], "desc": "Rnd 6 (Ct 1)"},
+            {"t1": [p[6], p[1]], "t2": [p[7], p[0]], "desc": "Rnd 6 (Ct 2)"},
+            {"t1": [p[7], p[8]], "t2": [p[0], p[3]], "desc": "Rnd 7 (Ct 1)"},
+            {"t1": [p[1], p[5]], "t2": [p[2], p[4]], "desc": "Rnd 7 (Ct 2)"},
+            {"t1": [p[8], p[6]], "t2": [p[1], p[4]], "desc": "Rnd 8 (Ct 1)"},
+            {"t1": [p[2], p[3]], "t2": [p[0], p[5]], "desc": "Rnd 8 (Ct 2)"},
+            {"t1": [p[6], p[7]], "t2": [p[2], p[5]], "desc": "Rnd 9 (Ct 1)"},
+            {"t1": [p[0], p[4]], "t2": [p[1], p[3]], "desc": "Rnd 9 (Ct 2)"},
+        ]
+
     if format_type == "12-Player":
         # Expected games: 33
         return [

--- a/jupr_app/ui/pages/match_uploader.py
+++ b/jupr_app/ui/pages/match_uploader.py
@@ -341,6 +341,7 @@ def render(ctx):
             "5-Player": 5,
             "6-Player": 5,
             "8-Player": 14,
+            "9-Player": 18,
             "12-Player": 33,
         }
 
@@ -358,7 +359,7 @@ def render(ctx):
                 cc1, cc2 = st.columns([1, 3])
                 t = cc1.selectbox(
                     f"Format C{i+1}",
-                    ["4-Player", "5-Player", "6-Player", "8-Player", "12-Player"],
+                    ["4-Player", "5-Player", "6-Player", "8-Player", "9-Player", "12-Player"],
                     key=f"mu_fmt_{i}",
                 )
                 expected_games = format_expected_games.get(t)


### PR DESCRIPTION
### Motivation
- Support a 9-player single round-robin into the Match Uploader so events with 9 players can be scheduled like other templates.
- The 9-player template should follow the same style as the 8-player template using "Rnd X (Ct Y)" descriptions and produce 9 rounds (2 matches + 1 bye per round).

### Description
- Add a `format_type == "9-Player"` branch to `jupr_app/domain/schedule.py` that returns the exact 9-round chart mapped to the provided `players` list (18 matches total, numbers converted 1-based -> p[N-1]).
- Expose the new format in `jupr_app/ui/pages/match_uploader.py` by adding `"9-Player": 18` to `format_expected_games` and inserting `"9-Player"` into the format select options between 8 and 12.
- PR note: "Add 9-player RR schedule template + expose in match uploader".

### Testing
- Ran a quick sanity script calling `get_match_schedule('9-Player', list(range(1,10)))` which returned 18 matches, and every match dict contained the keys `t1`, `t2`, and `desc` (both checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a2290da08326afdea9cd1395d798)