### PR TITLE
Make get_secret resilient to missing secrets.toml and prefer environment variables

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import os
 import time
 import traceback
 from collections.abc import Mapping
 
 import streamlit as st
 import pandas as pd  # kept because pages may rely on it
+from streamlit.errors import StreamlitSecretNotFoundError
 
 
 # -------------------------
@@ -25,22 +27,39 @@ PUBLIC_BASE_URL = "https://8lkemld946rmtwwptk2gcs.streamlit.app"
 # -------------------------
 def get_secret(path: list[str], default=None):
     """
-    Safe nested secret getter that works with Streamlit's secrets object.
-    Never raises KeyError.
+    Safe nested secret getter.
+    Priority: environment variables (Fly) -> st.secrets (Streamlit Cloud) -> default.
+    Never raises when secrets.toml is missing.
     """
+    env_var_map = {
+        ("supabase", "url"): "SUPABASE_URL",
+        ("supabase", "anon_key"): "SUPABASE_ANON_KEY",
+        ("supabase", "key"): "SUPABASE_KEY",
+        ("supabase", "service_role_key"): "SUPABASE_SERVICE_ROLE_KEY",
+        ("supabase", "admin_password"): "SUPABASE_ADMIN_PASSWORD",
+        ("supabase", "admin_session_secret"): "SUPABASE_ADMIN_SESSION_SECRET",
+        ("admin_session_secret",): "ADMIN_SESSION_SECRET",
+    }
+
+    env_var = env_var_map.get(tuple(path))
+    if env_var:
+        env_value = os.getenv(env_var)
+        if env_value:
+            return env_value
+
     try:
         cur: object = st.secrets
+        for k in path:
+            if not isinstance(cur, Mapping):
+                return default
+            if k not in cur:
+                return default
+            cur = cur[k]
+        return cur
+    except StreamlitSecretNotFoundError:
+        return default
     except Exception:
         return default
-
-    for k in path:
-        if not isinstance(cur, Mapping):
-            return default
-        if k not in cur:
-            return default
-        cur = cur[k]
-
-    return cur
 
 
 # -------------------------


### PR DESCRIPTION
### Motivation
- Fix a startup crash caused by touching `st.secrets` when no `secrets.toml` exists (e.g. on Fly.io), and prefer Fly environment variables when available.
- Maintain compatibility with the existing `secrets.toml` structure so Streamlit Cloud still works unchanged.

### Description
- Added `import os` and `from streamlit.errors import StreamlitSecretNotFoundError` and replaced `get_secret()` with an env-first, guarded implementation that maps requested secret paths to the required Fly env vars and returns non-empty env values when present.
- All `st.secrets` access is now performed only inside a `try/except` block that catches `StreamlitSecretNotFoundError` and other exceptions and returns the provided `default` on error.
- Kept call sites unchanged so `_get_admin_session_secret()` continues to call `get_secret(["supabase","admin_session_secret"], "")` and fall back to `get_secret(["admin_session_secret"], "")`.
- Only `streamlit_app.py` was modified.

### Testing
- Ran `python -m py_compile streamlit_app.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b8d57a448832697613b0f4d87a777)