### PR TITLE
PR23: Admin routing fully session-state driven

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -529,11 +529,13 @@ def main():
         tournament_match = re.fullmatch(r"tournament/([^/]+)", deep_route)
         route_match = re.fullmatch(r"tournament/([^/]+)/division/([^/]+)", deep_route)
         if tournament_match:
-            st.query_params["tournament_id"] = tournament_match.group(1)
+            if PUBLIC_MODE:
+                st.query_params["tournament_id"] = tournament_match.group(1)
             deep_label = "🏆 Tournament Bracket"
         if route_match:
-            st.query_params["tournament_id"] = route_match.group(1)
-            st.query_params["division_id"] = route_match.group(2)
+            if PUBLIC_MODE:
+                st.query_params["tournament_id"] = route_match.group(1)
+                st.query_params["division_id"] = route_match.group(2)
             deep_label = "🏆 Tournament Bracket" if PUBLIC_MODE else "🏆 Division Manager"
 
         if PUBLIC_MODE:
@@ -582,17 +584,14 @@ def main():
                 st.session_state["main_nav"] = sel
 
         # -------------------------
-        # Keep URL synced (canonical deep links)
+        # Keep URL synced ONLY in public mode
         # -------------------------
-        try:
-            st.query_params["page"] = LABEL_TO_PAGE_KEY.get(sel, "leaderboards")
-            if PUBLIC_MODE:
+        if PUBLIC_MODE:
+            try:
+                st.query_params["page"] = LABEL_TO_PAGE_KEY.get(sel, "leaderboards")
                 st.query_params["public"] = "1"
-            else:
-                if "public" in st.query_params:
-                    st.query_params.pop("public", None)
-        except Exception:
-            pass
+            except Exception:
+                pass
 
         # -------------------------
         # Render page


### PR DESCRIPTION
### Motivation
- Prevent admin-mode interactions from mutating the URL so admin sessions are fully driven by `st.session_state` and no longer depend on URL state.
- Preserve existing public UX where deep links and shareable URLs still work via query parameters.
- Avoid accidental leakage of admin state into the public URL and ensure predictable canonical deep links only for public users.

### Description
- Guarded route-based deep-route writes so `tournament_id` and `division_id` are only written to `st.query_params` when `PUBLIC_MODE` is true.
- Replaced the previous URL-sync block with a public-only sync that writes `page` and `public=1` only when `PUBLIC_MODE` is true.
- Removed admin-mode query-param mutation/cleanup behavior so admin navigation relies solely on `st.session_state`.

### Testing
- Ran `python -m py_compile streamlit_app.py` which succeeded without syntax errors.
- Verified with `rg`/search that all remaining `st.query_params` writes in `streamlit_app.py` are guarded by `if PUBLIC_MODE:` and therefore only occur in public mode.
- Manual code inspection of the modified `streamlit_app.py` deep-link and URL-sync sections to confirm behavior matches the objective.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699242ec0e1483269a0e47381c7e121e)