### PR TITLE
Enable matches upsert via unique index + fallback for replay_history

### DIFF
--- a/jupr_app/domain/replay_history.py
+++ b/jupr_app/domain/replay_history.py
@@ -5,11 +5,21 @@ import time
 from typing import Any, Callable, Dict, Optional
 
 import pandas as pd
+from postgrest.exceptions import APIError
 
 from jupr_app.domain.ratings import calculate_hybrid_elo
 from jupr_app.domain.constants import DEFAULT_K_FACTOR
 
 FULL_RESET_LABEL = "ALL (Full System Reset)"
+
+
+def _get_api_error_code(exc: APIError) -> str | None:
+    code = getattr(exc, "code", None)
+    if code:
+        return str(code)
+    if exc.args and isinstance(exc.args[0], dict):
+        return exc.args[0].get("code")
+    return None
 
 
 def _exec_with_retry(fn, *, retries: int = 6, base_sleep: float = 0.5):
@@ -232,24 +242,28 @@ def replay_history(
     total = len(matches_to_update)
     chunk_size = 500
     completed = 0
-    use_conflict = "club_id,id"
     for chunk_index, start in enumerate(range(0, total, chunk_size), start=1):
         chunk = matches_to_update[start : start + chunk_size]
 
-        def do_upsert(conflict_key: str):
-            return supabase.table("matches").upsert(chunk, on_conflict=conflict_key).execute()
+        def do_upsert():
+            return supabase.table("matches").upsert(chunk, on_conflict="club_id,id").execute()
 
         try:
             try:
-                _exec_with_retry(lambda: do_upsert(use_conflict))
-            except Exception as exc:
-                msg = str(exc)
-                conflict_invalid = "on_conflict" in msg or "conflict" in msg
-                if use_conflict == "club_id,id" and conflict_invalid:
-                    use_conflict = "id"
-                    _exec_with_retry(lambda: do_upsert(use_conflict))
-                else:
+                _exec_with_retry(do_upsert)
+            except APIError as exc:
+                if _get_api_error_code(exc) != "42P10":
                     raise
+                for row in chunk:
+                    row_id = int(row["id"])
+                    payload = {k: v for k, v in row.items() if k not in {"id", "club_id"}}
+                    _exec_with_retry(
+                        lambda row_id=row_id, payload=payload: supabase.table("matches")
+                        .update(payload)
+                        .eq("club_id", club_id)
+                        .eq("id", row_id)
+                        .execute()
+                    )
         except Exception as exc:
             raise RuntimeError(f"Failed matches upsert chunk {chunk_index}: {exc}") from exc
 

--- a/migrations/20260211_matches_unique_club_id_id.sql
+++ b/migrations/20260211_matches_unique_club_id_id.sql
@@ -1,0 +1,15 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM matches
+        GROUP BY club_id, id
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION
+            'Cannot add unique index matches_club_id_id_key: duplicate (club_id, id) rows exist in matches. Clean duplicates first.';
+    END IF;
+END
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS matches_club_id_id_key ON matches (club_id, id);


### PR DESCRIPTION
### Motivation
- Make bulk match snapshot rewrites fast and reliable by enabling real UPSERT semantics on the `matches` table using a DB-side unique constraint on `(club_id, id)`. 
- Avoid failures (Postgres error `42P10`) when calling `upsert(..., on_conflict="club_id,id")` on databases that do not yet have the constraint. 
- Preserve existing behavior by falling back to the slower per-row update approach when the unique constraint is not present. 

### Description
- Add migration `migrations/20260211_matches_unique_club_id_id.sql` that checks for duplicate `(club_id, id)` rows and raises a clear exception if any exist, then creates an idempotent unique index `matches_club_id_id_key` on `(club_id, id)`. 
- Update `jupr_app/domain/replay_history.py` to import `APIError` and add `_get_api_error_code` helper for extracting PostgREST/Postgres error codes. 
- Change match rewrite logic to always call `upsert(..., on_conflict="club_id,id")` for chunked upserts and catch `APIError` with code `42P10`, falling back to per-row `update(...).eq("club_id", club_id).eq("id", row_id)` for that chunk (each call wrapped with `_exec_with_retry`). 
- Keep progress callback (`progress_cb`) and all replay logic / snapshot fields unchanged. 

### Testing
- Ran `python -m compileall jupr_app/domain/replay_history.py`, which succeeded (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf929fe5c83268d5f66ee2a51e962)