### PR TITLE
db: seed badge_fact_registry with initial facts

### DIFF
--- a/migrations/20260806_badge_fact_registry_seed.sql
+++ b/migrations/20260806_badge_fact_registry_seed.sql
@@ -1,0 +1,14 @@
+-- Seed initial badge facts used by rule conditions.
+insert into badge_fact_registry (fact_key, description, data_type, allowed_scope)
+values
+    ('best_win_streak', 'Longest win streak', 'numeric', 'overall'),
+    ('total_matches', 'Total matches played', 'numeric', 'overall'),
+    ('rating_delta', 'Delta between starting and current rating', 'numeric', 'overall'),
+    ('is_league_champion', 'Player is league champion', 'boolean', 'league'),
+    ('is_event_winner', 'Player won an event', 'boolean', 'event'),
+    ('is_undefeated_event', 'Player undefeated in an event', 'boolean', 'event')
+on conflict (fact_key) do update set
+    description = excluded.description,
+    data_type = excluded.data_type,
+    allowed_scope = excluded.allowed_scope
+;


### PR DESCRIPTION
### Motivation
- Seed the `badge_fact_registry` table with the initial fact keys used by badge rule conditions in a way that is safe to run multiple times and does not alter existing migration logic.

### Description
- Add `migrations/20260806_badge_fact_registry_seed.sql` which inserts six facts (`best_win_streak`, `total_matches`, `rating_delta`, `is_league_champion`, `is_event_winner`, `is_undefeated_event`) and uses an idempotent `INSERT ... ON CONFLICT (fact_key) DO UPDATE` to keep reruns safe.

### Testing
- Verified the migration file contents and formatting with `sed -n '1,200p' migrations/20260806_badge_fact_registry_seed.sql` and `nl -ba migrations/20260806_badge_fact_registry_seed.sql`, and checked workspace status with `git status --short`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699323962d288326b44229cf69e6c601)