### PR TITLE
feat: make fact_engine idempotent using processed_match_facts guard table

### DIFF
--- a/jupr_app/domain/gamification/badge_worker.py
+++ b/jupr_app/domain/gamification/badge_worker.py
@@ -49,6 +49,7 @@ def process_badge_eval_queue(
                         player_ids=player_ids,
                         match_payload=payload_json,
                         context_id=context_id,
+                        match_id=str(job.get("match_id") or "") or None,
                     )
                 if USE_BADGE_ENGINE_V3:
                     v3_badge_ids = _v3_badge_ids_with_conditions(supabase, badge_ids)
@@ -163,4 +164,3 @@ def _v3_badge_ids_with_conditions(supabase: Any, badge_ids: set[str]) -> set[str
         for row in condition_rows
         if row.get("badge_id")
     }
-

--- a/jupr_app/domain/gamification/fact_engine.py
+++ b/jupr_app/domain/gamification/fact_engine.py
@@ -14,6 +14,7 @@ def update_match_facts_for_players(
     player_ids: list[int],
     match_payload: dict,
     context_id: str = "overall",
+    match_id: str | None = None,
 ):
     """Incrementally update badge facts for players for a single match payload.
 
@@ -24,14 +25,14 @@ def update_match_facts_for_players(
     - rating_delta
     - upset_wins
 
-    The update is idempotent through a per-player/match guard fact key.
+    The update is idempotent through a per-player/match guard table.
     """
     if supabase is None or not club_id or not player_ids:
         return
 
     payload = dict(match_payload or {})
-    match_id = str(payload.get("match_id") or payload.get("id") or "").strip()
-    if not match_id:
+    resolved_match_id = str(match_id or payload.get("match_id") or payload.get("id") or "").strip()
+    if not resolved_match_id:
         return
 
     score_t1 = _safe_int(payload.get("score_t1", payload.get("s1")))
@@ -45,7 +46,7 @@ def update_match_facts_for_players(
     normalized_players = sorted({int(pid) for pid in player_ids})
 
     for pid in normalized_players:
-        if _already_processed_match(supabase, str(club_id), int(pid), context_id, match_id):
+        if not _insert_processed_match_guard(supabase, str(club_id), resolved_match_id, int(pid)):
             continue
 
         _increment_numeric_fact(supabase, str(club_id), int(pid), context_id, "total_matches", 1.0, now_iso)
@@ -77,8 +78,6 @@ def update_match_facts_for_players(
 
         if won and _is_upset_win_for_player(int(pid), payload, team1, team2):
             _increment_numeric_fact(supabase, str(club_id), int(pid), context_id, "upset_wins", 1.0, now_iso)
-
-        _mark_match_processed(supabase, str(club_id), int(pid), context_id, match_id, now_iso)
 
 
 def _extract_team(payload: dict[str, Any], keys: tuple[str, str]) -> set[int]:
@@ -129,29 +128,60 @@ def _is_upset_win_for_player(player_id: int, payload: dict[str, Any], team1: set
     return False
 
 
-def _fact_guard_key(match_id: str) -> str:
-    return f"_match_guard:{match_id}"
+def _insert_processed_match_guard(supabase: Any, club_id: str, match_id: str, player_id: int) -> bool:
+    payload = {
+        "club_id": str(club_id),
+        "match_id": str(match_id),
+        "player_id": int(player_id),
+    }
+    existed_before = _processed_match_guard_exists(supabase, str(club_id), str(match_id), int(player_id))
+    try:
+        resp = (
+            supabase.table("processed_match_facts")
+            .insert(
+                payload,
+                on_conflict="club_id,match_id,player_id",
+                ignore_duplicates=True,
+                returning="representation",
+            )
+            .execute()
+        )
+    except TypeError:
+        resp = (
+            supabase.table("processed_match_facts")
+            .upsert(payload, on_conflict="club_id,match_id,player_id")
+            .execute()
+        )
+    inserted_rows = _response_rowcount(resp)
+    if inserted_rows is not None:
+        return inserted_rows > 0
+    exists_after = _processed_match_guard_exists(supabase, str(club_id), str(match_id), int(player_id))
+    return (not existed_before) and exists_after
 
 
-def _already_processed_match(supabase: Any, club_id: str, player_id: int, context_id: str, match_id: str) -> bool:
-    rows = _read_fact_rows(supabase, club_id, player_id, context_id, _fact_guard_key(match_id))
+def _processed_match_guard_exists(supabase: Any, club_id: str, match_id: str, player_id: int) -> bool:
+    rows = (
+        supabase.table("processed_match_facts")
+        .select("player_id")
+        .eq("club_id", str(club_id))
+        .eq("match_id", str(match_id))
+        .eq("player_id", int(player_id))
+        .limit(1)
+        .execute()
+        .data
+        or []
+    )
     return bool(rows)
 
 
-def _mark_match_processed(supabase: Any, club_id: str, player_id: int, context_id: str, match_id: str, now_iso: str) -> None:
-    sb_upsert(
-        supabase,
-        "player_badge_facts",
-        {
-            "club_id": club_id,
-            "player_id": int(player_id),
-            "context_id": context_id,
-            "fact_key": _fact_guard_key(match_id),
-            "fact_value_num": 1.0,
-            "updated_at": now_iso,
-        },
-        conflict="club_id,player_id,context_id,fact_key",
-    )
+def _response_rowcount(resp: Any) -> int | None:
+    data = getattr(resp, "data", None)
+    if isinstance(data, list):
+        return len(data)
+    count = getattr(resp, "count", None)
+    if isinstance(count, int):
+        return count
+    return None
 
 
 def _read_fact_rows(supabase: Any, club_id: str, player_id: int, context_id: str, fact_key: str) -> list[dict[str, Any]]:

--- a/supabase/migrations/202602160002_processed_match_facts.sql
+++ b/supabase/migrations/202602160002_processed_match_facts.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS public.processed_match_facts (
+  club_id TEXT NOT NULL,
+  match_id TEXT NOT NULL,
+  player_id BIGINT NOT NULL,
+  PRIMARY KEY (club_id, match_id, player_id)
+);

--- a/tests/test_badge_worker.py
+++ b/tests/test_badge_worker.py
@@ -19,6 +19,7 @@ class FakeTable:
         self.sort_desc = False
         self.limit_count = None
         self.update_payload = None
+        self._insert_result = None
 
     def select(self, _cols):
         return self
@@ -44,15 +45,32 @@ class FakeTable:
         self.update_payload = payload
         return self
 
-    def insert(self, payload):
+    def insert(self, payload, **kwargs):
         if self.storage.get("raise_missing_table"):
             raise APIError({"code": "PGRST205", "message": "missing table"})
         rows = payload if isinstance(payload, list) else [payload]
         stored = self.storage.setdefault(self.name, [])
+        conflict_cols = [c.strip() for c in str(kwargs.get("on_conflict") or "").split(",") if c.strip()]
+        ignore_duplicates = bool(kwargs.get("ignore_duplicates"))
+        inserted = []
         for row in rows:
             row = dict(row)
-            row.setdefault("id", f"{self.name}_{len(stored) + 1}")
-            stored.append(row)
+            match = None
+            if conflict_cols:
+                for current in stored:
+                    if all(str(current.get(c)) == str(row.get(c)) for c in conflict_cols):
+                        match = current
+                        break
+            if match is not None and ignore_duplicates:
+                continue
+            if match is None:
+                row.setdefault("id", f"{self.name}_{len(stored) + 1}")
+                stored.append(row)
+                inserted.append(row)
+            else:
+                match.update(row)
+                inserted.append(match)
+        self._insert_result = inserted
         return self
 
     def upsert(self, rows, on_conflict=None):
@@ -76,6 +94,10 @@ class FakeTable:
     def execute(self):
         if self.storage.get("raise_missing_table"):
             raise APIError({"code": "PGRST205", "message": "missing table"})
+        if self._insert_result is not None:
+            data = list(self._insert_result)
+            self._insert_result = None
+            return SimpleNamespace(data=data)
         data = list(self.storage.get(self.name, []))
         for op, column, value in self.filters:
             if op == "eq":
@@ -141,7 +163,7 @@ def _build_ctx(supabase=None):
 def test_worker_processes_queue_and_awards_badge():
     storage = {
         "badges": [{"club_id": "club", "badge_id": "grinder", "status": "published", "award_count": 0, "is_locked": False}],
-        "badge_rule_conditions": [{"badge_id": "grinder", "fact_key": "matches_seen", "operator": ">=", "value_numeric": 1}],
+        "badge_rule_conditions": [{"badge_id": "grinder", "fact_key": "total_matches", "operator": ">=", "value_numeric": 1}],
         "player_badge_facts": [],
         "player_badges": [],
     }
@@ -162,7 +184,7 @@ def test_worker_processes_queue_and_awards_badge():
 def test_worker_dedupes_duplicate_events():
     storage = {
         "badges": [{"club_id": "club", "badge_id": "grinder", "status": "published", "award_count": 0, "is_locked": False}],
-        "badge_rule_conditions": [{"badge_id": "grinder", "fact_key": "matches_seen", "operator": ">=", "value_numeric": 1}],
+        "badge_rule_conditions": [{"badge_id": "grinder", "fact_key": "total_matches", "operator": ">=", "value_numeric": 1}],
         "player_badge_facts": [],
         "player_badges": [],
     }
@@ -189,7 +211,7 @@ def test_worker_dedupes_duplicate_events():
 def test_worker_error_marks_queue(monkeypatch):
     storage = {
         "badges": [{"club_id": "club", "badge_id": "grinder", "status": "published", "award_count": 0, "is_locked": False}],
-        "badge_rule_conditions": [{"badge_id": "grinder", "fact_key": "matches_seen", "operator": ">=", "value_numeric": 1}],
+        "badge_rule_conditions": [{"badge_id": "grinder", "fact_key": "total_matches", "operator": ">=", "value_numeric": 1}],
         "player_badge_facts": [],
         "player_badges": [],
     }
@@ -227,3 +249,33 @@ def test_enqueue_badge_eval_missing_table_is_ignored():
         match_id="m1",
     )
     assert storage.get(BADGE_QUEUE_TABLE) is None
+
+
+def test_worker_passes_match_id_to_fact_engine(monkeypatch):
+    storage = {
+        "badges": [{"club_id": "club", "badge_id": "grinder", "status": "published", "award_count": 0, "is_locked": False}],
+        "badge_rule_conditions": [{"badge_id": "grinder", "fact_key": "total_matches", "operator": ">=", "value_numeric": 1}],
+        "player_badge_facts": [],
+        "player_badges": [],
+    }
+    supabase = FakeSupabase(storage)
+    enqueue_badge_eval(
+        supabase,
+        club_id="club",
+        event_type="match_recorded",
+        player_ids=[1],
+        match_id="m42",
+    )
+
+    captured = {}
+
+    def fake_update(*_args, **kwargs):
+        captured["match_id"] = kwargs.get("match_id")
+
+    monkeypatch.setattr(
+        "jupr_app.domain.gamification.badge_worker.update_match_facts_for_players",
+        fake_update,
+    )
+    process_badge_eval_queue(supabase, max_jobs=1, time_budget_seconds=2, ctx=_build_ctx(supabase))
+
+    assert captured["match_id"] == "m42"

--- a/tests/test_fact_engine.py
+++ b/tests/test_fact_engine.py
@@ -11,6 +11,7 @@ class FakeTable:
         self.name = name
         self.filters: list[tuple[str, str, object]] = []
         self.limit_count = None
+        self._result_override = None
 
     def select(self, _cols):
         return self
@@ -21,6 +22,31 @@ class FakeTable:
 
     def limit(self, count):
         self.limit_count = int(count)
+        return self
+
+    def insert(self, payload, **kwargs):
+        rows = payload if isinstance(payload, list) else [payload]
+        existing = self.storage.setdefault(self.name, [])
+        keys = [k.strip() for k in str(kwargs.get("on_conflict") or "").split(",") if k.strip()]
+        ignore_duplicates = bool(kwargs.get("ignore_duplicates"))
+        inserted = []
+        for row in rows:
+            row = dict(row)
+            match = None
+            if keys:
+                for current in existing:
+                    if all(str(current.get(k)) == str(row.get(k)) for k in keys):
+                        match = current
+                        break
+            if match is not None and ignore_duplicates:
+                continue
+            if match is None:
+                existing.append(row)
+                inserted.append(row)
+            else:
+                match.update(row)
+                inserted.append(match)
+        self._result_override = inserted
         return self
 
     def upsert(self, payload, on_conflict=None):
@@ -42,6 +68,10 @@ class FakeTable:
         return self
 
     def execute(self):
+        if self._result_override is not None:
+            rows = list(self._result_override)
+            self._result_override = None
+            return SimpleNamespace(data=rows)
         rows = list(self.storage.get(self.name, []))
         for op, column, value in self.filters:
             if op == "eq":
@@ -184,3 +214,65 @@ def test_rating_delta_and_upset_wins():
     assert _fact_num(storage, 3, "rating_delta") == 30.0
     assert _fact_num(storage, 1, "upset_wins") == 1.0
     assert _fact_num(storage, 3, "upset_wins") == 0.0
+
+
+def test_retry_keeps_streak_values_correct():
+    storage = {
+        "players": [
+            {"club_id": "club", "id": 1, "rating": 1260.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 2, "rating": 1260.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 3, "rating": 1260.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 4, "rating": 1260.0, "starting_rating": 1200.0},
+        ],
+        "player_badge_facts": [],
+    }
+    supabase = FakeSupabase(storage)
+
+    first_win = {
+        "match_id": "m-streak-1",
+        "score_t1": 11,
+        "score_t2": 8,
+        "t1_p1": 1,
+        "t1_p2": 2,
+        "t2_p1": 3,
+        "t2_p2": 4,
+    }
+    second_win = first_win | {"match_id": "m-streak-2"}
+
+    update_match_facts_for_players(supabase, "club", [1, 2], first_win)
+    update_match_facts_for_players(supabase, "club", [1, 2], first_win)
+    update_match_facts_for_players(supabase, "club", [1, 2], second_win)
+
+    assert _fact_num(storage, 1, "current_win_streak") == 2.0
+    assert _fact_num(storage, 1, "best_win_streak") == 2.0
+
+
+def test_retry_keeps_total_matches_accurate():
+    storage = {
+        "players": [
+            {"club_id": "club", "id": 1, "rating": 1260.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 2, "rating": 1260.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 3, "rating": 1260.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 4, "rating": 1260.0, "starting_rating": 1200.0},
+        ],
+        "player_badge_facts": [],
+    }
+    supabase = FakeSupabase(storage)
+
+    match_1 = {
+        "match_id": "m-total-1",
+        "score_t1": 11,
+        "score_t2": 9,
+        "t1_p1": 1,
+        "t1_p2": 2,
+        "t2_p1": 3,
+        "t2_p2": 4,
+    }
+    match_2 = match_1 | {"match_id": "m-total-2"}
+
+    update_match_facts_for_players(supabase, "club", [1, 2, 3, 4], match_1)
+    update_match_facts_for_players(supabase, "club", [1, 2, 3, 4], match_1)
+    update_match_facts_for_players(supabase, "club", [1, 2, 3, 4], match_2)
+
+    for pid in [1, 2, 3, 4]:
+        assert _fact_num(storage, pid, "total_matches") == 2.0


### PR DESCRIPTION
### Motivation
- Avoid double-counting when badge worker retries or duplicate jobs run by making per-player/match processing idempotent at the DB level.
- Provide a lightweight guard table so the fact engine can claim a (club_id, match_id, player_id) tuple before mutating player facts.

### Description
- Add a Supabase migration `supabase/migrations/202602160002_processed_match_facts.sql` that creates `public.processed_match_facts (club_id, match_id, player_id)` primary key.
- Change `update_match_facts_for_players` in `jupr_app/domain/gamification/fact_engine.py` to accept an explicit `match_id`, attempt a conflict-safe insert into `processed_match_facts`, and skip processing when the guard indicates the match/player was already processed, falling back to upsert semantics when necessary.
- Update `jupr_app/domain/gamification/badge_worker.py` to pass the queued job `match_id` into the fact engine so the guard key is derived from the queue payload.
- Extend tests and adjust test fakes to simulate insert/upsert semantics for `processed_match_facts`, and add tests covering idempotent processing, streak correctness after retries, accurate `total_matches` after retries, and worker propagation of `match_id`.

### Testing
- Added and updated unit tests in `tests/test_fact_engine.py` and `tests/test_badge_worker.py` to validate idempotency and match-id propagation.
- Ran `pytest tests/test_fact_engine.py tests/test_badge_worker.py` and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69935120fc708326b7e4a687d2c3eda0)