### PR TITLE
Add leaderboards snapshot card to Command Center

### DIFF
--- a/jupr_app/ui/components/leaderboards_snapshot_ui.py
+++ b/jupr_app/ui/components/leaderboards_snapshot_ui.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LeaderboardPlayer:
+    name: str
+    rating: int
+    movement: int
+    division: str | None = None
+
+
+def _placeholder_leaderboard_players() -> list[LeaderboardPlayer]:
+    """Temporary placeholder leaderboard snapshot until live query integration."""
+    return [
+        LeaderboardPlayer(name="M. Santos", rating=1985, movement=2, division="D1"),
+        LeaderboardPlayer(name="R. Patel", rating=1962, movement=-1, division="D1"),
+        LeaderboardPlayer(name="K. Nguyen", rating=1948, movement=1, division="D2"),
+        LeaderboardPlayer(name="A. Gomez", rating=1931, movement=0, division="D2"),
+        LeaderboardPlayer(name="L. Kim", rating=1914, movement=-2),
+    ]
+
+
+def _movement_badge(player: LeaderboardPlayer) -> str:
+    if player.movement > 0:
+        return (
+            '<span class="cc-lb-move cc-lb-move-up" '
+            f'aria-label="Moved up {player.movement} positions">↑ {player.movement}</span>'
+        )
+    if player.movement < 0:
+        movement = abs(player.movement)
+        return (
+            '<span class="cc-lb-move cc-lb-move-down" '
+            f'aria-label="Moved down {movement} positions">↓ {movement}</span>'
+        )
+    return '<span class="cc-lb-move cc-lb-move-flat" aria-label="No movement">→ 0</span>'
+
+
+def render_leaderboards_snapshot_html() -> str:
+    rows: list[str] = []
+    for index, player in enumerate(_placeholder_leaderboard_players(), start=1):
+        division = f'<span class="cc-lb-division">{player.division}</span>' if player.division else ""
+        rows.append(
+            f"""
+            <article class="cc-lb-row" aria-label="Leaderboard player {player.name}">
+              <div class="cc-lb-player-wrap">
+                <span class="cc-lb-rank">#{index}</span>
+                <div>
+                  <p class="cc-lb-player">{player.name}</p>
+                  <p class="cc-lb-meta">Rating {player.rating}</p>
+                </div>
+              </div>
+              <div class="cc-lb-right">
+                {division}
+                {_movement_badge(player)}
+              </div>
+            </article>
+            """.strip()
+        )
+
+    return (
+        """
+        <section class="cc-leaderboards" aria-label="Leaderboards snapshot">
+          <div class="cc-leaderboards-header">
+            <h3>Leaderboards Snapshot</h3>
+            <p>Top 5 players across all competitions (placeholder source data).</p>
+          </div>
+          <div class="cc-lb-grid">
+        """
+        + "".join(rows)
+        + """
+          </div>
+        </section>
+        """
+    )

--- a/jupr_app/ui/pages/command_center.py
+++ b/jupr_app/ui/pages/command_center.py
@@ -4,6 +4,7 @@ import streamlit as st
 
 from jupr_app.ui.components.active_competitions_ui import render_active_competitions_html
 from jupr_app.ui.components.command_center_alerts import render_alerts_html
+from jupr_app.ui.components.leaderboards_snapshot_ui import render_leaderboards_snapshot_html
 from jupr_app.ui.components.theme_toggle import render_theme_toggle
 from jupr_app.ui.components.weekly_recaps_ui import render_weekly_recap_builder_html
 from jupr_app.ui.theme import MATCH_COLORS
@@ -388,6 +389,112 @@ def _inject_command_center_css(theme_mode: str) -> None:
             background: var(--cc-accent-soft);
           }}
 
+          .cc-leaderboards {{
+            grid-column: 1 / -1;
+            border: 1px solid var(--cc-border);
+            background: var(--cc-panel);
+            box-shadow: var(--cc-shadow);
+            border-radius: 16px;
+            color: var(--cc-text);
+            padding: 1rem 1.2rem 1.2rem;
+          }}
+
+          .cc-leaderboards-header h3 {{
+            margin: 0;
+            font-size: 1.1rem;
+          }}
+
+          .cc-leaderboards-header p {{
+            margin: 0.35rem 0 0;
+            color: var(--cc-muted);
+            font-size: 0.85rem;
+          }}
+
+          .cc-lb-grid {{
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 0.75rem;
+            margin-top: 0.95rem;
+          }}
+
+          .cc-lb-row {{
+            border: 1px solid var(--cc-border);
+            border-radius: 12px;
+            background: var(--cc-bg);
+            padding: 0.75rem 0.85rem;
+            display: grid;
+            grid-template-columns: 1fr auto;
+            align-items: center;
+            gap: 0.6rem;
+          }}
+
+          .cc-lb-player-wrap {{
+            display: flex;
+            align-items: center;
+            gap: 0.7rem;
+            min-width: 0;
+          }}
+
+          .cc-lb-rank {{
+            font-size: 0.84rem;
+            font-weight: 800;
+            color: var(--cc-muted);
+            min-width: 2.2rem;
+          }}
+
+          .cc-lb-player {{
+            margin: 0;
+            font-size: 0.94rem;
+            font-weight: 700;
+            color: var(--cc-text);
+            line-height: 1.25;
+          }}
+
+          .cc-lb-meta {{
+            margin: 0.22rem 0 0;
+            font-size: 0.79rem;
+            color: var(--cc-muted);
+          }}
+
+          .cc-lb-right {{
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            justify-content: flex-end;
+          }}
+
+          .cc-lb-division,
+          .cc-lb-move {{
+            display: inline-flex;
+            align-items: center;
+            border-radius: 999px;
+            border: 1px solid var(--cc-border);
+            padding: 0.16rem 0.5rem;
+            font-size: 0.72rem;
+            font-weight: 700;
+            line-height: 1.25;
+          }}
+
+          .cc-lb-division {{
+            color: var(--cc-muted);
+            background: color-mix(in srgb, var(--cc-bg) 82%, var(--cc-panel));
+          }}
+
+          .cc-lb-move-up {{
+            border-color: color-mix(in srgb, {MATCH_COLORS['win']} 45%, var(--cc-border));
+            background: color-mix(in srgb, {MATCH_COLORS['win']} 18%, var(--cc-bg));
+          }}
+
+          .cc-lb-move-down {{
+            border-color: color-mix(in srgb, {MATCH_COLORS['loss']} 45%, var(--cc-border));
+            background: color-mix(in srgb, {MATCH_COLORS['loss']} 16%, var(--cc-bg));
+          }}
+
+          .cc-lb-move-flat {{
+            border-color: color-mix(in srgb, #6b7280 45%, var(--cc-border));
+            background: color-mix(in srgb, #6b7280 14%, var(--cc-bg));
+          }}
+
         </style>
 
         <div class="cc-root" data-theme="{theme_mode}">
@@ -414,6 +521,7 @@ def _inject_command_center_css(theme_mode: str) -> None:
             {render_alerts_html()}
             {render_weekly_recap_builder_html()}
             {render_active_competitions_html()}
+            {render_leaderboards_snapshot_html()}
           </div>
         </div>
         """,


### PR DESCRIPTION
### Motivation
- Provide a compact Leaderboards snapshot in the Command Center showing the top players (top 5), their ratings, movement (up/down/flat) and optional division tags using the app's theme tokens and grid typography patterns.

### Description
- Add new component `jupr_app/ui/components/leaderboards_snapshot_ui.py` which defines a `LeaderboardPlayer` dataclass, placeholder top-5 data, movement-badge logic, and `render_leaderboards_snapshot_html()` to produce the card HTML.
- Wire the new component into the Command Center by importing `render_leaderboards_snapshot_html` and rendering it immediately below Active Competitions in `jupr_app/ui/pages/command_center.py`.
- Add Command Center CSS for the leaderboard card and its elements (card surface, grid rows, rank/metadata, division pill, movement badges) using existing theme tokens and `MATCH_COLORS` to keep consistent theming.

### Testing
- Ran `python -m compileall jupr_app/ui/pages/command_center.py jupr_app/ui/components/leaderboards_snapshot_ui.py` and compilation succeeded.
- Launched the app with `streamlit run streamlit_app.py --server.port 8501 --server.headless true` and the server started successfully for visual verification.
- Captured a UI screenshot programmatically via Playwright against `http://127.0.0.1:8501/?page=command_center` to validate the new card rendering, and the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fefe0194483269c5b9055f64d0d81)