### PR TITLE
Add skeleton loading placeholders for Command Center panels

### DIFF
--- a/jupr_app/ui/components/active_competitions_ui.py
+++ b/jupr_app/ui/components/active_competitions_ui.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from jupr_app.ui.components.card import Card
+from jupr_app.ui.components.skeleton import render_card_skeleton, render_header_skeleton
 
 
 @dataclass(frozen=True)
@@ -26,7 +27,9 @@ def _placeholder_competitions() -> list[CompetitionCard]:
             name="Ladder League",
             status="Active",
             actions=(
-                CompetitionAction("Enter Result", "/?page=league_results", style="primary"),
+                CompetitionAction(
+                    "Enter Result", "/?page=league_results", style="primary"
+                ),
                 CompetitionAction("View Standings", "/?page=leaderboards"),
             ),
         ),
@@ -34,7 +37,9 @@ def _placeholder_competitions() -> list[CompetitionCard]:
             name="Challenge Ladder",
             status="Active",
             actions=(
-                CompetitionAction("Enter Result", "/?page=record_match", style="primary"),
+                CompetitionAction(
+                    "Enter Result", "/?page=record_match", style="primary"
+                ),
                 CompetitionAction("View Standings", "/?page=challenge_ladder"),
             ),
         ),
@@ -42,7 +47,9 @@ def _placeholder_competitions() -> list[CompetitionCard]:
             name="Tournament",
             status="Upcoming",
             actions=(
-                CompetitionAction("Enter Result", "/?page=record_match", style="primary"),
+                CompetitionAction(
+                    "Enter Result", "/?page=record_match", style="primary"
+                ),
                 CompetitionAction("View Standings", "/?page=tournaments"),
             ),
         ),
@@ -50,7 +57,9 @@ def _placeholder_competitions() -> list[CompetitionCard]:
             name="Round Robin",
             status="Active",
             actions=(
-                CompetitionAction("Enter Result", "/?page=record_match", style="primary"),
+                CompetitionAction(
+                    "Enter Result", "/?page=record_match", style="primary"
+                ),
                 CompetitionAction("View Standings", "/?page=leaderboards"),
             ),
         ),
@@ -58,14 +67,37 @@ def _placeholder_competitions() -> list[CompetitionCard]:
             name="Moneyball",
             status="Closed",
             actions=(
-                CompetitionAction("Enter Result", "/?page=record_match", style="primary"),
+                CompetitionAction(
+                    "Enter Result", "/?page=record_match", style="primary"
+                ),
                 CompetitionAction("View Standings", "/?page=moneyball"),
             ),
         ),
     ]
 
 
-def render_active_competitions_html() -> str:
+def render_active_competitions_html(is_loading: bool = False) -> str:
+    if is_loading:
+        return Card(
+            """
+              <div class="cc-competitions-header">
+            """
+            + render_header_skeleton()
+            + """
+              </div>
+              <div class="cc-competition-grid">
+            """
+            + "".join(render_card_skeleton() for _ in range(5))
+            + """
+              </div>
+            """,
+            elevation=2,
+            interactive=False,
+            class_name="cc-competitions",
+            tag="section",
+            attrs='aria-label="Active competitions"',
+        )
+
     cards: list[str] = []
     for card in _placeholder_competitions():
         actions = "".join(

--- a/jupr_app/ui/components/command_center_alerts.py
+++ b/jupr_app/ui/components/command_center_alerts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from jupr_app.ui.components.card import Card
+from jupr_app.ui.components.skeleton import render_card_skeleton, render_header_skeleton
 
 
 @dataclass(frozen=True)
@@ -53,7 +54,28 @@ def _placeholder_alert_items() -> list[AlertItem]:
     ]
 
 
-def render_alerts_html() -> str:
+def render_alerts_html(is_loading: bool = False) -> str:
+    if is_loading:
+        return Card(
+            """
+              <div class="cc-alerts-header">
+            """
+            + render_header_skeleton()
+            + """
+              </div>
+              <div class="cc-alert-grid">
+            """
+            + "".join(render_card_skeleton() for _ in range(4))
+            + """
+              </div>
+            """,
+            elevation=2,
+            interactive=False,
+            class_name="cc-alerts",
+            tag="section",
+            attrs='aria-label="Admin alerts" data-alert-count="0"',
+        )
+
     active_items = [item for item in _placeholder_alert_items() if item.count > 0]
     total_active_alerts = sum(item.count for item in active_items)
 

--- a/jupr_app/ui/components/leaderboards_snapshot_ui.py
+++ b/jupr_app/ui/components/leaderboards_snapshot_ui.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from jupr_app.ui.components.skeleton import (
+    render_header_skeleton,
+    render_table_row_skeleton,
+)
+
 
 @dataclass(frozen=True)
 class LeaderboardPlayer:
@@ -34,13 +39,37 @@ def _movement_badge(player: LeaderboardPlayer) -> str:
             '<span class="cc-lb-move cc-lb-move-down" '
             f'aria-label="Moved down {movement} positions">↓ {movement}</span>'
         )
-    return '<span class="cc-lb-move cc-lb-move-flat" aria-label="No movement">→ 0</span>'
+    return (
+        '<span class="cc-lb-move cc-lb-move-flat" aria-label="No movement">→ 0</span>'
+    )
 
 
-def render_leaderboards_snapshot_html() -> str:
+def render_leaderboards_snapshot_html(is_loading: bool = False) -> str:
+    if is_loading:
+        return (
+            """
+            <section class="cc-leaderboards" aria-label="Leaderboards snapshot">
+              <div class="cc-leaderboards-header">
+            """
+            + render_header_skeleton()
+            + """
+              </div>
+              <div class="cc-lb-grid">
+            """
+            + "".join(render_table_row_skeleton() for _ in range(5))
+            + """
+              </div>
+            </section>
+            """
+        )
+
     rows: list[str] = []
     for index, player in enumerate(_placeholder_leaderboard_players(), start=1):
-        division = f'<span class="cc-lb-division">{player.division}</span>' if player.division else ""
+        division = (
+            f'<span class="cc-lb-division">{player.division}</span>'
+            if player.division
+            else ""
+        )
         rows.append(
             f"""
             <article class="cc-lb-row" aria-label="Leaderboard player {player.name}">

--- a/jupr_app/ui/components/skeleton.py
+++ b/jupr_app/ui/components/skeleton.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+
+def skeleton_css() -> str:
+    """Shared CSS for low-contrast shimmer skeleton placeholders."""
+    return """
+      @keyframes cc-skeleton-shimmer {
+        0% {
+          background-position: 180% 0;
+        }
+        100% {
+          background-position: -80% 0;
+        }
+      }
+
+      .cc-skeleton-block {
+        border-radius: 10px;
+        display: block;
+        width: 100%;
+        background: linear-gradient(
+          100deg,
+          color-mix(in srgb, var(--cc-muted) 10%, transparent) 30%,
+          color-mix(in srgb, var(--cc-muted) 18%, transparent) 50%,
+          color-mix(in srgb, var(--cc-muted) 10%, transparent) 70%
+        );
+        background-size: 220% 100%;
+        animation: cc-skeleton-shimmer 1.8s ease-in-out infinite;
+      }
+
+      .cc-skeleton-header {
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      .cc-skeleton-row {
+        border: 1px solid var(--cc-border);
+        border-radius: 12px;
+        background: color-mix(in srgb, var(--cc-bg) 90%, var(--cc-panel));
+        padding: 0.75rem 0.85rem;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+        gap: 0.7rem;
+        min-height: 72px;
+      }
+
+      .cc-skeleton-row-left {
+        display: flex;
+        align-items: center;
+        gap: 0.7rem;
+      }
+
+      .cc-skeleton-chip-wrap {
+        display: inline-flex;
+        gap: 0.45rem;
+      }
+
+      .cc-skeleton-card {
+        border: 1px solid var(--cc-border);
+        border-radius: 12px;
+        background: var(--cc-bg);
+        padding: 0.8rem 0.9rem;
+        min-height: 114px;
+        display: grid;
+        align-content: space-between;
+        gap: 0.7rem;
+      }
+
+      .cc-skeleton-card-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+    """
+
+
+def _block(height_px: int, width: str, class_name: str = "") -> str:
+    klass = "cc-skeleton-block"
+    if class_name:
+        klass += f" {class_name}"
+    return f'<span class="{klass}" style="height:{height_px}px; width:{width};"></span>'
+
+
+def render_header_skeleton() -> str:
+    return (
+        '<div class="cc-skeleton-header" aria-hidden="true">'
+        + _block(20, "42%")
+        + _block(12, "68%")
+        + "</div>"
+    )
+
+
+def render_table_row_skeleton() -> str:
+    return (
+        '<article class="cc-skeleton-row" aria-hidden="true">'
+        '<div class="cc-skeleton-row-left">'
+        + _block(24, "40px")
+        + '<div style="display:grid; gap:0.4rem; width:100%;">'
+        + _block(14, "52%")
+        + _block(11, "36%")
+        + "</div></div>"
+        + '<div class="cc-skeleton-chip-wrap">'
+        + _block(20, "44px")
+        + _block(20, "56px")
+        + "</div></article>"
+    )
+
+
+def render_card_skeleton() -> str:
+    return (
+        '<article class="cc-skeleton-card" aria-hidden="true">'
+        '<div style="display:grid; gap:0.6rem;">'
+        + _block(16, "60%")
+        + _block(12, "38%")
+        + "</div>"
+        + '<div class="cc-skeleton-card-actions">'
+        + _block(30, "116px")
+        + _block(30, "128px")
+        + "</div></article>"
+    )

--- a/jupr_app/ui/pages/command_center.py
+++ b/jupr_app/ui/pages/command_center.py
@@ -2,18 +2,27 @@ from __future__ import annotations
 
 import streamlit as st
 
-from jupr_app.ui.components.active_competitions_ui import render_active_competitions_html
+from jupr_app.ui.components.active_competitions_ui import (
+    render_active_competitions_html,
+)
 from jupr_app.ui.components.card import Card, card_css
 from jupr_app.ui.components.command_center_alerts import render_alerts_html
-from jupr_app.ui.components.command_center_public_nav import render_public_navigation_html
-from jupr_app.ui.components.leaderboards_snapshot_ui import render_leaderboards_snapshot_html
+from jupr_app.ui.components.command_center_public_nav import (
+    render_public_navigation_html,
+)
+from jupr_app.ui.components.leaderboards_snapshot_ui import (
+    render_leaderboards_snapshot_html,
+)
+from jupr_app.ui.components.skeleton import skeleton_css
 from jupr_app.ui.components.theme_toggle import render_theme_toggle
 from jupr_app.ui.components.weekly_recaps_ui import render_weekly_recap_builder_html
 from jupr_app.ui.theme import MATCH_COLORS
 from jupr_app.ui.theme_tokens import get_theme_tokens
 
 
-def _inject_command_center_css(theme_mode: str) -> None:
+def _inject_command_center_css(
+    theme_mode: str, show_loading_skeletons: bool = False
+) -> None:
     tokens = get_theme_tokens(theme_mode)
     hero_html = Card(
         """
@@ -65,6 +74,7 @@ def _inject_command_center_css(theme_mode: str) -> None:
           }}
 
           {card_css()}
+          {skeleton_css()}
 
           .cc-header {{
             grid-column: 1 / -1;
@@ -610,10 +620,10 @@ def _inject_command_center_css(theme_mode: str) -> None:
 
             {hero_html}
 
-            {render_alerts_html()}
+            {render_alerts_html(is_loading=show_loading_skeletons)}
             {render_weekly_recap_builder_html()}
-            {render_active_competitions_html()}
-            {render_leaderboards_snapshot_html()}
+            {render_active_competitions_html(is_loading=show_loading_skeletons)}
+            {render_leaderboards_snapshot_html(is_loading=show_loading_skeletons)}
             {render_public_navigation_html()}
           </div>
         </div>
@@ -633,4 +643,7 @@ def render(ctx) -> None:
     with col_r:
         theme_mode = render_theme_toggle(key="cc_theme_toggle", label="Dark theme")
 
-    _inject_command_center_css(theme_mode)
+    show_loading_skeletons = bool(st.session_state.get("cc_loading_skeletons", False))
+    _inject_command_center_css(
+        theme_mode, show_loading_skeletons=show_loading_skeletons
+    )


### PR DESCRIPTION
### Motivation

- Replace transient Streamlit spinners with lightweight, theme-aware skeleton placeholders for a smoother loading experience that preserves layout dimensions. 
- Provide reusable skeleton primitives so multiple Command Center panels can show consistent low-contrast shimmer placeholders in both dark and light modes.

### Description

- Add `jupr_app/ui/components/skeleton.py` implementing shared skeleton CSS plus three primitives: header skeleton (`render_header_skeleton`), card skeleton (`render_card_skeleton`), and table-row skeleton (`render_table_row_skeleton`) with a subtle `cc-skeleton-shimmer` animation that uses existing theme CSS variables.
- Integrate skeletons into Leaderboards snapshot by adding `is_loading` to `render_leaderboards_snapshot_html` to render header + 5 table-row skeletons while preserving container layout and spacing.
- Integrate skeletons into Active Competitions by adding `is_loading` to `render_active_competitions_html` to render header + 5 card skeletons inside the competitions card wrapper.
- Integrate skeletons into Alerts panel by adding `is_loading` to `render_alerts_html` to render header + 4 card skeletons while preserving panel dimensions and `data-alert-count` semantics.
- Wire the shared skeleton CSS into the Command Center page via `skeleton_css()` and expose a session-state toggle (`cc_loading_skeletons`) used to call the `is_loading` paths so the skeletons can be toggled on/off without changing existing layout.

### Testing

- Compiled modified modules with `python -m compileall <files>` and compilation completed successfully for the changed files. 
- Ran `pytest -q tests/test_ui_color_tokens.py`, which failed due to repository-wide hard-coded color literals detected in existing UI files; this failure is unrelated to the skeleton integration and no new hard-coded colors were introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914e6fc9b48326abb91143098a1107)