### PR TITLE
feat: add historical fact replay tool for V3 migration

### DIFF
--- a/jupr_app/domain/gamification/fact_replay.py
+++ b/jupr_app/domain/gamification/fact_replay.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any
+
+from jupr_app.domain.gamification.fact_engine import update_match_facts_for_players
+
+
+def rebuild_facts_from_history(supabase: Any, club_id: str) -> dict[str, int]:
+    """Rebuild ``player_badge_facts`` by replaying all matches in historical order.
+
+    The replay is idempotent because ``update_match_facts_for_players`` enforces
+    per-player match guards via ``processed_match_facts``.
+    """
+    if supabase is None or not str(club_id).strip():
+        return {"matches_seen": 0, "matches_processed": 0, "players_touched": 0}
+
+    rows = (
+        supabase.table("matches")
+        .select("id,date,score_t1,score_t2,t1_p1,t1_p2,t2_p1,t2_p2")
+        .eq("club_id", str(club_id))
+        .order("date", desc=False)
+        .execute()
+        .data
+        or []
+    )
+
+    matches_processed = 0
+    touched_players: set[int] = set()
+
+    for row in rows:
+        players = _extract_players(row)
+        if not players:
+            continue
+
+        winner_team = _winner_team(row)
+        payload = {
+            "match_id": row.get("id"),
+            "id": row.get("id"),
+            "score_t1": row.get("score_t1"),
+            "score_t2": row.get("score_t2"),
+            "t1_p1": row.get("t1_p1"),
+            "t1_p2": row.get("t1_p2"),
+            "t2_p1": row.get("t2_p1"),
+            "t2_p2": row.get("t2_p2"),
+            "winner_team": winner_team,
+            "loser_team": 2 if winner_team == 1 else 1 if winner_team == 2 else None,
+        }
+
+        update_match_facts_for_players(
+            supabase,
+            str(club_id),
+            players,
+            payload,
+            match_id=str(row.get("id") or ""),
+        )
+        matches_processed += 1
+        touched_players.update(players)
+
+    return {
+        "matches_seen": len(rows),
+        "matches_processed": matches_processed,
+        "players_touched": len(touched_players),
+    }
+
+
+def _extract_players(row: dict[str, Any]) -> list[int]:
+    players: set[int] = set()
+    for key in ("t1_p1", "t1_p2", "t2_p1", "t2_p2"):
+        pid = _safe_int(row.get(key))
+        if pid is not None:
+            players.add(pid)
+    return sorted(players)
+
+
+def _winner_team(row: dict[str, Any]) -> int | None:
+    score_t1 = _safe_int(row.get("score_t1"))
+    score_t2 = _safe_int(row.get("score_t2"))
+    if score_t1 is None or score_t2 is None:
+        return None
+    if score_t1 > score_t2:
+        return 1
+    if score_t2 > score_t1:
+        return 2
+    return None
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -10,6 +10,7 @@ from postgrest.exceptions import APIError
 from jupr_app.domain.ratings import calculate_hybrid_elo
 from jupr_app.domain.constants import DEFAULT_K_FACTOR
 from jupr_app.domain.gamification.ensure_badges import ensure_badges
+from jupr_app.domain.gamification.fact_replay import rebuild_facts_from_history
 from jupr_app.domain.gamification.badge_state import ALLOWED_BADGE_STATES, can_transition_badge_state
 from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
 from jupr_app.ui.layout import page_shell
@@ -133,6 +134,32 @@ def render(ctx):
         time.sleep(0.6)
         st.rerun()
 
+
+    st.divider()
+
+    # -------------------------
+    # Historical Fact Replay
+    # -------------------------
+    st.subheader("🧱 Historical Fact Replay")
+    st.caption("Rebuild player badge facts from full match history in ascending date order.")
+    if st.button("Rebuild Badge Facts from History", key="badge_fact_replay"):
+        with st.spinner("Rebuilding badge facts from history..."):
+            try:
+                replay_summary = rebuild_facts_from_history(supabase, club_id=club_id)
+            except Exception as exc:  # noqa: BLE001 - UI should not crash
+                st.error("Failed to rebuild badge facts from history.")
+                st.exception(exc)
+            else:
+                st.success("Historical fact replay completed.")
+                st.info(
+                    " · ".join(
+                        [
+                            f"Matches seen: {replay_summary['matches_seen']}",
+                            f"Matches processed: {replay_summary['matches_processed']}",
+                            f"Players touched: {replay_summary['players_touched']}",
+                        ]
+                    )
+                )
 
     st.divider()
 

--- a/tests/test_fact_replay.py
+++ b/tests/test_fact_replay.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from jupr_app.domain.gamification.fact_replay import rebuild_facts_from_history
+
+
+class FakeTable:
+    def __init__(self, storage: dict, name: str):
+        self.storage = storage
+        self.name = name
+        self.filters: list[tuple[str, str, object]] = []
+        self.limit_count: int | None = None
+        self._result_override = None
+        self._order_by: str | None = None
+        self._order_desc: bool = False
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, column, value):
+        self.filters.append(("eq", column, value))
+        return self
+
+    def limit(self, count):
+        self.limit_count = int(count)
+        return self
+
+    def order(self, column, desc=False):
+        self._order_by = str(column)
+        self._order_desc = bool(desc)
+        return self
+
+    def insert(self, payload, **kwargs):
+        rows = payload if isinstance(payload, list) else [payload]
+        existing = self.storage.setdefault(self.name, [])
+        keys = [k.strip() for k in str(kwargs.get("on_conflict") or "").split(",") if k.strip()]
+        ignore_duplicates = bool(kwargs.get("ignore_duplicates"))
+        inserted = []
+        for row in rows:
+            row = dict(row)
+            match = None
+            if keys:
+                for current in existing:
+                    if all(str(current.get(k)) == str(row.get(k)) for k in keys):
+                        match = current
+                        break
+            if match is not None and ignore_duplicates:
+                continue
+            if match is None:
+                existing.append(row)
+                inserted.append(row)
+            else:
+                match.update(row)
+                inserted.append(match)
+        self._result_override = inserted
+        return self
+
+    def upsert(self, payload, on_conflict=None):
+        keys = [k.strip() for k in str(on_conflict or "").split(",") if k.strip()]
+        rows = payload if isinstance(payload, list) else [payload]
+        existing = self.storage.setdefault(self.name, [])
+        for row in rows:
+            row = dict(row)
+            match = None
+            if keys:
+                for current in existing:
+                    if all(str(current.get(k)) == str(row.get(k)) for k in keys):
+                        match = current
+                        break
+            if match is None:
+                existing.append(row)
+            else:
+                match.update(row)
+        return self
+
+    def execute(self):
+        if self._result_override is not None:
+            rows = list(self._result_override)
+            self._result_override = None
+            return SimpleNamespace(data=rows)
+
+        rows = list(self.storage.get(self.name, []))
+        for op, column, value in self.filters:
+            if op == "eq":
+                rows = [r for r in rows if str(r.get(column)) == str(value)]
+
+        if self._order_by is not None:
+            rows = sorted(rows, key=lambda row: str(row.get(self._order_by) or ""), reverse=self._order_desc)
+
+        if self.limit_count is not None:
+            rows = rows[: self.limit_count]
+
+        return SimpleNamespace(data=rows)
+
+
+class FakeSupabase:
+    def __init__(self, storage: dict):
+        self.storage = storage
+
+    def table(self, name: str):
+        return FakeTable(self.storage, name)
+
+
+def _fact_num(storage: dict, player_id: int, fact_key: str) -> float:
+    for row in storage.get("player_badge_facts", []):
+        if int(row["player_id"]) == int(player_id) and row["fact_key"] == fact_key:
+            return float(row.get("fact_value_num") or 0.0)
+    return 0.0
+
+
+def test_rebuild_facts_from_history_streaks_and_idempotency():
+    storage = {
+        "players": [
+            {"club_id": "club", "id": 1, "rating": 1260.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 2, "rating": 1240.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 3, "rating": 1220.0, "starting_rating": 1200.0},
+            {"club_id": "club", "id": 4, "rating": 1210.0, "starting_rating": 1200.0},
+        ],
+        "matches": [
+            {
+                "id": "m2",
+                "club_id": "club",
+                "date": "2026-01-02T10:00:00Z",
+                "score_t1": 11,
+                "score_t2": 7,
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+            },
+            {
+                "id": "m1",
+                "club_id": "club",
+                "date": "2026-01-01T10:00:00Z",
+                "score_t1": 11,
+                "score_t2": 9,
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+            },
+            {
+                "id": "m3",
+                "club_id": "club",
+                "date": "2026-01-03T10:00:00Z",
+                "score_t1": 5,
+                "score_t2": 11,
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+            },
+        ],
+        "player_badge_facts": [],
+        "processed_match_facts": [],
+    }
+    supabase = FakeSupabase(storage)
+
+    first = rebuild_facts_from_history(supabase, club_id="club")
+
+    assert first["matches_seen"] == 3
+    assert first["matches_processed"] == 3
+    assert first["players_touched"] == 4
+
+    assert _fact_num(storage, 1, "total_matches") == 3.0
+    assert _fact_num(storage, 1, "current_win_streak") == 0.0
+    assert _fact_num(storage, 1, "best_win_streak") == 2.0
+
+    assert _fact_num(storage, 3, "total_matches") == 3.0
+    assert _fact_num(storage, 3, "current_win_streak") == 1.0
+    assert _fact_num(storage, 3, "best_win_streak") == 1.0
+
+    second = rebuild_facts_from_history(supabase, club_id="club")
+
+    assert second["matches_seen"] == 3
+    assert second["matches_processed"] == 3
+    assert second["players_touched"] == 4
+
+    assert _fact_num(storage, 1, "total_matches") == 3.0
+    assert _fact_num(storage, 1, "best_win_streak") == 2.0
+    assert _fact_num(storage, 3, "total_matches") == 3.0
+
+    assert len(storage["processed_match_facts"]) == 12


### PR DESCRIPTION
### Motivation
- Provide an admin-facing tool to rebuild V3 `player_badge_facts` from full match history to support the V3 migration and ensure badge facts reflect historical match order.
- Reuse the existing fact engine logic so live and replayed processing behave identically and idempotently via the `processed_match_facts` guard.
- Allow operators to run the rebuild from the UI and get a concise replay summary for operational visibility.

### Description
- Add `jupr_app/domain/gamification/fact_replay.py` implementing `rebuild_facts_from_history(supabase, club_id)` which loads matches ordered by `date ASC`, extracts players, determines winners/losers, and replays each match through `update_match_facts_for_players` while returning a small summary (`matches_seen`, `matches_processed`, `players_touched`).
- Wire a new Admin Tools UI action in `jupr_app/ui/pages/admin_tools.py` labeled "Rebuild Badge Facts from History" that calls `rebuild_facts_from_history`, displays success/error state, and shows replay metrics.
- Add unit test `tests/test_fact_replay.py` that validates ordered-streak construction, that `best_win_streak` persists across later losses, and idempotency (no double counting on second run).

### Testing
- Ran `pytest -q tests/test_fact_replay.py tests/test_fact_engine.py` and all tests passed (`6 passed`).
- Launched the Streamlit app with `streamlit run streamlit_app.py --server.headless true --server.port 8501` to verify the new Admin Tools button and captured a UI screenshot artifact.
- Committed the new module, UI update, and test file under the change titled `feat: add historical fact replay tool for V3 migration`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699355e4dc90832683c0aae2204ca902)