### PR TITLE
PR28: Add background job monitor to admin dashboard

### DIFF
--- a/jupr_app/domain/job_monitor.py
+++ b/jupr_app/domain/job_monitor.py
@@ -1,0 +1,16 @@
+import pandas as pd
+
+
+def fetch_recent_jobs(supabase, club_id: str, limit: int = 25):
+    try:
+        resp = (
+            supabase.table("jobs")
+            .select("*")
+            .eq("club_id", club_id)
+            .order("created_at", desc=True)
+            .limit(limit)
+            .execute()
+        )
+        return pd.DataFrame(resp.data or [])
+    except Exception:
+        return pd.DataFrame()

--- a/jupr_app/ui/pages/admin_dashboard.py
+++ b/jupr_app/ui/pages/admin_dashboard.py
@@ -4,6 +4,7 @@ import html
 
 import streamlit as st
 
+from jupr_app.domain.job_monitor import fetch_recent_jobs
 from jupr_app.domain.system_health import get_system_health
 from jupr_app.ui.layout import page_shell
 
@@ -62,3 +63,17 @@ def render(ctx):
     c1.metric("Total Matches", health.get("match_count"))
     c2.metric("Pending Badge Jobs", health.get("pending_badge_jobs"))
     c3.metric("Last Check (UTC)", health.get("timestamp")[:19])
+
+    st.divider()
+    st.subheader("Background Jobs")
+
+    df_jobs = fetch_recent_jobs(ctx.supabase, ctx.club_id)
+
+    if df_jobs.empty:
+        st.info("No recent jobs.")
+    else:
+        st.dataframe(
+            df_jobs.reindex(columns=["job_type", "status", "created_at", "completed_at"]),
+            use_container_width=True,
+            hide_index=True,
+        )

--- a/migrations/20260215_jobs_table.sql
+++ b/migrations/20260215_jobs_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  club_id text NOT NULL,
+  job_type text NOT NULL,
+  status text NOT NULL DEFAULT 'pending',
+  created_at timestamptz DEFAULT now(),
+  started_at timestamptz,
+  completed_at timestamptz,
+  error text
+);


### PR DESCRIPTION
### Motivation
- Provide administrators with visibility into background job activity directly on the admin dashboard. 
- Prevent admin UI crashes when the jobs table is missing or queries fail by handling errors gracefully. 
- Surface recent job metadata (type, status, timestamps) to help debug and monitor background processing.

### Description
- Add migration `migrations/20260215_jobs_table.sql` to create a `jobs` table for tracking background jobs. 
- Add `jupr_app/domain/job_monitor.py` implementing `fetch_recent_jobs(supabase, club_id, limit)` which loads recent jobs and returns a `pandas.DataFrame`, returning an empty DataFrame on any exception. 
- Update `jupr_app/ui/pages/admin_dashboard.py` to import `fetch_recent_jobs` and render a new **Background Jobs** panel below the existing System Health section, showing an empty state with `st.info("No recent jobs.")` or a compact table of `job_type`, `status`, `created_at`, and `completed_at`. 
- The panel is shown only within the existing admin gate so public mode behavior is unchanged.

### Testing
- Ran `python -m compileall jupr_app/domain/job_monitor.py jupr_app/ui/pages/admin_dashboard.py` which succeeded. 
- Ran `pytest -q tests/test_imports.py` which passed (`1 passed`). 
- Attempted to run `streamlit` for a visual smoke test, but the app process did not remain active in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924d6984848326a27973dcf5c9190c)