### PR TITLE
Add public navigation section to Command Center

### DIFF
--- a/jupr_app/ui/components/command_center_public_nav.py
+++ b/jupr_app/ui/components/command_center_public_nav.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PublicNavCard:
+    title: str
+    description: str
+    href: str
+
+
+def _public_nav_cards() -> list[PublicNavCard]:
+    return [
+        PublicNavCard(
+            title="Leaderboards",
+            description="View current rankings and key performance trends.",
+            href="/?page=leaderboards&public=1",
+        ),
+        PublicNavCard(
+            title="Weekly Recap",
+            description="Catch up on the latest highlights and club storylines.",
+            href="/?page=weekly_recap&public=1",
+        ),
+        PublicNavCard(
+            title="Player Profiles",
+            description="Look up player bios, ratings history, and match activity.",
+            href="/?page=players&public=1",
+        ),
+        PublicNavCard(
+            title="Standings",
+            description="Browse full standings snapshots for active programs.",
+            href="/?page=leaderboards&public=1",
+        ),
+    ]
+
+
+def render_public_navigation_html() -> str:
+    cards = "".join(
+        (
+            f"""
+            <article class=\"cc-public-card\" aria-label=\"Public link {card.title}\">
+              <h4>{card.title}</h4>
+              <p>{card.description}</p>
+              <a class=\"cc-public-link\" href=\"{card.href}\" target=\"_self\">Open view →</a>
+            </article>
+            """.strip()
+        )
+        for card in _public_nav_cards()
+    )
+
+    return (
+        """
+        <section class="cc-public-nav" aria-label="Public navigation">
+          <div class="cc-public-header">
+            <h3>Public Navigation</h3>
+            <p>Quick links to fan-facing views outside admin workflows.</p>
+          </div>
+          <div class="cc-public-grid">
+        """
+        + cards
+        + """
+          </div>
+        </section>
+        """
+    )

--- a/jupr_app/ui/pages/command_center.py
+++ b/jupr_app/ui/pages/command_center.py
@@ -4,6 +4,7 @@ import streamlit as st
 
 from jupr_app.ui.components.active_competitions_ui import render_active_competitions_html
 from jupr_app.ui.components.command_center_alerts import render_alerts_html
+from jupr_app.ui.components.command_center_public_nav import render_public_navigation_html
 from jupr_app.ui.components.leaderboards_snapshot_ui import render_leaderboards_snapshot_html
 from jupr_app.ui.components.theme_toggle import render_theme_toggle
 from jupr_app.ui.components.weekly_recaps_ui import render_weekly_recap_builder_html
@@ -495,6 +496,78 @@ def _inject_command_center_css(theme_mode: str) -> None:
             background: color-mix(in srgb, #6b7280 14%, var(--cc-bg));
           }}
 
+          .cc-public-nav {{
+            grid-column: 1 / -1;
+            border: 1px solid var(--cc-border);
+            background: color-mix(in srgb, var(--cc-bg) 86%, var(--cc-panel));
+            box-shadow: var(--cc-shadow);
+            border-radius: 16px;
+            color: var(--cc-text);
+            padding: 1rem 1.2rem 1.2rem;
+          }}
+
+          .cc-public-header h3 {{
+            margin: 0;
+            font-size: 1.1rem;
+          }}
+
+          .cc-public-header p {{
+            margin: 0.35rem 0 0;
+            color: var(--cc-muted);
+            font-size: 0.85rem;
+          }}
+
+          .cc-public-grid {{
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 0.75rem;
+            margin-top: 0.95rem;
+          }}
+
+          .cc-public-card {{
+            border: 1px solid var(--cc-border);
+            border-radius: 12px;
+            background: color-mix(in srgb, var(--cc-bg) 92%, var(--cc-panel));
+            padding: 0.8rem 0.9rem;
+          }}
+
+          .cc-public-card h4 {{
+            margin: 0;
+            font-size: 0.95rem;
+          }}
+
+          .cc-public-card p {{
+            margin: 0.45rem 0 0;
+            color: var(--cc-muted);
+            font-size: 0.82rem;
+            min-height: 2.4rem;
+          }}
+
+          .cc-public-link {{
+            display: inline-flex;
+            margin-top: 0.7rem;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 0.79rem;
+            border-radius: 10px;
+            border: 1px solid var(--cc-border);
+            color: var(--cc-text);
+            background: var(--cc-bg);
+            padding: 0.42rem 0.62rem;
+            transition: background 120ms ease, border-color 120ms ease, transform 120ms ease;
+          }}
+
+          .cc-public-link:hover {{
+            border-color: var(--cc-accent-border);
+            background: color-mix(in srgb, var(--cc-accent-soft) 75%, var(--cc-bg));
+            transform: translateY(-1px);
+          }}
+
+          .cc-public-link:focus-visible {{
+            outline: 2px solid var(--cc-accent-border);
+            outline-offset: 2px;
+          }}
+
         </style>
 
         <div class="cc-root" data-theme="{theme_mode}">
@@ -522,6 +595,7 @@ def _inject_command_center_css(theme_mode: str) -> None:
             {render_weekly_recap_builder_html()}
             {render_active_competitions_html()}
             {render_leaderboards_snapshot_html()}
+            {render_public_navigation_html()}
           </div>
         </div>
         """,


### PR DESCRIPTION
### Motivation
- Provide quick access from the Command Center to public-facing views (Leaderboards, Weekly Recap, Player Profiles, Standings) so admins can jump to public pages for review or sharing.
- Visually separate public/fan-facing navigation from admin cards using a muted panel treatment while preserving dark/light theming.
- Use existing theme tokens so the new section respects the app's dark/light color system and accessibility patterns.

### Description
- Added a new component `jupr_app/ui/components/command_center_public_nav.py` that defines `PublicNavCard` and `render_public_navigation_html()` to emit four public navigation cards linking to public pages (`public=1`).
- Integrated the new public nav into the Command Center layout by importing and calling `render_public_navigation_html()` at the bottom of `jupr_app/ui/pages/command_center.py`.
- Injected new CSS rules in `_inject_command_center_css()` to style the public section and cards using theme tokens and a muted background so the public area is visually distinct from admin cards.
- Links for each card point to canonical public routes (query params) so the cards open the public views in the same app.

### Testing
- Compiled the changed modules with `python -m compileall jupr_app/ui/pages/command_center.py jupr_app/ui/components/command_center_public_nav.py` and compilation succeeded. 
- Launched the app with `python -m streamlit run app.py --server.port 8501 --server.headless true` for visual verification and the server started successfully. 
- Captured a Playwright screenshot of `/?page=command_center` to verify rendering; screenshot was generated successfully as a visual artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ff48de37c832683e216d7ab54060e)