### PR TITLE
Add Weekly Recap Builder card to Command Center UI

### DIFF
--- a/jupr_app/ui/components/weekly_recaps_ui.py
+++ b/jupr_app/ui/components/weekly_recaps_ui.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RecapAction:
+    label: str
+    href: str
+    style: str = "secondary"
+
+
+def render_weekly_recap_builder_html() -> str:
+    """Render command-center weekly recap controls (UI only, no action handling)."""
+    actions = [
+        RecapAction("Build Recap", "/?page=weekly_recap_admin&recap_action=build", style="primary"),
+        RecapAction("Preview Recap", "/?page=weekly_recap_admin&recap_action=preview"),
+        RecapAction("Publish Recap", "/?page=weekly_recap_admin&recap_action=publish"),
+    ]
+
+    action_links = "".join(
+        (
+            f'<a class="cc-recap-btn cc-recap-btn-{action.style}" '
+            f'href="{action.href}" target="_self">{action.label}</a>'
+        )
+        for action in actions
+    )
+
+    return (
+        """
+        <section class="cc-recap" aria-label="Weekly recap builder">
+          <div class="cc-recap-header">
+            <h3>Weekly Recap Builder</h3>
+            <p>Prepare, review, and publish the weekly summary.</p>
+          </div>
+          <div class="cc-recap-status-wrap">
+            <p class="cc-recap-status-label">Current recap status</p>
+            <p class="cc-recap-status-value">Draft not started</p>
+          </div>
+          <div class="cc-recap-actions">
+        """
+        + action_links
+        + """
+          </div>
+        </section>
+        """
+    )

--- a/jupr_app/ui/pages/command_center.py
+++ b/jupr_app/ui/pages/command_center.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import streamlit as st
 
+from jupr_app.ui.components.command_center_alerts import render_alerts_html
 from jupr_app.ui.components.theme_toggle import render_theme_toggle
+from jupr_app.ui.components.weekly_recaps_ui import render_weekly_recap_builder_html
 from jupr_app.ui.theme import MATCH_COLORS
 from jupr_app.ui.theme_tokens import get_theme_tokens
 
@@ -198,6 +200,85 @@ def _inject_command_center_css(theme_mode: str) -> None:
             border-color: var(--cc-accent-border);
             background: var(--cc-accent-soft);
           }}
+
+          .cc-recap {{
+            grid-column: 1 / -1;
+            border: 1px solid var(--cc-border);
+            background: var(--cc-panel);
+            box-shadow: var(--cc-shadow);
+            border-radius: 16px;
+            color: var(--cc-text);
+            padding: 1rem 1.2rem 1.2rem;
+          }}
+
+          .cc-recap-header h3 {{
+            margin: 0;
+            font-size: 1.1rem;
+          }}
+
+          .cc-recap-header p {{
+            margin: 0.35rem 0 0;
+            color: var(--cc-muted);
+            font-size: 0.85rem;
+          }}
+
+          .cc-recap-status-wrap {{
+            margin-top: 0.95rem;
+            border: 1px solid var(--cc-border);
+            background: var(--cc-bg);
+            border-radius: 12px;
+            padding: 0.75rem 0.9rem;
+          }}
+
+          .cc-recap-status-label {{
+            margin: 0;
+            font-size: 0.78rem;
+            color: var(--cc-muted);
+            letter-spacing: 0.01em;
+          }}
+
+          .cc-recap-status-value {{
+            margin: 0.35rem 0 0;
+            font-size: 1.02rem;
+            font-weight: 700;
+            color: var(--cc-text);
+          }}
+
+          .cc-recap-actions {{
+            margin-top: 0.95rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.6rem;
+          }}
+
+          .cc-recap-btn {{
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 0.82rem;
+            border-radius: 10px;
+            border: 1px solid var(--cc-border);
+            color: var(--cc-text);
+            background: var(--cc-bg);
+            padding: 0.5rem 0.75rem;
+            transition: background 120ms ease, border-color 120ms ease, transform 120ms ease;
+          }}
+
+          .cc-recap-btn:hover {{
+            border-color: var(--cc-accent-border);
+            background: color-mix(in srgb, var(--cc-accent-soft) 75%, var(--cc-bg));
+            transform: translateY(-1px);
+          }}
+
+          .cc-recap-btn:focus-visible {{
+            outline: 2px solid var(--cc-accent-border);
+            outline-offset: 2px;
+          }}
+
+          .cc-recap-btn-primary {{
+            border-color: var(--cc-accent-border);
+            background: var(--cc-accent-soft);
+          }}
+
         </style>
 
         <div class="cc-root" data-theme="{theme_mode}">
@@ -222,6 +303,7 @@ def _inject_command_center_css(theme_mode: str) -> None:
             </div>
 
             {render_alerts_html()}
+            {render_weekly_recap_builder_html()}
           </div>
         </div>
         """,


### PR DESCRIPTION
### Motivation
- Provide an Admin-facing Weekly Recap Builder section in the Command Center to surface recap status and primary actions (build / preview / publish) before implementing recap business logic.
- Keep visuals consistent with existing command-center styling by using theme tokens and accessible interaction states for buttons.

### Description
- Add a new component `jupr_app/ui/components/weekly_recaps_ui.py` with `render_weekly_recap_builder_html()` that returns the recap card HTML with a placeholder status and three action links wired to `/?page=weekly_recap_admin&recap_action=build|preview|publish`.
- Update `jupr_app/ui/pages/command_center.py` to import and render the new recap builder immediately below the Alerts section by calling `render_weekly_recap_builder_html()`.
- Inject CSS for the recap card and buttons into the command center markup using existing theme tokens (`--cc-bg`, `--cc-panel`, `--cc-text`, `--cc-border`, `--cc-accent-*`) and add hover/focus interaction styles.
- No backend recap generation, preview, or publish logic was implemented; only UI and routing hooks were added.

### Testing
- Compiled the modified modules with `python -m compileall jupr_app/ui/pages/command_center.py jupr_app/ui/components/weekly_recaps_ui.py` which succeeded.
- Launched the app using `streamlit run app.py --server.port 8501 --server.headless true` for visual verification which started successfully.
- Captured a Playwright screenshot of `http://127.0.0.1:8501/?page=command_center` to validate placement and visuals (screenshot artifact saved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fb57a62108326a5a3fa87567a2e73)