### PR TITLE
Add migration for multi-division tournament support (PR23)

### DIFF
--- a/migrations/20260215_add_tournament_divisions.sql
+++ b/migrations/20260215_add_tournament_divisions.sql
@@ -1,0 +1,42 @@
+-- Multi-division tournament support
+-- Additive, club-scoped tables for tournament divisions, entries, and matches.
+
+CREATE TABLE IF NOT EXISTS public.tournament_divisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  club_id text NOT NULL,
+  tournament_id uuid NOT NULL REFERENCES public.tournaments(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  format text NOT NULL,
+  max_teams integer,
+  status text NOT NULL DEFAULT 'draft',
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS tournament_divisions_club_tournament_title_key
+  ON public.tournament_divisions (club_id, tournament_id, title);
+
+CREATE TABLE IF NOT EXISTS public.division_entries (
+  id uuid PRIMARY KEY,
+  club_id text NOT NULL,
+  division_id uuid NOT NULL REFERENCES public.tournament_divisions(id) ON DELETE CASCADE,
+  team_id uuid NOT NULL REFERENCES public.teams(id),
+  seed integer,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS division_entries_club_division_team_key
+  ON public.division_entries (club_id, division_id, team_id);
+
+CREATE TABLE IF NOT EXISTS public.division_matches (
+  id uuid PRIMARY KEY,
+  club_id text NOT NULL,
+  division_id uuid NOT NULL REFERENCES public.tournament_divisions(id) ON DELETE CASCADE,
+  round_number integer NOT NULL,
+  bracket_position integer NOT NULL,
+  team_a_id uuid NOT NULL REFERENCES public.teams(id),
+  team_b_id uuid NOT NULL REFERENCES public.teams(id),
+  winner_team_id uuid REFERENCES public.teams(id),
+  score_json jsonb,
+  status text NOT NULL DEFAULT 'scheduled',
+  created_at timestamptz DEFAULT now()
+);


### PR DESCRIPTION
### Motivation
- Add additive schema to support multi-division tournaments while keeping all new tables club-scoped and non-destructive.
- Enforce FK relationships so divisions, entries, and matches are strongly tied to existing tournaments and teams.

### Description
- Create `public.tournament_divisions` with `club_id`, `tournament_id` FK to `public.tournaments(id) ON DELETE CASCADE`, unique index on `(club_id, tournament_id, title)`, and defaults for `id` and `created_at`.
- Create `public.division_entries` with `club_id`, FK `division_id -> tournament_divisions(id) ON DELETE CASCADE`, FK `team_id -> public.teams(id)`, and unique index on `(club_id, division_id, team_id)`.
- Create `public.division_matches` with `club_id`, FK `division_id -> tournament_divisions(id) ON DELETE CASCADE`, team FKs to `public.teams(id)`, `score_json`, `status` default, and `created_at` timestamp.
- Use `IF NOT EXISTS` on table and unique index creation for idempotence and make no RLS or rating logic changes.

### Testing
- Created and inspected the migration file `migrations/20260215_add_tournament_divisions.sql` using `sed -n '1,220p'` and `nl -ba` to verify contents and structure.
- Confirmed idempotence patterns by using `CREATE TABLE IF NOT EXISTS` and `CREATE UNIQUE INDEX IF NOT EXISTS` in the SQL.
- Searched existing migrations with `rg --files migrations` and inspected tournament table migration to confirm FK target tables (`public.tournaments`, `public.teams`) are present in the schema files.
- No destructive operations were run and no database runtime migration was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69920aca1a488326bf940d14960af36e)