### PR TITLE
Filter merged players from leaderboards

### DIFF
--- a/jupr_app/data/load.py
+++ b/jupr_app/data/load.py
@@ -30,6 +30,7 @@ PLAYER_BADGES_OPTIONAL_COLUMNS = [
     "revoked_by",
     "revoke_reason",
 ]
+MERGED_PLAYER_MARKER = "(MERGED into "
 
 
 def _missing_player_badges_columns(exc: APIError) -> set[str]:
@@ -90,6 +91,20 @@ def _fetch_player_badges(supabase, club_id: str) -> tuple[pd.DataFrame, bool, st
     return df_player_badges, schema_degraded, schema_degraded_reason
 
 
+def _drop_merged_players(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty or "name" not in df.columns:
+        return df
+    merged_mask = (
+        df["name"]
+        .fillna("")
+        .astype(str)
+        .str.contains(MERGED_PLAYER_MARKER, case=False, regex=False)
+    )
+    if not merged_mask.any():
+        return df
+    return df.loc[~merged_mask].copy()
+
+
 def load_data(supabase, club_id: str, match_limit: int = 5000):
     """
     Loads club-scoped tables and returns:
@@ -118,6 +133,7 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
             df_players_all = pd.DataFrame(p_resp.data or [])
 
             df_players_all = add_activity_columns(df_players_all)
+            df_players_all = _drop_merged_players(df_players_all)
 
             # Active players (inactive_at is authoritative when present)
             if not df_players_all.empty and "inactive_at" in df_players_all.columns:

--- a/tests/test_load_data_merged_players.py
+++ b/tests/test_load_data_merged_players.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from jupr_app.data.load import _drop_merged_players
+
+
+def test_drop_merged_players_filters_marker():
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "name": [
+                "Alice",
+                "Bob (MERGED into Alice #1)",
+                None,
+            ],
+        }
+    )
+
+    filtered = _drop_merged_players(df)
+
+    assert filtered["id"].tolist() == [1, 3]
+    assert "Bob (MERGED into Alice #1)" not in filtered["name"].fillna("").tolist()


### PR DESCRIPTION
### Motivation
- Merged player "tombstones" (names renamed to include "(MERGED into ") were being retained in loaded player data and could appear on leaderboards when "See all" was selected.
- The intent is to ensure merged players never surface in standings/leaderboards or leak into name/id mappings used by stories and links.

### Description
- Add a `MERGED_PLAYER_MARKER` constant and a helper `_drop_merged_players(df: pd.DataFrame)` that removes rows whose `name` contains the marker using robust Pandas string handling.  
- Apply `_drop_merged_players` to `df_players_all` immediately after `add_activity_columns(df_players_all)` so merged rows are removed before computing active players.  
- Because the filter runs before building `id_to_name` and `name_to_id`, mappings are constructed from the filtered player set and merged names cannot leak into other contexts.  
- Add `tests/test_load_data_merged_players.py` which constructs a fake `df_players_all` including a merged-name row and asserts it is removed.

### Testing
- Ran the new unit test with `pytest -q tests/test_load_data_merged_players.py` which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a96a06648326b0622c315cf44cbb)