### PR TITLE
Update weekly recap Challenge Ladder to tiered match results

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -7,6 +7,8 @@ from zoneinfo import ZoneInfo
 import pandas as pd
 from postgrest.exceptions import APIError
 
+from jupr_app.domain.challenge_ladder import normalize_tier_id, tier_idx, tier_title
+
 DEFAULT_AWARD_DESCRIPTIONS = {
     "TOP_PERFORMER_WEEK": (
         "The strongest overall performance of the week, based on win–loss results across multiple matches. "
@@ -888,62 +890,66 @@ def _fetch_rr_event_names(supabase, rr_events: list[str]) -> dict[str, str]:
 
 
 def _empty_challenge_ladder_summary() -> dict:
-    return {"count": 0, "by_tier": [], "highlights": []}
+    return {"title": "Match Results", "by_tier": []}
+
+
+def _format_rank(rank_value) -> str:
+    rank_int = _safe_int(rank_value)
+    return f"#{rank_int}" if rank_int is not None else "#?"
+
+
+def _tier_label_for_recap(tier_id: str) -> str:
+    normalized_tier_id = normalize_tier_id(tier_id)
+    label = str(tier_title(normalized_tier_id) or normalized_tier_id)
+    primary_label = label.split("—", 1)[0].strip()
+    if not primary_label:
+        primary_label = normalized_tier_id or "Unknown"
+    if not primary_label.lower().endswith("tier"):
+        primary_label = f"{primary_label} Tier"
+    return primary_label
 
 
 def _summarize_challenge_ladder_rows(rows: list[dict], id_to_name: dict[int, str]) -> dict:
-    completed_rows: list[dict] = []
+    grouped_lines: dict[str, list[str]] = {}
+    tier_sort_values: dict[str, int] = {}
+
     for row in rows or []:
-        winner_id = _safe_int(row.get("winner_id"))
-        if winner_id is None:
-            continue
-        completed_rows.append(row)
-
-    if not completed_rows:
-        return _empty_challenge_ladder_summary()
-
-    tier_counts: dict[str, int] = {}
-    highlights: list[dict] = []
-    for row in completed_rows:
-        tier_id = str(row.get("tier_id") or "Unknown")
-        tier_counts[tier_id] = tier_counts.get(tier_id, 0) + 1
-
-        if len(highlights) >= 6:
-            continue
-
-        challenge_id = row.get("id")
         winner_id = _safe_int(row.get("winner_id"))
         challenger_id = _safe_int(row.get("challenger_id"))
         defender_id = _safe_int(row.get("defender_id"))
-        if winner_id is None:
+        status = str(row.get("status") or "").strip().upper()
+        if status != "COMPLETED" or winner_id is None:
             continue
 
+        normalized_tier_id = normalize_tier_id(str(row.get("tier_id") or ""))
+        tier_label = _tier_label_for_recap(normalized_tier_id)
+        tier_sort_values[tier_label] = tier_idx(normalized_tier_id)
+
+        challenger_name = id_to_name.get(challenger_id, f"#{challenger_id}") if challenger_id is not None else "Unknown"
+        defender_name = id_to_name.get(defender_id, f"#{defender_id}") if defender_id is not None else "Unknown"
+        challenger_rank = _format_rank(row.get("challenger_rank_at_create"))
+        defender_rank = _format_rank(row.get("defender_rank_at_create"))
+
         if winner_id == challenger_id:
-            loser_id = defender_id
-            outcome = "Challenger win"
-        elif winner_id == defender_id:
-            loser_id = challenger_id
-            outcome = "Defended"
+            line = f"{challenger_rank} {challenger_name} beat {defender_rank} {defender_name}"
         else:
-            loser_id = challenger_id if challenger_id is not None else defender_id
-            outcome = "Completed"
+            line = f"{defender_rank} {defender_name} defended vs {challenger_rank} {challenger_name}"
 
-        winner_name = id_to_name.get(winner_id, f"#{winner_id}")
-        loser_name = id_to_name.get(loser_id, f"#{loser_id}") if loser_id is not None else "Unknown"
-        highlights.append(
-            {
-                "display": (
-                    f"{tier_id} • {winner_name} beat {loser_name} "
-                    f"({outcome}) • #{challenge_id}"
-                )
-            }
+        grouped_lines.setdefault(tier_label, []).append(line)
+
+    if not grouped_lines:
+        return _empty_challenge_ladder_summary()
+
+    by_tier = [
+        {"tier": tier, "lines": lines}
+        for tier, lines in sorted(
+            grouped_lines.items(),
+            key=lambda item: (tier_sort_values.get(item[0], 999), item[0]),
         )
-
-    by_tier = [{"tier_id": tier_id, "count": count} for tier_id, count in sorted(tier_counts.items())]
+    ]
     return {
-        "count": len(completed_rows),
+        "title": "Match Results",
         "by_tier": by_tier,
-        "highlights": highlights,
     }
 
 
@@ -957,7 +963,10 @@ def _fetch_challenge_ladder_week_summary(
     if supabase is None:
         return _empty_challenge_ladder_summary()
 
-    select_cols = "id,tier_id,challenger_id,defender_id,winner_id,status,completed_at"
+    select_cols = (
+        "id,tier_id,challenger_id,defender_id,winner_id,status,completed_at,"
+        "challenger_rank_at_create,defender_rank_at_create"
+    )
     try:
         response = (
             supabase.table("ladder_challenges")

--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -67,22 +67,33 @@ def build_weekly_recap_html(
         for item in (rr_items or [])
         if isinstance(item, dict)
     )
-    challenge_ladder_count = int(challenge_ladder.get("count") or 0)
-    challenge_ladder_highlights = [
-        item for item in (challenge_ladder.get("highlights") or []) if isinstance(item, dict)
+    challenge_ladder_tiers = [
+        item for item in (challenge_ladder.get("by_tier") or []) if isinstance(item, dict)
     ]
-    challenge_ladder_items = "".join(
-        f"<li>{escape(str(item.get('display', '')))}</li>"
-        for item in challenge_ladder_highlights
-        if str(item.get("display", "")).strip() != ""
-    )
+    challenge_ladder_tier_sections: list[str] = []
+    for tier_item in challenge_ladder_tiers:
+        tier_label = str(tier_item.get("tier") or "").strip()
+        lines = [
+            str(line).strip()
+            for line in (tier_item.get("lines") or [])
+            if str(line).strip() != ""
+        ]
+        if not tier_label or not lines:
+            continue
+        tier_lines_html = "".join(f"<li>{escape(line)}</li>" for line in lines)
+        challenge_ladder_tier_sections.append(
+            f"<div class='muted-label'>{escape(tier_label)}:</div><ul class='compact'>{tier_lines_html}</ul>"
+        )
+
     challenge_ladder_section_html = ""
-    if challenge_ladder_count > 0 and challenge_ladder_items.strip():
+    if challenge_ladder_tier_sections:
+        title = str(challenge_ladder.get("title") or "Match Results")
+        body = f"<div class='muted-label'>{escape(title)}</div>{''.join(challenge_ladder_tier_sections)}"
         challenge_ladder_section_html = (
             "<div class='section'>"
             + _render_simple_card(
                 title="Challenge Ladder",
-                body_html=f"<ul class='compact'>{challenge_ladder_items}</ul>",
+                body_html=body,
                 accent_class="accent-ink",
             )
             + "</div>"

--- a/tests/test_weekly_recap_challenge_ladder.py
+++ b/tests/test_weekly_recap_challenge_ladder.py
@@ -1,61 +1,102 @@
 from jupr_app.domain.recaps.weekly_recap import _summarize_challenge_ladder_rows
 
 
-def test_summarize_challenge_ladder_rows_builds_counts_and_highlights():
+def test_summarize_challenge_ladder_rows_groups_match_results_by_tier():
     rows = [
         {
             "id": 101,
-            "tier_id": "A1",
+            "tier_id": "PREM",
             "challenger_id": 10,
             "defender_id": 20,
             "winner_id": 10,
             "status": "COMPLETED",
+            "challenger_rank_at_create": 8,
+            "defender_rank_at_create": 4,
         },
         {
             "id": 102,
-            "tier_id": "A1",
+            "tier_id": "ADV",
             "challenger_id": 30,
             "defender_id": 40,
             "winner_id": 40,
-            "status": "FORFEITED",
+            "status": "COMPLETED",
+            "challenger_rank_at_create": 5,
+            "defender_rank_at_create": 2,
         },
         {
             "id": 103,
-            "tier_id": "B2",
+            "tier_id": "ADV",
             "challenger_id": 50,
             "defender_id": 60,
-            "winner_id": None,
-            "status": "COMPLETED",
+            "winner_id": 50,
+            "status": "PENDING_ACCEPTANCE",
+            "challenger_rank_at_create": 1,
+            "defender_rank_at_create": 3,
         },
     ]
 
     summary = _summarize_challenge_ladder_rows(
         rows,
-        id_to_name={10: "Ada", 20: "Ben", 30: "Cal", 40: "Dee"},
+        id_to_name={10: "Ana", 20: "Bob", 30: "Luis", 40: "Marco"},
     )
 
-    assert summary["count"] == 2
-    assert summary["by_tier"] == [{"tier_id": "A1", "count": 2}]
-    assert summary["highlights"] == [
-        {"display": "A1 • Ada beat Ben (Challenger win) • #101"},
-        {"display": "A1 • Dee beat Cal (Defended) • #102"},
-    ]
+    assert summary == {
+        "title": "Match Results",
+        "by_tier": [
+            {"tier": "Premier Tier", "lines": ["#8 Ana beat #4 Bob"]},
+            {"tier": "Advanced Tier", "lines": ["#2 Marco defended vs #5 Luis"]},
+        ],
+    }
 
 
-def test_summarize_challenge_ladder_rows_limits_highlights_to_six():
+def test_summarize_challenge_ladder_rows_uses_unknown_rank_when_missing():
     rows = [
         {
-            "id": idx,
-            "tier_id": "T1",
-            "challenger_id": idx,
-            "defender_id": 999,
-            "winner_id": idx,
+            "id": 201,
+            "tier_id": "EMER",
+            "challenger_id": 99,
+            "defender_id": 100,
+            "winner_id": 100,
             "status": "COMPLETED",
+            "challenger_rank_at_create": None,
+            "defender_rank_at_create": "",
         }
-        for idx in range(1, 9)
+    ]
+
+    summary = _summarize_challenge_ladder_rows(rows, id_to_name={99: "Chal", 100: "Def"})
+
+    assert summary == {
+        "title": "Match Results",
+        "by_tier": [
+            {"tier": "Developing Tier", "lines": ["#? Def defended vs #? Chal"]},
+        ],
+    }
+
+
+def test_summarize_challenge_ladder_rows_returns_empty_structure_for_no_completed_matches():
+    rows = [
+        {
+            "id": 300,
+            "tier_id": "PREM",
+            "challenger_id": 1,
+            "defender_id": 2,
+            "winner_id": None,
+            "status": "COMPLETED",
+            "challenger_rank_at_create": 1,
+            "defender_rank_at_create": 2,
+        },
+        {
+            "id": 301,
+            "tier_id": "ADV",
+            "challenger_id": 3,
+            "defender_id": 4,
+            "winner_id": 4,
+            "status": "FORFEITED",
+            "challenger_rank_at_create": 3,
+            "defender_rank_at_create": 4,
+        },
     ]
 
     summary = _summarize_challenge_ladder_rows(rows, id_to_name={})
 
-    assert summary["count"] == 8
-    assert len(summary["highlights"]) == 6
+    assert summary == {"title": "Match Results", "by_tier": []}

--- a/tests/test_weekly_recap_layout_challenge_ladder.py
+++ b/tests/test_weekly_recap_layout_challenge_ladder.py
@@ -1,0 +1,44 @@
+from jupr_app.ui.components.weekly_recap_layout import build_weekly_recap_html
+
+
+def _base_recap(challenge_ladder: dict) -> dict:
+    return {
+        "week_start": "2026-01-05",
+        "week_end": "2026-01-11",
+        "numbers": {},
+        "spotlight": [],
+        "around_club": {"leagues": [], "round_robins": []},
+        "around_descriptions": {},
+        "challenge_ladder": challenge_ladder,
+        "looking_ahead": [],
+        "meta": {},
+    }
+
+
+def test_build_weekly_recap_html_renders_challenge_ladder_match_results_by_tier():
+    recap = _base_recap(
+        {
+            "title": "Match Results",
+            "by_tier": [
+                {"tier": "Premier Tier", "lines": ["#8 Ana beat #4 Bob"]},
+                {"tier": "Advanced Tier", "lines": ["#2 Marco defended vs #5 Luis"]},
+            ],
+        }
+    )
+
+    html = build_weekly_recap_html(recap, print_view=False)
+
+    assert "Challenge Ladder" in html
+    assert "<div class='muted-label'>Match Results</div>" in html
+    assert "<div class='muted-label'>Premier Tier:</div>" in html
+    assert "#8 Ana beat #4 Bob" in html
+    assert "<div class='muted-label'>Advanced Tier:</div>" in html
+    assert "#2 Marco defended vs #5 Luis" in html
+
+
+def test_build_weekly_recap_html_hides_challenge_ladder_without_lines():
+    recap = _base_recap({"title": "Match Results", "by_tier": [{"tier": "Premier Tier", "lines": []}]})
+
+    html = build_weekly_recap_html(recap, print_view=False)
+
+    assert "Challenge Ladder" not in html


### PR DESCRIPTION
### Motivation
- Replace the previous mixed-count/highlights ladder output with a focused "Match Results" recap that only shows completed ladder challenges grouped by tier and formatted as simple match-result lines. 
- Use existing tier metadata via `tier_title(...)` and normalize tier ids so tier headers are user-friendly and consistent.

### Description
- Change `_fetch_challenge_ladder_week_summary` to select `challenger_rank_at_create` and `defender_rank_at_create` and preserve the APIError/fallback behavior. 
- Replace the old summary builder with `_summarize_challenge_ladder_rows` that filters to `status == "COMPLETED"`, groups results by normalized tier, formats lines using ranks (`#?` fallback) and winner to produce `{"title":"Match Results","by_tier":[{"tier":"Premier Tier","lines":[...]}...]}`. 
- Update UI in `weekly_recap_layout.py` to consume the new `challenge_ladder.by_tier` structure, render a card titled "Challenge Ladder" only when at least one tier has lines, and print a muted label `Match Results` followed by tier headers and compact lists. 
- Add/update unit tests to validate grouping/formatting, rank fallback, completed-only filtering, and UI rendering/hiding behavior.

### Testing
- Ran unit tests: `pytest -q tests/test_weekly_recap_challenge_ladder.py tests/test_weekly_recap_layout_challenge_ladder.py` and all tests passed (`5 passed`).
- Attempted an automated Playwright screenshot to visually validate the rendered HTML, but the headless Chromium crashed in this environment (no screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b53c52d408326b156fca34b9cbc3e)