### PR TITLE
Fix raw HTML badge wrapper leak in Leaderboards Trophy View

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -1353,6 +1353,11 @@ def render(ctx):
             badge_html = "".join(
                 f'<span class="lb-badge">{html.escape(b)}</span>' for b in status_badges
             )
+            badge_row_html = ""
+            if badge_html.strip():
+                badge_row_html = (
+                    f'<div class="lb-row" style="gap:6px; margin-top:8px;">{badge_html}</div>'
+                )
 
             story_badges_html = ""
             player_id = row.get("_pid")
@@ -1397,7 +1402,7 @@ def render(ctx):
                     <span style="color:{gain_color};">{gain_val:+.3f} Δ</span>
                 </div>
                 {story_badges_html}
-                <div class="lb-row" style="gap:6px; margin-top:8px;">{badge_html}</div>
+                {badge_row_html}
             </div>
             """
             st.markdown(textwrap.dedent(card_html), unsafe_allow_html=True)


### PR DESCRIPTION
### Motivation
- Prevent stray raw HTML from appearing in Trophy View rows when `badge_html` is empty by avoiding rendering an empty `<div class="lb-row">` wrapper.

### Description
- In `jupr_app/ui/pages/leaderboards.py` the Trophy View loop now builds `badge_row_html` only when `badge_html.strip()` is non-empty and replaces the unconditional `<div class="lb-row" ...>{badge_html}</div>` insertion with `{badge_row_html}` so the wrapper is emitted only when there is badge content.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/leaderboards.py` (passed) and performed a smoke startup with `streamlit run streamlit_app.py --server.headless true --server.port 8765` which launched and a screenshot of the Trophy View was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b520eb3d0832687a980b7cf97efb3)