### PR TITLE
Add temporary debug prints before matches insert

### DIFF
--- a/services/match_pipeline.py
+++ b/services/match_pipeline.py
@@ -135,6 +135,10 @@ def _insert_match_record(
         payload["idempotency_key"] = idempotency_key
 
     matches_table = supabase.table("matches")
+    print("===== DEBUG: MATCH INSERT =====")
+    print("FINAL INSERT PAYLOAD KEYS:", list(payload.keys()))
+    print("FINAL INSERT PAYLOAD:", payload)
+    print("================================")
     insert_response = matches_table.insert(payload).execute()
     inserted_rows = getattr(insert_response, "data", None) or []
     if not inserted_rows:


### PR DESCRIPTION
### Motivation
- Add lightweight, temporary logging to inspect the finalized insert payload immediately before writing to Supabase so it's easier to troubleshoot failing inserts.

### Description
- Inserted four `print` debug statements in `_insert_match_record` (in `services/match_pipeline.py`) immediately before the call to `matches_table.insert(payload).execute()` to output a header, the payload keys, the full payload, and a footer; no logic, imports, return behavior, or structure were changed.

### Testing
- Ran `python -m py_compile services/match_pipeline.py` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ab3735648326815077650485bfb7)