### PR TITLE
Prefer env vars for admin auth with Streamlit secrets fallback

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -22,15 +22,20 @@ LOCAL_PUBLIC_BASE_URL_DEFAULT = "http://localhost:8501"
 
 
 def _get_admin_password() -> str:
-    import os
-
-    return os.environ.get("SUPABASE_ADMIN_PASSWORD", "")
+    return (
+        os.getenv("SUPABASE_ADMIN_PASSWORD")
+        or st.secrets.get("supabase", {}).get("admin_password", "")
+        or ""
+    )
 
 
 def _get_session_secret() -> str:
-    import os
-
-    return os.environ.get("SUPABASE_ADMIN_SESSION_SECRET", "")
+    return (
+        os.getenv("SUPABASE_ADMIN_SESSION_SECRET")
+        or st.secrets.get("supabase", {}).get("admin_session_secret", "")
+        or st.secrets.get("admin_session_secret", "")
+        or ""
+    )
 
 
 def _sign(exp: int, secret: str) -> str:


### PR DESCRIPTION
### Motivation
- Ensure production (Fly) deployments use environment secrets while preserving local dev and existing session behavior by falling back to `st.secrets` when env vars are not present.

### Description
- Updated `streamlit_app.py` to change `_get_admin_password()` and `_get_session_secret()` to prefer `os.getenv("SUPABASE_ADMIN_PASSWORD")` and `os.getenv("SUPABASE_ADMIN_SESSION_SECRET")` respectively, then fall back to `st.secrets` keys (`"supabase"["admin_password"]`, `"supabase"["admin_session_secret"]`, and `"admin_session_secret"`) and finally an empty string.

### Testing
- Ran `python -m compileall streamlit_app.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994abafa6b083269180b5d7cf583942)