### PR TITLE
Add submit_match hook flag and disable hooks in match_processing

### DIFF
--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -333,6 +333,8 @@ def process_matches(
                         context_id=context_id,
                         match_payload=match_row,
                         idempotency_key=idempotency_key,
+                        # match_processing already persists league_ratings; avoid pipeline hook double writes.
+                        run_context_hooks=False,
                     )
                 )
 

--- a/services/match_pipeline.py
+++ b/services/match_pipeline.py
@@ -41,6 +41,7 @@ def submit_match(
     context_id: Optional[str],
     match_payload: Dict[str, Any],
     idempotency_key: Optional[str] = None,
+    run_context_hooks: bool = True,
 ) -> Dict[str, Any]:
     """Validate input and route to canonical pipeline steps.
 
@@ -66,13 +67,21 @@ def submit_match(
         idempotency_key=idempotency_key,
     )
     rating_result = _apply_rating_engine_stub(match_payload=match_payload)
-    hooks_result = _run_context_hooks(
-        club_id=club_id,
-        context_type=context_type,
-        context_id=context_id,
-        match_payload=match_payload,
-        rating_result=rating_result,
-    )
+    hooks_result: Dict[str, Any]
+    if run_context_hooks:
+        hooks_result = _run_context_hooks(
+            club_id=club_id,
+            context_type=context_type,
+            context_id=context_id,
+            match_payload=match_payload,
+            rating_result=rating_result,
+        )
+    else:
+        hooks_result = {
+            "stub": True,
+            "name": "run_context_hooks",
+            "action": "skipped_by_flag",
+        }
 
     return {
         "ok": True,


### PR DESCRIPTION
### Motivation
- The pipeline's league context hook and `match_processing` both wrote to `league_ratings`, causing duplicate updates and inconsistent standings when `match_processing` snapshots are not league snapshots. 
- The minimal containment fix is to let callers opt out of pipeline context hooks so `match_processing` can remain the sole writer to `league_ratings` for its flow.

### Description
- Add an optional `run_context_hooks: bool = True` parameter to `services.match_pipeline.submit_match()` so existing callers keep current behavior by default. 
- Gate the call to `_run_context_hooks(...)` behind `run_context_hooks` and return a stubbed hooks result (`{"stub": True, "name": "run_context_hooks", "action": "skipped_by_flag"}`) when hooks are disabled. 
- Update `jupr_app/domain/match_processing.py` to call `submit_match(..., run_context_hooks=False)` with an inline comment explaining that `match_processing` already updates `league_ratings` and must avoid pipeline hook double writes. 

### Testing
- Ran `python -m compileall .` and compilation completed successfully. 
- Verified the new parameter is present with `python -c "from services.match_pipeline import submit_match; import inspect; print('run_context_hooks' in inspect.signature(submit_match).parameters)"` which printed `True`. 
- Confirmed `process_matches` imports correctly with `python -c "from jupr_app.domain.match_processing import process_matches; print('ok')"` which printed `ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f77332e88326bcde4d5506b6c59b)