### PR TITLE
Fix inert Explain links in Player Search ratings history table

### DIFF
--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -1906,7 +1906,10 @@ def render(ctx):
             show["Result"] = show["Result"].map(result_badge)
             show["Overall Δ"] = show.apply(lambda row: delta_span(row["Overall Δ"], row["delta_raw"]), axis=1)
             show["Explain"] = show["Explain"].map(
-                lambda url: f"<a href='{url}' target='_self'>Explain</a>" if url else ""
+                lambda url: (
+                    f"<a href=\"{html.escape(str(url), quote=True)}\" "
+                    f"target=\"_blank\" rel=\"noopener noreferrer\">Explain</a>"
+                ) if url else ""
             )
 
             show = show[["date", "League", "Score", "Result", "match_type", "Overall Δ", "Overall After", "Explain"]]


### PR DESCRIPTION
### Motivation
- The "Explain" anchors in the Ratings → Overall Match History table used `target='_self'`, which is often blocked or swallowed by Streamlit’s in-app routing/iframe/CSP behavior and caused clicks to do nothing.

### Description
- Change the `Explain` column mapping to emit anchors that open in a new tab using `target="_blank" rel="noopener noreferrer"` and escape the URL with `html.escape(..., quote=True)` to avoid malformed HTML when URLs contain quotes.

### Testing
- Ran a local Python sanity check that builds a Match Explorer URL with `build_match_explorer_link(...)`, formats the anchor as used in `players.py`, and verified the anchor is generated and contains `target="_blank"` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d19febfe083268727c6b9de935ca7)