### PR TITLE
Add Tres Palapas Weekly Recap: DB, generator, admin & public UI, print layout

### DIFF
--- a/jupr_app/domain/recaps/__init__.py
+++ b/jupr_app/domain/recaps/__init__.py
@@ -1,0 +1,3 @@
+from .weekly_recap import compute_weekly_recap, get_spotlight_candidates, get_week_bounds
+
+__all__ = ["compute_weekly_recap", "get_spotlight_candidates", "get_week_bounds"]

--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -1,0 +1,709 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+
+
+@dataclass
+class SpotlightCandidate:
+    candidate_id: str
+    key: str
+    label: str
+    display: str
+    player_ids: list[int]
+    event_key: tuple[str, str] | None
+    value_json: dict
+    band: str | None = None
+
+
+def get_week_bounds(week_start: date, tz_name: str) -> tuple[datetime, datetime]:
+    tz = ZoneInfo(tz_name)
+    start_local = datetime.combine(week_start, time.min).replace(tzinfo=tz)
+    end_local = start_local + timedelta(days=7) - timedelta(microseconds=1)
+    return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
+
+
+def compute_weekly_recap(ctx, week_start: date, *, tz_name: str = "America/Mazatlan") -> dict:
+    recap, _ = _compute_weekly_recap_payload(ctx, week_start, tz_name=tz_name)
+    return recap
+
+
+def get_spotlight_candidates(ctx, week_start: date, *, tz_name: str = "America/Mazatlan") -> dict[str, list[dict]]:
+    _, candidates = _compute_weekly_recap_payload(ctx, week_start, tz_name=tz_name)
+    return {
+        key: [candidate.__dict__ for candidate in items]
+        for key, items in candidates.items()
+    }
+
+
+def _compute_weekly_recap_payload(ctx, week_start: date, *, tz_name: str) -> tuple[dict, dict[str, list[SpotlightCandidate]]]:
+    club_id = str(ctx.club_id)
+    supabase = getattr(ctx, "supabase", None)
+    df_matches = getattr(ctx, "df_matches", pd.DataFrame())
+    id_to_name = getattr(ctx, "id_to_name", {}) or {}
+    df_players_all = getattr(ctx, "df_players_all", pd.DataFrame())
+
+    start_dt_utc, end_dt_utc = get_week_bounds(week_start, tz_name)
+    df_week = _load_week_matches(df_matches, supabase, club_id, start_dt_utc, end_dt_utc)
+    df_week = _filter_week_matches(df_week)
+
+    rating_map = _build_rating_map(df_players_all)
+
+    stats, event_stats, event_meta, giant_slayer_candidates = _compute_stats(
+        df_week, rating_map
+    )
+
+    spotlight_candidates = _build_spotlight_candidates(
+        stats, giant_slayer_candidates, id_to_name
+    )
+    spotlight = _select_spotlight_items(spotlight_candidates)
+
+    numbers = _build_numbers(df_week, stats, event_meta, supabase, club_id, start_dt_utc, end_dt_utc)
+
+    around_club = _build_around_club(
+        event_stats,
+        event_meta,
+        id_to_name,
+        supabase,
+    )
+
+    week_end = week_start + timedelta(days=6)
+    recap = {
+        "club_id": club_id,
+        "week_start": week_start.isoformat(),
+        "week_end": week_end.isoformat(),
+        "numbers": numbers,
+        "spotlight": [item.__dict__ for item in spotlight],
+        "around_club": around_club,
+        "looking_ahead": ["", "", ""],
+        "meta": {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "tz_name": tz_name,
+        },
+    }
+    return recap, spotlight_candidates
+
+
+def _load_week_matches(
+    df_matches: pd.DataFrame | None,
+    supabase,
+    club_id: str,
+    start_dt: datetime,
+    end_dt: datetime,
+) -> pd.DataFrame:
+    if df_matches is not None and not df_matches.empty:
+        df_local = df_matches.copy()
+        df_local["date_dt"] = pd.to_datetime(df_local.get("date", None), utc=True, errors="coerce")
+        in_range = df_local[(df_local["date_dt"] >= start_dt) & (df_local["date_dt"] <= end_dt)].copy()
+        if not in_range.empty:
+            return in_range
+
+    if supabase is None:
+        return pd.DataFrame()
+
+    select_cols = [
+        "id",
+        "date",
+        "league",
+        "match_type",
+        "week_tag",
+        "t1_p1",
+        "t1_p2",
+        "t2_p1",
+        "t2_p2",
+        "score_t1",
+        "score_t2",
+        "t1_p1_r",
+        "t1_p2_r",
+        "t2_p1_r",
+        "t2_p2_r",
+        "t1_p1_r_end",
+        "t1_p2_r_end",
+        "t2_p1_r_end",
+        "t2_p2_r_end",
+        "context_type",
+        "context_id",
+        "tournament_id",
+    ]
+    response = (
+        supabase.table("matches")
+        .select(",".join(select_cols))
+        .eq("club_id", club_id)
+        .gte("date", start_dt.isoformat())
+        .lte("date", end_dt.isoformat())
+        .execute()
+    )
+    return pd.DataFrame(response.data or [])
+
+
+def _filter_week_matches(df_matches: pd.DataFrame) -> pd.DataFrame:
+    if df_matches is None or df_matches.empty:
+        return pd.DataFrame()
+    df = df_matches.copy()
+    df["score_t1"] = pd.to_numeric(df.get("score_t1", 0), errors="coerce").fillna(0).astype(int)
+    df["score_t2"] = pd.to_numeric(df.get("score_t2", 0), errors="coerce").fillna(0).astype(int)
+    df = df[(df["score_t1"] + df["score_t2"]) > 0].copy()
+    if "context_type" in df.columns:
+        df = df[df["context_type"].fillna("").astype(str).str.upper() != "TOURNAMENT"].copy()
+    if "tournament_id" in df.columns:
+        df = df[df["tournament_id"].isna()].copy()
+    if "match_type" in df.columns:
+        df = df[df["match_type"].fillna("").astype(str) != "Tournament"].copy()
+    df["league"] = df.get("league", "").fillna("").astype(str).str.strip()
+    df["match_type"] = df.get("match_type", "").fillna("").astype(str).str.strip()
+    df["week_tag"] = df.get("week_tag", "").fillna("").astype(str).str.strip()
+    df["date_dt"] = pd.to_datetime(df.get("date", None), utc=True, errors="coerce")
+    return df
+
+
+def _build_rating_map(df_players_all: pd.DataFrame | None) -> dict[int, float]:
+    if df_players_all is None or df_players_all.empty:
+        return {}
+    if "id" not in df_players_all.columns:
+        return {}
+    rating_col = "rating" if "rating" in df_players_all.columns else None
+    if rating_col is None:
+        return {}
+    ids = df_players_all["id"].astype(int)
+    ratings = pd.to_numeric(df_players_all[rating_col], errors="coerce").fillna(1200.0).astype(float)
+    return dict(zip(ids, ratings))
+
+
+def _safe_int(value) -> int | None:
+    try:
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _safe_float(value, default: float | None = None) -> float | None:
+    try:
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _resolve_event_key(match: dict) -> tuple[str, str] | None:
+    league = str(match.get("league", "") or "").strip()
+    match_type = str(match.get("match_type", "") or "").strip()
+    week_tag = str(match.get("week_tag", "") or "").strip()
+    if match_type == "PopUp":
+        context_id = match.get("context_id")
+        if context_id is None or str(context_id).strip() == "":
+            fallback = ":".join([x for x in [league, week_tag] if x]) or "POPUP"
+            return ("RR", fallback)
+        return ("RR", str(context_id))
+    if not league or league.upper() in {"OVERALL", "POPUP"}:
+        return None
+    return ("LEAGUE", league)
+
+
+def _compute_stats(
+    df_week: pd.DataFrame,
+    rating_map: dict[int, float],
+) -> tuple[dict, dict, dict, list[dict]]:
+    stats: dict[int, dict] = {}
+    event_stats: dict[tuple[str, str], dict[int, dict]] = {}
+    event_meta: dict[str, dict[str, dict]] = {"leagues": {}, "round_robins": {}}
+    giant_slayer_candidates: list[dict] = []
+
+    if df_week is None or df_week.empty:
+        return stats, event_stats, event_meta, giant_slayer_candidates
+
+    df_sorted = df_week.sort_values(["date_dt", "id"], ascending=[True, True])
+
+    for _, row in df_sorted.iterrows():
+        match = row.to_dict()
+        p1 = _safe_int(match.get("t1_p1"))
+        p2 = _safe_int(match.get("t1_p2"))
+        p3 = _safe_int(match.get("t2_p1"))
+        p4 = _safe_int(match.get("t2_p2"))
+        if any(pid is None for pid in (p1, p2, p3, p4)):
+            continue
+        s1 = int(match.get("score_t1", 0) or 0)
+        s2 = int(match.get("score_t2", 0) or 0)
+        if (s1 + s2) <= 0:
+            continue
+        t1_win = s1 > s2
+        t2_win = s2 > s1
+
+        r1 = _safe_float(match.get("t1_p1_r"), rating_map.get(p1, 1200.0))
+        r2 = _safe_float(match.get("t1_p2_r"), rating_map.get(p2, 1200.0))
+        r3 = _safe_float(match.get("t2_p1_r"), rating_map.get(p3, 1200.0))
+        r4 = _safe_float(match.get("t2_p2_r"), rating_map.get(p4, 1200.0))
+
+        r1_end = _safe_float(match.get("t1_p1_r_end"), r1)
+        r2_end = _safe_float(match.get("t1_p2_r_end"), r2)
+        r3_end = _safe_float(match.get("t2_p1_r_end"), r3)
+        r4_end = _safe_float(match.get("t2_p2_r_end"), r4)
+
+        team1_avg = (r1 + r2) / 2.0 if r1 is not None and r2 is not None else None
+        team2_avg = (r3 + r4) / 2.0 if r3 is not None and r4 is not None else None
+
+        event_key = _resolve_event_key(match)
+        if event_key is not None:
+            if event_key[0] == "LEAGUE":
+                event_meta["leagues"].setdefault(event_key[1], {})
+            elif event_key[0] == "RR":
+                event_meta["round_robins"].setdefault(event_key[1], {})
+
+        def update_player(pid: int, win: int, loss: int, opp_avg: float | None, pre: float | None, end: float | None):
+            if pid not in stats:
+                stats[pid] = {
+                    "games": 0,
+                    "wins": 0,
+                    "losses": 0,
+                    "opponent_ratings": [],
+                    "start_rating": None,
+                    "end_rating": None,
+                    "event_keys": [],
+                }
+            entry = stats[pid]
+            entry["games"] += 1
+            entry["wins"] += win
+            entry["losses"] += loss
+            if opp_avg is not None:
+                entry["opponent_ratings"].append(float(opp_avg))
+            if event_key is not None:
+                entry["event_keys"].append(event_key)
+            if entry["start_rating"] is None and pre is not None:
+                entry["start_rating"] = float(pre)
+            if end is not None:
+                entry["end_rating"] = float(end)
+
+        def update_event(pid: int, win: int, loss: int, opp_avg: float | None, pre: float | None, end: float | None):
+            if event_key is None:
+                return
+            if event_key not in event_stats:
+                event_stats[event_key] = {}
+            if pid not in event_stats[event_key]:
+                event_stats[event_key][pid] = {
+                    "games": 0,
+                    "wins": 0,
+                    "losses": 0,
+                    "opponent_ratings": [],
+                    "start_rating": None,
+                    "end_rating": None,
+                }
+            entry = event_stats[event_key][pid]
+            entry["games"] += 1
+            entry["wins"] += win
+            entry["losses"] += loss
+            if opp_avg is not None:
+                entry["opponent_ratings"].append(float(opp_avg))
+            if entry["start_rating"] is None and pre is not None:
+                entry["start_rating"] = float(pre)
+            if end is not None:
+                entry["end_rating"] = float(end)
+
+        update_player(p1, int(t1_win), int(t2_win), team2_avg, r1, r1_end)
+        update_player(p2, int(t1_win), int(t2_win), team2_avg, r2, r2_end)
+        update_player(p3, int(t2_win), int(t1_win), team1_avg, r3, r3_end)
+        update_player(p4, int(t2_win), int(t1_win), team1_avg, r4, r4_end)
+
+        update_event(p1, int(t1_win), int(t2_win), team2_avg, r1, r1_end)
+        update_event(p2, int(t1_win), int(t2_win), team2_avg, r2, r2_end)
+        update_event(p3, int(t2_win), int(t1_win), team1_avg, r3, r3_end)
+        update_event(p4, int(t2_win), int(t1_win), team1_avg, r4, r4_end)
+
+        if t1_win and team1_avg is not None and team2_avg is not None:
+            gap = team2_avg - team1_avg
+            if gap > 0:
+                giant_slayer_candidates.append(
+                    {
+                        "player_ids": [p1, p2],
+                        "gap_elo": gap,
+                        "gap_jupr": gap / 400.0,
+                        "match_id": match.get("id"),
+                        "event_key": event_key,
+                    }
+                )
+        if t2_win and team1_avg is not None and team2_avg is not None:
+            gap = team1_avg - team2_avg
+            if gap > 0:
+                giant_slayer_candidates.append(
+                    {
+                        "player_ids": [p3, p4],
+                        "gap_elo": gap,
+                        "gap_jupr": gap / 400.0,
+                        "match_id": match.get("id"),
+                        "event_key": event_key,
+                    }
+                )
+
+    _finalize_rating_deltas(stats, rating_map)
+    for event_players in event_stats.values():
+        _finalize_rating_deltas(event_players, rating_map)
+
+    return stats, event_stats, event_meta, giant_slayer_candidates
+
+
+def _finalize_rating_deltas(stats: dict[int, dict], rating_map: dict[int, float]) -> None:
+    for pid, entry in stats.items():
+        start = entry.get("start_rating")
+        end = entry.get("end_rating")
+        if start is None:
+            start = rating_map.get(pid, 1200.0)
+        if end is None:
+            end = rating_map.get(pid, start)
+        entry["start_rating"] = float(start)
+        entry["end_rating"] = float(end)
+        delta = float(end) - float(start)
+        entry["raw_elo_delta"] = delta
+        entry["delta_jupr"] = delta / 400.0
+
+
+def _build_spotlight_candidates(
+    stats: dict[int, dict],
+    giant_slayer_candidates: list[dict],
+    id_to_name: dict[int, str],
+) -> dict[str, list[SpotlightCandidate]]:
+    if not stats:
+        return {}
+
+    start_ratings = [entry.get("start_rating") for entry in stats.values() if entry.get("start_rating") is not None]
+    median = pd.Series(start_ratings).median() if start_ratings else None
+
+    def band_for_player(pid: int) -> str | None:
+        if median is None:
+            return None
+        rating = stats.get(pid, {}).get("start_rating")
+        if rating is None:
+            return None
+        return "top" if float(rating) >= float(median) else "bottom"
+
+    candidates: dict[str, list[SpotlightCandidate]] = {
+        "TOP_PERFORMER_WEEK": [],
+        "BIGGEST_JUMP_WEEK": [],
+        "GIANT_SLAYER_WEEK": [],
+        "GRIND_WEEK": [],
+        "PERFECT_RUN": [],
+    }
+
+    for pid, entry in stats.items():
+        games = int(entry.get("games", 0))
+        wins = int(entry.get("wins", 0))
+        losses = int(entry.get("losses", 0))
+        opp_ratings = entry.get("opponent_ratings", [])
+        avg_opp = sum(opp_ratings) / len(opp_ratings) if opp_ratings else 0.0
+        delta = float(entry.get("delta_jupr", 0.0))
+        name = id_to_name.get(pid, f"#{pid}")
+
+        event_key = None
+        event_keys = entry.get("event_keys", [])
+        if event_keys:
+            event_key = max(set(event_keys), key=event_keys.count)
+
+        if games >= 4:
+            candidates["TOP_PERFORMER_WEEK"].append(
+                SpotlightCandidate(
+                    candidate_id=f"player:{pid}",
+                    key="TOP_PERFORMER_WEEK",
+                    label="Top Performer",
+                    display=f"{name} — {wins}-{losses} (+{wins - losses})",
+                    player_ids=[pid],
+                    event_key=event_key,
+                    value_json={"wins": wins, "losses": losses, "games": games, "avg_opponent_rating": avg_opp},
+                    band=band_for_player(pid),
+                )
+            )
+        if games >= 3 and delta > 0:
+            candidates["BIGGEST_JUMP_WEEK"].append(
+                SpotlightCandidate(
+                    candidate_id=f"player:{pid}",
+                    key="BIGGEST_JUMP_WEEK",
+                    label="Biggest Jump",
+                    display=f"{name} — +{delta:.2f} JUPR",
+                    player_ids=[pid],
+                    event_key=event_key,
+                    value_json={"delta_jupr": delta, "games": games},
+                    band=band_for_player(pid),
+                )
+            )
+        candidates["GRIND_WEEK"].append(
+            SpotlightCandidate(
+                candidate_id=f"player:{pid}",
+                key="GRIND_WEEK",
+                label="Grind Week",
+                display=f"{name} — {games} games",
+                player_ids=[pid],
+                event_key=event_key,
+                value_json={"games": games},
+                band=band_for_player(pid),
+            )
+        )
+        if games >= 5 and losses == 0 and wins > 0:
+            candidates["PERFECT_RUN"].append(
+                SpotlightCandidate(
+                    candidate_id=f"player:{pid}",
+                    key="PERFECT_RUN",
+                    label="Perfect Run",
+                    display=f"{name} — {wins}-0",
+                    player_ids=[pid],
+                    event_key=event_key,
+                    value_json={"wins": wins, "games": games},
+                    band=band_for_player(pid),
+                )
+            )
+
+    if giant_slayer_candidates:
+        for candidate in giant_slayer_candidates:
+            players = candidate["player_ids"]
+            name = " + ".join([id_to_name.get(pid, f"#{pid}") for pid in players])
+            gap = float(candidate["gap_jupr"])
+            avg_band = None
+            if median is not None:
+                avg_rating = sum(stats.get(pid, {}).get("start_rating", median) for pid in players) / len(players)
+                avg_band = "top" if avg_rating >= float(median) else "bottom"
+            candidates["GIANT_SLAYER_WEEK"].append(
+                SpotlightCandidate(
+                    candidate_id=f"team:{'-'.join(str(pid) for pid in players)}:match:{candidate.get('match_id')}",
+                    key="GIANT_SLAYER_WEEK",
+                    label="Giant Slayer",
+                    display=f"{name} — +{gap:.2f} JUPR gap",
+                    player_ids=players,
+                    event_key=candidate.get("event_key"),
+                    value_json={
+                        "gap_elo": candidate.get("gap_elo"),
+                        "gap_jupr": gap,
+                        "match_id": candidate.get("match_id"),
+                    },
+                    band=avg_band,
+                )
+            )
+
+    candidates["TOP_PERFORMER_WEEK"].sort(
+        key=lambda x: (x.value_json.get("wins", 0) - x.value_json.get("losses", 0), x.value_json.get("avg_opponent_rating", 0)),
+        reverse=True,
+    )
+    candidates["BIGGEST_JUMP_WEEK"].sort(key=lambda x: x.value_json.get("delta_jupr", 0), reverse=True)
+    candidates["GRIND_WEEK"].sort(key=lambda x: x.value_json.get("games", 0), reverse=True)
+    candidates["PERFECT_RUN"].sort(key=lambda x: (x.value_json.get("wins", 0), x.value_json.get("games", 0)), reverse=True)
+    candidates["GIANT_SLAYER_WEEK"].sort(key=lambda x: x.value_json.get("gap_jupr", 0), reverse=True)
+
+    return candidates
+
+
+def _select_spotlight_items(candidates: dict[str, list[SpotlightCandidate]]) -> list[SpotlightCandidate]:
+    selected: list[SpotlightCandidate] = []
+    used_events: set[tuple[str, str]] = set()
+    bands: set[str] = set()
+
+    order = [
+        "TOP_PERFORMER_WEEK",
+        "BIGGEST_JUMP_WEEK",
+        "GIANT_SLAYER_WEEK",
+        "GRIND_WEEK",
+        "PERFECT_RUN",
+    ]
+
+    for key in order:
+        if key not in candidates or not candidates[key]:
+            continue
+        missing_band = None
+        if bands == {"top"}:
+            missing_band = "bottom"
+        elif bands == {"bottom"}:
+            missing_band = "top"
+
+        options = candidates[key]
+        filtered = [c for c in options if c.event_key is None or c.event_key not in used_events]
+        if filtered:
+            options = filtered
+        if missing_band:
+            banded = [c for c in options if c.band == missing_band]
+            if banded:
+                options = banded
+        choice = options[0]
+        selected.append(choice)
+        if choice.event_key is not None:
+            used_events.add(choice.event_key)
+        if choice.band:
+            bands.add(choice.band)
+        if len(selected) >= 6:
+            break
+
+    return selected
+
+
+def _build_numbers(
+    df_week: pd.DataFrame,
+    stats: dict[int, dict],
+    event_meta: dict,
+    supabase,
+    club_id: str,
+    start_dt: datetime,
+    end_dt: datetime,
+) -> dict:
+    match_count = int(len(df_week)) if df_week is not None else 0
+    player_ids = list(stats.keys())
+    league_count = len(event_meta.get("leagues", {}))
+    rr_count = len(event_meta.get("round_robins", {}))
+
+    new_faces = _compute_new_faces(supabase, club_id, player_ids, start_dt, end_dt)
+
+    return {
+        "matches": match_count,
+        "players": len(player_ids),
+        "leagues": league_count,
+        "round_robins": rr_count,
+        "new_faces": len(new_faces),
+    }
+
+
+def _compute_new_faces(
+    supabase,
+    club_id: str,
+    player_ids: list[int],
+    start_dt: datetime,
+    end_dt: datetime,
+) -> list[int]:
+    if not player_ids or supabase is None:
+        return []
+    ids_str = ",".join(str(pid) for pid in player_ids)
+    or_filter = ",".join(
+        [
+            f"t1_p1.in.({ids_str})",
+            f"t1_p2.in.({ids_str})",
+            f"t2_p1.in.({ids_str})",
+            f"t2_p2.in.({ids_str})",
+        ]
+    )
+    response = (
+        supabase.table("matches")
+        .select("date,t1_p1,t1_p2,t2_p1,t2_p2")
+        .eq("club_id", club_id)
+        .or_(or_filter)
+        .execute()
+    )
+    df = pd.DataFrame(response.data or [])
+    if df.empty:
+        return []
+    df["date_dt"] = pd.to_datetime(df.get("date", None), utc=True, errors="coerce")
+    first_dates: dict[int, datetime] = {}
+    for _, row in df.iterrows():
+        dt = row.get("date_dt")
+        if dt is None or pd.isna(dt):
+            continue
+        for col in ["t1_p1", "t1_p2", "t2_p1", "t2_p2"]:
+            pid = _safe_int(row.get(col))
+            if pid is None or pid not in player_ids:
+                continue
+            current = first_dates.get(pid)
+            if current is None or dt < current:
+                first_dates[pid] = dt
+
+    new_faces = [pid for pid, dt in first_dates.items() if start_dt <= dt <= end_dt]
+    return new_faces
+
+
+def _build_around_club(
+    event_stats: dict,
+    event_meta: dict,
+    id_to_name: dict[int, str],
+    supabase,
+) -> dict:
+    league_events = sorted(event_meta.get("leagues", {}).keys())
+    rr_events = sorted(event_meta.get("round_robins", {}).keys())
+    total_events = len(league_events) + len(rr_events)
+    highlight_count = 2 if total_events <= 8 else 1
+    short_labels = total_events >= 15
+
+    rr_name_map = _fetch_rr_event_names(supabase, rr_events)
+
+    league_items = []
+    for league in league_events:
+        event_key = ("LEAGUE", league)
+        highlights = _event_highlights(
+            event_stats.get(event_key, {}),
+            id_to_name,
+            highlight_count,
+            short_labels,
+            prefer_jump=True,
+        )
+        league_items.append({"league_name": league, "highlights": highlights})
+
+    rr_items = []
+    for rr_event in rr_events:
+        event_key = ("RR", rr_event)
+        highlights = _event_highlights(
+            event_stats.get(event_key, {}),
+            id_to_name,
+            1 if highlight_count == 1 else 2,
+            short_labels,
+            prefer_jump=False,
+        )
+        rr_items.append(
+            {
+                "event_id": rr_event,
+                "event_name": rr_name_map.get(rr_event, "Pop-Up Event"),
+                "highlights": highlights,
+            }
+        )
+
+    return {"leagues": league_items, "round_robins": rr_items}
+
+
+def _event_highlights(
+    stats: dict[int, dict],
+    id_to_name: dict[int, str],
+    count: int,
+    short_labels: bool,
+    prefer_jump: bool,
+) -> list[dict]:
+    if not stats:
+        return []
+
+    def top_performer():
+        best = max(stats.items(), key=lambda item: (item[1].get("wins", 0), item[1].get("games", 0)))
+        pid, entry = best
+        name = id_to_name.get(pid, f"#{pid}")
+        wins = int(entry.get("wins", 0))
+        losses = int(entry.get("losses", 0))
+        label = "Top" if short_labels else "Top Performer"
+        display = f"{name} — {wins}-{losses}" if not short_labels else f"{name} {wins}-{losses}"
+        return {"key": "TOP_PERFORMER", "label": label, "display": display, "player_ids": [pid]}
+
+    def biggest_jump():
+        best = max(stats.items(), key=lambda item: item[1].get("delta_jupr", 0))
+        pid, entry = best
+        delta = float(entry.get("delta_jupr", 0))
+        if delta <= 0:
+            return None
+        name = id_to_name.get(pid, f"#{pid}")
+        label = "Jump" if short_labels else "Biggest Jump"
+        display = f"{name} — +{delta:.2f}" if short_labels else f"{name} — +{delta:.2f} JUPR"
+        return {"key": "BIGGEST_JUMP", "label": label, "display": display, "player_ids": [pid]}
+
+    highlights = []
+    jump = biggest_jump()
+    top = top_performer()
+    if prefer_jump and jump is not None and (jump["display"]):
+        highlights.append(jump)
+    else:
+        highlights.append(top)
+    if count > 1:
+        if prefer_jump:
+            if top["key"] != highlights[0]["key"]:
+                highlights.append(top)
+        else:
+            if jump is not None:
+                highlights.append(jump)
+    return highlights[:count]
+
+
+def _fetch_rr_event_names(supabase, rr_events: list[str]) -> dict[str, str]:
+    if supabase is None:
+        return {}
+    ids = [eid for eid in rr_events if eid and not eid.startswith("POPUP")]
+    if not ids:
+        return {}
+    response = supabase.table("events").select("id,name").in_("id", ids).execute()
+    return {row["id"]: row.get("name") or "Pop-Up Event" for row in (response.data or [])}

--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import streamlit as st
+
+
+def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | None = None) -> None:
+    week_start = recap.get("week_start")
+    week_end = recap.get("week_end")
+    title = title_override or "Tres Palapas Weekly Recap"
+
+    date_label = ""
+    if week_start and week_end:
+        try:
+            start_dt = datetime.fromisoformat(str(week_start))
+            end_dt = datetime.fromisoformat(str(week_end))
+            date_label = f"{start_dt.strftime('%b %d')} – {end_dt.strftime('%b %d')}"
+        except Exception:
+            date_label = f"{week_start} – {week_end}"
+
+    numbers = recap.get("numbers", {})
+    spotlight = recap.get("spotlight", [])
+    around = recap.get("around_club", {})
+    looking_ahead = recap.get("looking_ahead", []) or []
+
+    league_items = around.get("leagues", []) or []
+    rr_items = around.get("round_robins", []) or []
+
+    html = f"""
+    <style>
+      .weekly-recap {{
+        font-family: 'Inter', sans-serif;
+        color: #111827;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 16px 20px 24px;
+        border: 1px solid #e5e7eb;
+        border-radius: 12px;
+        background: #ffffff;
+      }}
+      .weekly-header {{
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        border-bottom: 2px solid #111827;
+        padding-bottom: 8px;
+        margin-bottom: 12px;
+      }}
+      .weekly-title {{
+        font-size: 28px;
+        font-weight: 700;
+      }}
+      .weekly-range {{
+        font-size: 14px;
+        font-weight: 600;
+        color: #374151;
+      }}
+      .numbers-strip {{
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: 8px;
+        margin-bottom: 16px;
+      }}
+      .number-card {{
+        background: #f3f4f6;
+        padding: 10px 8px;
+        border-radius: 10px;
+        text-align: center;
+      }}
+      .number-value {{
+        font-size: 20px;
+        font-weight: 700;
+      }}
+      .number-label {{
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: #6b7280;
+      }}
+      .section {{
+        margin-top: 14px;
+      }}
+      .section h3 {{
+        font-size: 18px;
+        margin: 0 0 6px;
+      }}
+      .subsection h4 {{
+        font-size: 14px;
+        margin: 8px 0 4px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #6b7280;
+      }}
+      .event-block {{
+        margin-bottom: 6px;
+      }}
+      .event-name {{
+        font-weight: 600;
+        font-size: 13px;
+      }}
+      ul.compact {{
+        margin: 4px 0 6px 18px;
+        padding: 0;
+      }}
+      ul.compact li {{
+        margin-bottom: 3px;
+        font-size: 13px;
+      }}
+      .looking-ahead li {{
+        font-size: 13px;
+      }}
+      @media print {{
+        body {{
+          margin: 0;
+        }}
+        .weekly-recap {{
+          border: none;
+          margin: 0;
+          padding: 0.4in 0.5in;
+          box-shadow: none;
+        }}
+        .no-print {{
+          display: none !important;
+        }}
+      }}
+    </style>
+    <div class=\"weekly-recap\">
+      <div class=\"weekly-header\">
+        <div class=\"weekly-title\">{title}</div>
+        <div class=\"weekly-range\">{date_label}</div>
+      </div>
+      <div class=\"numbers-strip\">
+        <div class=\"number-card\"><div class=\"number-value\">{numbers.get('matches', 0)}</div><div class=\"number-label\">Matches</div></div>
+        <div class=\"number-card\"><div class=\"number-value\">{numbers.get('players', 0)}</div><div class=\"number-label\">Players</div></div>
+        <div class=\"number-card\"><div class=\"number-value\">{numbers.get('leagues', 0)}</div><div class=\"number-label\">Leagues</div></div>
+        <div class=\"number-card\"><div class=\"number-value\">{numbers.get('round_robins', 0)}</div><div class=\"number-label\">Pop-Ups</div></div>
+        <div class=\"number-card\"><div class=\"number-value\">{numbers.get('new_faces', 0)}</div><div class=\"number-label\">New Faces</div></div>
+      </div>
+      <div class=\"section\">
+        <h3>Spotlight Reel</h3>
+        <ul class=\"compact\">
+          {''.join(f\"<li><strong>{item.get('label')}</strong>: {item.get('display')}</li>\" for item in spotlight)}
+        </ul>
+      </div>
+      <div class=\"section\">
+        <h3>Around the Club</h3>
+        <div class=\"subsection\">
+          <h4>Leagues</h4>
+          {''.join(_render_event_block(item['league_name'], item.get('highlights', [])) for item in league_items)}
+        </div>
+        <div class=\"subsection\">
+          <h4>Round Robins</h4>
+          {''.join(_render_event_block(item.get('event_name', 'Pop-Up Event'), item.get('highlights', [])) for item in rr_items)}
+        </div>
+      </div>
+      <div class=\"section\">
+        <h3>Looking Ahead</h3>
+        <ul class=\"compact looking-ahead\">
+          {''.join(f\"<li>{item}</li>\" for item in looking_ahead if str(item).strip() != '')}
+        </ul>
+      </div>
+    </div>
+    """
+
+    st.markdown(html, unsafe_allow_html=True)
+
+
+def _render_event_block(name: str, highlights: list[dict]) -> str:
+    items = "".join(f\"<li>{h.get('display')}</li>\" for h in highlights)
+    return f\"<div class='event-block'><div class='event-name'>{name}</div><ul class='compact'>{items}</ul></div>\"

--- a/jupr_app/ui/pages/__init__.py
+++ b/jupr_app/ui/pages/__init__.py
@@ -19,6 +19,8 @@ from . import admin_guide
 from . import moneyball
 from . import league_results
 from . import league_printout
+from . import weekly_recap
+from . import weekly_recap_admin
 from . import theme_gallery
 from . import tournaments
 from . import tournament_manager
@@ -41,6 +43,8 @@ __all__ = [
     "moneyball",
     "league_results",
     "league_printout",
+    "weekly_recap",
+    "weekly_recap_admin",
     "theme_gallery",
     "tournaments",
     "tournament_manager",

--- a/jupr_app/ui/pages/weekly_recap.py
+++ b/jupr_app/ui/pages/weekly_recap.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from jupr_app.ui.components.weekly_recap_layout import render_weekly_recap
+from jupr_app.ui.layout import page_shell
+
+
+def render(ctx):
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("🗞️ Tres Palapas Weekly Recap", "Club-wide weekly recap.", mode_label=mode_label)
+
+    supabase = ctx.supabase
+    club_id = str(ctx.club_id)
+
+    response = (
+        supabase.table("weekly_recaps")
+        .select("week_start,week_end,status,final_json")
+        .eq("club_id", club_id)
+        .eq("status", "published")
+        .order("week_start", desc=True)
+        .execute()
+    )
+    published = response.data or []
+    if not published:
+        st.info("No published recaps yet.")
+        return
+
+    week_options = [row["week_start"] for row in published]
+    selected_week = st.selectbox("Select week", options=week_options, format_func=str)
+    selected_row = next((row for row in published if row["week_start"] == selected_week), published[0])
+
+    recap = selected_row.get("final_json") or {}
+    render_weekly_recap(recap, print_view=False)
+
+    st.caption("Tip: use your browser print dialog for a bulletin-board-ready PDF.")
+    base_url = st.session_state.get("base_url", "")
+    if base_url:
+        print_url = f"{base_url}/?page=weekly_recap&public=1"
+        st.link_button("Open Print-Friendly View", print_url)
+
+    if not bool(ctx.public_mode):
+        draft_check = (
+            supabase.table("weekly_recaps")
+            .select("week_start")
+            .eq("club_id", club_id)
+            .eq("status", "draft")
+            .eq("week_start", selected_week)
+            .execute()
+        )
+        if draft_check.data:
+            st.info("Draft exists for this week; public view shows published only.")

--- a/jupr_app/ui/pages/weekly_recap_admin.py
+++ b/jupr_app/ui/pages/weekly_recap_admin.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import streamlit as st
+
+from jupr_app.domain.recaps.weekly_recap import compute_weekly_recap, get_spotlight_candidates
+from jupr_app.ui.components.weekly_recap_layout import render_weekly_recap
+from jupr_app.ui.layout import page_shell
+
+
+def _get_default_week_start(tz_name: str) -> date:
+    today = datetime.now(ZoneInfo(tz_name)).date()
+    return today - timedelta(days=today.weekday())
+
+
+def _load_weekly_row(supabase, club_id: str, week_start: date) -> dict | None:
+    response = (
+        supabase.table("weekly_recaps")
+        .select("*")
+        .eq("club_id", club_id)
+        .eq("week_start", week_start.isoformat())
+        .execute()
+    )
+    if response.data:
+        return response.data[0]
+    return None
+
+
+def _apply_edits(generated_json: dict, edits_json: dict, candidates: dict[str, list[dict]]) -> dict:
+    recap = deepcopy(generated_json or {})
+    if not recap:
+        return recap
+
+    looking_ahead = edits_json.get("looking_ahead")
+    if looking_ahead:
+        recap["looking_ahead"] = looking_ahead
+
+    spotlight = recap.get("spotlight", []) or []
+    spotlight_by_key = {item.get("key"): item for item in spotlight}
+    overrides = edits_json.get("spotlight_overrides", {})
+    for key, candidate_id in overrides.items():
+        options = {item.get("candidate_id"): item for item in candidates.get(key, [])}
+        selected = options.get(candidate_id)
+        if selected:
+            spotlight_by_key[key] = selected
+
+    dropped = set(edits_json.get("spotlight_drop", []))
+    updated = [item for key, item in spotlight_by_key.items() if key not in dropped]
+
+    order_map = edits_json.get("spotlight_order", {})
+    if order_map:
+        updated.sort(key=lambda item: order_map.get(item.get("key"), 999))
+
+    recap["spotlight"] = updated
+    return recap
+
+
+def render(ctx):
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("🗞️ Weekly Recap Admin", "Generate, edit, and publish the weekly recap.", mode_label=mode_label)
+
+    if not bool(getattr(ctx, "admin_logged_in", False)):
+        st.error("Admin login required.")
+        st.stop()
+
+    supabase = ctx.supabase
+    club_id = str(ctx.club_id)
+    tz_name = "America/Mazatlan"
+
+    week_start = st.date_input("Week start (Monday)", value=_get_default_week_start(tz_name))
+
+    row = _load_weekly_row(supabase, club_id, week_start)
+    status = row.get("status") if row else "draft"
+
+    st.write(f"Status: **{status}**")
+
+    if st.button("Generate Draft"):
+        with st.spinner("Generating weekly recap..."):
+            recap = compute_weekly_recap(ctx, week_start, tz_name=tz_name)
+            payload = {
+                "club_id": club_id,
+                "week_start": week_start.isoformat(),
+                "week_end": recap.get("week_end"),
+                "status": "draft",
+                "generated_json": recap,
+                "edits_json": {},
+                "final_json": recap,
+            }
+            supabase.table("weekly_recaps").upsert(payload, on_conflict="club_id,week_start").execute()
+            st.success("Draft generated.")
+            row = _load_weekly_row(supabase, club_id, week_start)
+
+    if not row:
+        st.info("No draft yet. Generate a draft to begin editing.")
+        return
+
+    generated_json = row.get("generated_json") or {}
+    edits_json = row.get("edits_json") or {}
+    candidates = get_spotlight_candidates(ctx, week_start, tz_name=tz_name)
+
+    st.subheader("Edit Draft")
+
+    default_looking = edits_json.get("looking_ahead") or generated_json.get("looking_ahead") or ["", "", ""]
+    looking_inputs = []
+    for idx in range(3):
+        looking_inputs.append(st.text_input(f"Looking Ahead #{idx + 1}", value=default_looking[idx] if idx < len(default_looking) else ""))
+
+    edits_json["looking_ahead"] = looking_inputs
+
+    spotlight = generated_json.get("spotlight", [])
+    spotlight_keys = [item.get("key") for item in spotlight if item.get("key")]
+
+    st.markdown("**Spotlight Reel Overrides**")
+    overrides = edits_json.get("spotlight_overrides", {})
+    order_map = edits_json.get("spotlight_order", {})
+    drop_list = set(edits_json.get("spotlight_drop", []))
+
+    for idx, key in enumerate(spotlight_keys):
+        options = candidates.get(key, [])
+        if not options:
+            continue
+        label = options[0].get("label", key)
+        option_labels = {item.get("candidate_id"): item.get("display", "") for item in options}
+        current = overrides.get(key)
+        if current not in option_labels:
+            current = options[0].get("candidate_id")
+        selection = st.selectbox(
+            f"{label} candidate",
+            options=list(option_labels.keys()),
+            format_func=lambda opt: option_labels.get(opt, opt),
+            index=list(option_labels.keys()).index(current) if current in option_labels else 0,
+        )
+        overrides[key] = selection
+        order_map[key] = st.number_input(f"Order for {label}", min_value=1, max_value=10, value=int(order_map.get(key, idx + 1)))
+        include = st.checkbox(f"Include {label}", value=key not in drop_list)
+        if not include:
+            drop_list.add(key)
+        else:
+            drop_list.discard(key)
+
+    edits_json["spotlight_overrides"] = overrides
+    edits_json["spotlight_order"] = order_map
+    edits_json["spotlight_drop"] = list(drop_list)
+
+    if st.button("Save Draft"):
+        final_json = _apply_edits(generated_json, edits_json, candidates)
+        payload = {
+            "club_id": club_id,
+            "week_start": week_start.isoformat(),
+            "week_end": generated_json.get("week_end"),
+            "status": "draft",
+            "generated_json": generated_json,
+            "edits_json": edits_json,
+            "final_json": final_json,
+        }
+        supabase.table("weekly_recaps").upsert(payload, on_conflict="club_id,week_start").execute()
+        st.success("Draft saved.")
+        row = _load_weekly_row(supabase, club_id, week_start)
+
+    preview = st.checkbox("Preview (Print View)", value=False)
+    if preview:
+        final_json = _apply_edits(generated_json, edits_json, candidates)
+        st.caption("Tip: use browser print to PDF for a bulletin-ready copy.")
+        render_weekly_recap(final_json, print_view=True)
+
+    if st.button("Publish"):
+        final_json = _apply_edits(generated_json, edits_json, candidates)
+        payload = {
+            "club_id": club_id,
+            "week_start": week_start.isoformat(),
+            "week_end": generated_json.get("week_end"),
+            "status": "published",
+            "generated_json": generated_json,
+            "edits_json": edits_json,
+            "final_json": final_json,
+            "published_at": datetime.now(timezone.utc).isoformat(),
+            "published_by": "admin",
+        }
+        supabase.table("weekly_recaps").upsert(payload, on_conflict="club_id,week_start").execute()
+        st.success("Published.")
+        row = _load_weekly_row(supabase, club_id, week_start)
+
+    if st.button("Unpublish"):
+        payload = {
+            "club_id": club_id,
+            "week_start": week_start.isoformat(),
+            "week_end": generated_json.get("week_end"),
+            "status": "draft",
+            "generated_json": generated_json,
+            "edits_json": edits_json,
+            "final_json": _apply_edits(generated_json, edits_json, candidates),
+            "published_at": None,
+            "published_by": None,
+        }
+        supabase.table("weekly_recaps").upsert(payload, on_conflict="club_id,week_start").execute()
+        st.success("Unpublished.")

--- a/migrations/20260207_weekly_recaps.sql
+++ b/migrations/20260207_weekly_recaps.sql
@@ -1,0 +1,35 @@
+create table if not exists public.weekly_recaps (
+    id uuid primary key default gen_random_uuid(),
+    club_id text not null,
+    week_start date not null,
+    week_end date not null,
+    status text not null default 'draft',
+    generated_json jsonb not null default '{}'::jsonb,
+    edits_json jsonb not null default '{}'::jsonb,
+    final_json jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    published_at timestamptz null,
+    published_by text null,
+    unique (club_id, week_start)
+);
+
+create index if not exists weekly_recaps_club_week_idx
+    on public.weekly_recaps (club_id, week_start desc);
+
+create index if not exists weekly_recaps_club_status_week_idx
+    on public.weekly_recaps (club_id, status, week_start desc);
+
+create or replace function public.set_updated_at_timestamp()
+returns trigger as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists weekly_recaps_set_updated_at on public.weekly_recaps;
+create trigger weekly_recaps_set_updated_at
+before update on public.weekly_recaps
+for each row
+execute function public.set_updated_at_timestamp();

--- a/tests/test_weekly_recap_bounds.py
+++ b/tests/test_weekly_recap_bounds.py
@@ -1,0 +1,9 @@
+from datetime import date, timedelta
+
+from jupr_app.domain.recaps.weekly_recap import get_week_bounds
+
+
+def test_week_bounds_seven_days():
+    start = date(2025, 1, 6)
+    start_dt, end_dt = get_week_bounds(start, "America/Mazatlan")
+    assert end_dt - start_dt == timedelta(days=7) - timedelta(microseconds=1)

--- a/tests/test_weekly_recap_delta.py
+++ b/tests/test_weekly_recap_delta.py
@@ -1,0 +1,34 @@
+import pandas as pd
+
+from jupr_app.domain.recaps.weekly_recap import _compute_stats
+
+
+def test_rating_delta_from_snapshots():
+    df = pd.DataFrame(
+        [
+            {
+                "id": 1,
+                "date": "2025-01-06T10:00:00Z",
+                "league": "Alpha",
+                "match_type": "League",
+                "week_tag": "Week 1",
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+                "score_t1": 11,
+                "score_t2": 7,
+                "t1_p1_r": 1200,
+                "t1_p2_r": 1200,
+                "t2_p1_r": 1200,
+                "t2_p2_r": 1200,
+                "t1_p1_r_end": 1240,
+                "t1_p2_r_end": 1210,
+                "t2_p1_r_end": 1190,
+                "t2_p2_r_end": 1190,
+            }
+        ]
+    )
+    df["date_dt"] = pd.to_datetime(df["date"], utc=True)
+    stats, _, _, _ = _compute_stats(df, rating_map={})
+    assert round(stats[1]["delta_jupr"], 2) == 0.10

--- a/tests/test_weekly_recap_spotlight.py
+++ b/tests/test_weekly_recap_spotlight.py
@@ -1,0 +1,57 @@
+import pandas as pd
+
+from jupr_app.domain.recaps.weekly_recap import _build_spotlight_candidates, _compute_stats
+
+
+def test_giant_slayer_selects_max_gap():
+    df = pd.DataFrame(
+        [
+            {
+                "id": 10,
+                "date": "2025-01-07T10:00:00Z",
+                "league": "Alpha",
+                "match_type": "League",
+                "week_tag": "Week 1",
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+                "score_t1": 11,
+                "score_t2": 9,
+                "t1_p1_r": 1100,
+                "t1_p2_r": 1100,
+                "t2_p1_r": 1300,
+                "t2_p2_r": 1300,
+                "t1_p1_r_end": 1110,
+                "t1_p2_r_end": 1110,
+                "t2_p1_r_end": 1290,
+                "t2_p2_r_end": 1290,
+            },
+            {
+                "id": 11,
+                "date": "2025-01-08T10:00:00Z",
+                "league": "Beta",
+                "match_type": "League",
+                "week_tag": "Week 1",
+                "t1_p1": 5,
+                "t1_p2": 6,
+                "t2_p1": 7,
+                "t2_p2": 8,
+                "score_t1": 11,
+                "score_t2": 8,
+                "t1_p1_r": 1000,
+                "t1_p2_r": 1000,
+                "t2_p1_r": 1400,
+                "t2_p2_r": 1400,
+                "t1_p1_r_end": 1020,
+                "t1_p2_r_end": 1020,
+                "t2_p1_r_end": 1380,
+                "t2_p2_r_end": 1380,
+            },
+        ]
+    )
+    df["date_dt"] = pd.to_datetime(df["date"], utc=True)
+    stats, _, _, giant_slayer = _compute_stats(df, rating_map={})
+    candidates = _build_spotlight_candidates(stats, giant_slayer, id_to_name={})
+    best = candidates["GIANT_SLAYER_WEEK"][0]
+    assert best.value_json["match_id"] == 11


### PR DESCRIPTION
### Motivation
- Replace the previous league-night printout with a club-wide "Tres Palapas Weekly Recap" (Mon–Sun) that is machine- and number-driven rather than subjective. 
- Provide an admin workflow to generate a draft, edit/override, preview a print-ready one-page layout, and publish so the public only sees published recaps. 
- Ensure every league and Pop-Up RR event with matches that week is represented, include a numeric Spotlight Reel, and add a small looking-ahead section editable by admins.

### Description
- Database migration: added `migrations/20260207_weekly_recaps.sql` to create `public.weekly_recaps` with JSON payloads (`generated_json`, `edits_json`, `final_json`), `status` tracking, unique `(club_id, week_start)`, indexes, and an `updated_at` trigger function. 
- Domain logic: implemented `jupr_app/domain/recaps/weekly_recap.py` exposing `get_week_bounds` and `compute_weekly_recap`, with match-loading fallback to Supabase, filtering rules, numeric per-player stats, new-faces detection, event grouping (LEAGUE / RR), Spotlight candidate generation (TOP_PERFORMER_WEEK, BIGGEST_JUMP_WEEK, GIANT_SLAYER_WEEK, GRIND_WEEK, PERFECT_RUN), guardrails (event dedup, skill-band diversity), and around-the-club compression rules. 
- UI & workflow: added print-ready renderer `jupr_app/ui/components/weekly_recap_layout.py`, admin editor page `jupr_app/ui/pages/weekly_recap_admin.py` implementing Generate → Edit → Preview → Publish workflow (storing `generated_json`, `edits_json`, and `final_json`), and public page `jupr_app/ui/pages/weekly_recap.py` that displays published-only recaps; wired pages into `jupr_app/ui/pages/__init__.py`. 
- Tests: added fast unit tests under `tests/` for week bounds, rating-delta snapshot handling, and Giant Slayer spotlight selection; created a small `__init__` for the recaps package.

### Testing
- Added unit tests: `tests/test_weekly_recap_bounds.py`, `tests/test_weekly_recap_delta.py`, and `tests/test_weekly_recap_spotlight.py`.
- Ran `pytest tests/test_weekly_recap_bounds.py tests/test_weekly_recap_delta.py tests/test_weekly_recap_spotlight.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698814a6cac88326bea4e3f3478f157a)