### PR TITLE
Add editable award descriptions to weekly recap and render in bulletin

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -6,6 +6,29 @@ from zoneinfo import ZoneInfo
 
 import pandas as pd
 
+DEFAULT_AWARD_DESCRIPTIONS = {
+    "TOP_PERFORMER_WEEK": (
+        "The strongest overall performance of the week, based on win–loss results across multiple matches. "
+        "This award highlights players who consistently showed up, competed well, and delivered results."
+    ),
+    "BIGGEST_JUMP_WEEK": (
+        "The largest JUPR rating improvement during the week. "
+        "This reflects meaningful progress against competition — not just wins, but growth."
+    ),
+    "GIANT_SLAYER_WEEK": (
+        "A standout win against a significantly higher-rated opponent or team. "
+        "This award celebrates fearless play and capitalizing on tough matchups."
+    ),
+    "GRIND_WEEK": (
+        "The players who logged the most matches during the week. "
+        "Consistency, availability, and willingness to compete are what earn this one."
+    ),
+    "PERFECT_RUN": (
+        "An undefeated week with a meaningful number of matches played. "
+        "No losses, no shortcuts — just clean execution start to finish."
+    ),
+}
+
 
 @dataclass
 class SpotlightCandidate:
@@ -95,6 +118,7 @@ def _compute_weekly_recap_payload(
         "week_end": week_end.isoformat(),
         "numbers": numbers,
         "spotlight": [item.__dict__ for item in spotlight],
+        "award_descriptions": dict(DEFAULT_AWARD_DESCRIPTIONS),
         "around_club": around_club,
         "looking_ahead": ["", "", ""],
         "meta": {

--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from html import escape
 
 import streamlit as st
 
@@ -27,11 +28,21 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
     league_items = around.get("leagues", []) or []
     rr_items = around.get("round_robins", []) or []
 
-    spotlight_html = "".join(
-        f"<li><strong>{(item or {}).get('label','')}</strong>: {(item or {}).get('display','')}</li>"
-        for item in (spotlight or [])
-        if isinstance(item, dict)
-    )
+    spotlight_items = []
+    for item in (spotlight or []):
+        if not isinstance(item, dict):
+            continue
+        label = (item or {}).get("label", "")
+        display = (item or {}).get("display", "")
+        description = (item or {}).get("description", "") or ""
+        desc_html = f"<span class=\"award-desc\">{escape(description)}</span><br/>" if description else ""
+        spotlight_items.append(
+            "<li>"
+            f"<strong>{label}</strong>: {desc_html}"
+            f"{display}"
+            "</li>"
+        )
+    spotlight_html = "".join(spotlight_items)
     leagues_html = "".join(
         _render_event_block((item or {}).get("league_name", "League"), (item or {}).get("highlights", []))
         for item in (league_items or [])
@@ -130,6 +141,10 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
       ul.compact li {{
         margin-bottom: 3px;
         font-size: 13px;
+      }}
+      .award-desc {{
+        color: #374151;
+        font-size: 12.5px;
       }}
       .looking-ahead li {{
         font-size: 13px;

--- a/jupr_app/ui/pages/weekly_recap_admin.py
+++ b/jupr_app/ui/pages/weekly_recap_admin.py
@@ -7,7 +7,11 @@ from zoneinfo import ZoneInfo
 import streamlit as st
 from postgrest.exceptions import APIError
 
-from jupr_app.domain.recaps.weekly_recap import compute_weekly_recap, get_spotlight_candidates
+from jupr_app.domain.recaps.weekly_recap import (
+    DEFAULT_AWARD_DESCRIPTIONS,
+    compute_weekly_recap,
+    get_spotlight_candidates,
+)
 from jupr_app.ui.components.weekly_recap_layout import render_weekly_recap
 from jupr_app.ui.layout import page_shell
 from jupr_app.ui.url import qp_get
@@ -52,6 +56,12 @@ def _apply_edits(generated_json: dict, edits_json: dict, candidates: dict[str, l
     recap = deepcopy(generated_json or {})
     if not recap:
         return recap
+
+    base_desc = generated_json.get("award_descriptions") or DEFAULT_AWARD_DESCRIPTIONS
+    edited_desc = edits_json.get("award_descriptions") or {}
+    merged_desc = dict(base_desc)
+    merged_desc.update(edited_desc)
+    recap["award_descriptions"] = merged_desc
 
     looking_ahead = edits_json.get("looking_ahead")
     if looking_ahead:
@@ -103,6 +113,9 @@ def _apply_edits(generated_json: dict, edits_json: dict, candidates: dict[str, l
     order_map = edits_json.get("spotlight_order", {})
     if order_map:
         updated.sort(key=lambda item: order_map.get(item.get("key"), 999))
+
+    for item in updated:
+        item["description"] = merged_desc.get(item.get("key", ""), "")
 
     recap["spotlight"] = updated
     return recap
@@ -164,6 +177,11 @@ def render(ctx):
     edits_json = row.get("edits_json") or {}
     candidates = get_spotlight_candidates(ctx, week_start, tz_name=tz_name, allow_ties=allow_ties)
 
+    base_desc = generated_json.get("award_descriptions") or DEFAULT_AWARD_DESCRIPTIONS
+    edited_desc = edits_json.get("award_descriptions") or {}
+    merged_desc = dict(base_desc)
+    merged_desc.update(edited_desc)
+
     st.subheader("Edit Draft")
 
     default_looking = edits_json.get("looking_ahead") or generated_json.get("looking_ahead") or ["", "", ""]
@@ -176,6 +194,23 @@ def render(ctx):
     spotlight = generated_json.get("spotlight", [])
     spotlight_keys = [item.get("key") for item in spotlight if item.get("key")]
     spotlight_by_key = {item.get("key"): item for item in spotlight if item.get("key")}
+
+    st.subheader("Award Descriptions")
+    award_desc_edits = edits_json.get("award_descriptions") or {}
+    for key in spotlight_keys:
+        label = key
+        options = candidates.get(key, [])
+        if options:
+            label = options[0].get("label", key)
+        else:
+            label = spotlight_by_key.get(key, {}).get("label", key)
+        award_desc_edits[key] = st.text_area(
+            f"{label} description",
+            value=merged_desc.get(key, ""),
+            height=120,
+            key=f"award_desc_{key}",
+        )
+    edits_json["award_descriptions"] = award_desc_edits
 
     st.markdown("**Spotlight Reel Overrides**")
     overrides = edits_json.get("spotlight_overrides", {})


### PR DESCRIPTION
### Motivation
- Provide full human-readable award explanations for each spotlight item so the bulletin is clearer to readers. 
- Allow admins to edit those award descriptions in the admin UI and ensure the final/published recap carries the chosen text.

### Description
- Add `DEFAULT_AWARD_DESCRIPTIONS` to `jupr_app/domain/recaps/weekly_recap.py` and include a copy as `recap["award_descriptions"]` in `_compute_weekly_recap_payload` so generated drafts contain default descriptions.
- In `jupr_app/ui/pages/weekly_recap_admin.py` merge generated and edited descriptions (`base_desc`, `edited_desc`, `merged_desc`), expose editable multi-line text areas for each spotlight key under a new `Award Descriptions` section, and persist edits to `edits_json["award_descriptions"]`.
- Update `_apply_edits` in the admin page to merge descriptions into the final recap and ensure each spotlight item in `recap["spotlight"]` contains `item["description"] = merged_desc.get(item.get("key",""), "")` for downstream rendering and publishing.
- Change `jupr_app/ui/components/weekly_recap_layout.py` to render the award description immediately after the award title and before the player lines, adding minimal styling (`.award-desc`) and escaping the description text for basic safety.
- Maintain backward compatibility by falling back to `DEFAULT_AWARD_DESCRIPTIONS` when `award_descriptions` is absent.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e9b646bc8326a566b3bd7e239ddb)