### PR TITLE
Guard match explorer links for incomplete rows

### DIFF
--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -1653,6 +1653,9 @@ def render(ctx):
             else:
                 return ""
 
+            if partner is None or opp1 is None or opp2 is None:
+                return ""
+
             return build_match_explorer_link(
                 ctx="OVERALL",
                 me=int(pid),


### PR DESCRIPTION
### Motivation
- Prevent generating invalid match-explorer links or raising errors when match rows are incomplete (e.g. singles/partial rows) by ensuring partner/opponent ids are present before building the link.

### Description
- Add a defensive check in `explain_link` (in `jupr_app/ui/pages/players.py`) to `return ""` when `partner`, `opp1`, or `opp2` is `None` before calling `build_match_explorer_link`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a6ff38f88326940a5004e61e2000)