### PR TITLE
Add system health panel to Command Center

### DIFF
--- a/jupr_app/domain/system_health.py
+++ b/jupr_app/domain/system_health.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timezone
+
+
+def get_system_health(supabase, club_id: str):
+    health = {}
+
+    try:
+        matches = (
+            supabase.table("matches")
+            .select("id", count="exact")
+            .eq("club_id", club_id)
+            .execute()
+        )
+        health["match_count"] = matches.count or 0
+    except Exception:
+        health["match_count"] = "ERR"
+
+    try:
+        q = (
+            supabase.table("badge_eval_queue")
+            .select("id", count="exact")
+            .eq("club_id", club_id)
+            .eq("status", "pending")
+            .execute()
+        )
+        health["pending_badge_jobs"] = q.count or 0
+    except Exception:
+        health["pending_badge_jobs"] = "N/A"
+
+    health["timestamp"] = datetime.now(timezone.utc).isoformat()
+
+    return health

--- a/jupr_app/ui/pages/admin_dashboard.py
+++ b/jupr_app/ui/pages/admin_dashboard.py
@@ -4,6 +4,7 @@ import html
 
 import streamlit as st
 
+from jupr_app.domain.system_health import get_system_health
 from jupr_app.ui.layout import page_shell
 
 
@@ -50,3 +51,14 @@ def render(ctx):
     _nav_card("Weekly Recap", "Generate & publish recap", "🗞️ Weekly Recap Admin")
 
     st.markdown("</div>", unsafe_allow_html=True)
+
+    st.divider()
+    st.subheader("System Health")
+
+    health = get_system_health(ctx.supabase, ctx.club_id)
+
+    c1, c2, c3 = st.columns(3)
+
+    c1.metric("Total Matches", health.get("match_count"))
+    c2.metric("Pending Badge Jobs", health.get("pending_badge_jobs"))
+    c3.metric("Last Check (UTC)", health.get("timestamp")[:19])


### PR DESCRIPTION
### Motivation
- Provide a lightweight operational view in the Command Center so admins can quickly see match volume, pending badge work, and when the last health check occurred.
- Avoid dashboard crashes when DB tables are missing by returning safe fallback values from the health check.

### Description
- Add `jupr_app/domain/system_health.py` with `get_system_health(supabase, club_id)` that counts matches from `matches`, counts pending jobs from `badge_eval_queue`, includes a UTC `timestamp`, and returns safe fallbacks on query errors.
- Update `jupr_app/ui/pages/admin_dashboard.py` to import and call `get_system_health` and render a new "System Health" section with three metrics: Total Matches, Pending Badge Jobs, and Last Check (UTC).
- Wrap queries in `try/except` to ensure the admin UI does not block or crash if tables are unavailable.

### Testing
- Ran `python -m compileall jupr_app/domain/system_health.py jupr_app/ui/pages/admin_dashboard.py` and compilation completed successfully.
- Launched the app with Streamlit (`PORT=8501 streamlit run app.py`) and confirmed the admin dashboard rendered without errors during a manual smoke check.
- Captured a Playwright screenshot of the running app which produced a UI artifact showing the new System Health panel.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924c97752c8326ab53f340c3aae4ff)