### PR TITLE
Fix seed_staging: allow global tables and skip unsafe deletes

### DIFF
--- a/tools/seed_staging.py
+++ b/tools/seed_staging.py
@@ -43,7 +43,7 @@ def apply_filters(query, club_col, club_id, time_col, since_iso):
 def fetch_all_rows(
     client: Client,
     table: str,
-    club_col: str,
+    club_col: Optional[str],
     club_id: str,
     time_col: Optional[str],
     since_iso: str,
@@ -69,11 +69,15 @@ def fetch_all_rows(
 def delete_slice(
     client: Client,
     table: str,
-    club_col: str,
+    club_col: Optional[str],
     club_id: str,
     time_col: Optional[str],
     since_iso: str,
 ) -> int:
+    # PostgREST forbids DELETE without WHERE
+    if not club_col and not time_col:
+        return 0
+
     query = client.table(table).delete(count="exact")
     query = apply_filters(query, club_col, club_id, time_col, since_iso)
     response = query.execute()
@@ -96,7 +100,7 @@ def process_table(
     prod: Client,
     staging: Client,
     table: str,
-    club_col: str,
+    club_col: Optional[str],
     club_id: str,
     time_col: Optional[str],
     since_iso: str,


### PR DESCRIPTION
### Motivation
- Avoid PostgREST error `DELETE requires a WHERE clause` when a table is configured with no `club_col` and no `time_col` (global table). 
- Treat `badges` as a global table (no club filter) and preserve fetch/upsert behavior while preventing accidental full-table deletes.

### Description
- Configure `badges` as a global table with `{"name": "badges", "club_col": None, "time_col": None}` in `TABLE_CONFIG` and preserve existing fetch/upsert flow. 
- Make `club_col` optional in `fetch_all_rows`, `delete_slice`, and `process_table` by using `Optional[str]` in their signatures. 
- Guard `delete_slice` so it returns early (`0`) when both `club_col` and `time_col` are unset to avoid issuing a `DELETE` without a `WHERE` clause. 
- Rely on existing `apply_filters()` behavior which only applies the club filter when `club_col` is truthy so global tables are not club-filtered.

### Testing
- Ran `python -m py_compile tools/seed_staging.py` which succeeded. 
- Attempted to trigger the GitHub Actions workflow to validate end-to-end, but the `gh` CLI is not available in the environment so the workflow rerun could not be executed (`gh: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698badfad9248326a3a9ab78f3600b09)