### PR TITLE
Improve player editor add flow: dedupe, safe insert, and auto-select

### DIFF
--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -4,10 +4,12 @@ import time
 from datetime import datetime, timezone
 
 from jupr_app.ui.layout import page_shell
+from jupr_app.domain.player_ops import safe_add_player
 
 def render(ctx):
     mode_label = "Public" if bool(ctx.public_mode) else "Admin"
     page_shell("👥 Player Editor", "Edit player records and league ratings.", mode_label=mode_label)
+    PICK_KEY = "player_editor_pick"
 
     if not bool(getattr(ctx, "admin_logged_in", False)):
         st.error("Admin login required.")
@@ -27,9 +29,28 @@ def render(ctx):
             name = st.text_input("Name")
             rating = st.number_input("Starting JUPR", 1.0, 7.0, 3.5, step=0.1)
             if st.form_submit_button("Add Player"):
+                name_clean = name.strip()
+                if not name_clean:
+                    st.error("Name required.")
+                    st.stop()
+                existing = (
+                    supabase.table("players")
+                    .select("id,name")
+                    .eq("club_id", club_id)
+                    .eq("name", name_clean)
+                    .limit(1)
+                    .execute()
+                    .data
+                    or []
+                )
+                if existing:
+                    st.info("Player already exists — opening existing record.")
+                    st.session_state[PICK_KEY] = name_clean
+                    time.sleep(0.1)
+                    st.rerun()
                 payload = {
                     "club_id": club_id,
-                    "name": name.strip(),
+                    "name": name_clean,
                     "rating": float(rating) * 400.0,
                     "starting_rating": float(rating) * 400.0,
                     "wins": 0,
@@ -38,9 +59,18 @@ def render(ctx):
                     "active": True,
                     "inactive_at": None,
                 }
-                supabase.table("players").insert(payload).execute()
-                st.success("Added. Use Refresh in sidebar to reload cached data.")
-                time.sleep(0.4)
+                ok, err = safe_add_player(
+                    supabase=supabase,
+                    club_id=club_id,
+                    name=name_clean,
+                    rating_jupr=float(rating),
+                )
+                if not ok:
+                    st.error(err or "Unable to add player.")
+                    st.stop()
+                st.success("Added.")
+                st.session_state[PICK_KEY] = name_clean
+                time.sleep(0.2)
                 st.rerun()
 
     st.divider()
@@ -53,7 +83,7 @@ def render(ctx):
         st.stop()
 
     all_names = sorted(df_players_all["name"].astype(str).tolist())
-    pick = st.selectbox("Select Player", [""] + all_names, index=0)
+    pick = st.selectbox("Select Player", [""] + all_names, index=0, key=PICK_KEY)
 
     if not pick:
         st.info("Pick a player to edit.")


### PR DESCRIPTION
### Motivation
- Prevent the page from crashing when adding a player that violates the unique (club_id, name) constraint.
- Make it possible to programmatically select a player in the "Select Player" control so the UI can jump into edit mode after add.
- Prefer existing helper logic for safe inserts to keep behavior consistent across pages.

### Description
- Added an import of `safe_add_player` and a stable selectbox key constant `PICK_KEY = "player_editor_pick"` at the top of `render()`.
- Updated the "Select Player" selectbox to use `key=PICK_KEY` so selection can be set programmatically.
- In the Add Player form, added `name_clean` validation and an exact lookup for an existing player by `club_id` and `name`, and if found set `st.session_state[PICK_KEY]` and `st.rerun()` to open the existing record.
- Replaced the raw insert with a call to `safe_add_player(...)`, and on success set `st.session_state[PICK_KEY]` and `st.rerun()` so newly created players are automatically selected and opened for editing.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a6a5c9688326ba1035785c36c92c)