### PR TITLE
Make PUBLIC_BASE_URL env-driven for Fly; update deploy workflow

### DIFF
--- a/.github/workflows/deploy_fly_staging.yml
+++ b/.github/workflows/deploy_fly_staging.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Set Fly secrets (staging)
         run: |
           flyctl secrets set \
+            PUBLIC_BASE_URL="${{ secrets.PUBLIC_BASE_URL }}" \
             SUPABASE_URL="${{ secrets.SUPABASE_URL }}" \
             SUPABASE_ANON_KEY="${{ secrets.SUPABASE_ANON_KEY }}" \
             SUPABASE_SERVICE_ROLE_KEY="${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -18,8 +18,8 @@ from streamlit.errors import StreamlitSecretNotFoundError
 # -------------------------
 CLUB_ID = "tres_palapas"
 
-# Public base URL used for share links + link buttons (Streamlit Cloud)
-PUBLIC_BASE_URL = "https://8lkemld946rmtwwptk2gcs.streamlit.app"
+# Local/dev fallback for share links + link buttons.
+LOCAL_PUBLIC_BASE_URL_DEFAULT = "http://localhost:8501"
 
 
 # -------------------------
@@ -39,6 +39,7 @@ def get_secret(path: list[str], default=None):
         ("supabase", "admin_password"): "SUPABASE_ADMIN_PASSWORD",
         ("supabase", "admin_session_secret"): "SUPABASE_ADMIN_SESSION_SECRET",
         ("admin_session_secret",): "ADMIN_SESSION_SECRET",
+        ("public_base_url",): "PUBLIC_BASE_URL",
     }
 
     env_var = env_var_map.get(tuple(path))
@@ -240,7 +241,11 @@ def main():
 
         # Make base_url available to all pages (leaderboards uses this for share links)
         # Use session_state because ctx is a frozen-ish dataclass and you don't want to refactor it mid-stream.
-        st.session_state["base_url"] = PUBLIC_BASE_URL
+        # Fly env vars required in production/staging: PUBLIC_BASE_URL, SUPABASE_URL,
+        # SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ADMIN_PASSWORD,
+        # and SUPABASE_ADMIN_SESSION_SECRET.
+        base_url = get_secret(["public_base_url"], LOCAL_PUBLIC_BASE_URL_DEFAULT)
+        st.session_state["base_url"] = str(base_url)
 
         # ---- Session defaults ----
         st.session_state.setdefault("deep_link_applied", False)


### PR DESCRIPTION
### Motivation
- Remove the remaining hard dependency on a Streamlit Cloud URL and allow Fly environment configuration for share links and link buttons.
- Provide a sensible local default so development still works when no env var or Streamlit secret is present.

### Description
- Replace the hardcoded Streamlit Cloud `PUBLIC_BASE_URL` with a local default `LOCAL_PUBLIC_BASE_URL_DEFAULT = "http://localhost:8501"` and set `st.session_state["base_url"]` from `get_secret(["public_base_url"], LOCAL_PUBLIC_BASE_URL_DEFAULT)`.
- Add an environment-variable mapping for `("public_base_url",)` → `PUBLIC_BASE_URL` in the existing `get_secret()` helper so env vars are checked first and `st.secrets.public_base_url` remains a valid fallback.
- Add a short inline note listing required Fly env vars: `PUBLIC_BASE_URL`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ADMIN_PASSWORD`, and `SUPABASE_ADMIN_SESSION_SECRET`.
- Update `.github/workflows/deploy_fly_staging.yml` to include `PUBLIC_BASE_URL="${{ secrets.PUBLIC_BASE_URL }}"` in the `flyctl secrets set` command for staging deploys.

### Testing
- Ran `python -m py_compile streamlit_app.py` which succeeded with no syntax errors.
- Executed a small runtime check that set `os.environ['PUBLIC_BASE_URL']='https://staging.example.com'` and verified `get_secret(['public_base_url'], ...)` returned the env value and that removing the env var fell back to the localhost default.
- Verified (via search) that the original hardcoded Streamlit Cloud URL was removed from the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb69e4a34832684cd17c2ef3da2b8)