### PR TITLE
Add Command Center admin landing page and default admin routing

### DIFF
--- a/jupr_app/ui/pages/__init__.py
+++ b/jupr_app/ui/pages/__init__.py
@@ -24,6 +24,7 @@ from . import weekly_recap_admin
 from . import theme_gallery
 from . import tournaments
 from . import tournament_manager
+from . import command_center
 
 __all__ = [
     "leaderboards",
@@ -48,4 +49,5 @@ __all__ = [
     "theme_gallery",
     "tournaments",
     "tournament_manager",
+    "command_center",
 ]

--- a/jupr_app/ui/pages/command_center.py
+++ b/jupr_app/ui/pages/command_center.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from jupr_app.ui.theme import MATCH_COLORS
+
+
+def _inject_command_center_css(theme_mode: str) -> None:
+    st.markdown(
+        f"""
+        <style>
+          .cc-root {{
+            --cc-bg: var(--bg);
+            --cc-panel: var(--panel);
+            --cc-text: var(--text-primary);
+            --cc-muted: var(--text-muted);
+            --cc-border: var(--border);
+            --cc-shadow: var(--shadow-lg);
+            --cc-accent-soft: var(--accent-soft);
+            --cc-accent-border: var(--accent-border);
+          }}
+
+          .cc-root[data-theme='dark'] {{
+            --cc-bg: #0B1220;
+            --cc-panel: #121A2A;
+            --cc-text: #E5E7EB;
+            --cc-muted: #94A3B8;
+            --cc-border: #243047;
+            --cc-shadow: 0 16px 36px rgba(0, 0, 0, 0.55);
+            --cc-accent-soft: rgba(59, 130, 246, 0.16);
+            --cc-accent-border: rgba(59, 130, 246, 0.35);
+          }}
+
+          .cc-root[data-theme='light'] {{
+            --cc-bg: #F8FAFC;
+            --cc-panel: #FFFFFF;
+            --cc-text: #0F172A;
+            --cc-muted: #64748B;
+            --cc-border: #DCE3EE;
+            --cc-shadow: 0 14px 32px rgba(15, 23, 42, 0.12);
+            --cc-accent-soft: rgba(47, 111, 237, 0.10);
+            --cc-accent-border: rgba(47, 111, 237, 0.28);
+          }}
+
+          .cc-root .block-container {{
+            max-width: 100%;
+            padding: 0.75rem 1.2rem 1.5rem;
+          }}
+
+          .cc-shell {{
+            display: grid;
+            grid-template-columns: repeat(12, minmax(0, 1fr));
+            gap: 1rem;
+            width: 100%;
+          }}
+
+          .cc-header,
+          .cc-hero {{
+            grid-column: 1 / -1;
+            border: 1px solid var(--cc-border);
+            background: var(--cc-panel);
+            box-shadow: var(--cc-shadow);
+            border-radius: 16px;
+            color: var(--cc-text);
+          }}
+
+          .cc-header {{
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 1rem 1.2rem;
+          }}
+
+          .cc-brand {{
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+          }}
+
+          .cc-logo {{
+            width: 36px;
+            height: 36px;
+            border-radius: 10px;
+            display: grid;
+            place-items: center;
+            border: 1px solid var(--cc-accent-border);
+            background: var(--cc-accent-soft);
+            font-size: 1.05rem;
+          }}
+
+          .cc-brand h1 {{ margin: 0; font-size: 1.05rem; }}
+          .cc-brand p {{ margin: 0.1rem 0 0; color: var(--cc-muted); font-size: 0.85rem; }}
+
+          .cc-actions {{
+            display: flex;
+            align-items: center;
+            gap: 0.65rem;
+          }}
+
+          .cc-badge {{
+            padding: 0.35rem 0.65rem;
+            border-radius: 999px;
+            border: 1px solid var(--cc-accent-border);
+            background: var(--cc-accent-soft);
+            font-size: 0.76rem;
+            font-weight: 700;
+          }}
+
+          .cc-hero {{
+            padding: 1.25rem;
+          }}
+          .cc-hero h2 {{ margin: 0; font-size: 1.35rem; }}
+          .cc-hero p {{ margin: 0.45rem 0 0; color: var(--cc-muted); }}
+          .cc-pill {{
+            display: inline-block;
+            margin-top: 0.8rem;
+            padding: 0.25rem 0.55rem;
+            border-radius: 999px;
+            font-size: 0.75rem;
+            color: #fff;
+            background: {MATCH_COLORS['win']};
+          }}
+        </style>
+
+        <div class="cc-root" data-theme="{theme_mode}">
+          <div class="cc-shell">
+            <div class="cc-header">
+              <div class="cc-brand">
+                <div class="cc-logo">🌵</div>
+                <div>
+                  <h1>JUPR Club Command Center</h1>
+                  <p>Admin operations hub</p>
+                </div>
+              </div>
+              <div class="cc-actions">
+                <span class="cc-badge">ADMIN</span>
+              </div>
+            </div>
+
+            <div class="cc-hero">
+              <h2>Record Match Result</h2>
+              <p>Placeholder hero card for the upcoming guided result entry workflow.</p>
+              <span class="cc-pill">Coming soon</span>
+            </div>
+          </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render(ctx) -> None:
+    if not bool(getattr(ctx, "admin_logged_in", False)):
+        st.error("Admin login required.")
+        st.stop()
+
+    default_theme = st.session_state.get("cc_theme_mode", "dark")
+    col_l, col_r = st.columns([0.85, 0.15])
+    with col_r:
+        is_dark = st.toggle("Dark theme", value=(default_theme == "dark"), key="cc_theme_toggle")
+    with col_l:
+        st.caption(" ")
+
+    st.session_state["cc_theme_mode"] = "dark" if is_dark else "light"
+    _inject_command_center_css(st.session_state["cc_theme_mode"])

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -370,10 +370,12 @@ def main():
             tournament_manager,
             weekly_recap,
             weekly_recap_admin,
+            command_center,
         )
 
         # ---- Router ----
         PAGES = {
+            "🧭 Command Center": command_center,
             "🏆 Leaderboards": leaderboards,
             "📊 League Results": league_results,
             "🖨️ League Night Printout": league_printout,
@@ -403,6 +405,8 @@ def main():
         }
 
         PAGE_KEY_TO_LABEL = {
+            "command_center": "🧭 Command Center",
+            "admin": "🧭 Command Center",
             "leaderboards": "🏆 Leaderboards",
             "league_results": "📊 League Results",
             "league_printout": "🖨️ League Night Printout",
@@ -433,6 +437,7 @@ def main():
         LABEL_TO_PAGE_KEY = {v: k for k, v in PAGE_KEY_TO_LABEL.items()}
 
         ADMIN_ONLY_LABELS = {
+            "🧭 Command Center",
             "🖨️ League Night Printout",
             "🏟️ League Manager",
             "📝 Match Uploader",
@@ -494,7 +499,12 @@ def main():
 
             # Ensure valid selection
             if "main_nav" not in st.session_state or st.session_state["main_nav"] not in visible_labels:
-                st.session_state["main_nav"] = visible_labels[0]
+                st.session_state["main_nav"] = "🧭 Command Center" if admin_logged_in else visible_labels[0]
+
+            prev_admin_logged_in = bool(st.session_state.get("prev_admin_logged_in", False))
+            if admin_logged_in and not prev_admin_logged_in:
+                st.session_state["main_nav"] = "🧭 Command Center"
+            st.session_state["prev_admin_logged_in"] = admin_logged_in
 
             if admin_logged_in and st.sidebar.button("🔄 Refresh data"):
                 get_data.clear()


### PR DESCRIPTION
### Motivation
- Provide a professional admin landing (Command Center) as the default destination for admins with a desktop-first full-width layout and theme support.
- Scaffold the initial UI for a guided "Record Match Result" workflow so future features can plug into a consistent admin shell.

### Description
- Added a new page module at `jupr_app/ui/pages/command_center.py` that injects CSS variables for light/dark themes and renders a header (club logo/name, admin badge) with a theme toggle and a hero placeholder card titled "Record Match Result".
- Wired the new page into the page registry by importing it in `jupr_app/ui/pages/__init__.py` so it is discoverable as a standard page module.
- Updated the main router in `streamlit_app.py` to include the Command Center in `PAGES`, mark it as admin-only, add `page=command_center` and `page=admin` deep-link aliases, and make Command Center the default landing when an admin logs in (including an initial post-login switch to the page).
- Kept all existing pages intact and only added routing and UI scaffolding so behavior for non-admin/public users is unchanged.

### Testing
- Compiled affected modules with `python -m py_compile streamlit_app.py jupr_app/ui/pages/command_center.py jupr_app/ui/pages/__init__.py`, which completed successfully.
- Launched the app with `streamlit run app.py --server.headless true --server.port 8501`, which started and served the app locally.
- Performed a browser render capture using Playwright against `http://127.0.0.1:8501/?page=admin`, which produced a screenshot artifact confirming the Command Center UI rendered; this check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f93192da88326a06989d1e1b28c17)