### PR TITLE
Add 6-team Round Robin tournament chart

### DIFF
--- a/jupr_app/domain/tournaments.py
+++ b/jupr_app/domain/tournaments.py
@@ -80,6 +80,56 @@ ROUND_ROBIN_TEMPLATES: dict[int, dict[str, Any]] = {
             },
         ],
     },
+    6: {
+        "teamCount": 6,
+        "rounds": [
+            {
+                "round": 1,
+                "games": [
+                    {"slot": 1, "teamA": 1, "teamB": 6},
+                    {"slot": 2, "teamA": 2, "teamB": 5},
+                    {"slot": 3, "teamA": 3, "teamB": 4},
+                ],
+                "byes": [],
+            },
+            {
+                "round": 2,
+                "games": [
+                    {"slot": 1, "teamA": 6, "teamB": 4},
+                    {"slot": 2, "teamA": 5, "teamB": 3},
+                    {"slot": 3, "teamA": 1, "teamB": 2},
+                ],
+                "byes": [],
+            },
+            {
+                "round": 3,
+                "games": [
+                    {"slot": 1, "teamA": 2, "teamB": 6},
+                    {"slot": 2, "teamA": 3, "teamB": 1},
+                    {"slot": 3, "teamA": 4, "teamB": 5},
+                ],
+                "byes": [],
+            },
+            {
+                "round": 4,
+                "games": [
+                    {"slot": 1, "teamA": 6, "teamB": 5},
+                    {"slot": 2, "teamA": 1, "teamB": 4},
+                    {"slot": 3, "teamA": 2, "teamB": 3},
+                ],
+                "byes": [],
+            },
+            {
+                "round": 5,
+                "games": [
+                    {"slot": 1, "teamA": 3, "teamB": 6},
+                    {"slot": 2, "teamA": 4, "teamB": 2},
+                    {"slot": 3, "teamA": 5, "teamB": 1},
+                ],
+                "byes": [],
+            },
+        ],
+    },
     7: {
         "teamCount": 7,
         "rounds": [

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -49,7 +49,7 @@ def render(ctx):
     with c1:
         tournament_name = st.text_input("Tournament name", key="tourney_create_name")
     with c2:
-        team_count = st.selectbox("Team count", [4, 5, 7, 8], key="tourney_create_team_count")
+        team_count = st.selectbox("Team count", [4, 5, 6, 7, 8], key="tourney_create_team_count")
     with c3:
         if st.button("Create", type="primary"):
             if not tournament_name.strip():
@@ -153,8 +153,8 @@ def render(ctx):
         with c2:
             new_team_count = st.selectbox(
                 "Team count",
-                [4, 5, 7, 8],
-                index=[4, 5, 7, 8].index(team_count_value),
+                [4, 5, 6, 7, 8],
+                index=[4, 5, 6, 7, 8].index(team_count_value),
                 disabled=team_count_locked,
                 key="tourney_team_count_select",
             )

--- a/tests/test_tournaments.py
+++ b/tests/test_tournaments.py
@@ -27,6 +27,33 @@ def test_round_robin_schedule_4():
     ]
 
 
+def test_round_robin_schedule_6():
+    team_ids = {1: "t1", 2: "t2", 3: "t3", 4: "t4", 5: "t5", 6: "t6"}
+    games = build_round_robin_games(tournament_id="tour1", team_ids_by_number=team_ids)
+
+    matchups = [
+        (g["rr_round_number"], g["rr_slot_number"], g["team_a_id"], g["team_b_id"]) for g in games
+    ]
+
+    assert matchups == [
+        (1, 1, "t1", "t6"),
+        (1, 2, "t2", "t5"),
+        (1, 3, "t3", "t4"),
+        (2, 1, "t6", "t4"),
+        (2, 2, "t5", "t3"),
+        (2, 3, "t1", "t2"),
+        (3, 1, "t2", "t6"),
+        (3, 2, "t3", "t1"),
+        (3, 3, "t4", "t5"),
+        (4, 1, "t6", "t5"),
+        (4, 2, "t1", "t4"),
+        (4, 3, "t2", "t3"),
+        (5, 1, "t3", "t6"),
+        (5, 2, "t4", "t2"),
+        (5, 3, "t5", "t1"),
+    ]
+
+
 def test_round_robin_standings_head_to_head():
     teams = [
         {"id": "t1", "team_number": 1},


### PR DESCRIPTION
### Motivation
- Add support for a 6-team Round Robin tournament to the main branch while porting only the minimal changes from the rebuild workstream and avoiding unrelated refactors.
- A direct fetch of the external `rebuild` branch was not possible from this environment, so the port was done by extracting the 6-team RR logic present in the local work and applying the minimal changes to `main`.

### Description
- Modified `jupr_app/domain/tournaments.py` to add a `6` entry in `ROUND_ROBIN_TEMPLATES` implementing a 5-round, 3-games-per-round schedule that produces the expected pairings and order.
- Modified `jupr_app/ui/pages/tournaments.py` to include `6` in the team-count `selectbox` used when creating a tournament and when editing team counts (no UI refactor, only the option list updated).
- Added `tests/test_tournaments.py::test_round_robin_schedule_6` to assert the exact RR matchup order produced by `build_round_robin_games` for 6 teams.
- All changes are committed on branch `jupr/add-6-team-rr-main` (local commit `1d57239`) and limited to the three files above; no CSV asset was required or added by this port.
- The schedule implemented here matches the intended 6-team Round Robin pairings and ordering from the rebuild scope as inspected locally, and no database schema or migration changes were introduced.

### Testing
- Ran `pytest -q tests/test_tournaments.py` and the test suite passed: `6 passed`.
- Verified via `git status`/`git show` that only `jupr_app/domain/tournaments.py`, `jupr_app/ui/pages/tournaments.py`, and `tests/test_tournaments.py` were modified and that a single focused commit `1d57239` contains the port.
- Confirmed UI wiring changes are additive (only list options changed) and do not introduce dependencies on rebuild-only components, so no further build-time changes were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699208336eac8326b68fe3c67214a092)