### PR TITLE
Fix weekly recap iframe rendering

### DIFF
--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -431,7 +431,10 @@ def build_weekly_recap_html(
 
 def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | None = None) -> None:
     html = build_weekly_recap_html(recap, print_view=print_view, title_override=title_override)
-    components.html(html, height=None, scrolling=False)
+    if print_view:
+        st.markdown(html, unsafe_allow_html=True)
+    else:
+        components.html(html, height=2400, scrolling=True)
 
 
 def _render_award_card(item: dict, *, theme: str) -> str:


### PR DESCRIPTION
### Motivation
- Prevent the Weekly Recap content from being clipped by the default iframe height when using `components.html`, and ensure print output captures the full recap.

### Description
- In `jupr_app/ui/components/weekly_recap_layout.py` switch `render_weekly_recap` to use `st.markdown(html, unsafe_allow_html=True)` when `print_view` is true and use `components.html(html, height=2400, scrolling=True)` otherwise to provide a generous iframe height and enable scrolling.

### Testing
- Started the Streamlit app and ran a Playwright script to capture `/?page=weekly_recap`, which produced a screenshot artifact successfully; no unit tests were run for this UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fced80948326984d675df0dcaccf)