### PR TITLE
Pin Python dependencies for stable deploys

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
- streamlit
- pandas
- supabase
- weasyprint==61.2
- pydyf==0.9.0
+streamlit==1.54.0
+pandas==2.3.3
+supabase==2.28.0
+weasyprint==61.2
+pydyf==0.9.0


### PR DESCRIPTION
### Motivation
- Pin top-level runtime dependencies (`streamlit`, `pandas`, `supabase`) to known-good versions to avoid surprise upstream breaks and ensure deterministic deploys.

### Description
- Update `requirements.txt` to set `streamlit==1.54.0`, `pandas==2.3.3`, and `supabase==2.28.0`, preserving the existing `weasyprint==61.2` and `pydyf==0.9.0` pins.

### Testing
- Ran `python -m pip install -r requirements.txt` (succeeded in the current environment), `python -m compileall .` (succeeded), and `python -c "import streamlit_app; print('ok')"` (printed `ok`), while a fresh-venv install attempt failed due to network/proxy restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699225b55eb08326bf5bbe4bf208af9a)