### PR TITLE
Enable V3 badge engine for new badges only

### DIFF
--- a/jupr_app/domain/gamification/badge_worker.py
+++ b/jupr_app/domain/gamification/badge_worker.py
@@ -43,18 +43,23 @@ def process_badge_eval_queue(
             badge_ids = _badge_ids_for_trigger(context, event_type)
             if badge_ids and player_ids:
                 _update_incremental_facts(supabase, job, player_ids, context_id)
+                v3_badge_ids: set[str] = set()
                 if v3_engine.USE_BADGE_ENGINE_V3:
+                    v3_badge_ids = _v3_badge_ids_with_conditions(supabase, badge_ids)
                     for pid in player_ids:
                         v3_context = _context_with_context_id(context, context_id)
-                        v3_engine.evaluate_badges_v3(pid, v3_context)
-                else:
+                        if v3_badge_ids:
+                            v3_engine.evaluate_badges_v3(pid, v3_context, allowed_badge_ids=v3_badge_ids)
+
+                v2_badge_ids = badge_ids - v3_badge_ids
+                if v2_badge_ids:
                     candidates = []
                     for pid in player_ids:
                         candidates.extend(
                             [
                                 c
                                 for c in compute_candidates_for_player(job_club_id, pid, ctx=context)
-                                if str(c.badge_id) in badge_ids
+                                if str(c.badge_id) in v2_badge_ids
                             ]
                         )
                     if candidates:
@@ -140,6 +145,34 @@ def _normalize_triggers(value: Any) -> list[str]:
     if isinstance(value, str):
         return [str(value)]
     return ["match_recorded", "match_updated"]
+
+
+def _v3_badge_ids_with_conditions(supabase: Any, badge_ids: set[str]) -> set[str]:
+    if supabase is None or not badge_ids:
+        return set()
+
+    badge_rows = supabase.table("badges").select("badge_id,status").in_("badge_id", list(badge_ids)).execute().data or []
+    eligible_status_badges = {
+        str(row.get("badge_id") or "")
+        for row in badge_rows
+        if row.get("badge_id") and row.get("status") is not None
+    }
+    if not eligible_status_badges:
+        return set()
+
+    condition_rows = (
+        supabase.table("badge_rule_conditions")
+        .select("badge_id")
+        .in_("badge_id", list(eligible_status_badges))
+        .execute()
+        .data
+        or []
+    )
+    return {
+        str(row.get("badge_id") or "")
+        for row in condition_rows
+        if row.get("badge_id")
+    }
 
 
 def _update_incremental_facts(

--- a/jupr_app/domain/gamification/v3_engine.py
+++ b/jupr_app/domain/gamification/v3_engine.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 
-USE_BADGE_ENGINE_V3 = False
+USE_BADGE_ENGINE_V3 = True
 
 _NUMERIC_OPERATORS = {
     ">": lambda left, right: left > right,
@@ -17,7 +17,7 @@ _NUMERIC_OPERATORS = {
 }
 
 
-def evaluate_badges_v3(player_id: int, context: Any) -> list[str]:
+def evaluate_badges_v3(player_id: int, context: Any, *, allowed_badge_ids: set[str] | None = None) -> list[str]:
     """Evaluate published V3 badges for a single player and award matches."""
     supabase = getattr(context, "supabase", None)
     club_id = str(getattr(context, "club_id", "") or "")
@@ -27,6 +27,9 @@ def evaluate_badges_v3(player_id: int, context: Any) -> list[str]:
 
     badges_resp = supabase.table("badges").select("badge_id,award_count,status,is_locked").eq("status", "published").execute()
     badges = badges_resp.data or []
+    if allowed_badge_ids is not None:
+        allowed = {str(badge_id) for badge_id in allowed_badge_ids}
+        badges = [row for row in badges if str(row.get("badge_id") or "") in allowed]
     if not badges:
         return []
 

--- a/tests/test_badge_v3_engine.py
+++ b/tests/test_badge_v3_engine.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import pytest
+import pandas as pd
 
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
+from jupr_app.domain.gamification.badge_types import BadgeCandidate
 from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
 from jupr_app.domain.gamification.v3_engine import evaluate_badges_v3
 
@@ -129,10 +130,15 @@ def test_evaluate_badges_v3_awards_and_locks_badge():
     assert storage["badges"][0]["is_locked"] is True
 
 
-def test_worker_dispatches_to_v3_when_flag_enabled(monkeypatch):
+def test_worker_uses_v3_for_new_badges_and_v2_for_legacy(monkeypatch):
     storage = {
-        "badges": [{"badge_id": "grinder", "status": "published", "award_count": 0, "is_locked": False}],
-        "badge_rule_conditions": [],
+        "badges": [
+            {"badge_id": "grinder", "status": "published", "award_count": 0, "is_locked": False},
+            {"badge_id": "legacy", "status": None, "award_count": 0, "is_locked": False},
+        ],
+        "badge_rule_conditions": [
+            {"badge_id": "grinder", "fact_key": "matches_seen", "operator": ">=", "value_numeric": 1},
+        ],
         "player_badge_facts": [],
         "player_badges": [],
     }
@@ -148,27 +154,52 @@ def test_worker_dispatches_to_v3_when_flag_enabled(monkeypatch):
     ctx = SimpleNamespace(
         supabase=supabase,
         club_id="club",
-        df_badges=SimpleNamespace(empty=True),
+        df_badges=pd.DataFrame(
+            [
+                {"badge_id": "grinder", "eval_triggers": ["match_recorded", "match_updated"]},
+                {"badge_id": "legacy", "eval_triggers": ["match_recorded", "match_updated"]},
+            ]
+        ),
         df_matches=None,
         df_players_all=None,
         df_leagues=None,
         df_meta=None,
     )
 
-    calls: list[int] = []
+    v3_calls: list[tuple[int, set[str]]] = []
 
-    def _fake_v3(player_id, _context):
-        calls.append(int(player_id))
+    def _fake_v3(player_id, _context, *, allowed_badge_ids=None):
+        v3_calls.append((int(player_id), set(allowed_badge_ids or set())))
         return []
 
     monkeypatch.setattr("jupr_app.domain.gamification.v3_engine.USE_BADGE_ENGINE_V3", True)
     monkeypatch.setattr("jupr_app.domain.gamification.v3_engine.evaluate_badges_v3", _fake_v3)
-    monkeypatch.setattr(
-        "jupr_app.domain.gamification.badge_worker.compute_candidates_for_player",
-        lambda *_args, **_kwargs: pytest.fail("v2 evaluator should not run when v3 flag is enabled"),
-    )
+
+    def _fake_candidates(*_args, **_kwargs):
+        return [
+            BadgeCandidate(
+                badge_id="legacy",
+                player_id=7,
+                club_id="club",
+                context_type="overall",
+                context_id="overall",
+                match_id=None,
+            ),
+            BadgeCandidate(
+                badge_id="grinder",
+                player_id=7,
+                club_id="club",
+                context_type="overall",
+                context_id="overall",
+                match_id=None,
+            ),
+        ]
+
+    monkeypatch.setattr("jupr_app.domain.gamification.badge_worker.compute_candidates_for_player", _fake_candidates)
 
     result = process_badge_eval_queue(supabase, max_jobs=1, time_budget_seconds=2, ctx=ctx)
 
     assert result["processed"] == 1
-    assert calls == [7]
+    assert v3_calls == [(7, {"grinder"})]
+    assert len(storage["player_badges"]) == 1
+    assert storage["player_badges"][0]["badge_id"] == "legacy"


### PR DESCRIPTION
### Motivation

- Enable the V3 badge engine for newly-defined/published badges while keeping legacy badge evaluation on the V2 evaluators so existing badges retain their current behavior.
- Ensure badges that are published but lack V3 rule conditions still flow through the V2 evaluator.

### Description

- Turned the V3 feature flag on by default by setting `USE_BADGE_ENGINE_V3 = True` in `v3_engine.py`.
- Added an `allowed_badge_ids` parameter to `evaluate_badges_v3` and filter published badges by that set so V3 evaluates only targeted badges.
- Updated the badge worker to compute `v3_badge_ids` (badges with a non-null `status` and at least one `badge_rule_conditions` row) and dispatch those to V3 while routing the remaining triggered badges to the legacy V2 evaluator.
- Added `_v3_badge_ids_with_conditions` helper to query eligible badges and updated/added tests to assert mixed routing behavior (V3 for new badges, V2 for legacy badges).

### Testing

- Ran `pytest -q tests/test_badge_v3_engine.py` and it succeeded with `2 passed`.
- Ran `pytest -q tests/test_badge_worker.py` and it succeeded with `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699326f14d108326970a7d853c7d2423)