### PR TITLE
Fix: Properly inspect Supabase insert errors in safe_add_player

### DIFF
--- a/jupr_app/domain/player_ops.py
+++ b/jupr_app/domain/player_ops.py
@@ -42,15 +42,23 @@ def safe_add_player(
         "inactive_at": None,
     }
 
-    try:
-        supabase.table("players").insert(payload).execute()
-        return True, ""
-    except Exception as e:
-        msg = str(e)
+    resp = supabase.table("players").insert(payload).execute()
+
+    # Supabase does not raise exceptions for PostgREST errors.
+    # Errors must be inspected on the response object.
+    error = getattr(resp, "error", None)
+
+    if error:
+        msg = str(error)
 
         # If duplicate key (23505) on normalized name, the player already exists — treat as OK.
         # supabase-py surfaces the code in the string; we match conservatively.
         if "23505" in msg or "uq_players_club_name_active" in msg:
             return True, ""
 
+        import logging
+
+        logging.warning(f"safe_add_player insert failed: {msg}")
         return False, msg
+
+    return True, ""


### PR DESCRIPTION
### Motivation
- `safe_add_player` was silently treating failed Supabase inserts as successes because it relied on exceptions rather than inspecting the response object. 
- Supabase/PostgREST surfaces errors on the response (`resp.error`) instead of raising, so failures were not propagated to callers. 
- This caused League Manager to assume players were created when inserts actually failed, producing inconsistent UI state.

### Description
- Replaced the `try/except` insert flow with `resp = supabase.table("players").insert(payload).execute()` and explicit inspection of `error = getattr(resp, "error", None)`. 
- Preserved existing duplicate-key handling by treating messages containing `"23505"` or `"uq_players_club_name_active"` as success. 
- Added a defensive `logging.warning` call to surface non-duplicate insert failures without changing the function signature or caller behavior. 
- Kept changes minimal and localized to `jupr_app/domain/player_ops.py` with no UI or schema modifications.

### Testing
- Ran `python -m py_compile jupr_app/domain/player_ops.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924be73ef88326a0ec8218a31a18b7)