### PR TITLE
feat(tournaments): allow safe playoff bracket regeneration

### DIFF
--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -353,6 +353,39 @@ def render(ctx):
             st.success("Playoff format saved.")
             st.rerun()
 
+        # --- Regenerate Playoff Bracket ---
+        if playoff_games:
+            if tournament.get("status") == "COMPLETE":
+                st.info("Tournament is complete. Bracket cannot be regenerated.")
+            else:
+                existing_scored = any(
+                    g.get("score_a") is not None or g.get("score_b") is not None
+                    for g in playoff_games
+                )
+
+                if existing_scored:
+                    st.warning("Playoff scores have already been entered. Bracket cannot be regenerated.")
+                else:
+                    if st.button("Regenerate Playoff Bracket", type="secondary"):
+                        supabase.table("tournament_games").delete().eq("tournament_id", tournament_id).eq("stage", "PLAYOFF").execute()
+
+                        standings = compute_round_robin_standings(
+                            list(teams_by_id.values()),
+                            rr_games,
+                        )
+
+                        games_payload = build_playoff_games(
+                            tournament_id=tournament_id,
+                            advance_count=int(tournament.get("playoff_advance_count")),
+                            standings=standings,
+                            best_of=int(tournament.get("playoff_best_of", 1)),
+                        )
+
+                        supabase.table("tournament_games").insert(games_payload).execute()
+
+                        st.success("Playoff bracket regenerated.")
+                        st.rerun()
+
         if not playoff_games:
             st.info("No playoff bracket generated yet.")
         if st.button("Generate Playoff Bracket", disabled=bool(playoff_games) or is_complete):


### PR DESCRIPTION
### Motivation
- Provide admins a way to regenerate playoff brackets when changing playoff format while preventing data corruption and rating inconsistencies.
- Ensure regeneration preserves RR-derived seeding and avoids mutating existing scored playoff data or completed tournaments.

### Description
- Added a regeneration UI block in the Playoffs tab (file `jupr_app/ui/pages/tournaments.py`) placed after saving format and before `_render_playoff_bracket`.
- Regeneration is blocked when `tournament.get("status") == "COMPLETE"` or when any playoff game has `score_a` or `score_b` set.
- When allowed, the flow performs a delete-only of `stage == "PLAYOFF"` rows and then recomputes RR `standings` via `compute_round_robin_standings` and rebuilds the playoff payload with `build_playoff_games` using the current `playoff_best_of` and `playoff_advance_count`, then inserts the new games.
- Preserves existing logic by not changing initial "Generate Playoff Bracket" flow, `_render_playoff_bracket`, `resolve_playoff_dependencies`, `resolve_series_results`, `_save_games`, or RR logic, and performs no in-place mutations of series/game numbering (delete + rebuild only).

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/tournaments.py` to validate syntax, which succeeded.
- Launched the app with `python -m streamlit run streamlit_app.py --server.headless true --server.port 8501` to validate the UI flow, which started successfully.
- Captured a UI screenshot via Playwright against `http://127.0.0.1:8501` to validate placement and controls, which produced an artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995211193488326aaf94f1f26665f83)