### PR TITLE
refactor: remove direct matches deletion from tournament save (enforce canonical sync separation)

### DIFF
--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -646,8 +646,6 @@ def _save_games(ctx, tournament, teams_by_id, game_map, stage: str):
                 filters={"id": game_id},
             )
 
-            supabase.table("matches").delete().eq("tournament_game_id", game_id).execute()
-
             updated_any = True
             continue
 
@@ -666,8 +664,6 @@ def _save_games(ctx, tournament, teams_by_id, game_map, stage: str):
             finalize_payload,
             filters={"id": game_id},
         )
-
-        supabase.table("matches").delete().eq("tournament_game_id", game_id).execute()
 
         match_payload = _build_match_payload(
             tournament,


### PR DESCRIPTION
### Motivation
- Enforce separation of concerns so the tournament UI layer only updates `tournament_games` and delegates all `matches` deletion/rebuild to the canonical `sync_tournament_game_to_match` flow.

### Description
- Removed both occurrences of `supabase.table("matches").delete().eq("tournament_game_id", game_id).execute()` from `_save_games` in `jupr_app/ui/pages/tournaments.py`, preserving the `tournament_games` updates and the subsequent call to `sync_tournament_game_to_match` while leaving all other logic unchanged.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/tournaments.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699361215d308326b80c9ed70df78813)