### PR TITLE
Fix weekly recap print pagination + tighten spotlight + hide empty Looking Ahead

### DIFF
--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -74,11 +74,15 @@ def build_weekly_recap_html(
         looking_ahead_accent = "accent-sand"
     elif theme == "newsletter_sep":
         looking_ahead_accent = "accent-ocean"
-    looking_card_html = _render_simple_card(
-        title="Looking Ahead",
-        body_html=f"<ul class='compact looking-ahead'>{looking_ahead_html}</ul>",
-        accent_class=looking_ahead_accent,
-    )
+    # Only render "Looking Ahead" when there is at least one non-empty bullet.
+    looking_card_html = ""
+    if looking_ahead_html.strip():
+        looking_card_html = _render_simple_card(
+            title="Looking Ahead",
+            body_html=f"<ul class='compact looking-ahead'>{looking_ahead_html}</ul>",
+            accent_class=looking_ahead_accent,
+        )
+    looking_section_html = f"<div class='section'>{looking_card_html}</div>" if looking_card_html else ""
 
     print_mode_notice = "<!-- PRINT MODE -->" if print_view else ""
     print_view_css = ".no-print { display: none !important; }" if print_view else ""
@@ -330,6 +334,50 @@ def build_weekly_recap_html(
             .event-grid {{
               grid-template-columns: 1fr 1fr;
             }}
+            /* ---- Pagination safety: prevent cards/sections from splitting across pages ---- */
+            .section,
+            .award-card,
+            .event-card,
+            .section-card,
+            .number-card {{
+              break-inside: avoid;
+              page-break-inside: avoid;
+            }}
+
+            /* ---- Print tightening: Spotlight cards become more bulletin-friendly ---- */
+            .weekly-recap {{
+              padding: 0.35in 0.45in;
+            }}
+            .section {{
+              margin-top: 10px;
+            }}
+            .award-grid,
+            .event-grid {{
+              gap: 8px;
+            }}
+            .award-card,
+            .event-card,
+            .section-card {{
+              padding: 10px;
+            }}
+            .award-card__desc {{
+              font-size: 11.5px;
+              line-height: 1.25;
+              /* Clamp long descriptions so Spotlight doesn't bloat the print/PDF */
+              display: -webkit-box;
+              -webkit-line-clamp: 2;
+              -webkit-box-orient: vertical;
+              overflow: hidden;
+            }}
+            .award-card__body {{
+              margin-top: 6px;
+              font-size: 12.5px;
+              line-height: 1.35;
+            }}
+            ul.compact li {{
+              margin-bottom: 4px;
+              font-size: 12.5px;
+            }}
           }}
           .looking-ahead li {{
             font-size: 13px;
@@ -372,9 +420,7 @@ def build_weekly_recap_html(
               {around_cards_html}
             </div>
           </div>
-          <div class="section">
-            {looking_card_html}
-          </div>
+          {looking_section_html}
         </div>
       </body>
     </html>


### PR DESCRIPTION
### Motivation
- Prevent cards and sections from splitting across pages when producing PDFs via the browser print dialog. 
- Make the Spotlight Reel more compact in print view by tightening spacing and clamping long descriptions so the printed recap stays concise. 
- Avoid rendering an empty "Looking Ahead" card when all bullets are blank. 

### Description
- Conditionally build and insert `looking_section_html` so the "Looking Ahead" card is only rendered when `looking_ahead_html` contains non-empty bullets. 
- Add print-specific CSS under `@media print` that sets `break-inside: avoid` and `page-break-inside: avoid` for `.section`, `.award-card`, `.event-card`, `.section-card`, and `.number-card` to keep elements together across page breaks. 
- Tighten print spacing by reducing padding/margins and grid gaps for `.award-grid`/`.event-grid` and reduce font sizes for award body and list items in print. 
- Clamp award descriptions in print to two lines using `display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;` so Spotlight entries cannot bloat the PDF. 
- Inject `looking_section_html` in the template in place of the previous unconditional Looking Ahead section. 

### Testing
- Applied the patch and committed the changes with `git add` / `git commit`, and the commit completed successfully. 
- Attempted an automated Playwright navigation to `/?page=weekly_recap&public=1&print=1` to exercise the print view, but Chromium crashed in this environment so the print/PDF flow could not be validated (Playwright run failed). 
- No other automated tests were run against the print/PDF rendering in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fa76e19c8326a89e1bd39933bd91)