### PR TITLE
Fix Debian gdk-pixbuf package and pin Python base image to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/packages.txt
+++ b/packages.txt
@@ -4,6 +4,6 @@ libharfbuzz0b
 libfontconfig1
 libfreetype6
 libcairo2
-libgdk-pixbuf2.0-0
+libgdk-pixbuf-2.0-0
 libffi8
 shared-mime-info


### PR DESCRIPTION
### Motivation
- Avoid apt failures during Fly.io builds by pinning to a stable Debian release and fixing an incorrect gdk-pixbuf package name.

### Description
- Change base image from `python:3.11-slim` to `python:3.11-slim-bookworm` and replace `libgdk-pixbuf2.0-0` with `libgdk-pixbuf-2.0-0` in `packages.txt`.

### Testing
- Attempted `docker build -t jupr-bookworm-fix .` but `docker` is not available in this environment so the full image build could not be run; ran `apt-cache show libgdk-pixbuf-2.0-0` which returned package metadata successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b8942664c83268aadbe80ee496030)