### PR TITLE
Add admin-editable Around the Club descriptions and render as themed cards

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -29,6 +29,13 @@ DEFAULT_AWARD_DESCRIPTIONS = {
     ),
 }
 
+DEFAULT_AROUND_LEAGUE_DESCRIPTION = (
+    "Weekly highlights from this league — top performer and biggest jump based on matches recorded this week."
+)
+DEFAULT_AROUND_RR_DESCRIPTION = (
+    "Pop-up results from this event — highlights based on matches recorded this week."
+)
+
 
 @dataclass
 class SpotlightCandidate:
@@ -110,6 +117,7 @@ def _compute_weekly_recap_payload(
         id_to_name,
         supabase,
     )
+    around_descriptions = apply_around_descriptions(around_club, None)
 
     week_end = week_start + timedelta(days=6)
     recap = {
@@ -120,6 +128,7 @@ def _compute_weekly_recap_payload(
         "spotlight": [item.__dict__ for item in spotlight],
         "award_descriptions": dict(DEFAULT_AWARD_DESCRIPTIONS),
         "around_club": around_club,
+        "around_descriptions": around_descriptions,
         "looking_ahead": ["", "", ""],
         "meta": {
             "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -772,6 +781,43 @@ def _build_around_club(
         )
 
     return {"leagues": league_items, "round_robins": rr_items}
+
+
+def build_around_descriptions(around_club: dict) -> dict[str, str]:
+    descriptions: dict[str, str] = {}
+    for league_item in around_club.get("leagues", []) or []:
+        league_name = str(league_item.get("league_name", "") or "").strip()
+        if league_name:
+            descriptions[f"LEAGUE:{league_name}"] = DEFAULT_AROUND_LEAGUE_DESCRIPTION
+    for rr_item in around_club.get("round_robins", []) or []:
+        event_id = str(rr_item.get("event_id", "") or "").strip()
+        if event_id:
+            descriptions[f"RR:{event_id}"] = DEFAULT_AROUND_RR_DESCRIPTION
+    return descriptions
+
+
+def apply_around_descriptions(around_club: dict, around_descriptions: dict | None) -> dict[str, str]:
+    defaults = build_around_descriptions(around_club)
+    merged = dict(defaults)
+    merged.update(around_descriptions or {})
+
+    for league_item in around_club.get("leagues", []) or []:
+        league_name = str(league_item.get("league_name", "") or "").strip()
+        if not league_name:
+            continue
+        desc_key = f"LEAGUE:{league_name}"
+        league_item["desc_key"] = desc_key
+        league_item["description"] = merged.get(desc_key, defaults.get(desc_key, DEFAULT_AROUND_LEAGUE_DESCRIPTION))
+
+    for rr_item in around_club.get("round_robins", []) or []:
+        event_id = str(rr_item.get("event_id", "") or "").strip()
+        if not event_id:
+            continue
+        desc_key = f"RR:{event_id}"
+        rr_item["desc_key"] = desc_key
+        rr_item["description"] = merged.get(desc_key, defaults.get(desc_key, DEFAULT_AROUND_RR_DESCRIPTION))
+
+    return merged
 
 
 def _event_highlights(

--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -5,6 +5,11 @@ from html import escape
 
 import streamlit as st
 
+from jupr_app.domain.recaps.weekly_recap import (
+    DEFAULT_AROUND_LEAGUE_DESCRIPTION,
+    DEFAULT_AROUND_RR_DESCRIPTION,
+    build_around_descriptions,
+)
 
 def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | None = None) -> None:
     week_start = recap.get("week_start")
@@ -24,6 +29,7 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
     numbers = recap.get("numbers", {})
     spotlight = recap.get("spotlight", [])
     around = recap.get("around_club", {})
+    around_descriptions = recap.get("around_descriptions") or build_around_descriptions(around)
     looking_ahead = recap.get("looking_ahead", []) or []
 
     league_items = around.get("leagues", []) or []
@@ -34,19 +40,34 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
         for item in (spotlight or [])
         if isinstance(item, dict)
     )
-    leagues_html = "".join(
-        _render_event_block((item or {}).get("league_name", "League"), (item or {}).get("highlights", []))
+    around_cards_html = "".join(
+        _render_event_card(
+            title=(item or {}).get("league_name", "League"),
+            description=_resolve_around_description(item or {}, around_descriptions, kind="league"),
+            highlights=(item or {}).get("highlights", []),
+            kind="league",
+        )
         for item in (league_items or [])
         if isinstance(item, dict)
     )
-    rr_html = "".join(
-        _render_event_block((item or {}).get("event_name", "Pop-Up Event"), (item or {}).get("highlights", []))
+    around_cards_html += "".join(
+        _render_event_card(
+            title=(item or {}).get("event_name", "Pop-Up Event"),
+            description=_resolve_around_description(item or {}, around_descriptions, kind="rr"),
+            highlights=(item or {}).get("highlights", []),
+            kind="rr",
+        )
         for item in (rr_items or [])
         if isinstance(item, dict)
     )
     looking_ahead_html = "".join(
-        f"<li>{item}</li>" for item in (looking_ahead or [])
+        f"<li>{escape(str(item))}</li>" for item in (looking_ahead or [])
         if str(item).strip() != ""
+    )
+    looking_card_html = _render_simple_card(
+        title="Looking Ahead",
+        body_html=f"<ul class='compact looking-ahead'>{looking_ahead_html}</ul>",
+        accent_class="accent-sunset",
     )
 
     print_mode_notice = "<!-- PRINT MODE -->" if print_view else ""
@@ -189,12 +210,51 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
         grid-template-columns: 1fr;
         gap: 10px;
       }}
+      .event-grid {{
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 10px;
+      }}
       .award-card {{
         border: 1px solid var(--border, #e5e7eb);
         border-left: 6px solid var(--accent, #111827);
         border-radius: 12px;
         background: var(--card, #ffffff);
         padding: 12px;
+      }}
+      .event-card,
+      .section-card {{
+        border: 1px solid var(--border, #e5e7eb);
+        border-left: 5px solid var(--accent, #111827);
+        border-radius: 12px;
+        background: var(--card, #ffffff);
+        padding: 12px;
+      }}
+      .event-card--rr {{
+        border-left-color: var(--accent2, var(--accent));
+      }}
+      .section-card.accent-sunset {{
+        border-left-color: var(--sunset, var(--accent2, var(--accent)));
+      }}
+      .section-card.accent-ocean {{
+        border-left-color: var(--ocean, var(--accent));
+      }}
+      .event-card__title,
+      .section-card__title {{
+        font-weight: 700;
+        font-size: 14px;
+      }}
+      .event-card__desc {{
+        margin-top: 6px;
+        color: var(--muted, #475569);
+        font-size: 12.5px;
+        line-height: 1.35;
+      }}
+      .event-card__body,
+      .section-card__body {{
+        margin-top: 8px;
+        font-size: 13px;
+        line-height: 1.45;
       }}
       .award-card__title {{
         font-weight: 800;
@@ -227,9 +287,15 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
         .award-grid {{
           grid-template-columns: 1fr 1fr;
         }}
+        .event-grid {{
+          grid-template-columns: 1fr 1fr;
+        }}
       }}
       @media print {{
         .award-grid {{
+          grid-template-columns: 1fr 1fr;
+        }}
+        .event-grid {{
           grid-template-columns: 1fr 1fr;
         }}
       }}
@@ -268,20 +334,12 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
       </div>
       <div class=\"section\">
         <h3>Around the Club</h3>
-        <div class=\"subsection\">
-          <h4>Leagues</h4>
-          {leagues_html}
-        </div>
-        <div class=\"subsection\">
-          <h4>Round Robins</h4>
-          {rr_html}
+        <div class=\"event-grid\">
+          {around_cards_html}
         </div>
       </div>
       <div class=\"section\">
-        <h3>Looking Ahead</h3>
-        <ul class=\"compact looking-ahead\">
-          {looking_ahead_html}
-        </ul>
+        {looking_card_html}
       </div>
     </div>
     """
@@ -313,10 +371,43 @@ def _render_award_card(item: dict, *, theme: str) -> str:
     )
 
 
-def _render_event_block(name: str, highlights: list[dict]) -> str:
+def _resolve_around_description(item: dict, around_descriptions: dict[str, str], *, kind: str) -> str:
+    description = str(item.get("description", "") or "").strip()
+    if description:
+        return description
+    if kind == "league":
+        name = str(item.get("league_name", "") or "").strip()
+        desc_key = item.get("desc_key") or f"LEAGUE:{name}"
+        return around_descriptions.get(desc_key, DEFAULT_AROUND_LEAGUE_DESCRIPTION)
+    event_id = str(item.get("event_id", "") or "").strip()
+    desc_key = item.get("desc_key") or f"RR:{event_id}"
+    return around_descriptions.get(desc_key, DEFAULT_AROUND_RR_DESCRIPTION)
+
+
+def _render_event_card(title: str, description: str, highlights: list[dict], *, kind: str) -> str:
     safe = [h for h in (highlights or []) if isinstance(h, dict)]
-    items = "".join(f"<li>{h.get('display','')}</li>" for h in safe if str(h.get("display","")).strip() != "")
-    return f"<div class='event-block'><div class='event-name'>{name}</div><ul class='compact'>{items}</ul></div>"
+    items = "".join(
+        f"<li>{escape(str(h.get('display', '')))}</li>"
+        for h in safe
+        if str(h.get("display", "")).strip() != ""
+    )
+    desc_html = f"<div class='event-card__desc'>{escape(description)}</div>" if description else ""
+    return (
+        f"<div class='event-card event-card--{kind}'>"
+        f"<div class='event-card__title'>{escape(title)}</div>"
+        f"{desc_html}"
+        f"<div class='event-card__body'><ul class='compact'>{items}</ul></div>"
+        "</div>"
+    )
+
+
+def _render_simple_card(title: str, body_html: str, *, accent_class: str) -> str:
+    return (
+        f"<div class='section-card {accent_class}'>"
+        f"<div class='section-card__title'>{escape(title)}</div>"
+        f"<div class='section-card__body'>{body_html}</div>"
+        "</div>"
+    )
 
 
 def _css_tokens_baja_v2() -> str:
@@ -352,6 +443,12 @@ def _css_tokens_baja_v2() -> str:
       .weekly-recap.theme-baja_v2 .award-card.accent-sunset {
         background: rgba(255, 106, 61, 0.06);
       }
+      .weekly-recap.theme-baja_v2 .event-card {
+        background: rgba(246, 231, 198, 0.35);
+      }
+      .weekly-recap.theme-baja_v2 .section-card {
+        background: rgba(255, 255, 255, 0.85);
+      }
     """
 
 
@@ -371,6 +468,10 @@ def _css_tokens_newsletter_sep() -> str:
       }
       .weekly-recap.theme-newsletter_sep .award-card.accent-ocean,
       .weekly-recap.theme-newsletter_sep .award-card.accent-sunset {
+        background: var(--soft, rgba(29, 78, 216, 0.06));
+      }
+      .weekly-recap.theme-newsletter_sep .event-card,
+      .weekly-recap.theme-newsletter_sep .section-card {
         background: var(--soft, rgba(29, 78, 216, 0.06));
       }
     """

--- a/jupr_app/ui/pages/weekly_recap_admin.py
+++ b/jupr_app/ui/pages/weekly_recap_admin.py
@@ -9,6 +9,10 @@ from postgrest.exceptions import APIError
 
 from jupr_app.domain.recaps.weekly_recap import (
     DEFAULT_AWARD_DESCRIPTIONS,
+    DEFAULT_AROUND_LEAGUE_DESCRIPTION,
+    DEFAULT_AROUND_RR_DESCRIPTION,
+    apply_around_descriptions,
+    build_around_descriptions,
     compute_weekly_recap,
     get_spotlight_candidates,
 )
@@ -65,7 +69,17 @@ def _apply_edits(generated_json: dict, edits_json: dict, candidates: dict[str, l
     edited_desc = edits_json.get("award_descriptions") or {}
     merged_desc = dict(base_desc)
     merged_desc.update(edited_desc)
+
     recap["award_descriptions"] = merged_desc
+
+    base_around_desc = generated_json.get("around_descriptions") or build_around_descriptions(
+        recap.get("around_club") or {}
+    )
+    edited_around_desc = edits_json.get("around_descriptions") or {}
+    merged_around_desc = dict(base_around_desc)
+    merged_around_desc.update(edited_around_desc)
+    recap["around_descriptions"] = merged_around_desc
+    apply_around_descriptions(recap.get("around_club") or {}, merged_around_desc)
 
     looking_ahead = edits_json.get("looking_ahead")
     if looking_ahead:
@@ -186,6 +200,13 @@ def render(ctx):
     merged_desc = dict(base_desc)
     merged_desc.update(edited_desc)
 
+    base_around_desc = generated_json.get("around_descriptions") or build_around_descriptions(
+        generated_json.get("around_club") or {}
+    )
+    edits_around_desc = edits_json.get("around_descriptions") or {}
+    merged_around_desc = dict(base_around_desc)
+    merged_around_desc.update(edits_around_desc)
+
     st.subheader("Edit Draft")
 
     default_looking = edits_json.get("looking_ahead") or generated_json.get("looking_ahead") or ["", "", ""]
@@ -215,6 +236,37 @@ def render(ctx):
             key=f"award_desc_{key}",
         )
     edits_json["award_descriptions"] = award_desc_edits
+
+    st.subheader("Around the Club Descriptions")
+    around_desc_edits = edits_json.get("around_descriptions") or {}
+    leagues = (generated_json.get("around_club") or {}).get("leagues") or []
+    round_robins = (generated_json.get("around_club") or {}).get("round_robins") or []
+    for league_item in leagues:
+        league_name = str(league_item.get("league_name", "") or "").strip()
+        if not league_name:
+            continue
+        key = f"LEAGUE:{league_name}"
+        default_text = base_around_desc.get(key, DEFAULT_AROUND_LEAGUE_DESCRIPTION)
+        around_desc_edits[key] = st.text_area(
+            f"League: {league_name}",
+            value=merged_around_desc.get(key, default_text),
+            height=100,
+            key=f"around_desc_{key}",
+        )
+    for rr_item in round_robins:
+        event_id = str(rr_item.get("event_id", "") or "").strip()
+        if not event_id:
+            continue
+        key = f"RR:{event_id}"
+        label = rr_item.get("event_name", "Pop-Up Event") or "Pop-Up Event"
+        default_text = base_around_desc.get(key, DEFAULT_AROUND_RR_DESCRIPTION)
+        around_desc_edits[key] = st.text_area(
+            f"Round Robin: {label}",
+            value=merged_around_desc.get(key, default_text),
+            height=100,
+            key=f"around_desc_{key}",
+        )
+    edits_json["around_descriptions"] = around_desc_edits
 
     st.markdown("**Spotlight Reel Overrides**")
     overrides = edits_json.get("spotlight_overrides", {})


### PR DESCRIPTION
### Motivation
- Provide stable, editable descriptions for the "Around the Club" items so admins can customize league and pop‑up blurbs that appear in the weekly bulletin.
- Make the Around the Club and Looking Ahead sections more visually consistent with Spotlight by rendering them as themed cards that stay print‑friendly.

### Description
- In `jupr_app/domain/recaps/weekly_recap.py` added default description constants `DEFAULT_AROUND_LEAGUE_DESCRIPTION` and `DEFAULT_AROUND_RR_DESCRIPTION`, added `build_around_descriptions` and `apply_around_descriptions`, and include `around_descriptions` in generated recap payloads while injecting `desc_key`/`description` into each `around_club` item for rendering convenience.
- In `jupr_app/ui/pages/weekly_recap_admin.py` merged generated + edited `around_descriptions`, added an "Around the Club Descriptions" section under `Edit Draft` that renders editable `st.text_area` fields for each league and round‑robin (keys use `LEAGUE:<name>` and `RR:<event_id>`), and updated `_apply_edits` to merge edits and apply them into the recap structure.
- In `jupr_app/ui/components/weekly_recap_layout.py` added helpers `_resolve_around_description`, `_render_event_card`, and `_render_simple_card`; replaced the plain event blocks with a responsive `.event-grid` of themed `.event-card` entries and rendered `Looking Ahead` as a single themed card, plus CSS tokens/styles for both `baja_v2` and `newsletter_sep` themes to keep print output clean.

### Testing
- No automated tests were executed for this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988f304bc6883268345c588b05928f5)