### PR TITLE
Fix: Import missing `re` module to prevent router crash

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,6 +6,7 @@ import hmac
 import os
 import time
 import traceback
+import re
 from collections.abc import Mapping
 
 import streamlit as st


### PR DESCRIPTION
### Motivation
- Fix a `NameError` crash in `streamlit_app.main()` caused by the router calling `re.fullmatch()` while the `re` module was not imported.

### Description
- Inserted the missing stdlib import `import re` directly under `import traceback` in `streamlit_app.py` and made no other changes.

### Testing
- Ran `python -m py_compile streamlit_app.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699215e4509c8326b6340e02ac1d1793)