### PR TITLE
feat(tournaments): add playoff_best_of and series_game_number migration

### DIFF
--- a/migrations/20260217_playoff_series_support.sql
+++ b/migrations/20260217_playoff_series_support.sql
@@ -1,0 +1,11 @@
+-- Add playoff format setting at tournament level
+ALTER TABLE public.tournaments
+ADD COLUMN IF NOT EXISTS playoff_best_of integer NOT NULL DEFAULT 1;
+
+-- Add series game tracking to tournament games
+ALTER TABLE public.tournament_games
+ADD COLUMN IF NOT EXISTS series_game_number integer NULL;
+
+-- Optional helpful index
+CREATE INDEX IF NOT EXISTS idx_tournament_games_series
+ON public.tournament_games (tournament_id, playoff_game_code, series_game_number);


### PR DESCRIPTION
### Motivation
- Add lightweight schema support for multi-game playoff series while preserving existing single-game behavior and avoiding destructive changes.

### Description
- Create migration `migrations/20260217_playoff_series_support.sql` that adds `playoff_best_of` to `public.tournaments` as `integer NOT NULL DEFAULT 1`, adds nullable `series_game_number` to `public.tournament_games`, and creates an optional index `idx_tournament_games_series` on `(tournament_id, playoff_game_code, series_game_number)`.

### Testing
- No automated tests were executed for this migration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994cd0f43808326aca06d3c83bfa3a6)