### PR TITLE
Whitelist match insert payload keys in match pipeline

### DIFF
--- a/services/match_pipeline.py
+++ b/services/match_pipeline.py
@@ -127,10 +127,28 @@ def _insert_match_record(
         if existing_rows:
             return dict(existing_rows[0])
 
-    payload: Dict[str, Any] = dict(match_payload)
+    ALLOWED_MATCH_COLUMNS = {
+        "t1_p1", "t1_p2", "t2_p1", "t2_p2",
+        "score_t1", "score_t2",
+        "elo_delta", "elo_delta_t1", "elo_delta_t2",
+        "t1_p1_r", "t1_p1_r_end",
+        "t1_p2_r", "t1_p2_r_end",
+        "t2_p1_r", "t2_p1_r_end",
+        "t2_p2_r", "t2_p2_r_end",
+        "league", "match_type", "week_tag",
+        "tournament_id", "tournament_game_id",
+        "date",
+    }
+
+    payload: Dict[str, Any] = {
+        k: v for k, v in match_payload.items()
+        if k in ALLOWED_MATCH_COLUMNS
+    }
+
     payload["club_id"] = club_id
     payload["context_type"] = context_type
     payload["context_id"] = context_id
+
     if idempotency_key:
         payload["idempotency_key"] = idempotency_key
 


### PR DESCRIPTION
### Motivation
- Prevent unintended or invalid keys from being inserted into the `matches` table by restricting the insert payload to an explicit allowlist.
- Keep idempotency behavior and downstream rating/hook logic unchanged while hardening the canonical insert step.

### Description
- In `_insert_match_record` (in `services/match_pipeline.py`) replace `payload = dict(match_payload)` with an `ALLOWED_MATCH_COLUMNS` allowlist and build `payload` by filtering `match_payload` to only those keys.
- Preserve assignment of `club_id`, `context_type`, `context_id`, and optional `idempotency_key` after filtering.
- Left idempotency lookup, the call to `matches_table.insert(payload).execute()`, and all rating/hook logic unchanged.

### Testing
- Ran `python -m py_compile services/match_pipeline.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992aeaeab7083268b8959ff9077e16d)