### PR TITLE
feat: add deterministic fact_engine for V3 badge evaluation (incremental, background-only)

### DIFF
--- a/jupr_app/domain/gamification/badge_worker.py
+++ b/jupr_app/domain/gamification/badge_worker.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from jupr_app.data.sb_write import sb_upsert
-
-from datetime import datetime, timezone
 import time
 from types import SimpleNamespace
 from typing import Any
@@ -12,6 +9,7 @@ import pandas as pd
 from jupr_app.data.load import load_data
 from jupr_app.domain.gamification.badge_catalog import BADGE_DEFINITIONS
 from jupr_app.domain.gamification.badge_queue import ack_badge_eval, dequeue_badge_eval
+from jupr_app.domain.gamification.fact_engine import update_match_facts_for_players
 from jupr_app.config import USE_BADGE_ENGINE_V3
 from jupr_app.domain.gamification import v3_engine
 
@@ -38,10 +36,20 @@ def process_badge_eval_queue(
             event_type = str(job.get("event_type") or "")
             player_ids = [int(pid) for pid in (job.get("player_ids") or [])]
             context_id = str(job.get("context_id") or "overall")
+            payload_json = dict(job.get("payload_json") or {})
+            if str(job.get("match_id") or ""):
+                payload_json.setdefault("match_id", str(job.get("match_id") or ""))
 
             badge_ids = _badge_ids_for_trigger(context, event_type)
             if badge_ids and player_ids:
-                _update_incremental_facts(supabase, job, player_ids, context_id)
+                if event_type in {"match_recorded", "match_updated"}:
+                    update_match_facts_for_players(
+                        supabase,
+                        club_id=job_club_id,
+                        player_ids=player_ids,
+                        match_payload=payload_json,
+                        context_id=context_id,
+                    )
                 if USE_BADGE_ENGINE_V3:
                     v3_badge_ids = _v3_badge_ids_with_conditions(supabase, badge_ids)
                     for pid in player_ids:
@@ -156,59 +164,3 @@ def _v3_badge_ids_with_conditions(supabase: Any, badge_ids: set[str]) -> set[str
         if row.get("badge_id")
     }
 
-
-def _update_incremental_facts(
-    supabase: Any,
-    job: dict[str, Any],
-    player_ids: list[int],
-    context_id: str,
-) -> None:
-    if supabase is None:
-        return
-    event_type = str(job.get("event_type") or "")
-    if event_type not in {"match_recorded", "match_updated"}:
-        return
-    for pid in player_ids:
-        _increment_fact(supabase, job, pid, context_id, "matches_seen", 1)
-
-
-def _increment_fact(
-    supabase: Any,
-    job: dict[str, Any],
-    player_id: int,
-    context_id: str,
-    fact_key: str,
-    delta: int,
-) -> None:
-    club_id = str(job.get("club_id") or "")
-    resp = (
-        supabase.table("player_badge_facts")
-        .select("fact_value_num")
-        .eq("club_id", club_id)
-        .eq("player_id", int(player_id))
-        .eq("context_id", context_id)
-        .eq("fact_key", fact_key)
-        .limit(1)
-        .execute()
-    )
-    rows = resp.data or []
-    current = 0
-    if rows:
-        try:
-            current = int(rows[0].get("fact_value_num") or 0)
-        except Exception:
-            current = 0
-    new_value = current + int(delta)
-    sb_upsert(
-        supabase,
-        "player_badge_facts",
-        {
-            "club_id": club_id,
-            "player_id": int(player_id),
-            "context_id": context_id,
-            "fact_key": fact_key,
-            "fact_value_num": new_value,
-            "updated_at": datetime.now(timezone.utc).isoformat(),
-        },
-        conflict="club_id,player_id,context_id,fact_key",
-    )

--- a/jupr_app/domain/gamification/fact_engine.py
+++ b/jupr_app/domain/gamification/fact_engine.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from jupr_app.data.sb_write import sb_upsert
+
+UPSET_THRESHOLD = 0.30
+
+
+def update_match_facts_for_players(
+    supabase: Any,
+    club_id: str,
+    player_ids: list[int],
+    match_payload: dict,
+    context_id: str = "overall",
+):
+    """Incrementally update badge facts for players for a single match payload.
+
+    Facts updated:
+    - total_matches
+    - current_win_streak
+    - best_win_streak
+    - rating_delta
+    - upset_wins
+
+    The update is idempotent through a per-player/match guard fact key.
+    """
+    if supabase is None or not club_id or not player_ids:
+        return
+
+    payload = dict(match_payload or {})
+    match_id = str(payload.get("match_id") or payload.get("id") or "").strip()
+    if not match_id:
+        return
+
+    score_t1 = _safe_int(payload.get("score_t1", payload.get("s1")))
+    score_t2 = _safe_int(payload.get("score_t2", payload.get("s2")))
+
+    team1 = _extract_team(payload, ("t1_p1", "t1_p2"))
+    team2 = _extract_team(payload, ("t2_p1", "t2_p2"))
+    winner_team = _winner_team(score_t1, score_t2)
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    normalized_players = sorted({int(pid) for pid in player_ids})
+
+    for pid in normalized_players:
+        if _already_processed_match(supabase, str(club_id), int(pid), context_id, match_id):
+            continue
+
+        _increment_numeric_fact(supabase, str(club_id), int(pid), context_id, "total_matches", 1.0, now_iso)
+
+        won = _player_won(int(pid), winner_team, team1, team2)
+        current_streak = _read_numeric_fact(supabase, str(club_id), int(pid), context_id, "current_win_streak")
+        best_streak = _read_numeric_fact(supabase, str(club_id), int(pid), context_id, "best_win_streak")
+
+        if won is True:
+            current_streak += 1.0
+            best_streak = max(best_streak, current_streak)
+        elif won is False:
+            current_streak = 0.0
+
+        _set_numeric_fact(supabase, str(club_id), int(pid), context_id, "current_win_streak", current_streak, now_iso)
+        _set_numeric_fact(supabase, str(club_id), int(pid), context_id, "best_win_streak", best_streak, now_iso)
+
+        current_rating = _read_player_rating(supabase, str(club_id), int(pid))
+        starting_rating = _read_player_starting_rating(supabase, str(club_id), int(pid), fallback=current_rating)
+        _set_numeric_fact(
+            supabase,
+            str(club_id),
+            int(pid),
+            context_id,
+            "rating_delta",
+            float(current_rating - starting_rating),
+            now_iso,
+        )
+
+        if won and _is_upset_win_for_player(int(pid), payload, team1, team2):
+            _increment_numeric_fact(supabase, str(club_id), int(pid), context_id, "upset_wins", 1.0, now_iso)
+
+        _mark_match_processed(supabase, str(club_id), int(pid), context_id, match_id, now_iso)
+
+
+def _extract_team(payload: dict[str, Any], keys: tuple[str, str]) -> set[int]:
+    members: set[int] = set()
+    for key in keys:
+        pid = _safe_int(payload.get(key))
+        if pid is not None:
+            members.add(int(pid))
+    return members
+
+
+def _winner_team(score_t1: int | None, score_t2: int | None) -> int | None:
+    if score_t1 is None or score_t2 is None:
+        return None
+    if score_t1 > score_t2:
+        return 1
+    if score_t2 > score_t1:
+        return 2
+    return None
+
+
+def _player_won(player_id: int, winner_team: int | None, team1: set[int], team2: set[int]) -> bool | None:
+    if winner_team is None:
+        return None
+    if player_id in team1:
+        return winner_team == 1
+    if player_id in team2:
+        return winner_team == 2
+    return None
+
+
+def _is_upset_win_for_player(player_id: int, payload: dict[str, Any], team1: set[int], team2: set[int]) -> bool:
+    t1_avg = _avg([
+        _safe_float(payload.get("t1_p1_r")),
+        _safe_float(payload.get("t1_p2_r")),
+    ])
+    t2_avg = _avg([
+        _safe_float(payload.get("t2_p1_r")),
+        _safe_float(payload.get("t2_p2_r")),
+    ])
+    if t1_avg is None or t2_avg is None:
+        return False
+
+    if player_id in team1:
+        return ((t2_avg - t1_avg) / 400.0) >= UPSET_THRESHOLD
+    if player_id in team2:
+        return ((t1_avg - t2_avg) / 400.0) >= UPSET_THRESHOLD
+    return False
+
+
+def _fact_guard_key(match_id: str) -> str:
+    return f"_match_guard:{match_id}"
+
+
+def _already_processed_match(supabase: Any, club_id: str, player_id: int, context_id: str, match_id: str) -> bool:
+    rows = _read_fact_rows(supabase, club_id, player_id, context_id, _fact_guard_key(match_id))
+    return bool(rows)
+
+
+def _mark_match_processed(supabase: Any, club_id: str, player_id: int, context_id: str, match_id: str, now_iso: str) -> None:
+    sb_upsert(
+        supabase,
+        "player_badge_facts",
+        {
+            "club_id": club_id,
+            "player_id": int(player_id),
+            "context_id": context_id,
+            "fact_key": _fact_guard_key(match_id),
+            "fact_value_num": 1.0,
+            "updated_at": now_iso,
+        },
+        conflict="club_id,player_id,context_id,fact_key",
+    )
+
+
+def _read_fact_rows(supabase: Any, club_id: str, player_id: int, context_id: str, fact_key: str) -> list[dict[str, Any]]:
+    resp = (
+        supabase.table("player_badge_facts")
+        .select("fact_value_num")
+        .eq("club_id", club_id)
+        .eq("player_id", int(player_id))
+        .eq("context_id", context_id)
+        .eq("fact_key", fact_key)
+        .limit(1)
+        .execute()
+    )
+    return resp.data or []
+
+
+def _read_numeric_fact(supabase: Any, club_id: str, player_id: int, context_id: str, fact_key: str) -> float:
+    rows = _read_fact_rows(supabase, club_id, player_id, context_id, fact_key)
+    if not rows:
+        return 0.0
+    return float(rows[0].get("fact_value_num") or 0.0)
+
+
+def _increment_numeric_fact(
+    supabase: Any,
+    club_id: str,
+    player_id: int,
+    context_id: str,
+    fact_key: str,
+    delta: float,
+    now_iso: str,
+) -> None:
+    current = _read_numeric_fact(supabase, club_id, player_id, context_id, fact_key)
+    _set_numeric_fact(supabase, club_id, player_id, context_id, fact_key, current + float(delta), now_iso)
+
+
+def _set_numeric_fact(
+    supabase: Any,
+    club_id: str,
+    player_id: int,
+    context_id: str,
+    fact_key: str,
+    value: float,
+    now_iso: str,
+) -> None:
+    sb_upsert(
+        supabase,
+        "player_badge_facts",
+        {
+            "club_id": club_id,
+            "player_id": int(player_id),
+            "context_id": context_id,
+            "fact_key": fact_key,
+            "fact_value_num": float(value),
+            "updated_at": now_iso,
+        },
+        conflict="club_id,player_id,context_id,fact_key",
+    )
+
+
+def _read_player_rating(supabase: Any, club_id: str, player_id: int) -> float:
+    resp = (
+        supabase.table("players")
+        .select("rating")
+        .eq("club_id", club_id)
+        .eq("id", int(player_id))
+        .limit(1)
+        .execute()
+    )
+    rows = resp.data or []
+    if not rows:
+        return 1200.0
+    return float(rows[0].get("rating") or 1200.0)
+
+
+def _read_player_starting_rating(supabase: Any, club_id: str, player_id: int, *, fallback: float) -> float:
+    resp = (
+        supabase.table("players")
+        .select("starting_rating,rating")
+        .eq("club_id", club_id)
+        .eq("id", int(player_id))
+        .limit(1)
+        .execute()
+    )
+    rows = resp.data or []
+    if not rows:
+        return float(fallback)
+    row = rows[0]
+    starting = row.get("starting_rating")
+    if starting is None:
+        starting = row.get("rating")
+    if starting is None:
+        return float(fallback)
+    return float(starting)
+
+
+def _avg(values: list[float | None]) -> float | None:
+    nums = [float(v) for v in values if v is not None]
+    if not nums:
+        return None
+    return sum(nums) / len(nums)
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -16,7 +16,6 @@ from jupr_app.domain.player_activity import (
     max_activity_time,
 )
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
-from jupr_app.domain.gamification.fact_pipeline import update_player_badge_facts_for_match_commit
 from services.match_pipeline import submit_match
 
 
@@ -54,7 +53,6 @@ def process_matches(
     island_updates: dict[tuple[int, str], dict[str, Any]] = {}  # (pid, league) -> {"r","start","w","l","mp"}
     last_game_updates: dict[int, datetime] = {}
     affected_players: set[int] = set()
-    match_payloads: list[dict[str, Any]] = []
 
     skipped_incomplete = 0
     skipped_empty = 0
@@ -316,11 +314,11 @@ def process_matches(
                 "tournament_game_id": m.get("tournament_game_id"),
             }
         )
-        match_payloads.append({"league": league_name, "date": dt_val, "score_t1": s1, "score_t2": s2})
 
     # -------------------------
     # Write match rows
     # -------------------------
+    queued_badge_events: list[dict[str, Any]] = []
     if db_matches:
         CHUNK_M = 300
         for i in range(0, len(db_matches), CHUNK_M):
@@ -340,6 +338,24 @@ def process_matches(
                         run_context_hooks=False,
                     )
                 )
+                queued_badge_events.append({
+                    "context_id": str(context_id or "overall"),
+                    "match_id": str(idempotency_key),
+                    "player_ids": [int(match_row["t1_p1"]), int(match_row["t1_p2"]), int(match_row["t2_p1"]), int(match_row["t2_p2"])],
+                    "payload": {
+                        "match_id": str(idempotency_key),
+                        "score_t1": int(match_row["score_t1"]),
+                        "score_t2": int(match_row["score_t2"]),
+                        "t1_p1": int(match_row["t1_p1"]),
+                        "t1_p2": int(match_row["t1_p2"]),
+                        "t2_p1": int(match_row["t2_p1"]),
+                        "t2_p2": int(match_row["t2_p2"]),
+                        "t1_p1_r": float(match_row["t1_p1_r"]),
+                        "t1_p2_r": float(match_row["t1_p2_r"]),
+                        "t2_p1_r": float(match_row["t2_p1_r"]),
+                        "t2_p2_r": float(match_row["t2_p2_r"]),
+                    },
+                })
 
     # -------------------------
     # Update overall player rows
@@ -401,22 +417,19 @@ def process_matches(
             ))
 
     # -------------------------
-    # Update V3 badge facts before enqueue
+    # Enqueue per-match badge jobs (facts are updated in badge_worker)
     # -------------------------
-    if supabase is not None and db_matches and has_non_popup_match:
-        update_player_badge_facts_for_match_commit(
-            supabase,
-            club_id=str(club_id),
-            overall_updates=overall_updates,
-        )
-
-        enqueue_badge_eval(
-            supabase,
-            club_id=str(club_id),
-            event_type="match_recorded",
-            player_ids=sorted(affected_players),
-            payload={"match_count": len(db_matches), "matches": match_payloads[:10]},
-        )
+    if supabase is not None and queued_badge_events and has_non_popup_match:
+        for event in queued_badge_events:
+            enqueue_badge_eval(
+                supabase,
+                club_id=str(club_id),
+                event_type="match_recorded",
+                player_ids=event["player_ids"],
+                context_id=event["context_id"],
+                match_id=event["match_id"],
+                payload=event["payload"],
+            )
 
     return {
         "inserted": len(db_matches),

--- a/tests/test_badge_v3_pipeline.py
+++ b/tests/test_badge_v3_pipeline.py
@@ -150,18 +150,8 @@ def test_badge_v3_pipeline_updates_facts_before_enqueue_and_award(monkeypatch):
     )
 
     ops = storage.get("ops", [])
-    queue_idx = ops.index(("badge_eval_queue", "insert"))
-    fact_indices = [i for i, op in enumerate(ops) if op == ("player_badge_facts", "upsert")]
-    assert fact_indices
-    assert max(fact_indices) < queue_idx
-
-    fact_rows = storage.get("player_badge_facts", [])
-    assert len(fact_rows) == 16
-    for pid in [1, 2, 3, 4]:
-        assert any(
-            row["player_id"] == pid and row["fact_key"] == "total_matches" and float(row["fact_value_num"]) == 1.0
-            for row in fact_rows
-        )
+    assert ("badge_eval_queue", "upsert") in ops
+    assert not storage.get("player_badge_facts", [])
 
     ctx = SimpleNamespace(
         supabase=supabase,
@@ -181,3 +171,10 @@ def test_badge_v3_pipeline_updates_facts_before_enqueue_and_award(monkeypatch):
     result = process_badge_eval_queue(supabase, max_jobs=1, time_budget_seconds=2, ctx=ctx)
     assert result == {"processed": 1, "errored": 0}
     assert len(storage.get("player_badges", [])) == 4
+
+    fact_rows = storage.get("player_badge_facts", [])
+    for pid in [1, 2, 3, 4]:
+        assert any(
+            row["player_id"] == pid and row["fact_key"] == "total_matches" and float(row["fact_value_num"]) == 1.0
+            for row in fact_rows
+        )

--- a/tests/test_fact_engine.py
+++ b/tests/test_fact_engine.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from jupr_app.domain.gamification.fact_engine import update_match_facts_for_players
+
+
+class FakeTable:
+    def __init__(self, storage: dict, name: str):
+        self.storage = storage
+        self.name = name
+        self.filters: list[tuple[str, str, object]] = []
+        self.limit_count = None
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, column, value):
+        self.filters.append(("eq", column, value))
+        return self
+
+    def limit(self, count):
+        self.limit_count = int(count)
+        return self
+
+    def upsert(self, payload, on_conflict=None):
+        keys = [k.strip() for k in str(on_conflict or "").split(",") if k.strip()]
+        rows = payload if isinstance(payload, list) else [payload]
+        existing = self.storage.setdefault(self.name, [])
+        for row in rows:
+            row = dict(row)
+            match = None
+            if keys:
+                for current in existing:
+                    if all(str(current.get(k)) == str(row.get(k)) for k in keys):
+                        match = current
+                        break
+            if match is None:
+                existing.append(row)
+            else:
+                match.update(row)
+        return self
+
+    def execute(self):
+        rows = list(self.storage.get(self.name, []))
+        for op, column, value in self.filters:
+            if op == "eq":
+                rows = [r for r in rows if str(r.get(column)) == str(value)]
+        if self.limit_count is not None:
+            rows = rows[: self.limit_count]
+        return SimpleNamespace(data=rows)
+
+
+class FakeSupabase:
+    def __init__(self, storage: dict):
+        self.storage = storage
+
+    def table(self, name: str):
+        return FakeTable(self.storage, name)
+
+
+def _fact_num(storage: dict, player_id: int, fact_key: str) -> float:
+    for row in storage.get("player_badge_facts", []):
+        if int(row["player_id"]) == int(player_id) and row["fact_key"] == fact_key:
+            return float(row.get("fact_value_num") or 0.0)
+    return 0.0
+
+
+def test_total_matches_and_idempotent_processing():
+    storage = {
+        "players": [
+            {"club_id": "club", "id": 1, "rating": 1280.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 2, "rating": 1240.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 3, "rating": 1220.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 4, "rating": 1180.0, "starting_rating": 1200.0},
+        ],
+        "player_badge_facts": [],
+    }
+    supabase = FakeSupabase(storage)
+
+    payload = {
+        "match_id": "m-1",
+        "score_t1": 11,
+        "score_t2": 8,
+        "t1_p1": 1,
+        "t1_p2": 2,
+        "t2_p1": 3,
+        "t2_p2": 4,
+        "t1_p1_r": 1180.0,
+        "t1_p2_r": 1160.0,
+        "t2_p1_r": 1320.0,
+        "t2_p2_r": 1300.0,
+    }
+
+    update_match_facts_for_players(supabase, "club", [1, 2, 3, 4], payload)
+    update_match_facts_for_players(supabase, "club", [1, 2, 3, 4], payload)
+
+    for pid in [1, 2, 3, 4]:
+        assert _fact_num(storage, pid, "total_matches") == 1.0
+
+
+def test_win_streak_best_streak_and_reset():
+    storage = {
+        "players": [
+            {"club_id": "club", "id": 1, "rating": 1260.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 2, "rating": 1260.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 3, "rating": 1260.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 4, "rating": 1260.0, "starting_rating": 1200.0},
+        ],
+        "player_badge_facts": [],
+    }
+    supabase = FakeSupabase(storage)
+
+    win_payload = {
+        "match_id": "m-win",
+        "score_t1": 11,
+        "score_t2": 7,
+        "t1_p1": 1,
+        "t1_p2": 2,
+        "t2_p1": 3,
+        "t2_p2": 4,
+    }
+    lose_payload = {
+        "match_id": "m-lose",
+        "score_t1": 5,
+        "score_t2": 11,
+        "t1_p1": 1,
+        "t1_p2": 2,
+        "t2_p1": 3,
+        "t2_p2": 4,
+    }
+
+    update_match_facts_for_players(supabase, "club", [1, 2], win_payload)
+    update_match_facts_for_players(supabase, "club", [1, 2], win_payload | {"match_id": "m-win-2"})
+    update_match_facts_for_players(supabase, "club", [1, 2], lose_payload)
+
+    assert _fact_num(storage, 1, "current_win_streak") == 0.0
+    assert _fact_num(storage, 1, "best_win_streak") == 2.0
+
+
+def test_rating_delta_and_upset_wins():
+    storage = {
+        "players": [
+            {"club_id": "club", "id": 1, "rating": 1280.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 2, "rating": 1260.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 3, "rating": 1330.0, "starting_rating": 1300.0},
+            {"club_id": "club", "id": 4, "rating": 1310.0, "starting_rating": 1300.0},
+        ],
+        "player_badge_facts": [],
+    }
+    supabase = FakeSupabase(storage)
+
+    upset_payload = {
+        "match_id": "m-upset",
+        "score_t1": 11,
+        "score_t2": 6,
+        "t1_p1": 1,
+        "t1_p2": 2,
+        "t2_p1": 3,
+        "t2_p2": 4,
+        "t1_p1_r": 1160.0,
+        "t1_p2_r": 1180.0,
+        "t2_p1_r": 1320.0,
+        "t2_p2_r": 1340.0,
+    }
+    non_upset_payload = {
+        "match_id": "m-non-upset",
+        "score_t1": 11,
+        "score_t2": 9,
+        "t1_p1": 3,
+        "t1_p2": 4,
+        "t2_p1": 1,
+        "t2_p2": 2,
+        "t1_p1_r": 1320.0,
+        "t1_p2_r": 1340.0,
+        "t2_p1_r": 1160.0,
+        "t2_p2_r": 1180.0,
+    }
+
+    update_match_facts_for_players(supabase, "club", [1, 2, 3, 4], upset_payload)
+    update_match_facts_for_players(supabase, "club", [1, 2, 3, 4], non_upset_payload)
+
+    assert _fact_num(storage, 1, "rating_delta") == 80.0
+    assert _fact_num(storage, 3, "rating_delta") == 30.0
+    assert _fact_num(storage, 1, "upset_wins") == 1.0
+    assert _fact_num(storage, 3, "upset_wins") == 0.0


### PR DESCRIPTION
### Motivation
- Ensure V3 badge evaluation sees incremental, persistent facts that are updated before evaluator runs and not recomputed from full history.
- Make fact updates idempotent and safe for job retries by guarding per `(club_id, player_id, context_id, match_id)`.
- Move fact updates into the background worker path so match ingest does not run inline badge evaluation or mutable fact writes.

### Description
- Add `jupr_app/domain/gamification/fact_engine.py` implementing `update_match_facts_for_players(...)` which incrementally updates `total_matches`, `current_win_streak`, `best_win_streak`, `rating_delta`, and `upset_wins` and uses a `_match_guard:<match_id>` fact to ensure idempotency via upserts to `player_badge_facts`.
- Update `badge_worker.process_badge_eval_queue` to call `update_match_facts_for_players(...)` (using job `payload_json` / `match_id`) before running V3 evaluation for each player.
- Change `match_processing.process_matches` to enqueue per-match badge jobs (including `match_id`, `context_id`, `player_ids`, and a compact `payload`) instead of writing V3 facts inline during match commit.
- Add unit tests in `tests/test_fact_engine.py` covering increments, streak logic, best-streak tracking, rating delta, upset detection, and idempotent retry behavior, and adjust `tests/test_badge_v3_pipeline.py` expectations to the new worker-driven flow.

### Testing
- Ran `pytest -q tests/test_fact_engine.py tests/test_badge_v3_pipeline.py` and both tests succeeded (`4 passed`).
- Python compilation checks (`python -m py_compile`) were executed on modified modules to ensure syntax correctness and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69934e8231608326a94045dabf7174e7)