### PR TITLE
PR24: Full-screen Admin Command Center (state-only routing)

### DIFF
--- a/jupr_app/ui/pages/admin_dashboard.py
+++ b/jupr_app/ui/pages/admin_dashboard.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from jupr_app.ui.layout import page_shell
+
+
+def _nav_button(label: str, target_label: str):
+    if st.button(label, use_container_width=True):
+        st.session_state["main_nav"] = target_label
+        st.rerun()
+
+
+def render(ctx):
+    if not bool(ctx.admin_logged_in):
+        st.error("Admin login required.")
+        st.stop()
+
+    page_shell(
+        "🧭 Command Center",
+        "Operational dashboard for administrators.",
+        mode_label="Admin",
+    )
+
+    st.subheader("Core Operations")
+
+    col1, col2, col3 = st.columns(3)
+
+    with col1:
+        _nav_button("🏟️ League Manager", "🏟️ League Manager")
+        _nav_button("📝 Match Uploader", "📝 Match Uploader")
+
+    with col2:
+        _nav_button("📝 Match Log", "📝 Match Log")
+        _nav_button("👥 Player Editor", "👥 Player Editor")
+
+    with col3:
+        _nav_button("⚙️ Admin Tools", "⚙️ Admin Tools")
+        _nav_button("🗞️ Weekly Recap Admin", "🗞️ Weekly Recap Admin")
+
+    st.divider()
+
+    st.subheader("Advanced")
+
+    col4, col5 = st.columns(2)
+
+    with col4:
+        _nav_button("🛠️ Challenge Ladder Admin", "🛠️ Challenge Ladder Admin")
+        _nav_button("🏆 Tournament Manager", "🏆 Tournament Manager")
+
+    with col5:
+        _nav_button("💰 Moneyball", "💰 Moneyball")
+        _nav_button("🎨 Theme QA", "🎨 Theme QA")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -404,13 +404,13 @@ def main():
             tournament_public,
             weekly_recap,
             weekly_recap_admin,
-            command_center,
+            admin_dashboard,
             record_match,
         )
 
         # ---- Router ----
         PAGES = {
-            "🧭 Command Center": command_center,
+            "🧭 Command Center": admin_dashboard,
             "🏆 Leaderboards": leaderboards,
             "📊 League Results": league_results,
             "🖨️ League Night Printout": league_printout,
@@ -423,6 +423,7 @@ def main():
 
             # Admin-only
             "🏟️ League Manager": league_manager,
+            "📝 Match Uploader": record_match,
             "🧾 Record Match": record_match,
             "📝 Match Log": match_log,
             "👥 Player Editor": player_editor,
@@ -482,6 +483,7 @@ def main():
             "🧭 Command Center",
             "🖨️ League Night Printout",
             "🏟️ League Manager",
+            "📝 Match Uploader",
             "🧾 Record Match",
             "📝 Match Log",
             "👥 Player Editor",
@@ -556,8 +558,14 @@ def main():
                 st.session_state["deep_link_applied"] = True
 
             # Ensure valid selection
-            if "main_nav" not in st.session_state or st.session_state["main_nav"] not in visible_labels:
-                st.session_state["main_nav"] = "🧭 Command Center" if admin_logged_in else visible_labels[0]
+            if "main_nav" not in st.session_state:
+                if admin_logged_in:
+                    st.session_state["main_nav"] = "🧭 Command Center"
+                else:
+                    st.session_state["main_nav"] = visible_labels[0]
+
+            if st.session_state["main_nav"] not in visible_labels:
+                st.session_state["main_nav"] = visible_labels[0]
 
             prev_admin_logged_in = bool(st.session_state.get("prev_admin_logged_in", False))
             if admin_logged_in and not prev_admin_logged_in:


### PR DESCRIPTION
### Motivation
- Provide a full-screen, admin-only Command Center that lets administrators navigate via in-app state changes rather than URL deep links or browser reloads.
- Make the admin landing experience explicit so newly-authenticated admins land on the Command Center page by default.

### Description
- Added a new admin page `jupr_app/ui/pages/admin_dashboard.py` that renders a full-screen Command Center and exposes navigation buttons which set `st.session_state["main_nav"]` and call `st.rerun()` to perform state-only routing.
- Wired the router to import and use `admin_dashboard` for the `"🧭 Command Center"` entry and kept navigation targets valid by mapping `"📝 Match Uploader"` to the existing `record_match` page.
- Added `"📝 Match Uploader"` to the `ADMIN_ONLY_LABELS` set so it is hidden from public mode and included for admin users.
- Adjusted session initialization logic so when `main_nav` is missing it defaults to `"🧭 Command Center"` for admins and otherwise falls back to the first visible label, and added a validation step to ensure `main_nav` remains in `visible_labels`.

### Testing
- Ran `python -m py_compile streamlit_app.py jupr_app/ui/pages/admin_dashboard.py` and the files compiled successfully (no syntax errors).
- Launched the app with `streamlit run streamlit_app.py` and captured a visual screenshot via an automated Playwright script to validate the new page rendered successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699243bd828c832689c87adae37f9b88)