### PR TITLE
feat(tournaments): implement best-of series logic

### DIFF
--- a/jupr_app/domain/tournaments/__init__.py
+++ b/jupr_app/domain/tournaments/__init__.py
@@ -521,6 +521,7 @@ def build_playoff_games(
     tournament_id: str,
     advance_count: int,
     standings: list[dict[str, Any]],
+    best_of: int = 1,
 ) -> list[dict[str, Any]]:
     template = PLAYOFF_TEMPLATES.get(int(advance_count))
     if not template:
@@ -529,25 +530,65 @@ def build_playoff_games(
     seed_map = {int(row["seed"]): row["team_id"] for row in standings}
     games: list[dict[str, Any]] = []
 
-    for game in template["games"]:
-        team_a_source = game["teamA"]
-        team_b_source = game["teamB"]
+    for template_game in template["games"]:
+        team_a_source = template_game["teamA"]
+        team_b_source = template_game["teamB"]
         team_a_id = seed_map.get(int(team_a_source["seed"])) if "seed" in team_a_source else None
         team_b_id = seed_map.get(int(team_b_source["seed"])) if "seed" in team_b_source else None
-        games.append(
-            {
-                "tournament_id": tournament_id,
-                "stage": "PLAYOFF",
-                "playoff_game_code": game["id"],
-                "playoff_round": game["round"],
-                "team_a_id": team_a_id,
-                "team_b_id": team_b_id,
-                "team_a_source": team_a_source,
-                "team_b_source": team_b_source,
-            }
-        )
+        for series_game in range(1, best_of + 1):
+            games.append(
+                {
+                    "tournament_id": tournament_id,
+                    "stage": "PLAYOFF",
+                    "playoff_game_code": template_game["id"],
+                    "series_game_number": series_game,
+                    "playoff_round": template_game["round"],
+                    "team_a_id": team_a_id,
+                    "team_b_id": team_b_id,
+                    "team_a_source": team_a_source,
+                    "team_b_source": team_b_source,
+                }
+            )
 
     return games
+
+
+def resolve_series_results(games: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Determines winner_team_id for a playoff series based on best-of logic.
+    Does NOT overwrite individual game winners.
+    """
+
+    updates = []
+    grouped: dict[str, list[dict]] = {}
+
+    for g in games:
+        if g.get("stage") != "PLAYOFF":
+            continue
+        grouped.setdefault(g.get("playoff_game_code"), []).append(g)
+
+    for code, series_games in grouped.items():
+        wins: dict[str, int] = {}
+        for g in series_games:
+            winner = g.get("winner_team_id")
+            if winner:
+                wins[winner] = wins.get(winner, 0) + 1
+
+        if not wins:
+            continue
+
+        # best-of-3 means first to 2
+        max_wins = max(wins.values())
+        winner_team = [k for k, v in wins.items() if v == max_wins][0]
+
+        required = 2 if len(series_games) >= 3 else 1
+        if max_wins >= required:
+            for g in series_games:
+                if g.get("winner_team_id") != winner_team:
+                    continue
+                updates.append({"id": g["id"], "series_winner_team_id": winner_team})
+
+    return updates
 
 
 def resolve_playoff_dependencies(games: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/test_tournaments.py
+++ b/tests/test_tournaments.py
@@ -1,9 +1,11 @@
 import pytest
 
 from jupr_app.domain.tournaments import (
+    build_playoff_games,
     build_round_robin_games,
     compute_podium_from_rr,
     compute_round_robin_standings,
+    resolve_series_results,
     resolve_playoff_dependencies,
     validate_podium_placements,
 )
@@ -117,6 +119,54 @@ def test_validate_podium_rejects_duplicate_teams():
 
     with pytest.raises(ValueError):
         validate_podium_placements(placements)
+
+
+def test_build_playoff_games_best_of_series():
+    standings = [
+        {"seed": 1, "team_id": "t1"},
+        {"seed": 2, "team_id": "t2"},
+        {"seed": 3, "team_id": "t3"},
+        {"seed": 4, "team_id": "t4"},
+    ]
+
+    games = build_playoff_games(
+        tournament_id="tour1",
+        advance_count=4,
+        standings=standings,
+        best_of=3,
+    )
+
+    p1_games = [g for g in games if g["playoff_game_code"] == "P1"]
+    p2_games = [g for g in games if g["playoff_game_code"] == "P2"]
+    p3_games = [g for g in games if g["playoff_game_code"] == "P3"]
+    p4_games = [g for g in games if g["playoff_game_code"] == "P4"]
+
+    assert len(games) == 12
+    assert [g["series_game_number"] for g in p1_games] == [1, 2, 3]
+    assert [g["series_game_number"] for g in p2_games] == [1, 2, 3]
+    assert [g["series_game_number"] for g in p3_games] == [1, 2, 3]
+    assert [g["series_game_number"] for g in p4_games] == [1, 2, 3]
+    assert {g["team_a_id"] for g in p1_games} == {"t1"}
+    assert {g["team_b_id"] for g in p1_games} == {"t4"}
+
+
+def test_resolve_series_results_best_of_three():
+    games = [
+        {"id": "g1", "stage": "PLAYOFF", "playoff_game_code": "P1", "winner_team_id": "t1"},
+        {"id": "g2", "stage": "PLAYOFF", "playoff_game_code": "P1", "winner_team_id": "t1"},
+        {"id": "g3", "stage": "PLAYOFF", "playoff_game_code": "P1", "winner_team_id": "t2"},
+        {"id": "g4", "stage": "PLAYOFF", "playoff_game_code": "P2", "winner_team_id": "t3"},
+        {"id": "g5", "stage": "PLAYOFF", "playoff_game_code": "P2", "winner_team_id": None},
+        {"id": "g6", "stage": "ROUND_ROBIN", "playoff_game_code": "P3", "winner_team_id": "t9"},
+    ]
+
+    updates = resolve_series_results(games)
+
+    assert updates == [
+        {"id": "g1", "series_winner_team_id": "t1"},
+        {"id": "g2", "series_winner_team_id": "t1"},
+        {"id": "g4", "series_winner_team_id": "t3"},
+    ]
 
 
 def test_resolve_playoff_dependencies():


### PR DESCRIPTION
### Motivation
- Enable playoff brackets to support best-of series (e.g., best-of-3) so a single playoff slot can represent a multi-game series and determine a series winner.

### Description
- Updated the signature of `build_playoff_games` to accept `best_of: int = 1` and generate multiple game entries per playoff template slot using a `series_game_number` field.
- Reworked the game creation loop to iterate `for template_game in template["games"]` and then `for series_game in range(1, best_of + 1)` so each series game keeps identical `team_a_id` / `team_b_id` assignments and includes `playoff_game_code` and `series_game_number`.
- Added `resolve_series_results(games: list[dict[str, Any]]) -> list[dict[str, Any]]` which groups playoff games by `playoff_game_code`, counts `winner_team_id` occurrences, determines the series winner based on best-of rules (first to 2 if there are 3+ games, otherwise 1), and returns updates that set `series_winner_team_id` for games belonging to a decided series without overwriting individual game winners.
- Did not change `resolve_playoff_dependencies`, `finalize_game`, match submission, or round-robin logic.

### Testing
- Added `test_build_playoff_games_best_of_series` and `test_resolve_series_results_best_of_three` to `tests/test_tournaments.py` to validate game generation and series resolution behavior.
- Ran the tournament domain tests with `pytest -q tests/test_tournaments.py` and all tests passed (8 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994e17786cc8326ba4e1d450bb849b1)