### PR TITLE
PR29: Responsive auto-resizing admin grid

### DIFF
--- a/jupr_app/ui/pages/admin_dashboard.py
+++ b/jupr_app/ui/pages/admin_dashboard.py
@@ -42,7 +42,7 @@ def render(ctx):
     )
 
     st.subheader("Core Operations")
-    st.markdown('<div class="jupr-grid">', unsafe_allow_html=True)
+    st.markdown('<div class="jupr-admin-grid">', unsafe_allow_html=True)
 
     _nav_card("League Manager", "Manage standings & divisions", "🏟️ League Manager")
     _nav_card("Match Uploader", "Fast score entry", "📝 Match Uploader")
@@ -58,11 +58,9 @@ def render(ctx):
 
     health = get_system_health(ctx.supabase, ctx.club_id)
 
-    c1, c2, c3 = st.columns(3)
-
-    c1.metric("Total Matches", health.get("match_count"))
-    c2.metric("Pending Badge Jobs", health.get("pending_badge_jobs"))
-    c3.metric("Last Check (UTC)", health.get("timestamp")[:19])
+    st.metric("Total Matches", health.get("match_count"))
+    st.metric("Pending Badge Jobs", health.get("pending_badge_jobs"))
+    st.metric("Last Check (UTC)", health.get("timestamp")[:19])
 
     st.divider()
     st.subheader("Background Jobs")

--- a/jupr_app/ui/theme_clean.py
+++ b/jupr_app/ui/theme_clean.py
@@ -241,6 +241,20 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         margin-top: 1rem;
       }}
 
+      /* Responsive Admin Grid */
+      .jupr-admin-grid {{
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1.25rem;
+        margin-top: 1rem;
+      }}
+
+      @media (max-width: 768px) {{
+        .jupr-admin-grid {{
+          grid-template-columns: 1fr;
+        }}
+      }}
+
       .jupr-admin-card {{
         border: 1px solid var(--border);
         border-radius: var(--radius);


### PR DESCRIPTION
### Motivation
- Provide a responsive admin dashboard card layout that auto-resizes to different screen widths and prevents horizontal overflow.
- Simplify the dashboard layout by removing `st.columns()` for the health metrics so the metrics render cleanly with the new layout.

### Description
- Added a new CSS utility `.jupr-admin-grid` in `apply_clean_theme()` that uses `repeat(auto-fit, minmax(280px, 1fr))` and spacing to allow cards to wrap responsively in `jupr_app/ui/theme_clean.py`.
- Added a mobile media query (`@media (max-width: 768px)`) that forces `.jupr-admin-grid` to a single column for small viewports.
- Updated `jupr_app/ui/pages/admin_dashboard.py` to render navigation cards inside `<div class="jupr-admin-grid">` and replaced the `st.columns()`-based metrics with direct `st.metric(...)` calls.

### Testing
- Compiled targeted Python modules with `python -m compileall jupr_app/ui/theme_clean.py jupr_app/ui/pages/admin_dashboard.py`, which completed successfully.
- Verified `st.columns` was removed by checking the source with a small Python snippet (`'st.columns' in text`), which returned `False`.
- Launched the app via `streamlit run streamlit_app.py --server.port 8501 --server.address 0.0.0.0` and captured a UI screenshot at `1440x900` to visually validate the multi-column layout (screenshot artifact produced).
- All automated checks and visual validation steps completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924ec1cefc8326a5c00e9295bb9b49)