### PR TITLE
Add manual PROD→STAGING seed workflow and script

### DIFF
--- a/.github/workflows/seed_staging.yml
+++ b/.github/workflows/seed_staging.yml
@@ -1,0 +1,45 @@
+name: Seed Staging from Production (Manual)
+
+# WARNING: This workflow copies selected data from PROD Supabase into STAGING Supabase.
+# It is intentionally manual-only (workflow_dispatch) for safety.
+on:
+  workflow_dispatch:
+    inputs:
+      club_id:
+        description: "Club to seed from production"
+        required: false
+        default: "tres_palapas"
+      days:
+        description: "Only copy rows from the last N days for time-windowed tables"
+        required: false
+        default: "180"
+
+jobs:
+  seed-staging:
+    name: Seed Staging (PROD -> STAGING)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install supabase pandas
+
+      - name: Run seed script
+        # WARNING: This step writes production data into staging.
+        env:
+          PROD_SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
+          PROD_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
+          STAGING_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+          STAGING_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
+          CLUB_ID: ${{ inputs.club_id }}
+          DAYS: ${{ inputs.days }}
+        run: python tools/seed_staging.py

--- a/tools/seed_staging.py
+++ b/tools/seed_staging.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""WARNING: This script copies data from PROD Supabase to STAGING Supabase."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from supabase import Client, create_client
+
+CHUNK_SIZE = 500
+PAGE_SIZE = 1000
+
+
+TABLE_CONFIG = [
+    {"name": "badges", "club_col": "club_id", "time_col": None},
+    {"name": "players", "club_col": "club_id", "time_col": None},
+    {"name": "leagues", "club_col": "club_id", "time_col": None},
+    {"name": "meta", "club_col": "club_id", "time_col": None},
+    {"name": "matches", "club_col": "club_id", "time_col": "date"},
+    {"name": "player_badges", "club_col": "club_id", "time_col": "created_at"},
+    {"name": "player_stories", "club_col": "club_id", "time_col": "created_at"},
+]
+
+
+def get_required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing required env var: {name}")
+    return value
+
+
+def apply_filters(query: Any, club_col: str, club_id: str, time_col: Optional[str], since_iso: str) -> Any:
+    query = query.eq(club_col, club_id)
+    if time_col:
+        query = query.gte(time_col, since_iso)
+    return query
+
+
+def fetch_all_rows(
+    client: Client,
+    table: str,
+    club_col: str,
+    club_id: str,
+    time_col: Optional[str],
+    since_iso: str,
+) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    start = 0
+
+    while True:
+        end = start + PAGE_SIZE - 1
+        query = client.table(table).select("*")
+        query = apply_filters(query, club_col, club_id, time_col, since_iso)
+        response = query.range(start, end).execute()
+
+        batch = response.data or []
+        rows.extend(batch)
+        if len(batch) < PAGE_SIZE:
+            break
+        start += PAGE_SIZE
+
+    return rows
+
+
+def delete_slice(
+    client: Client,
+    table: str,
+    club_col: str,
+    club_id: str,
+    time_col: Optional[str],
+    since_iso: str,
+) -> int:
+    query = client.table(table).delete(count="exact")
+    query = apply_filters(query, club_col, club_id, time_col, since_iso)
+    response = query.execute()
+    return int(response.count or 0)
+
+
+def upsert_rows(client: Client, table: str, rows: List[Dict[str, Any]]) -> int:
+    if not rows:
+        return 0
+
+    total = 0
+    for i in range(0, len(rows), CHUNK_SIZE):
+        chunk = rows[i : i + CHUNK_SIZE]
+        client.table(table).upsert(chunk).execute()
+        total += len(chunk)
+    return total
+
+
+def process_table(
+    prod: Client,
+    staging: Client,
+    table: str,
+    club_col: str,
+    club_id: str,
+    time_col: Optional[str],
+    since_iso: str,
+) -> Tuple[int, int, int]:
+    deleted = delete_slice(staging, table, club_col, club_id, time_col, since_iso)
+    rows = fetch_all_rows(prod, table, club_col, club_id, time_col, since_iso)
+    upserted = upsert_rows(staging, table, rows)
+    return deleted, len(rows), upserted
+
+
+def main() -> None:
+    # WARNING: This operation copies data from PROD -> STAGING.
+    prod_url = get_required_env("PROD_SUPABASE_URL")
+    prod_key = get_required_env("PROD_SUPABASE_SERVICE_ROLE_KEY")
+    staging_url = get_required_env("STAGING_SUPABASE_URL")
+    staging_key = get_required_env("STAGING_SUPABASE_SERVICE_ROLE_KEY")
+
+    club_id = os.getenv("CLUB_ID", "tres_palapas")
+    days = int(os.getenv("DAYS", "180"))
+
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    since_iso = since.isoformat()
+
+    prod = create_client(prod_url, prod_key)
+    staging = create_client(staging_url, staging_key)
+
+    print("WARNING: Seeding STAGING from PROD")
+    print(f"Club: {club_id}")
+    print(f"Window: last {days} days (since {since_iso})")
+
+    for cfg in TABLE_CONFIG:
+        table = cfg["name"]
+        deleted, fetched, upserted = process_table(
+            prod=prod,
+            staging=staging,
+            table=table,
+            club_col=cfg["club_col"],
+            club_id=club_id,
+            time_col=cfg["time_col"],
+            since_iso=since_iso,
+        )
+        print(
+            f"[{table}] deleted_from_staging={deleted} "
+            f"fetched_from_prod={fetched} upserted_to_staging={upserted}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a safe, manual way to seed the `jupr-staging` Supabase instance from production for debugging or refresh purposes. 
- Ensure the operation is safe-by-default by scoping to a club and a time window and by exposing the action only via a manual trigger.

### Description
- Add `tools/seed_staging.py`, a `supabase-py` script that reads from PROD and writes to STAGING, requires `PROD_SUPABASE_URL`, `PROD_SUPABASE_SERVICE_ROLE_KEY`, `STAGING_SUPABASE_URL`, and `STAGING_SUPABASE_SERVICE_ROLE_KEY`, and accepts optional `CLUB_ID` (default `tres_palapas`) and `DAYS` (default `180`).
- The script processes tables in the controlled order `badges`, `players`, `leagues`, `meta`, `matches`, `player_badges`, `player_stories`, and applies time-window filters (`matches` by `date`, `player_badges`/`player_stories` by `created_at`).
- For each table the script deletes the matching slice in STAGING (club + time window), fetches rows from PROD with pagination, and upserts into STAGING in configurable chunks, printing per-table deleted/fetched/upserted counts.
- Add `.github/workflows/seed_staging.yml` as a manual-only `workflow_dispatch` workflow that accepts `club_id` and `days` inputs, sets up Python 3.11, installs `supabase` and `pandas`, and runs `python tools/seed_staging.py` while passing secrets and inputs via environment variables; the workflow contains explicit warnings and has no automatic triggers.

### Testing
- Successfully type-checked/compiled the script with `python -m py_compile tools/seed_staging.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b95afa81883268d37da7f524be69b)