### PR TITLE
Add admin secrets to Fly staging deploy workflow

### DIFF
--- a/.github/workflows/deploy_fly_staging.yml
+++ b/.github/workflows/deploy_fly_staging.yml
@@ -24,6 +24,8 @@ jobs:
             SUPABASE_URL="${{ secrets.SUPABASE_URL }}" \
             SUPABASE_ANON_KEY="${{ secrets.SUPABASE_ANON_KEY }}" \
             SUPABASE_SERVICE_ROLE_KEY="${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
+            SUPABASE_ADMIN_PASSWORD="${{ secrets.SUPABASE_ADMIN_PASSWORD }}" \
+            SUPABASE_ADMIN_SESSION_SECRET="${{ secrets.SUPABASE_ADMIN_SESSION_SECRET }}" \
             --app jupr-staging
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,3 +16,13 @@ Run in Supabase SQL editor.
 - Guard against None
 - Never block UI with heavy compute
 - Use caching carefully
+
+## Staging Deploy Secrets (GitHub Actions)
+The `.github/workflows/deploy_fly_staging.yml` workflow expects these GitHub repository secrets:
+- `PUBLIC_BASE_URL`
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_ADMIN_PASSWORD`
+- `SUPABASE_ADMIN_SESSION_SECRET`
+- `FLY_API_TOKEN`


### PR DESCRIPTION
### Motivation
- The staging deploy omitted admin credentials required by the running app (used in `streamlit_app.py`), causing admin-authenticated flows to fail.
- Secrets must be provided without ever logging their values to ensure staging mirrors runtime requirements while keeping credentials safe.

### Description
- Add `SUPABASE_ADMIN_PASSWORD` and `SUPABASE_ADMIN_SESSION_SECRET` to the `flyctl secrets set` call in `.github/workflows/deploy_fly_staging.yml` so staging receives the admin credentials.
- Keep existing secret wiring unchanged by continuing to set secrets via `flyctl secrets set` with values sourced from `${{ secrets.* }}` and using `FLY_API_TOKEN` from the job `env`.
- Add a short note to `docs/CONTRIBUTING.md` listing all required GitHub secrets for the staging deploy, including the two new admin secrets.

### Testing
- Ran `git diff -- .github/workflows/deploy_fly_staging.yml docs/CONTRIBUTING.md` to verify the workflow and docs diffs include the new secret entries and the doc note, and the check succeeded.
- Inspected the modified files (`nl -ba .github/workflows/deploy_fly_staging.yml` and `nl -ba docs/CONTRIBUTING.md`) to confirm the added lines are correct and no secrets are printed, and the inspection succeeded.
- Confirmed repository status shows only the intended files were modified, and that check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699229ea95cc83269389d962ce95f328)