### PR TITLE
Add session-persistent theme tokens and Command Center theme toggle

### DIFF
--- a/jupr_app/ui/components/theme_toggle.py
+++ b/jupr_app/ui/components/theme_toggle.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from jupr_app.ui.theme_tokens import ThemeMode, get_theme_mode, set_theme_mode
+
+
+def render_theme_toggle(*, key: str = "global_theme_toggle", label: str = "Dark mode") -> ThemeMode:
+    current_mode = get_theme_mode()
+    is_dark = st.toggle(label, value=(current_mode == "dark"), key=key)
+    return set_theme_mode("dark" if is_dark else "light")

--- a/jupr_app/ui/pages/command_center.py
+++ b/jupr_app/ui/pages/command_center.py
@@ -2,41 +2,34 @@ from __future__ import annotations
 
 import streamlit as st
 
+from jupr_app.ui.components.theme_toggle import render_theme_toggle
 from jupr_app.ui.theme import MATCH_COLORS
+from jupr_app.ui.theme_tokens import get_theme_tokens
 
 
 def _inject_command_center_css(theme_mode: str) -> None:
+    tokens = get_theme_tokens(theme_mode)
     st.markdown(
         f"""
         <style>
           .cc-root {{
-            --cc-bg: var(--bg);
-            --cc-panel: var(--panel);
-            --cc-text: var(--text-primary);
-            --cc-muted: var(--text-muted);
-            --cc-border: var(--border);
+            --cc-bg: {tokens["bg"]};
+            --cc-panel: {tokens["card_bg"]};
+            --cc-text: {tokens["text_primary"]};
+            --cc-muted: {tokens["text_secondary"]};
+            --cc-border: {tokens["border_subtle"]};
             --cc-shadow: var(--shadow-lg);
             --cc-accent-soft: var(--accent-soft);
             --cc-accent-border: var(--accent-border);
           }}
 
           .cc-root[data-theme='dark'] {{
-            --cc-bg: #0B1220;
-            --cc-panel: #121A2A;
-            --cc-text: #E5E7EB;
-            --cc-muted: #94A3B8;
-            --cc-border: #243047;
             --cc-shadow: 0 16px 36px rgba(0, 0, 0, 0.55);
             --cc-accent-soft: rgba(59, 130, 246, 0.16);
             --cc-accent-border: rgba(59, 130, 246, 0.35);
           }}
 
           .cc-root[data-theme='light'] {{
-            --cc-bg: #F8FAFC;
-            --cc-panel: #FFFFFF;
-            --cc-text: #0F172A;
-            --cc-muted: #64748B;
-            --cc-border: #DCE3EE;
             --cc-shadow: 0 14px 32px rgba(15, 23, 42, 0.12);
             --cc-accent-soft: rgba(47, 111, 237, 0.10);
             --cc-accent-border: rgba(47, 111, 237, 0.28);
@@ -133,7 +126,7 @@ def _inject_command_center_css(theme_mode: str) -> None:
                 </div>
               </div>
               <div class="cc-actions">
-                <span class="cc-badge">ADMIN</span>
+                <span class="cc-badge">ADMIN • {theme_mode.upper()}</span>
               </div>
             </div>
 
@@ -154,12 +147,10 @@ def render(ctx) -> None:
         st.error("Admin login required.")
         st.stop()
 
-    default_theme = st.session_state.get("cc_theme_mode", "dark")
     col_l, col_r = st.columns([0.85, 0.15])
-    with col_r:
-        is_dark = st.toggle("Dark theme", value=(default_theme == "dark"), key="cc_theme_toggle")
     with col_l:
         st.caption(" ")
+    with col_r:
+        theme_mode = render_theme_toggle(key="cc_theme_toggle", label="Dark theme")
 
-    st.session_state["cc_theme_mode"] = "dark" if is_dark else "light"
-    _inject_command_center_css(st.session_state["cc_theme_mode"])
+    _inject_command_center_css(theme_mode)

--- a/jupr_app/ui/theme_tokens.py
+++ b/jupr_app/ui/theme_tokens.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import streamlit as st
+
+ThemeMode = Literal["light", "dark"]
+THEME_SESSION_KEY = "ui_theme_mode"
+
+_THEME_TOKENS: dict[ThemeMode, dict[str, str]] = {
+    "light": {
+        "bg": "#F8FAFC",
+        "card_bg": "#FFFFFF",
+        "text_primary": "#0F172A",
+        "text_secondary": "#64748B",
+        "border_subtle": "#DCE3EE",
+    },
+    "dark": {
+        "bg": "#0B1220",
+        "card_bg": "#121A2A",
+        "text_primary": "#E5E7EB",
+        "text_secondary": "#94A3B8",
+        "border_subtle": "#243047",
+    },
+}
+
+
+def get_theme_mode(default: ThemeMode = "dark") -> ThemeMode:
+    mode = str(st.session_state.get(THEME_SESSION_KEY, default)).lower()
+    if mode not in _THEME_TOKENS:
+        mode = default
+    st.session_state[THEME_SESSION_KEY] = mode
+    return mode  # type: ignore[return-value]
+
+
+def set_theme_mode(mode: str) -> ThemeMode:
+    normalized = "dark" if str(mode).lower() == "dark" else "light"
+    st.session_state[THEME_SESSION_KEY] = normalized
+    return normalized
+
+
+def get_theme_tokens(mode: ThemeMode | None = None) -> dict[str, str]:
+    resolved_mode: ThemeMode = mode or get_theme_mode()
+    return _THEME_TOKENS[resolved_mode]


### PR DESCRIPTION
### Motivation
- Provide a simple global theme system (light/dark) so UI pages can share consistent design tokens. 
- Allow users to toggle mode in the Command Center and have that choice persist during the Streamlit session. 
- Surface minimal, reusable color tokens (`bg`, `card_bg`, `text_primary`, `text_secondary`, `border_subtle`) for easy integration into other pages later.

### Description
- Added `jupr_app/ui/theme_tokens.py` which defines light/dark token sets and exposes `get_theme_mode`, `set_theme_mode`, and `get_theme_tokens` that store the selected mode in `st.session_state` under `ui_theme_mode`.
- Added a reusable theme toggle component `jupr_app/ui/components/theme_toggle.py` with `render_theme_toggle` that reads and updates the shared session theme key.
- Integrated the toggle into `jupr_app/ui/pages/command_center.py`, replaced the previous per-page toggle plumbing with the new component, and switched header/hero CSS variables to use token values from `get_theme_tokens`.
- Kept changes localized to the theme module, component, and Command Center import/use only (other pages were not modified beyond importing the theme system as requested).

### Testing
- Ran `python -m py_compile jupr_app/ui/theme_tokens.py jupr_app/ui/components/theme_toggle.py jupr_app/ui/pages/command_center.py`, which completed successfully.
- Attempted an automated Playwright screenshot to visually validate the header toggle, but the browser process crashed (SIGSEGV) in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fb3a97904832698e64139a2a66cb4)