### PR TITLE
Defer Streamlit app imports to avoid import-time session_state errors

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -10,13 +10,6 @@ from collections.abc import Mapping
 import streamlit as st
 import pandas as pd  # kept because pages may rely on it
 
-from jupr_app.data.client import make_supabase
-from jupr_app.data.load import load_data
-from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
-from jupr_app.ui.context import AppContext
-from jupr_app.ui.theme_clean import apply_clean_theme
-from jupr_app.ui.url import qp_get
-
 
 # -------------------------
 # CONFIG
@@ -127,6 +120,8 @@ def get_supabase():
     admin_password = "..."  # your chosen admin login password
     admin_session_secret = "..."  # used to sign short-lived admin sessions
     """
+    from jupr_app.data.client import make_supabase
+
     url = get_secret(["supabase", "url"], "")
     key = get_secret(["supabase", "anon_key"], "") or get_secret(["supabase", "key"], "")
 
@@ -156,6 +151,8 @@ def get_supabase():
 
 @st.cache_data(ttl=30)
 def get_data(club_id: str):
+    from jupr_app.data.load import load_data
+
     supabase = get_supabase()
     return load_data(supabase, club_id, match_limit=5000)
 
@@ -203,6 +200,10 @@ def main():
     Main Streamlit entrypoint. Keep this deterministic for reloads.
     """
     try:
+        from jupr_app.ui.context import AppContext
+        from jupr_app.ui.theme_clean import apply_clean_theme
+        from jupr_app.ui.url import qp_get
+
         st.set_page_config(
             page_title="JUPR Leagues",
             layout="wide",
@@ -304,6 +305,8 @@ def main():
             )
 
         if df_player_badges is not None and df_player_badges.empty:
+            from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
+
             player_ids = []
             if df_players_all is not None and not df_players_all.empty and "id" in df_players_all.columns:
                 player_ids = df_players_all["id"].dropna().astype(int).tolist()


### PR DESCRIPTION
### Motivation
- Prevent crashes on startup when imported modules access `st.session_state[...]` at import time by avoiding import-time side effects.  
- Keep all `st.session_state` usage inside runtime/render scopes so the app can start even when `session_state` is empty.  
- Make the app more robust to Streamlit reloads and import-time execution order issues.

### Description
- Moved `make_supabase` import into the runtime `get_supabase()` function so Supabase client creation is deferred until needed.  
- Moved `load_data` import into the runtime `get_data()` function so data loading helpers are only imported at call time.  
- Deferred UI-related imports (`AppContext`, `apply_clean_theme`, `qp_get`) into `main()` and the `enqueue_badge_eval` import into the badge-enqueue branch so page modules are lazily imported at render time.  
- All changes are contained in `streamlit_app.py` and preserve existing behavior while eliminating import-time module dependencies.

### Testing
- Ran repository-wide static searches (`rg`) and an AST-based script to detect module-level `st.session_state[...]` subscripts, which reported no module-top-level occurrences after the change (searches succeeded).  
- Performed local verification of the modified `streamlit_app.py` file contents and committed the change (commit succeeded).  
- No unit or integration test suite (e.g. `pytest`) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fed2ef8c832690c5774a35497e08)