### PR TITLE
Always render Weekly Recap via components.html (iframe)

### DIFF
--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -431,12 +431,8 @@ def build_weekly_recap_html(
 
 def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | None = None) -> None:
     html = build_weekly_recap_html(recap, print_view=print_view, title_override=title_override)
-    # Admin preview uses iframe to prevent Streamlit escaping <style>.
-    render_mode = st.session_state.get("weekly_recap_render_mode", "")
-    if render_mode == "iframe":
-        components.html(html, height=2600, scrolling=True)
-    else:
-        st.markdown(html, unsafe_allow_html=True)
+    height = 2600 if not print_view else 3000
+    components.html(html, height=height, scrolling=True)
 
 
 def _render_award_card(item: dict, *, theme: str) -> str:


### PR DESCRIPTION
### Motivation
- Fix an issue where CSS in the recap HTML (rules starting with `* { ... }`) was being interpreted as Markdown list items when rendered with `st.markdown`, causing raw CSS and bullets to appear on the Weekly Recap page.

### Description
- Update `render_weekly_recap` to always render the built HTML via `components.html(html, height=..., scrolling=True)` (using `2600` by default and `3000` for print view) and remove the `st.markdown(..., unsafe_allow_html=True)` fallback.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69890262f13c8326b7c7e70a7c7e9d19)