### PR TITLE
Allow ties in weekly recap spotlights (admin checkbox + tie logic)

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -26,20 +26,38 @@ def get_week_bounds(week_start: date, tz_name: str) -> tuple[datetime, datetime]
     return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
 
 
-def compute_weekly_recap(ctx, week_start: date, *, tz_name: str = "America/Mazatlan") -> dict:
-    recap, _ = _compute_weekly_recap_payload(ctx, week_start, tz_name=tz_name)
+def compute_weekly_recap(
+    ctx,
+    week_start: date,
+    *,
+    tz_name: str = "America/Mazatlan",
+    allow_ties: bool = True,
+) -> dict:
+    recap, _ = _compute_weekly_recap_payload(ctx, week_start, tz_name=tz_name, allow_ties=allow_ties)
     return recap
 
 
-def get_spotlight_candidates(ctx, week_start: date, *, tz_name: str = "America/Mazatlan") -> dict[str, list[dict]]:
-    _, candidates = _compute_weekly_recap_payload(ctx, week_start, tz_name=tz_name)
+def get_spotlight_candidates(
+    ctx,
+    week_start: date,
+    *,
+    tz_name: str = "America/Mazatlan",
+    allow_ties: bool = True,
+) -> dict[str, list[dict]]:
+    _, candidates = _compute_weekly_recap_payload(ctx, week_start, tz_name=tz_name, allow_ties=allow_ties)
     return {
         key: [candidate.__dict__ for candidate in items]
         for key, items in candidates.items()
     }
 
 
-def _compute_weekly_recap_payload(ctx, week_start: date, *, tz_name: str) -> tuple[dict, dict[str, list[SpotlightCandidate]]]:
+def _compute_weekly_recap_payload(
+    ctx,
+    week_start: date,
+    *,
+    tz_name: str,
+    allow_ties: bool = True,
+) -> tuple[dict, dict[str, list[SpotlightCandidate]]]:
     club_id = str(ctx.club_id)
     supabase = getattr(ctx, "supabase", None)
     df_matches = getattr(ctx, "df_matches", pd.DataFrame())
@@ -59,7 +77,7 @@ def _compute_weekly_recap_payload(ctx, week_start: date, *, tz_name: str) -> tup
     spotlight_candidates = _build_spotlight_candidates(
         stats, giant_slayer_candidates, id_to_name
     )
-    spotlight = _select_spotlight_items(spotlight_candidates)
+    spotlight = _select_spotlight_items(spotlight_candidates, allow_ties=allow_ties)
 
     numbers = _build_numbers(df_week, stats, event_meta, supabase, club_id, start_dt_utc, end_dt_utc)
 
@@ -82,6 +100,7 @@ def _compute_weekly_recap_payload(ctx, week_start: date, *, tz_name: str) -> tup
         "meta": {
             "generated_at": datetime.now(timezone.utc).isoformat(),
             "tz_name": tz_name,
+            "allow_ties": allow_ties,
         },
     }
     return recap, spotlight_candidates
@@ -491,7 +510,61 @@ def _build_spotlight_candidates(
     return candidates
 
 
-def _select_spotlight_items(candidates: dict[str, list[SpotlightCandidate]]) -> list[SpotlightCandidate]:
+def _float_equal(a: float | None, b: float | None, eps: float = 1e-9) -> bool:
+    if a is None or b is None:
+        return a is b
+    return abs(float(a) - float(b)) <= eps
+
+
+def _metric_key_for_candidate(key: str, candidate: SpotlightCandidate) -> tuple | None:
+    values = candidate.value_json or {}
+    if key == "TOP_PERFORMER_WEEK":
+        wins = int(values.get("wins", 0))
+        losses = int(values.get("losses", 0))
+        avg_opp = values.get("avg_opponent_rating")
+        return (wins - losses, float(avg_opp) if avg_opp is not None else None)
+    if key == "BIGGEST_JUMP_WEEK":
+        return (float(values.get("delta_jupr", 0.0)),)
+    if key == "GRIND_WEEK":
+        return (int(values.get("games", 0)),)
+    if key == "PERFECT_RUN":
+        return (int(values.get("wins", 0)),)
+    if key == "GIANT_SLAYER_WEEK":
+        return (float(values.get("gap_jupr", 0.0)),)
+    return None
+
+
+def _make_tie_candidate(key: str, candidate: SpotlightCandidate, other: SpotlightCandidate) -> SpotlightCandidate:
+    def split_display(display: str) -> tuple[str, str | None]:
+        parts = display.split("—", 1)
+        name = parts[0].strip()
+        suffix = parts[1].strip() if len(parts) > 1 else None
+        return name, suffix
+
+    name1, suffix = split_display(candidate.display)
+    name2, _ = split_display(other.display)
+    combined_name = f"{name1} + {name2}"
+    display = f"{combined_name} — {suffix}" if suffix else combined_name
+    player_ids = list(dict.fromkeys(candidate.player_ids + other.player_ids))
+    value_json = dict(candidate.value_json or {})
+    value_json["tied"] = True
+    return SpotlightCandidate(
+        candidate_id=f"tie:{key}:{'+'.join(str(pid) for pid in player_ids)}",
+        key=key,
+        label=candidate.label,
+        display=display,
+        player_ids=player_ids,
+        event_key=None,
+        value_json=value_json,
+        band=None,
+    )
+
+
+def _select_spotlight_items(
+    candidates: dict[str, list[SpotlightCandidate]],
+    *,
+    allow_ties: bool = True,
+) -> list[SpotlightCandidate]:
     selected: list[SpotlightCandidate] = []
     used_events: set[tuple[str, str]] = set()
     bands: set[str] = set()
@@ -522,6 +595,32 @@ def _select_spotlight_items(candidates: dict[str, list[SpotlightCandidate]]) -> 
             if banded:
                 options = banded
         choice = options[0]
+        if allow_ties and key in {
+            "TOP_PERFORMER_WEEK",
+            "BIGGEST_JUMP_WEEK",
+            "GIANT_SLAYER_WEEK",
+            "GRIND_WEEK",
+            "PERFECT_RUN",
+        }:
+            metric_key = _metric_key_for_candidate(key, choice)
+            if metric_key is not None:
+                for candidate in options[1:]:
+                    other_key = _metric_key_for_candidate(key, candidate)
+                    if other_key is None or len(other_key) != len(metric_key):
+                        continue
+                    matches = True
+                    for left, right in zip(metric_key, other_key):
+                        if isinstance(left, float) or isinstance(right, float):
+                            if not _float_equal(left, right):
+                                matches = False
+                                break
+                        else:
+                            if left != right:
+                                matches = False
+                                break
+                    if matches:
+                        choice = _make_tie_candidate(key, choice, candidate)
+                        break
         selected.append(choice)
         if choice.event_key is not None:
             used_events.add(choice.event_key)

--- a/jupr_app/ui/pages/weekly_recap_admin.py
+++ b/jupr_app/ui/pages/weekly_recap_admin.py
@@ -92,6 +92,7 @@ def render(ctx):
     tz_name = "America/Mazatlan"
 
     week_start = st.date_input("Week start (Monday)", value=_get_default_week_start(tz_name))
+    allow_ties = st.checkbox("Allow ties (show 2 players when tied)", value=True)
 
     try:
         row = _load_weekly_row(supabase, club_id, week_start)
@@ -105,7 +106,7 @@ def render(ctx):
 
     if st.button("Generate Draft"):
         with st.spinner("Generating weekly recap..."):
-            recap = compute_weekly_recap(ctx, week_start, tz_name=tz_name)
+            recap = compute_weekly_recap(ctx, week_start, tz_name=tz_name, allow_ties=allow_ties)
             payload = {
                 "club_id": club_id,
                 "week_start": week_start.isoformat(),
@@ -130,7 +131,7 @@ def render(ctx):
 
     generated_json = row.get("generated_json") or {}
     edits_json = row.get("edits_json") or {}
-    candidates = get_spotlight_candidates(ctx, week_start, tz_name=tz_name)
+    candidates = get_spotlight_candidates(ctx, week_start, tz_name=tz_name, allow_ties=allow_ties)
 
     st.subheader("Edit Draft")
 


### PR DESCRIPTION
### Motivation
- Provide admins an option to surface TWO players in a single spotlight when they tie on the top metric without changing the existing overrides UX which expects one spotlight item per key.
- Keep spotlight keys unique in the recap while enabling a single spotlight item to represent two tied players for display and selection.

### Description
- UI: Added checkbox `Allow ties (show 2 players when tied)` (default `True`) next to the `week_start` input and pass `allow_ties` when generating drafts and when loading spotlight candidates (updated `jupr_app/ui/pages/weekly_recap_admin.py`).
- API: Threaded `allow_ties` through `compute_weekly_recap`, `get_spotlight_candidates`, and `_compute_weekly_recap_payload`, and persisted it in recap meta as `recap["meta"]["allow_ties"]` (updated `jupr_app/domain/recaps/weekly_recap.py`).
- Tie logic: Implemented helpers `_float_equal(a,b,eps=1e-9)`, `_metric_key_for_candidate(key,c)`, and `_make_tie_candidate(key,c1,c2)` and updated `_select_spotlight_items(..., allow_ties=True)` to detect second candidate with identical top metric for player-based keys and produce a single combined `SpotlightCandidate` with:
  - `candidate_id` like `tie:{key}:{pid1}+{pid2}`
  - merged `player_ids` and `value_json["tied"] = True`
  - `event_key = None`, `band = None`
  - combined `display` of the form `Name1 + Name2 — <same metric suffix>`
- Metrics compared per requirements using exact integer equality for counts and 1e-9 tolerance for floating metrics (wins-losses + avg opponent rating for `TOP_PERFORMER_WEEK`, `delta_jupr` for `BIGGEST_JUMP_WEEK`, `games` for `GRIND_WEEK`, `wins` for `PERFECT_RUN`, `gap_jupr` for `GIANT_SLAYER_WEEK`).
- Preserved existing behavior when `allow_ties` is `False` and left candidate lists intact so admin overrides UX continues to operate with one candidate id per override key.

### Testing
- No automated tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e458d92083269702d0cbc522bece)