### PR TITLE
Harden leaderboard story sanitization

### DIFF
--- a/jupr_app/ui/helpers.py
+++ b/jupr_app/ui/helpers.py
@@ -158,6 +158,7 @@ def sanitize_story_text(raw: str | None) -> str:
     text = "" if raw is None else str(raw)
     text = html.unescape(text)
     text = re.sub(r"<[^>]+>", " ", text)
+    text = text.replace("<", " ").replace(">", " ")
     text = re.sub(r"\s+", " ", text)
     return text.strip()
 

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -1,5 +1,6 @@
 import html
 import logging
+import re
 import textwrap
 import urllib.parse
 import streamlit as st
@@ -22,6 +23,10 @@ from jupr_app.domain.story_stats import (
 
 logger = logging.getLogger(__name__)
 MAX_STORY_BADGES = 2
+_STORY_HTML_RE = re.compile(
+    r"</?(div|span|br|p|ul|li|strong|em|a|img|table|tr|td|th)\b",
+    re.IGNORECASE,
+)
 
 
 def _safe_text(value: object) -> str:
@@ -82,6 +87,51 @@ def _build_partner_story(partner: dict, id_to_name: dict[int, str]) -> str:
         f"Best partner: {partner_name} ({games} games, {win_pct_str}). "
         f"Your best results come with {partner_name}: {win_pct_str} over {games} games."
     )
+
+
+def _story_has_html(raw: str | None) -> bool:
+    if not raw:
+        return False
+    return bool(_STORY_HTML_RE.search(str(raw)))
+
+
+def _log_story_html_warning(
+    raw_story: str | None,
+    player_id: object,
+    source: str,
+    admin_logged_in: bool,
+) -> None:
+    if not admin_logged_in or not raw_story:
+        return
+    if not _story_has_html(raw_story):
+        return
+    snippet = re.sub(r"\s+", " ", str(raw_story).strip())[:120]
+    logger.warning(
+        "Leaderboards story HTML detected (player_id=%s, %s): %s",
+        player_id,
+        source,
+        snippet,
+    )
+
+
+def _extract_story_from_row(row: pd.Series | dict) -> tuple[str | None, str | None]:
+    for key in ("story", "story_text", "story_html"):
+        try:
+            if key not in row:
+                continue
+            value = row.get(key)
+        except Exception:
+            continue
+        try:
+            if pd.isna(value):
+                continue
+        except Exception:
+            if value is None:
+                continue
+        text = str(value).strip()
+        if text:
+            return text, f"df_column:{key}"
+    return None, None
 
 
 def _player_profile_url(pid, public_mode, ctx):
@@ -1167,6 +1217,14 @@ def render(ctx):
             limit = 50
             st.session_state["lb_limit"] = 50
 
+        if admin_logged_in:
+            if st.button("Refresh leaderboard cache", key="lb_refresh_cache"):
+                try:
+                    st.cache_data.clear()
+                    st.cache_resource.clear()
+                except Exception:
+                    logger.exception("Failed to clear leaderboard caches")
+
         story_badges_by_player = {}
         story_badges_df = pd.DataFrame()
         story_player_ids = []
@@ -1272,9 +1330,18 @@ def render(ctx):
                 story_badges_html = (
                     '<div class="lb-badge-strip"><span class="lb-badge">New</span></div>'
                 )
-            story_text = build_badge_story(row, story_badges)
-            if not story_text:
-                story_text = build_badge_story(row, [])
+            story_text = None
+            story_source = None
+            df_story, df_source = _extract_story_from_row(row)
+            if df_story:
+                story_text = df_story
+                story_source = f"source={df_source}"
+            else:
+                story_text = build_badge_story(row, story_badges)
+                story_source = "source=build_badge_story"
+                if not story_text:
+                    story_text = build_badge_story(row, [])
+                    story_source = "source=build_badge_story:fallback"
             if pd.notna(player_id):
                 try:
                     pid_int = int(player_id)
@@ -1290,6 +1357,8 @@ def render(ctx):
                         inserts.append(_build_partner_story(partner, id_to_name))
                 if inserts:
                     story_text = f"{story_text} {' '.join(inserts)}".strip()
+                    story_source = f"{story_source}+rival_partner" if story_source else "source=rival_partner"
+            _log_story_html_warning(story_text, player_id, story_source or "source=unknown", admin_logged_in)
             story_text = sanitize_story_text(story_text)
             safe_story_html = html.escape(story_text)
             story_text_html = f'<div class="lb-story-text">{safe_story_html}</div>'

--- a/tests/test_badge_story.py
+++ b/tests/test_badge_story.py
@@ -45,6 +45,8 @@ def test_build_badge_story_no_badges_active():
         story
         == "Active this season with 12 games logged—badges will start appearing as the reel fills."
     )
+    assert "<" not in sanitize_story_text(story)
+    assert ">" not in sanitize_story_text(story)
 
 
 def test_sanitize_story_text_strips_html():

--- a/tests/test_leaderboards_story_escape.py
+++ b/tests/test_leaderboards_story_escape.py
@@ -9,3 +9,14 @@ def test_safe_text_escapes_html_story():
 def test_safe_text_escapes_div_tags():
     raw_story = "<div>Already escaped</div>"
     assert leaderboards._safe_text(raw_story) == "&lt;div&gt;Already escaped&lt;/div&gt;"
+
+
+def test_story_sanitize_removes_legacy_html_wrappers():
+    raw_story = (
+        '<div class="lb-story-text">Active this season with 10 games logged.</div>'
+        '<div class="lb-row" style="gap:6px;"></div>'
+    )
+    cleaned = leaderboards.sanitize_story_text(raw_story)
+    assert "<div" not in cleaned
+    assert "lb-row" not in cleaned
+    assert "Active this season with 10 games logged." in cleaned


### PR DESCRIPTION
### Motivation
- Legacy/DF-provided story strings sometimes contained raw HTML wrappers (e.g. `<div class="lb-story-text">…</div>`) or tags coming from dataframe columns, which could appear verbatim in the rendered leaderboard cards.
- The intent is to guarantee stories are always displayed as plain text at the final render boundary and to surface instrumentation when HTML is found so admins can diagnose sources.

### Description
- Added stricter sanitization in `sanitize_story_text(...)` to remove leftover angle brackets so no `<` or `>` remain after cleaning.  (file: `jupr_app/ui/helpers.py`)
- Introduced HTML-detection (`_STORY_HTML_RE`), extraction of story values from dataframe row columns (`_extract_story_from_row`), and admin-only warning logging (`_log_story_html_warning`) that records `player_id`, a 120-char snippet, and the producing source (e.g., `source=build_badge_story`, `source=df_column:story_html`). (file: `jupr_app/ui/pages/leaderboards.py`)
- Ensured the render boundary enforces the invariant `story_text = sanitize_story_text(story_text)` followed by `safe_story_html = html.escape(story_text)` before inserting into the HTML card so only escaped plain text is rendered. (file: `jupr_app/ui/pages/leaderboards.py`)
- Prefer explicit dataframe story columns (`story`, `story_text`, `story_html`) when present and record which path produced the story for logging/diagnostics. (file: `jupr_app/ui/pages/leaderboards.py`)
- Added an admin-only "Refresh leaderboard cache" button that attempts to clear Streamlit caches to reduce stale/legacy HTML content persisting. (file: `jupr_app/ui/pages/leaderboards.py`)
- Added/extended tests to cover legacy HTML wrappers and to assert the active-season path is sanitized. (files: `tests/test_leaderboards_story_escape.py`, `tests/test_badge_story.py`)

### Testing
- Ran the targeted unit tests `tests/test_leaderboards_story_escape.py` and `tests/test_badge_story.py` with `pytest`, collecting 8 tests in total and all passed (`8 passed in ~1.9s`).
- The tests verify angle-bracket removal from legacy HTML wrappers and that the active-season badge story path remains free of `<` or `>` after sanitization.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988b4fd36ec8326bbef58dd334cf142)