### PR TITLE
Add enterprise elevation and motion tokens with global CSS utilities

### DIFF
--- a/jupr_app/ui/layout.py
+++ b/jupr_app/ui/layout.py
@@ -7,6 +7,85 @@ import streamlit as st
 from jupr_app.ui.theme_clean import topbar
 
 
+def _inject_elevation_motion_css() -> None:
+    st.markdown(
+        """
+        <style>
+          :root {
+            --elev-0: none;
+            --elev-1: 0 1px 2px rgba(15, 23, 42, 0.08), 0 1px 1px rgba(15, 23, 42, 0.04);
+            --elev-2: 0 6px 18px rgba(15, 23, 42, 0.12), 0 2px 6px rgba(15, 23, 42, 0.08);
+            --elev-3: 0 14px 36px rgba(15, 23, 42, 0.18), 0 4px 12px rgba(15, 23, 42, 0.10);
+
+            --motion-fast: 120ms;
+            --motion-standard: 180ms;
+            --motion-medium: 240ms;
+            --motion-easing-standard: cubic-bezier(0.4, 0.0, 0.2, 1);
+          }
+
+          html[data-theme="dark"] {
+            --elev-1: 0 1px 2px rgba(0, 0, 0, 0.45), 0 1px 1px rgba(0, 0, 0, 0.28);
+            --elev-2: 0 8px 20px rgba(0, 0, 0, 0.52), 0 3px 8px rgba(0, 0, 0, 0.36);
+            --elev-3: 0 16px 40px rgba(0, 0, 0, 0.62), 0 6px 14px rgba(0, 0, 0, 0.42);
+          }
+
+          @media (prefers-color-scheme: dark) {
+            :root {
+              --elev-1: 0 1px 2px rgba(0, 0, 0, 0.45), 0 1px 1px rgba(0, 0, 0, 0.28);
+              --elev-2: 0 8px 20px rgba(0, 0, 0, 0.52), 0 3px 8px rgba(0, 0, 0, 0.36);
+              --elev-3: 0 16px 40px rgba(0, 0, 0, 0.62), 0 6px 14px rgba(0, 0, 0, 0.42);
+            }
+          }
+
+          .elev-1,
+          .elev-2,
+          .elev-3 {
+            transition:
+              box-shadow var(--motion-standard) var(--motion-easing-standard),
+              transform var(--motion-fast) var(--motion-easing-standard);
+            will-change: box-shadow, transform;
+          }
+
+          .elev-1 {
+            box-shadow: var(--elev-1);
+          }
+
+          .elev-2 {
+            box-shadow: var(--elev-2);
+          }
+
+          .elev-3 {
+            box-shadow: var(--elev-3);
+          }
+
+          .elev-1:hover,
+          .elev-2:hover,
+          .elev-3:hover {
+            transform: translateY(-1px);
+          }
+
+          .elev-1:hover {
+            box-shadow: var(--elev-2);
+          }
+
+          .elev-2:hover,
+          .elev-3:hover {
+            box-shadow: var(--elev-3);
+          }
+
+          .elev-1:active,
+          .elev-2:active,
+          .elev-3:active {
+            transform: translateY(0);
+            box-shadow: var(--elev-1);
+            transition-duration: var(--motion-fast);
+          }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
 def page_shell(
     title: str,
     subtitle: str = "",
@@ -17,6 +96,8 @@ def page_shell(
     """
     Render a consistent page chrome wrapper (topbar + spacing).
     """
+    _inject_elevation_motion_css()
+
     resolved_right_html = right_html
     if not resolved_right_html and mode_label:
         resolved_right_html = f'<span class="jupr-pill neutral">{html.escape(mode_label)}</span>'

--- a/jupr_app/ui/theme/elevation.py
+++ b/jupr_app/ui/theme/elevation.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ElevationLevel:
+    level: int
+    light_shadow: str
+    dark_shadow: str
+
+
+ELEVATION_LEVELS: dict[int, ElevationLevel] = {
+    0: ElevationLevel(level=0, light_shadow="none", dark_shadow="none"),
+    1: ElevationLevel(
+        level=1,
+        light_shadow="0 1px 2px rgba(15, 23, 42, 0.08), 0 1px 1px rgba(15, 23, 42, 0.04)",
+        dark_shadow="0 1px 2px rgba(0, 0, 0, 0.45), 0 1px 1px rgba(0, 0, 0, 0.28)",
+    ),
+    2: ElevationLevel(
+        level=2,
+        light_shadow="0 6px 18px rgba(15, 23, 42, 0.12), 0 2px 6px rgba(15, 23, 42, 0.08)",
+        dark_shadow="0 8px 20px rgba(0, 0, 0, 0.52), 0 3px 8px rgba(0, 0, 0, 0.36)",
+    ),
+    3: ElevationLevel(
+        level=3,
+        light_shadow="0 14px 36px rgba(15, 23, 42, 0.18), 0 4px 12px rgba(15, 23, 42, 0.10)",
+        dark_shadow="0 16px 40px rgba(0, 0, 0, 0.62), 0 6px 14px rgba(0, 0, 0, 0.42)",
+    ),
+}
+
+
+def get_elevation_shadow(level: int, *, dark_mode: bool = False) -> str:
+    token = ELEVATION_LEVELS.get(level, ELEVATION_LEVELS[0])
+    return token.dark_shadow if dark_mode else token.light_shadow

--- a/jupr_app/ui/theme/motion.py
+++ b/jupr_app/ui/theme/motion.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+MOTION_DURATION_FAST_MS = 120
+MOTION_DURATION_STANDARD_MS = 180
+MOTION_DURATION_MEDIUM_MS = 240
+MOTION_EASING_STANDARD = "cubic-bezier(0.4, 0.0, 0.2, 1)"
+
+MOTION_TOKENS = {
+    "fast": f"{MOTION_DURATION_FAST_MS}ms",
+    "standard": f"{MOTION_DURATION_STANDARD_MS}ms",
+    "medium": f"{MOTION_DURATION_MEDIUM_MS}ms",
+    "easing": MOTION_EASING_STANDARD,
+}


### PR DESCRIPTION
### Motivation

- Provide a small, enterprise-grade elevation and motion system to support layered depth and refined animations across the Command Center UI. 
- Expose theme-aware elevation tokens so shadows adapt to light and dark modes consistently. 
- Centralize motion timing and easing tokens to keep interaction timing consistent across components.

### Description

- Add `jupr_app/ui/theme/elevation.py` which defines four elevation levels (0–3) using a frozen `ElevationLevel` dataclass and a `get_elevation_shadow()` accessor for theme-aware lookups. 
- Add `jupr_app/ui/theme/motion.py` which defines motion durations `fast` (120ms), `standard` (180ms), `medium` (240ms) and an easing token `cubic-bezier(0.4, 0.0, 0.2, 1)` exposed via `MOTION_TOKENS`. 
- Inject global CSS from `page_shell` in `jupr_app/ui/layout.py` via a new `_inject_elevation_motion_css()` helper which publishes CSS variables, dark-mode overrides, and utility classes `.elev-1`, `.elev-2`, `.elev-3`. 
- Implement hover transitions and active press states that use the motion tokens for consistent durations and easing without modifying individual pages.

### Testing

- Ran `python -m compileall jupr_app/ui/layout.py jupr_app/ui/theme/elevation.py jupr_app/ui/theme/motion.py` which completed successfully. 
- Launched the app with `streamlit run streamlit_app.py --server.headless true --server.port 8501` which started the server and served the app on `http://127.0.0.1:8501`. 
- Attempted automated visual validation via Playwright to capture a screenshot, but the Chromium process crashed in this environment (SIGSEGV), so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699007c3a0808326bc1215e98203eae0)