### PR TITLE
Add GitHub Actions workflow to deploy jupr-staging to Fly

### DIFF
--- a/.github/workflows/deploy_fly_staging.yml
+++ b/.github/workflows/deploy_fly_staging.yml
@@ -1,0 +1,33 @@
+name: Deploy JUPR STAGING to Fly.io
+
+on:
+  push:
+    branches:
+      - rebuild
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+        with:
+          version: latest
+
+      - name: Set Fly secrets (staging)
+        run: |
+          flyctl secrets set \
+            SUPABASE_URL="${{ secrets.SUPABASE_URL }}" \
+            SUPABASE_ANON_KEY="${{ secrets.SUPABASE_ANON_KEY }}" \
+            SUPABASE_SERVICE_ROLE_KEY="${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
+            --app jupr-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Deploy to Fly.io (staging)
+        run: flyctl deploy --remote-only --app jupr-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
### Motivation
- Add a GitHub Actions workflow to automatically deploy the JUPR staging app to Fly.io on pushes to the `rebuild` branch, including syncing Supabase secrets and using `flyctl` for deployment.

### Description
- Create `.github/workflows/deploy_fly_staging.yml` with the provided workflow that checks out the repo, sets up the Fly CLI, sets `SUPABASE_*` secrets for `jupr-staging`, and runs `flyctl deploy --remote-only --app jupr-staging`, and commit it on branch `rebuild`.

### Testing
- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b81cedf288326816970e0418243e2)