### PR TITLE
Sanitize leaderboard story text

### DIFF
--- a/jupr_app/ui/helpers.py
+++ b/jupr_app/ui/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import re
 import urllib.parse
 
@@ -151,6 +152,14 @@ def build_badge_story(player_row: dict | pd.Series, earned_badges: list[dict]) -
         games_str = f"{games} game" + ("s" if games != 1 else "")
         return f"Active this season with {games_str} logged."
     return story
+
+
+def sanitize_story_text(raw: str | None) -> str:
+    text = "" if raw is None else str(raw)
+    text = html.unescape(text)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
 
 
 def _row_value(row: dict | pd.Series, keys: list[str]):

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -12,7 +12,7 @@ from jupr_app.ui.public_links import build_public_url, public_link_button
 from jupr_app.ui.layout import page_shell
 from jupr_app.ui.theme_clean import callout
 from jupr_app.ui.pages.players import badge_icon
-from jupr_app.ui.helpers import build_badge_story
+from jupr_app.ui.helpers import build_badge_story, sanitize_story_text
 from jupr_app.domain.gamification.requirements import load_requirements_map
 from jupr_app.domain.story_stats import (
     build_best_partner_map,
@@ -1290,8 +1290,9 @@ def render(ctx):
                         inserts.append(_build_partner_story(partner, id_to_name))
                 if inserts:
                     story_text = f"{story_text} {' '.join(inserts)}".strip()
-            safe_story_text = _safe_text(story_text)
-            story_text_html = f'<div class="lb-story-text">{safe_story_text}</div>'
+            story_text = sanitize_story_text(story_text)
+            safe_story_html = html.escape(story_text)
+            story_text_html = f'<div class="lb-story-text">{safe_story_html}</div>'
             card_html = f"""
             <div class="lb-standings-card">
                 <div class="lb-standings-top">

--- a/tests/test_badge_story.py
+++ b/tests/test_badge_story.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from jupr_app.ui.helpers import build_badge_story
+from jupr_app.ui.helpers import build_badge_story, sanitize_story_text
 
 
 def test_build_badge_story_with_badges_and_stats():
@@ -45,3 +45,8 @@ def test_build_badge_story_no_badges_active():
         story
         == "Active this season with 12 games logged—badges will start appearing as the reel fills."
     )
+
+
+def test_sanitize_story_text_strips_html():
+    text = sanitize_story_text("<div>Hello<br>World</div>")
+    assert text == "Hello World"


### PR DESCRIPTION
### Motivation
- Prevent raw HTML from appearing in player story text on the Leaderboards page by normalizing and stripping any embedded tags or entities.
- Ensure stories rendered into HTML templates cannot inject markup while preserving intended whitespace.

### Description
- Add `sanitize_story_text(raw: str | None) -> str` to `jupr_app/ui/helpers.py` to convert `None` to `""`, `html.unescape()` input, remove HTML tags with `re.sub(r"<[^>]+>", " ", ...)`, collapse repeated whitespace with `re.sub(r"\s+", " ", ...)`, and `strip()` the result.
- Import and apply the sanitizer in `jupr_app/ui/pages/leaderboards.py` (`from jupr_app.ui.helpers import build_badge_story, sanitize_story_text`) and run `story_text = sanitize_story_text(story_text)` before rendering Story View content.
- Escape the sanitized text prior to interpolating into the HTML template using `html.escape(story_text)` to avoid injection while not double-escaping intentional template HTML.
- Add a regression test `tests/test_badge_story.py::test_sanitize_story_text_strips_html` that verifies `sanitize_story_text("<div>Hello<br>World</div>") == "Hello World"`.

### Testing
- Ran `pytest tests/test_badge_story.py` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b358e10883268b41548172f5b7c7)