### PR TITLE
Implement divisions management UI in Tournament Manager

### DIFF
--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -1,8 +1,155 @@
 from __future__ import annotations
 
+from collections import Counter
+
 import streamlit as st
 
 from jupr_app.ui.layout import page_shell
+
+DIVISION_FORMATS = ["single_elim", "double_elim", "rr", "pool_to_bracket"]
+TAB_OPTIONS = {"overview": "Overview", "divisions": "Divisions"}
+
+
+def _get_tournaments(supabase, club_id: str) -> list[dict]:
+    resp = (
+        supabase.table("tournaments")
+        .select("id,name,status,created_at")
+        .eq("club_id", club_id)
+        .order("created_at", desc=True)
+        .execute()
+    )
+    return resp.data or []
+
+
+def _get_divisions(supabase, club_id: str, tournament_id: str) -> list[dict]:
+    resp = (
+        supabase.table("tournament_divisions")
+        .select("id,title,format,max_teams,status,created_at")
+        .eq("club_id", club_id)
+        .eq("tournament_id", tournament_id)
+        .order("created_at", desc=False)
+        .execute()
+    )
+    return resp.data or []
+
+
+def _get_entry_counts(supabase, club_id: str, division_ids: list[str]) -> dict[str, int]:
+    if not division_ids:
+        return {}
+    resp = (
+        supabase.table("division_entries")
+        .select("division_id")
+        .eq("club_id", club_id)
+        .in_("division_id", division_ids)
+        .execute()
+    )
+    rows = resp.data or []
+    return dict(Counter(str(row.get("division_id")) for row in rows if row.get("division_id")))
+
+
+def _insert_division(supabase, club_id: str, tournament_id: str, title: str, fmt: str, max_teams: int | None) -> None:
+    payload = {
+        "club_id": club_id,
+        "tournament_id": tournament_id,
+        "title": title,
+        "format": fmt,
+        "status": "draft",
+    }
+    if max_teams is not None:
+        payload["max_teams"] = int(max_teams)
+    supabase.table("tournament_divisions").insert(payload).execute()
+
+
+def _render_division_modal(supabase, club_id: str, tournament_id: str) -> None:
+    @st.dialog("Add Division")
+    def add_division_dialog() -> None:
+        with st.form("add_division_form"):
+            title = st.text_input("Division Title", max_chars=120)
+            fmt = st.selectbox("Format", options=DIVISION_FORMATS, index=0)
+            max_teams_raw = st.text_input("Max Teams (optional)", value="")
+            submitted = st.form_submit_button("Create Division", use_container_width=True)
+
+        if not submitted:
+            return
+
+        clean_title = title.strip()
+        if not clean_title:
+            st.error("Division Title is required.")
+            return
+
+        clean_max: int | None = None
+        raw = max_teams_raw.strip()
+        if raw:
+            if not raw.isdigit() or int(raw) <= 0:
+                st.error("Max Teams must be a positive whole number.")
+                return
+            clean_max = int(raw)
+
+        try:
+            _insert_division(supabase, club_id, tournament_id, clean_title, fmt, clean_max)
+            st.success("Division created.")
+            st.rerun()
+        except Exception as exc:
+            st.error(f"Could not create division: {exc}")
+
+    add_division_dialog()
+
+
+def _render_divisions_tab(supabase, club_id: str, tournament: dict) -> None:
+    tournament_id = str(tournament["id"])
+
+    cta_col, _ = st.columns([1, 3])
+    with cta_col:
+        if st.button("+ Add Division", use_container_width=True, key="tm_add_division_btn"):
+            st.session_state["tm_show_add_division_dialog"] = True
+
+    if st.session_state.get("tm_show_add_division_dialog", False):
+        st.session_state["tm_show_add_division_dialog"] = False
+        _render_division_modal(supabase, club_id, tournament_id)
+
+    try:
+        divisions = _get_divisions(supabase, club_id, tournament_id)
+    except Exception as exc:
+        st.error(f"Could not load divisions: {exc}")
+        return
+
+    if not divisions:
+        st.info("No divisions yet. Create one to get started.")
+        return
+
+    division_ids = [str(d["id"]) for d in divisions if d.get("id")]
+    try:
+        counts = _get_entry_counts(supabase, club_id, division_ids)
+    except Exception as exc:
+        st.error(f"Could not load division entry counts: {exc}")
+        counts = {}
+
+    for row in divisions:
+        division_id = str(row.get("id", ""))
+        with st.container(border=True):
+            left, right = st.columns([3, 2])
+            with left:
+                st.subheader(str(row.get("title") or "Untitled Division"))
+                st.caption(f"Format: {row.get('format') or '—'}")
+                st.caption(f"Team count: {counts.get(division_id, 0)}")
+                st.caption(f"Status: {row.get('status') or 'draft'}")
+            with right:
+                st.button(
+                    "Manage Entries",
+                    key=f"manage_entries_{division_id}",
+                    use_container_width=True,
+                    type="secondary",
+                    disabled=True,
+                    help="Entries management is coming next.",
+                )
+                st.button(
+                    "Generate Bracket",
+                    key=f"generate_bracket_{division_id}",
+                    use_container_width=True,
+                    type="primary",
+                    disabled=True,
+                    help="Bracket generation is not implemented yet.",
+                )
 
 
 def render(ctx):
@@ -13,4 +160,52 @@ def render(ctx):
         st.error("Admin login required.")
         st.stop()
 
-    st.info("Tournament Manager tools are under construction.")
+    supabase = getattr(ctx, "supabase", None)
+    club_id = getattr(ctx, "club_id", None)
+    if supabase is None or club_id is None:
+        st.error("Missing required application context.")
+        st.stop()
+
+    requested_tab = str(st.query_params.get("tm_tab", "divisions"))
+    if requested_tab not in TAB_OPTIONS:
+        requested_tab = "divisions"
+
+    selected_tab = st.radio(
+        "Tournament Manager Sections",
+        options=list(TAB_OPTIONS.keys()),
+        index=list(TAB_OPTIONS.keys()).index(requested_tab),
+        format_func=lambda key: TAB_OPTIONS[key],
+        horizontal=True,
+        label_visibility="collapsed",
+        key="tm_tab_selector",
+    )
+    st.query_params["tm_tab"] = selected_tab
+
+    tournaments = _get_tournaments(supabase, str(club_id))
+    if not tournaments:
+        st.info("No tournaments found for this club yet.")
+        return
+
+    selected_tournament_id = str(st.query_params.get("tournament_id", str(tournaments[0]["id"])))
+    tournament_ids = [str(t["id"]) for t in tournaments]
+    if selected_tournament_id not in tournament_ids:
+        selected_tournament_id = tournament_ids[0]
+
+    current_idx = tournament_ids.index(selected_tournament_id)
+    tournament_label_options = [f"{t['name']} ({t.get('status', 'draft')})" for t in tournaments]
+    selected_idx = st.selectbox(
+        "Tournament",
+        options=list(range(len(tournaments))),
+        index=current_idx,
+        format_func=lambda i: tournament_label_options[i],
+        key="tm_tournament_selector",
+    )
+
+    tournament = tournaments[int(selected_idx)]
+    st.query_params["tournament_id"] = str(tournament["id"])
+
+    if selected_tab == "divisions":
+        _render_divisions_tab(supabase, str(club_id), tournament)
+        return
+
+    st.info("Overview is coming soon.")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -463,6 +463,7 @@ def main():
             "theme_qa": "🎨 Theme QA",
             "tournaments": "🏆 Tournaments",
             "tournament_manager": "🏆 Tournament Manager",
+            "tournament_divisions": "🏆 Tournament Manager",
             "weekly_recap": "🗞️ Weekly Recap",
 
             # Admin-only deep links


### PR DESCRIPTION
### Motivation
- Provide a desktop-first admin UI to manage tournament divisions (create divisions, view counts, and prepare for entry/bracket flows). 
- Keep UI rendering light and deterministic by moving DB reads/writes into small helper functions and storing UI state in `st.query_params` and `st.session_state`.
- Use the existing Supabase client pattern for all writes and scope new rows to `club_id` with `status='draft'`.

### Description
- Added division management to `jupr_app/ui/pages/tournament_manager.py` including helpers: `_get_tournaments`, `_get_divisions`, `_get_entry_counts`, and `_insert_division` which use `supabase.table(...).execute()` for DB access. 
- Implemented a `Divisions` tab with a `+ Add Division` button that opens an `Add Division` modal collecting `Division Title`, `Format` (`single_elim`, `double_elim`, `rr`, `pool_to_bracket`), and optional `Max Teams` with validation and Supabase insert on submit. 
- Rendered division cards showing title, format, team count (queried from `division_entries`), status, and placeholder buttons `Manage Entries` and `Generate Bracket` (bracket logic not implemented). 
- Added deterministic routing state for the Tournament Manager via `tm_tab` and `tournament_id` query params and registered a deep-link alias in `streamlit_app.py` so links can target the page reliably.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/tournament_manager.py streamlit_app.py` and the files compiled successfully. 
- Launched the app with `streamlit run streamlit_app.py` and exercised the new `/?page=tournament_manager&tm_tab=divisions` UI. 
- Captured a Playwright screenshot of the Divisions tab to validate layout and modal wiring, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69920ba0d0d8832698c2292cf49a9706)