### PR TITLE
Use flexbox on print to fix WeasyPrint grid collapse in weekly recap PDF

### DIFF
--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -329,10 +329,45 @@ def build_weekly_recap_html(
             }}
           }}
           @media print {{
+            /* ---- WeasyPrint/PDF safety: avoid CSS Grid (can collapse to text flow) ---- */
+            .numbers-strip {{
+              display: flex !important;
+              flex-wrap: wrap !important;
+              gap: 10px !important;
+            }}
+            .number-card {{
+              flex: 1 1 calc(20% - 10px) !important;
+              min-width: 120px !important;
+            }}
+
+            .award-grid,
+            .event-grid {{
+              display: flex !important;
+              flex-wrap: wrap !important;
+              gap: 10px !important;
+            }}
+            .award-card,
+            .event-card,
+            .section-card {{
+              box-sizing: border-box !important;
+            }}
+            .award-card,
+            .event-card {{
+              flex: 1 1 calc(50% - 10px) !important;
+              min-width: 280px !important;
+            }}
+
+            /* If the page width is narrow, fall back to single column */
+            @page {{
+              size: Letter;
+            }}
+
             .award-grid {{
+              /* legacy rule kept for browsers, but flex overrides above handle PDF */
               grid-template-columns: 1fr 1fr;
             }}
             .event-grid {{
+              /* legacy rule kept for browsers, but flex overrides above handle PDF */
               grid-template-columns: 1fr 1fr;
             }}
             /* ---- Pagination safety: prevent cards/sections from splitting across pages ---- */
@@ -378,6 +413,13 @@ def build_weekly_recap_html(
             ul.compact li {{
               margin-bottom: 4px;
               font-size: 12.5px;
+            }}
+          }}
+          @media print and (max-width: 640px) {{
+            .award-card,
+            .event-card {{
+              flex: 1 1 100% !important;
+              min-width: 0 !important;
             }}
           }}
           .looking-ahead li {{


### PR DESCRIPTION
### Motivation
- WeasyPrint does not reliably support CSS Grid which caused the weekly recap PDF to collapse into a linear text flow, so print-specific layout fallbacks are needed to match the on-page preview.

### Description
- Added `@media print` CSS overrides in `jupr_app/ui/components/weekly_recap_layout.py` to replace grid layouts with flexbox for the `.numbers-strip`, `.award-grid`, and `.event-grid` selectors.
- Enforced two-column card sizing for print with `.award-card` and `.event-card` set to `flex: 1 1 calc(50% - 10px)` and `min-width` fallbacks, and added a narrow-width fallback `@media print and (max-width: 640px)` forcing single-column cards with `flex: 1 1 100%`.
- Preserved existing pagination safety rules (`break-inside` / `page-break-inside`) and print tightening (padding, gaps, description clamping), and left legacy `grid-template-columns` rules in place for browser behavior.
- Added an `@page { size: Letter; }` rule to standardize print sizing for PDF rendering.

### Testing
- No automated tests were run for this layout-only change (visual verification recommended: Download PDF via Weekly Recap Admin and compare to print preview).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698903bc4c848326b5587d7ca144ad06)