### PR TITLE
Add Active Competitions grid to Admin Command Center

### DIFF
--- a/jupr_app/ui/components/active_competitions_ui.py
+++ b/jupr_app/ui/components/active_competitions_ui.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CompetitionAction:
+    label: str
+    href: str
+    style: str = "secondary"
+
+
+@dataclass(frozen=True)
+class CompetitionCard:
+    name: str
+    status: str
+    actions: tuple[CompetitionAction, ...]
+
+
+def _placeholder_competitions() -> list[CompetitionCard]:
+    """Temporary placeholder competition metadata until live data is wired."""
+    return [
+        CompetitionCard(
+            name="Ladder League",
+            status="Active",
+            actions=(
+                CompetitionAction("Enter Result", "/?page=league_results", style="primary"),
+                CompetitionAction("View Standings", "/?page=leaderboards"),
+            ),
+        ),
+        CompetitionCard(
+            name="Challenge Ladder",
+            status="Active",
+            actions=(
+                CompetitionAction("Enter Result", "/?page=challenge_ladder_admin", style="primary"),
+                CompetitionAction("View Standings", "/?page=challenge_ladder"),
+            ),
+        ),
+        CompetitionCard(
+            name="Tournament",
+            status="Upcoming",
+            actions=(
+                CompetitionAction("Enter Result", "/?page=tournament_manager", style="primary"),
+                CompetitionAction("View Standings", "/?page=tournaments"),
+            ),
+        ),
+        CompetitionCard(
+            name="Round Robin",
+            status="Active",
+            actions=(
+                CompetitionAction("Enter Result", "/?page=tournaments", style="primary"),
+                CompetitionAction("View Standings", "/?page=leaderboards"),
+            ),
+        ),
+        CompetitionCard(
+            name="Moneyball",
+            status="Closed",
+            actions=(
+                CompetitionAction("Enter Result", "/?page=moneyball", style="primary"),
+                CompetitionAction("View Standings", "/?page=moneyball"),
+            ),
+        ),
+    ]
+
+
+def render_active_competitions_html() -> str:
+    cards: list[str] = []
+    for card in _placeholder_competitions():
+        actions = "".join(
+            (
+                f'<a class="cc-competition-btn cc-competition-btn-{action.style}" '
+                f'href="{action.href}" target="_self">{action.label}</a>'
+            )
+            for action in card.actions
+        )
+
+        cards.append(
+            f"""
+            <article class="cc-competition-card" aria-label="{card.name}">
+              <div class="cc-competition-top">
+                <h4>{card.name}</h4>
+                <span class="cc-competition-status cc-competition-status-{card.status.lower()}">{card.status}</span>
+              </div>
+              <div class="cc-competition-actions">
+                {actions}
+              </div>
+            </article>
+            """.strip()
+        )
+
+    return (
+        """
+        <section class="cc-competitions" aria-label="Active competitions">
+          <div class="cc-competitions-header">
+            <h3>Active Competitions</h3>
+            <p>Monitor live programs and jump directly to key admin actions.</p>
+          </div>
+          <div class="cc-competition-grid">
+        """
+        + "".join(cards)
+        + """
+          </div>
+        </section>
+        """
+    )

--- a/jupr_app/ui/pages/command_center.py
+++ b/jupr_app/ui/pages/command_center.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import streamlit as st
 
+from jupr_app.ui.components.active_competitions_ui import render_active_competitions_html
 from jupr_app.ui.components.command_center_alerts import render_alerts_html
 from jupr_app.ui.components.theme_toggle import render_theme_toggle
 from jupr_app.ui.components.weekly_recaps_ui import render_weekly_recap_builder_html
@@ -279,6 +280,114 @@ def _inject_command_center_css(theme_mode: str) -> None:
             background: var(--cc-accent-soft);
           }}
 
+          .cc-competitions {{
+            grid-column: 1 / -1;
+            border: 1px solid var(--cc-border);
+            background: var(--cc-panel);
+            box-shadow: var(--cc-shadow);
+            border-radius: 16px;
+            color: var(--cc-text);
+            padding: 1rem 1.2rem 1.2rem;
+          }}
+
+          .cc-competitions-header h3 {{
+            margin: 0;
+            font-size: 1.1rem;
+          }}
+
+          .cc-competitions-header p {{
+            margin: 0.35rem 0 0;
+            color: var(--cc-muted);
+            font-size: 0.85rem;
+          }}
+
+          .cc-competition-grid {{
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 0.75rem;
+            margin-top: 0.95rem;
+          }}
+
+          .cc-competition-card {{
+            border: 1px solid var(--cc-border);
+            border-radius: 12px;
+            background: var(--cc-bg);
+            padding: 0.8rem 0.9rem;
+          }}
+
+          .cc-competition-top {{
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 0.6rem;
+          }}
+
+          .cc-competition-top h4 {{
+            margin: 0;
+            font-size: 0.95rem;
+          }}
+
+          .cc-competition-status {{
+            display: inline-flex;
+            align-items: center;
+            border-radius: 999px;
+            padding: 0.18rem 0.55rem;
+            font-size: 0.72rem;
+            font-weight: 700;
+            border: 1px solid var(--cc-border);
+            color: var(--cc-text);
+          }}
+
+          .cc-competition-status-active {{
+            border-color: color-mix(in srgb, {MATCH_COLORS['win']} 45%, var(--cc-border));
+            background: color-mix(in srgb, {MATCH_COLORS['win']} 16%, var(--cc-bg));
+          }}
+
+          .cc-competition-status-upcoming {{
+            border-color: color-mix(in srgb, {MATCH_COLORS['draw']} 45%, var(--cc-border));
+            background: color-mix(in srgb, {MATCH_COLORS['draw']} 16%, var(--cc-bg));
+          }}
+
+          .cc-competition-status-closed {{
+            border-color: color-mix(in srgb, #6b7280 45%, var(--cc-border));
+            background: color-mix(in srgb, #6b7280 16%, var(--cc-bg));
+          }}
+
+          .cc-competition-actions {{
+            margin-top: 0.7rem;
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+          }}
+
+          .cc-competition-btn {{
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 0.79rem;
+            border-radius: 10px;
+            border: 1px solid var(--cc-border);
+            color: var(--cc-text);
+            background: var(--cc-bg);
+            padding: 0.42rem 0.62rem;
+            transition: background 120ms ease, border-color 120ms ease, transform 120ms ease;
+          }}
+
+          .cc-competition-btn:hover {{
+            border-color: var(--cc-accent-border);
+            background: color-mix(in srgb, var(--cc-accent-soft) 75%, var(--cc-bg));
+            transform: translateY(-1px);
+          }}
+
+          .cc-competition-btn:focus-visible {{
+            outline: 2px solid var(--cc-accent-border);
+            outline-offset: 2px;
+          }}
+
+          .cc-competition-btn-primary {{
+            border-color: var(--cc-accent-border);
+            background: var(--cc-accent-soft);
+          }}
+
         </style>
 
         <div class="cc-root" data-theme="{theme_mode}">
@@ -304,6 +413,7 @@ def _inject_command_center_css(theme_mode: str) -> None:
 
             {render_alerts_html()}
             {render_weekly_recap_builder_html()}
+            {render_active_competitions_html()}
           </div>
         </div>
         """,


### PR DESCRIPTION
### Motivation
- Surface currently active competitions in the Admin Command Center so admins can quickly jump to key workflows after alerts and the Weekly Recap builder.
- Provide a responsive card-based UI that works with the existing theming system so it looks correct in dark and light modes.
- Use placeholder data and routes until live competition data and handlers are wired.

### Description
- Added a new UI component `jupr_app/ui/components/active_competitions_ui.py` that renders an "Active Competitions" responsive card grid with cards for `Ladder League`, `Challenge Ladder`, `Tournament`, `Round Robin`, and `Moneyball` and each card includes a status and quick action buttons routed to existing pages.
- Updated `jupr_app/ui/pages/command_center.py` to import `render_active_competitions_html` and render the Active Competitions section immediately below the Weekly Recap Builder.
- Implemented theme-token-aware CSS within `_inject_command_center_css` in `command_center.py` using existing variables like `--cc-bg`, `--cc-panel`, `--cc-text`, and `--cc-accent-*`, and added status-specific styles for Active/Upcoming/Closed and button styles (`.cc-competition-btn`, `.cc-competition-btn-primary`).
- The component currently uses placeholder `CompetitionCard` data and links to existing pages (e.g., `/?page=league_results`, `/?page=challenge_ladder_admin`, `/?page=tournament_manager`, `/?page=tournaments`, `/?page=moneyball`) until back-end wiring is available.

### Testing
- Ran `python -m compileall jupr_app/ui/pages/command_center.py jupr_app/ui/components/active_competitions_ui.py` and compilation succeeded.
- Launched the app with `streamlit run app.py --server.port 8501 --server.headless true` and validated the layout visually via a Playwright screenshot of `http://127.0.0.1:8501/?page=command_center`, which confirmed the new section rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fc085a6948326a172531dd6d5620f)