### PR TITLE
Fix weekly recap f-string rendering

### DIFF
--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -27,6 +27,22 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
     league_items = around.get("leagues", []) or []
     rr_items = around.get("round_robins", []) or []
 
+    spotlight_html = "".join(
+        f"<li><strong>{item.get('label')}</strong>: {item.get('display')}</li>"
+        for item in spotlight
+    )
+    leagues_html = "".join(
+        _render_event_block(item.get("league_name", "League"), item.get("highlights", []))
+        for item in league_items
+    )
+    rr_html = "".join(
+        _render_event_block(item.get("event_name", "Pop-Up Event"), item.get("highlights", []))
+        for item in rr_items
+    )
+    looking_ahead_html = "".join(
+        f"<li>{item}</li>" for item in looking_ahead if str(item).strip() != ""
+    )
+
     html = f"""
     <style>
       .weekly-recap {{
@@ -140,24 +156,24 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
       <div class=\"section\">
         <h3>Spotlight Reel</h3>
         <ul class=\"compact\">
-          {''.join(f\"<li><strong>{item.get('label')}</strong>: {item.get('display')}</li>\" for item in spotlight)}
+          {spotlight_html}
         </ul>
       </div>
       <div class=\"section\">
         <h3>Around the Club</h3>
         <div class=\"subsection\">
           <h4>Leagues</h4>
-          {''.join(_render_event_block(item['league_name'], item.get('highlights', [])) for item in league_items)}
+          {leagues_html}
         </div>
         <div class=\"subsection\">
           <h4>Round Robins</h4>
-          {''.join(_render_event_block(item.get('event_name', 'Pop-Up Event'), item.get('highlights', [])) for item in rr_items)}
+          {rr_html}
         </div>
       </div>
       <div class=\"section\">
         <h3>Looking Ahead</h3>
         <ul class=\"compact looking-ahead\">
-          {''.join(f\"<li>{item}</li>\" for item in looking_ahead if str(item).strip() != '')}
+          {looking_ahead_html}
         </ul>
       </div>
     </div>
@@ -167,5 +183,8 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
 
 
 def _render_event_block(name: str, highlights: list[dict]) -> str:
-    items = "".join(f\"<li>{h.get('display')}</li>\" for h in highlights)
-    return f\"<div class='event-block'><div class='event-name'>{name}</div><ul class='compact'>{items}</ul></div>\"
+    items = "".join(f"<li>{h.get('display')}</li>" for h in highlights)
+    return (
+        f"<div class='event-block'><div class='event-name'>{name}</div>"
+        f"<ul class='compact'>{items}</ul></div>"
+    )


### PR DESCRIPTION
### Motivation
- Nested f-strings with backslash-escaped quotes in the large HTML f-string were causing a SyntaxError and made the template hard to maintain.
- Precomputing HTML fragments reduces escaping complexity and improves readability and safety when interpolating into the main template.

### Description
- Precompute `spotlight_html`, `leagues_html`, `rr_html`, and `looking_ahead_html` before the main `html = f"""..."""` block and replace the inline `join` expressions with these variables.
- Replace inline `''.join(f"..." ...)` expressions in the template with `{spotlight_html}`, `{leagues_html}`, `{rr_html}`, and `{looking_ahead_html}` respectively.
- Simplify `_render_event_block` to build `items` using normal quotes and return the block using a multi-line `f"..."` expression to avoid escaped nested f-strings.
- Keep the overall HTML structure unchanged while removing problematic nested f-string escapes.

### Testing
- Ran `python -m py_compile jupr_app/ui/components/weekly_recap_layout.py` and it completed without errors.
- Verified the module imports and compiles with no SyntaxError reported by the Python byte-compiler.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698817a128e88326893ce483bf27ed38)