### PR TITLE
rebuild: migrate Supabase + admin config to ENV variables (Fly-compatible)

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -22,11 +22,15 @@ LOCAL_PUBLIC_BASE_URL_DEFAULT = "http://localhost:8501"
 
 
 def _get_admin_password() -> str:
-    return os.getenv("ADMIN_PASSWORD", "")
+    import os
+
+    return os.environ.get("SUPABASE_ADMIN_PASSWORD", "")
 
 
 def _get_session_secret() -> str:
-    return os.getenv("ADMIN_SESSION_SECRET", "")
+    import os
+
+    return os.environ.get("SUPABASE_ADMIN_SESSION_SECRET", "")
 
 
 def _sign(exp: int, secret: str) -> str:
@@ -37,7 +41,7 @@ def _sign(exp: int, secret: str) -> str:
 def _create_admin_session():
     secret = _get_session_secret()
     if not secret:
-        st.error("ADMIN_SESSION_SECRET missing.")
+        st.error("SUPABASE_ADMIN_SESSION_SECRET missing.")
         st.stop()
 
     exp = int(time.time()) + ADMIN_SESSION_TTL_SECONDS
@@ -87,22 +91,31 @@ def _validate_admin_session() -> bool:
 @st.cache_resource
 def get_supabase():
     """
-    Production Supabase client.
-    Requires Fly environment variables:
-    SUPABASE_URL
-    SUPABASE_SERVICE_ROLE_KEY
+    Supabase bootstrap using environment variables (Fly-compatible).
+
+    Required ENV variables:
+        SUPABASE_URL
+        SUPABASE_ANON_KEY
     """
+    import os
 
     from jupr_app.data.client import make_supabase
 
-    url = os.getenv("SUPABASE_URL")
-    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("SUPABASE_URL", "")
+    key = os.environ.get("SUPABASE_ANON_KEY", "")
 
-    if not url:
-        raise RuntimeError("Missing SUPABASE_URL environment variable.")
+    if not url or not key:
+        st.error("Supabase environment variables are missing.")
+        st.code(
+            "Required environment variables:\n"
+            "SUPABASE_URL\n"
+            "SUPABASE_ANON_KEY\n"
+        )
+        st.stop()
 
-    if not key:
-        raise RuntimeError("Missing SUPABASE_SERVICE_ROLE_KEY environment variable.")
+    if not url.startswith("https://"):
+        st.error("SUPABASE_URL appears invalid.")
+        st.stop()
 
     return make_supabase(url, key)
 
@@ -202,8 +215,8 @@ def main():
         # Make base_url available to all pages (leaderboards uses this for share links)
         # Use session_state because ctx is a frozen-ish dataclass and you don't want to refactor it mid-stream.
         # Fly env vars required in production/staging: PUBLIC_BASE_URL, SUPABASE_URL,
-        # SUPABASE_SERVICE_ROLE_KEY, ADMIN_PASSWORD,
-        # and ADMIN_SESSION_SECRET.
+        # SUPABASE_ANON_KEY, SUPABASE_ADMIN_PASSWORD,
+        # and SUPABASE_ADMIN_SESSION_SECRET.
         base_url = os.getenv("PUBLIC_BASE_URL", LOCAL_PUBLIC_BASE_URL_DEFAULT)
         st.session_state["base_url"] = str(base_url)
 


### PR DESCRIPTION
### Motivation
- Remove Streamlit `st.secrets` usage and make Supabase + admin authentication bootstrap deterministic from environment variables for Fly deployments.
- Prevent 401 Invalid API key errors by wiring runtime config to the expected `SUPABASE_*` env names and fail fast in the UI when missing or malformed.

### Description
- Replaced `get_supabase()` in `streamlit_app.py` to read `SUPABASE_URL` and `SUPABASE_ANON_KEY` from the environment and return `make_supabase(url, key)`; UI shows an error and stops if variables are missing.
- Added a simple startup guard that rejects non-HTTPS `SUPABASE_URL` and surfaces an explanatory Streamlit error before stopping startup.
- Migrated admin auth lookups to use `SUPABASE_ADMIN_PASSWORD` and `SUPABASE_ADMIN_SESSION_SECRET` via `_get_admin_password()` and `_get_session_secret()` respectively, and updated related inline messages/comments accordingly.
- Did not change any domain or database logic and retained existing helpers (did not remove `get_secret()` elsewhere).

### Testing
- Ran `python -m py_compile streamlit_app.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69947922de748326a44ca5984d85ff29)