### PR TITLE
Render Weekly Recap with components.html to prevent raw CSS display

### DIFF
--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from html import escape
 
 import streamlit as st
+import streamlit.components.v1 as components
 
 from jupr_app.domain.recaps.weekly_recap import (
     DEFAULT_AROUND_LEAGUE_DESCRIPTION,
@@ -430,7 +431,7 @@ def build_weekly_recap_html(
 
 def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | None = None) -> None:
     html = build_weekly_recap_html(recap, print_view=print_view, title_override=title_override)
-    st.markdown(html, unsafe_allow_html=True)
+    components.html(html, height=None, scrolling=False)
 
 
 def _render_award_card(item: dict, *, theme: str) -> str:


### PR DESCRIPTION
### Motivation
- Streamlit was escaping the inline `<style>` block when the Weekly Recap HTML was rendered via `st.markdown(...)`, causing raw CSS text to appear on the page and breaking print/PDF styling.

### Description
- Import `streamlit.components.v1 as components` and replace the call to `st.markdown(html, unsafe_allow_html=True)` with `components.html(html, height=None, scrolling=False)` in `jupr_app/ui/components/weekly_recap_layout.py` to render the full HTML blob without markdown escaping.

### Testing
- Attempted to capture a screenshot by navigating to `http://127.0.0.1:8501/?page=weekly_recap` with a Playwright script, but the page was not reachable and the run failed with `net::ERR_EMPTY_RESPONSE` so visual validation could not be completed.
- Change was staged and committed locally with `git commit` (no unit tests were executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fc1a0350832689fa367cbe201aaf)