### PR TITLE
Restrict League Night Printout to admins

### DIFF
--- a/jupr_app/ui/pages/league_printout.py
+++ b/jupr_app/ui/pages/league_printout.py
@@ -359,8 +359,11 @@ def _build_printout_txt(league_name: str, week_num: int, weekly_rating: pd.DataF
 
 
 def render(ctx):
-    PUBLIC_MODE = bool(getattr(ctx, "public_mode", False))
-    mode_label = "Public" if PUBLIC_MODE else "Admin"
+    if bool(getattr(ctx, "public_mode", False)) or not bool(getattr(ctx, "admin_logged_in", False)):
+        st.error("This page is only available to admins.")
+        return
+
+    mode_label = "Admin"
     page_shell("🖨️ League Night Printout", "Shareable weekly + season summary.", mode_label=mode_label)
 
     df_matches = getattr(ctx, "df_matches", None)
@@ -461,7 +464,7 @@ def render(ctx):
     txt_text = _build_printout_txt(selected_league, int(selected_week), weekly_rating, weekly_wins, awards)
 
     st.markdown("### Export")
-    ex1, ex2, ex3 = st.columns([1, 1, 2])
+    ex1, ex2 = st.columns(2)
     ex1.download_button(
         "Download HTML",
         data=html_text,
@@ -476,8 +479,3 @@ def render(ctx):
         mime="text/plain",
         use_container_width=True,
     )
-
-    base_url = st.session_state.get("base_url", "")
-    public_url = f"{base_url}/?page=league_printout&public=1&league={quote(selected_league)}&week={int(selected_week)}"
-    ex3.caption("Public share link")
-    ex3.code(public_url)

--- a/jupr_app/ui/pages/match_uploader.py
+++ b/jupr_app/ui/pages/match_uploader.py
@@ -3,7 +3,6 @@
 import time
 import re
 from datetime import datetime
-from urllib.parse import quote
 
 import pandas as pd
 import streamlit as st
@@ -27,29 +26,9 @@ def _parse_week_num(week_tag: str) -> int | None:
         return None
 
 
-def _render_printout_link_notice() -> None:
-    payload = st.session_state.get("mu_last_printout")
-    if not isinstance(payload, dict):
-        return
-    league = str(payload.get("league", "")).strip()
-    week_tag = payload.get("week_tag", "")
-    week_num = _parse_week_num(week_tag)
-    if not league or week_num is None:
-        return
-    base_url = st.session_state.get("base_url", "")
-    if not base_url:
-        return
-    url = f"{base_url}/?page=league_printout&public=1&league={quote(league)}&week={week_num}"
-    st.success("League scores posted. Share the public League Night Printout with members.")
-    st.link_button("Open Public Printout", url)
-    st.code(url)
-    st.session_state.pop("mu_last_printout", None)
-
-
 def render(ctx):
     mode_label = "Public" if bool(ctx.public_mode) else "Admin"
     page_shell("📝 Match Uploader", "Quick entry for pop-up or league matches.", mode_label=mode_label)
-    _render_printout_link_notice()
 
     if not bool(getattr(ctx, "admin_logged_in", False)):
         st.error("Admin only.")
@@ -217,8 +196,6 @@ def render(ctx):
                 df_leagues=df_leagues,
                 df_meta=df_meta,
             )
-            if not is_popup:
-                st.session_state["mu_last_printout"] = {"league": selected_league, "week_tag": week_tag}
             st.success("✅ Processed!")
             time.sleep(0.8)
             st.rerun()
@@ -530,11 +507,6 @@ def render(ctx):
                             st.error("Failed to submit matches.")
                             st.exception(e)
                             st.stop()
-                        if not bool(st.session_state.mu_active_is_popup):
-                            st.session_state["mu_last_printout"] = {
-                                "league": st.session_state.mu_active_lg,
-                                "week_tag": st.session_state.mu_active_wk,
-                            }
                         st.success(
                             f"Inserted {res.get('inserted', 0)} • "
                             f"Skipped incomplete {res.get('skipped_incomplete', 0)} • "

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -405,6 +405,7 @@ def main():
         LABEL_TO_PAGE_KEY = {v: k for k, v in PAGE_KEY_TO_LABEL.items()}
 
         ADMIN_ONLY_LABELS = {
+            "🖨️ League Night Printout",
             "🏟️ League Manager",
             "📝 Match Uploader",
             "📝 Match Log",
@@ -431,7 +432,6 @@ def main():
         PUBLIC_NAV_KEYS = [
             "leaderboards",
             "league_results",
-            "league_printout",
             "weekly_recap",
             "match_explorer",
             "players",


### PR DESCRIPTION
### Motivation
- Prevent the League Night Printout from being visible or shareable to the public while keeping it available to admins.
- Stop generation and emission of public deep links and share URLs for the printout to avoid public access.

### Description
- Marked the printout as admin-only by adding `"🖨️ League Night Printout"` to `ADMIN_ONLY_LABELS` and removed `"league_printout"` from `PUBLIC_NAV_KEYS` in `streamlit_app.py` so it no longer appears in public nav or public ordering.
- Gate the page in `jupr_app/ui/pages/league_printout.py` by returning early with `st.error("This page is only available to admins.")` when `ctx.public_mode` is true or `ctx.admin_logged_in` is false, and retained admin-only UI and downloads while removing the public share link UI.
- Removed the public-share link emission and associated session state usage from `jupr_app/ui/pages/match_uploader.py` by deleting the `_render_printout_link_notice` helper and the places that set `st.session_state["mu_last_printout"]` so uploads no longer produce public printout links.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69881ac9d4a88326b68c691200d4ab1e)