### PR TITLE
Add branded print themes for Weekly Recap (Baja V2 & September Newsletter)

### DIFF
--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -10,6 +10,7 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
     week_start = recap.get("week_start")
     week_end = recap.get("week_end")
     title = title_override or "Tres Palapas Weekly Recap"
+    theme = (recap.get("meta") or {}).get("print_theme", "classic")
 
     date_label = ""
     if week_start and week_end:
@@ -64,44 +65,80 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
     html = f"""
     <style>
       {print_view_css}
+      {_css_common_print()}
+      {_css_tokens_baja_v2()}
+      {_css_tokens_newsletter_sep()}
+      {_css_layout_overrides_for_theme(theme)}
       .weekly-recap {{
         font-family: 'Inter', sans-serif;
-        color: #111827;
+        color: var(--ink);
         max-width: 900px;
         margin: 0 auto;
         padding: 16px 20px 24px;
-        border: 1px solid #e5e7eb;
+        border: 1px solid var(--border);
         border-radius: 12px;
-        background: #ffffff;
+        background: var(--card);
+        --ink: #111827;
+        --muted: #475569;
+        --border: #e5e7eb;
+        --bg: #ffffff;
+        --card: #ffffff;
+        --accent: #111827;
+        --accent2: #6b7280;
+        --stat-bg: #f3f4f6;
+        --pill-bg: #f3f4f6;
+      }}
+      .weekly-hero {{
+        margin-bottom: 12px;
+      }}
+      .weekly-hero__bar {{
+        display: none;
+        height: 6px;
+        border-radius: 999px;
+        margin-bottom: 10px;
+        background: linear-gradient(90deg, var(--accent), var(--accent2));
       }}
       .weekly-header {{
         display: flex;
         justify-content: space-between;
-        align-items: baseline;
-        border-bottom: 2px solid #111827;
-        padding-bottom: 8px;
-        margin-bottom: 12px;
+        align-items: center;
+        border-bottom: 3px solid var(--accent);
+        padding-bottom: 10px;
+        gap: 12px;
       }}
       .weekly-title {{
         font-size: 28px;
         font-weight: 700;
       }}
-      .weekly-range {{
-        font-size: 14px;
+      .weekly-subtitle {{
+        font-size: 12.5px;
+        color: var(--muted);
+        margin-top: 4px;
+      }}
+      .weekly-range-pill {{
+        font-size: 12px;
         font-weight: 600;
-        color: #374151;
+        padding: 6px 12px;
+        border-radius: 999px;
+        background: var(--pill-bg);
+        color: var(--ink);
+        border: 1px solid var(--border);
+        white-space: nowrap;
       }}
       .numbers-strip {{
         display: grid;
         grid-template-columns: repeat(5, 1fr);
-        gap: 8px;
+        gap: 10px;
         margin-bottom: 16px;
       }}
       .number-card {{
-        background: #f3f4f6;
+        background: var(--stat-bg);
         padding: 10px 8px;
         border-radius: 10px;
         text-align: center;
+        border: 1px solid var(--border);
+        border-top: 4px solid var(--accent);
+        box-shadow: none;
       }}
       .number-value {{
         font-size: 20px;
@@ -111,64 +148,71 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
         font-size: 11px;
         text-transform: uppercase;
         letter-spacing: 0.06em;
-        color: #6b7280;
+        color: var(--muted);
       }}
       .section {{
         margin-top: 14px;
       }}
       .section h3 {{
         font-size: 18px;
-        margin: 0 0 6px;
+        margin: 0 0 8px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }}
+      .section h3::before {{
+        content: "";
+        width: 10px;
+        height: 10px;
+        background: var(--accent2);
+        border-radius: 3px;
+        display: inline-block;
       }}
       .subsection h4 {{
-        font-size: 14px;
-        margin: 8px 0 4px;
+        font-size: 13px;
+        margin: 10px 0 4px;
         text-transform: uppercase;
         letter-spacing: 0.05em;
-        color: #6b7280;
+        color: var(--muted);
       }}
       .event-block {{
-        margin-bottom: 6px;
+        margin-bottom: 8px;
       }}
       .event-name {{
         font-weight: 600;
         font-size: 13px;
       }}
       ul.compact {{
-        margin: 4px 0 6px 18px;
+        margin: 6px 0 8px 18px;
         padding: 0;
       }}
       ul.compact li {{
-        margin-bottom: 3px;
+        margin-bottom: 6px;
         font-size: 13px;
       }}
       .award-desc {{
-        color: #374151;
+        color: var(--muted);
         font-size: 12.5px;
       }}
       .looking-ahead li {{
         font-size: 13px;
       }}
-      @media print {{
-        body {{
-          margin: 0;
-        }}
-        .weekly-recap {{
-          border: none;
-          margin: 0;
-          padding: 0.4in 0.5in;
-          box-shadow: none;
-        }}
-        .no-print {{
-          display: none !important;
-        }}
+      a {{
+        color: var(--accent);
+        text-decoration: underline;
       }}
     </style>
     {print_mode_notice}
-    <div class=\"weekly-recap\">
-      <div class=\"weekly-header\">
-        <div class=\"weekly-title\">{title}</div>
-        <div class=\"weekly-range\">{date_label}</div>
+    <div class=\"weekly-recap theme-{theme}\">
+      <div class=\"weekly-hero\">
+        <div class=\"weekly-hero__bar\"></div>
+        <div class=\"weekly-header\">
+          <div>
+            <div class=\"weekly-title\">{title}</div>
+            <div class=\"weekly-subtitle\">Tres Palapas Baja Pickleball Resort • Los Barriles, BCS</div>
+          </div>
+          <div class=\"weekly-range-pill\">{date_label}</div>
+        </div>
       </div>
       <div class=\"numbers-strip\">
         <div class=\"number-card\"><div class=\"number-value\">{numbers.get('matches', 0)}</div><div class=\"number-label\">Matches</div></div>
@@ -210,3 +254,91 @@ def _render_event_block(name: str, highlights: list[dict]) -> str:
     safe = [h for h in (highlights or []) if isinstance(h, dict)]
     items = "".join(f"<li>{h.get('display','')}</li>" for h in safe if str(h.get("display","")).strip() != "")
     return f"<div class='event-block'><div class='event-name'>{name}</div><ul class='compact'>{items}</ul></div>"
+
+
+def _css_tokens_baja_v2() -> str:
+    return """
+      .weekly-recap.theme-baja_v2 {
+        --ink: #111827;
+        --muted: #475569;
+        --border: #e5e7eb;
+        --bg: #ffffff;
+        --card: #ffffff;
+        --sand: #f6e7c6;
+        --ocean: #0ea5a4;
+        --sunset: #ff6a3d;
+        --accent: var(--ocean);
+        --accent2: var(--sunset);
+        --stat-bg: var(--sand);
+        --pill-bg: #ffffff;
+      }
+      .weekly-recap.theme-baja_v2 .weekly-hero__bar {
+        display: block;
+        background: linear-gradient(90deg, #0ea5a4, #ff6a3d);
+      }
+      .weekly-recap.theme-baja_v2 .weekly-range-pill {
+        background: #fff7ed;
+      }
+    """
+
+
+def _css_tokens_newsletter_sep() -> str:
+    return """
+      .weekly-recap.theme-newsletter_sep {
+        --ink: #111827;
+        --muted: #475569;
+        --border: #e5e7eb;
+        --bg: #ffffff;
+        --card: #ffffff;
+        --accent: #1d4ed8;
+        --accent2: #0f766e;
+        --soft: rgba(29, 78, 216, 0.08);
+        --stat-bg: var(--soft);
+        --pill-bg: var(--soft);
+      }
+    """
+
+
+def _css_common_print() -> str:
+    return """
+      * {
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+      }
+      @media print {
+        body {
+          margin: 0;
+        }
+        .weekly-recap {
+          border: none;
+          margin: 0;
+          padding: 0.4in 0.5in;
+          box-shadow: none;
+        }
+        .weekly-hero__bar {
+          box-shadow: none;
+        }
+        .number-card {
+          box-shadow: none;
+        }
+        .no-print {
+          display: none !important;
+        }
+      }
+    """
+
+
+def _css_layout_overrides_for_theme(theme: str) -> str:
+    if theme == "newsletter_sep":
+        return """
+      .weekly-recap.theme-newsletter_sep {
+        background: var(--card);
+      }
+      """
+    if theme == "baja_v2":
+        return """
+      .weekly-recap.theme-baja_v2 {
+        background: var(--card);
+      }
+      """
+    return ""

--- a/jupr_app/ui/pages/weekly_recap_admin.py
+++ b/jupr_app/ui/pages/weekly_recap_admin.py
@@ -57,6 +57,10 @@ def _apply_edits(generated_json: dict, edits_json: dict, candidates: dict[str, l
     if not recap:
         return recap
 
+    if "print_theme" in edits_json:
+        meta = recap.setdefault("meta", {})
+        meta["print_theme"] = edits_json.get("print_theme")
+
     base_desc = generated_json.get("award_descriptions") or DEFAULT_AWARD_DESCRIPTIONS
     edited_desc = edits_json.get("award_descriptions") or {}
     merged_desc = dict(base_desc)
@@ -300,6 +304,18 @@ def render(ctx):
         st.rerun()
 
     st.markdown("<div class='no-print'>", unsafe_allow_html=True)
+    theme_options = {
+        "Baja Flair V2 (Flyer)": "baja_v2",
+        "September Newsletter": "newsletter_sep",
+        "Classic (Neutral)": "classic",
+    }
+    current_theme = edits_json.get("print_theme") or "baja_v2"
+    if current_theme not in theme_options.values():
+        current_theme = "baja_v2"
+    labels = list(theme_options.keys())
+    values = list(theme_options.values())
+    selected_label = st.selectbox("Bulletin style", options=labels, index=values.index(current_theme))
+    edits_json["print_theme"] = theme_options[selected_label]
     preview = st.checkbox("Preview (Print View)", value=print_mode)
     if preview:
         final_json = _apply_edits(generated_json, edits_json, candidates)


### PR DESCRIPTION
### Motivation
- Provide branded, print-ready PDF styling for the Weekly Recap so bulletins match official collateral (Baja Flair V2 flyer or September newsletter palette).  
- Make the theme selectable in the admin UI and ensure the chosen theme is preserved through preview/save/publish flows.  

### Description
- Added a "Bulletin style" select box to the Weekly Recap Admin with options `Baja Flair V2 (Flyer) -> baja_v2`, `September Newsletter -> newsletter_sep`, and `Classic (Neutral) -> classic`, defaulting to `baja_v2` when not set, and persisted to `edits_json["print_theme"]` (file: `jupr_app/ui/pages/weekly_recap_admin.py`).
- Ensure `_apply_edits()` writes the selected theme into the recap metadata at `recap["meta"]["print_theme"]`, creating `meta` if missing for backward compatibility (file: `jupr_app/ui/pages/weekly_recap_admin.py`).
- Refactored weekly recap CSS to use theme tokens and print-safe rules, introducing helper functions `_css_tokens_baja_v2()`, `_css_tokens_newsletter_sep()`, `_css_common_print()`, and `_css_layout_overrides_for_theme(theme)` and applying them in `render_weekly_recap()` (file: `jupr_app/ui/components/weekly_recap_layout.py`).
- Implemented the two theme token sets (`baja_v2` and `newsletter_sep`) using CSS variables for `--ink`, `--muted`, `--border`, `--card`, `--accent`, `--accent2`, and theme-specific tokens like `--sand`/`--ocean`/`--sunset` or `--soft` to style stat tiles, accents, and pill elements.
- Minimal structural/markup updates to the header to support branding: added a `weekly-hero` with a thin top gradient bar (visible for Baja V2), a subtitle line `Tres Palapas Baja Pickleball Resort • Los Barriles, BCS`, and a right-aligned date range pill; numbers strip and section headers were restyled to use variables and print-safe borders/accents.
- Print handling improvements: added `-webkit-print-color-adjust: exact` / `print-color-adjust: exact`, removed heavy shadows in `@media print`, enforced print-safe backgrounds, and ensured links are underlined for editorial theme consistency.
- Kept existing content generation and blocks (`spotlight_html`, `leagues_html`, `rr_html`) unchanged to maintain backward compatibility and existing data flows.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988eba7e0fc8326b844d7cb59d9e0ba)