### PR TITLE
Fix: Streamlit scriptrunner import crash + pin dependency

### DIFF
--- a/jupr_app/auth/cookies.py
+++ b/jupr_app/auth/cookies.py
@@ -1,7 +1,16 @@
 from http.cookies import SimpleCookie
 
 import streamlit.components.v1 as components
-from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
+
+# NOTE:
+# get_script_run_ctx is an internal Streamlit API and may change across versions.
+# We guard the import for compatibility and pin Streamlit in requirements.txt.
+try:
+    # Modern Streamlit
+    from streamlit.runtime.scriptrunner import get_script_run_ctx
+except ImportError:
+    # Legacy fallback
+    from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 
 COOKIE_NAME = "jupr_admin_session"
 


### PR DESCRIPTION
### Motivation
- The app crashed at startup because `get_script_run_ctx` was imported from the removed internal path `streamlit.runtime.scriptrunner.script_run_context` causing `ModuleNotFoundError`.
- The intent is to make the import resilient to Streamlit internal path changes and ensure deterministic deployments by pinning Streamlit.
- The change must be minimal, avoid touching auth logic, and avoid heavy work at import time.

### Description
- Added a dependency guard comment at the top of `jupr_app/auth/cookies.py` explaining `get_script_run_ctx` is internal and may change.
- Replaced the single direct import with a resilient try/except that first imports `from streamlit.runtime.scriptrunner import get_script_run_ctx` and falls back to `from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx` on `ImportError`.
- Verified `requirements.txt` already pins Streamlit as `streamlit==1.54.0`, so no change to the file was necessary.
- Change is limited to import handling and a comment; no auth/cookie/session logic was modified.

### Testing
- Ran an automated import sanity check: `python - <<'PY'\nfrom jupr_app.auth.cookies import get_script_run_ctx\nprint('import_ok', callable(get_script_run_ctx))\nPY` which printed that the callable import succeeded (passed).
- Inspected `requirements.txt` with `sed` to confirm Streamlit is pinned to `streamlit==1.54.0` (passed).
- Committed the change and verified the diff with `git show --stat --patch` to ensure only `jupr_app/auth/cookies.py` was modified (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699253ffc0208326a0ff76c1a2dcd294)