### PR TITLE
Add Supabase-compatible V3 badge engine schema migration

### DIFF
--- a/supabase/migrations/202602160001_badge_engine_v3_schema.sql
+++ b/supabase/migrations/202602160001_badge_engine_v3_schema.sql
@@ -1,0 +1,49 @@
+-- V3 Badge Engine Schema Migration
+-- Idempotent, Supabase-compatible migration
+
+-- 1. Extend badges_v2
+ALTER TABLE public.badges_v2
+ADD COLUMN IF NOT EXISTS status TEXT CHECK (status IN ('draft','published','archived')) DEFAULT 'draft',
+ADD COLUMN IF NOT EXISTS is_locked BOOLEAN DEFAULT false,
+ADD COLUMN IF NOT EXISTS award_count INTEGER DEFAULT 0,
+ADD COLUMN IF NOT EXISTS published_at TIMESTAMPTZ NULL,
+ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ NULL,
+ADD COLUMN IF NOT EXISTS club_id TEXT NULL,
+ADD COLUMN IF NOT EXISTS is_system_badge BOOLEAN DEFAULT false,
+ADD COLUMN IF NOT EXISTS created_by_admin_id TEXT NULL;
+
+-- 2. Badge Fact Registry
+CREATE TABLE IF NOT EXISTS public.badge_fact_registry (
+  fact_key TEXT PRIMARY KEY,
+  description TEXT NOT NULL,
+  data_type TEXT CHECK (data_type IN ('numeric','boolean')) NOT NULL,
+  allowed_scope TEXT CHECK (allowed_scope IN ('overall','league','event')) NOT NULL
+);
+
+-- 3. Badge Rule Conditions (V3)
+CREATE TABLE IF NOT EXISTS public.badge_rule_conditions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  badge_id UUID NOT NULL REFERENCES public.badges_v2(id) ON DELETE CASCADE,
+  fact_key TEXT NOT NULL REFERENCES public.badge_fact_registry(fact_key),
+  operator TEXT CHECK (operator IN ('>=','>','=','<=','<','is')) NOT NULL,
+  value_numeric NUMERIC NULL,
+  value_boolean BOOLEAN NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- 4. Club Roles Table (if not already present)
+CREATE TABLE IF NOT EXISTS public.club_user_roles (
+  club_id TEXT NOT NULL,
+  user_id UUID NOT NULL,
+  role TEXT CHECK (role IN ('admin','coordinator','score_entry')) NOT NULL,
+  assigned_by UUID NULL,
+  assigned_at TIMESTAMPTZ DEFAULT now(),
+  PRIMARY KEY (club_id, user_id)
+);
+
+-- 5. Indexes
+CREATE INDEX IF NOT EXISTS idx_badge_rule_conditions_badge_id
+ON public.badge_rule_conditions (badge_id);
+
+CREATE INDEX IF NOT EXISTS idx_badges_v2_club_id
+ON public.badges_v2 (club_id);


### PR DESCRIPTION
### Motivation
- Introduce the V3 Badge Engine schema to support badge lifecycle, ownership/club scoping, badge fact registry, and rule-based conditions.

### Description
- Add a new idempotent SQL migration at `supabase/migrations/202602160001_badge_engine_v3_schema.sql` containing the full V3 schema changes.
- Extend `public.badges_v2` with lifecycle and metadata columns using `ADD COLUMN IF NOT EXISTS` and appropriate `CHECK` constraints and defaults.
- Create `public.badge_fact_registry`, `public.badge_rule_conditions`, and `public.club_user_roles` using `CREATE TABLE IF NOT EXISTS` with necessary keys and references.
- Add supporting indexes with `CREATE INDEX IF NOT EXISTS` for `badge_rule_conditions.badge_id` and `badges_v2.club_id`.

### Testing
- Verified the migration file contents with `nl -ba supabase/migrations/202602160001_badge_engine_v3_schema.sql`, which printed the new SQL and returned successfully.
- Performed repository checks with `git status --short` and committed the new file with `git commit`, both of which succeeded and show the migration as added.
- No database apply/run was executed as part of these automated steps in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932d135248832698514eb2c232c474)