### PR TITLE
fix(tournaments): correctly finalize deciding game in best-of series

### DIFF
--- a/jupr_app/domain/tournaments/__init__.py
+++ b/jupr_app/domain/tournaments/__init__.py
@@ -598,11 +598,24 @@ def resolve_series_results(games: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 opponents = [tid for tid in wins.keys() if tid != team_id]
                 loser_id = opponents[0] if opponents else None
 
-                # Use highest series_game_number as deciding game
-                deciding_game = sorted(
+                # Sort series games by series_game_number ascending
+                ordered_games = sorted(
                     series_games,
                     key=lambda x: x.get("series_game_number") or 1,
-                )[-1]
+                )
+
+                win_counter = 0
+                deciding_game = None
+
+                for g in ordered_games:
+                    if g.get("winner_team_id") == team_id:
+                        win_counter += 1
+                        if win_counter == required:
+                            deciding_game = g
+                            break
+
+                if not deciding_game:
+                    continue
 
                 updates.append(
                     {

--- a/tests/test_tournaments.py
+++ b/tests/test_tournaments.py
@@ -200,13 +200,13 @@ def test_resolve_series_results_best_of_three():
     assert len(updates) == 2
     by_id = {u["id"]: u for u in updates}
 
-    assert by_id["g3"]["winner_team_id"] == "t1"
-    assert by_id["g3"]["loser_team_id"] == "t2"
-    assert by_id["g3"]["finalized_at"]
+    assert by_id["g2"]["winner_team_id"] == "t1"
+    assert by_id["g2"]["loser_team_id"] == "t2"
+    assert by_id["g2"]["finalized_at"]
 
-    assert by_id["g5"]["winner_team_id"] == "t3"
-    assert by_id["g5"]["loser_team_id"] is None
-    assert by_id["g5"]["finalized_at"]
+    assert by_id["g4"]["winner_team_id"] == "t3"
+    assert by_id["g4"]["loser_team_id"] is None
+    assert by_id["g4"]["finalized_at"]
 
 
 def test_best_of_three_series_winner():


### PR DESCRIPTION
### Motivation
- The deciding-game selection previously always picked the highest `series_game_number`, which caused a 2–0 sweep to finalize game 3 instead of the actual deciding game and prevented downstream playoff dependency resolution from populating (e.g., Bronze placement).
- The change is scoped to only correct the deciding-game selection in series finalization so dependent slots and loser propagation work correctly.

### Description
- Replace the deciding-game selection in `resolve_series_results` with logic that sorts series games by `series_game_number` and picks the game where the winning team reaches the required wins. 
- Preserve the existing update payload structure (`id`, `winner_team_id`, `loser_team_id`, `finalized_at`) and do not alter win counting, required-win calculation, grouping, or other functions. 
- Updated `tests/test_tournaments.py` to assert the corrected deciding-game IDs for the best-of scenarios. 
- Only `jupr_app/domain/tournaments/__init__.py` and `tests/test_tournaments.py` were modified. 

### Testing
- Ran `pytest -q tests/test_tournaments.py -k resolve_series_results` during development which initially failed until the test expectations were adjusted. 
- Ran `pytest -q tests/test_tournaments.py` after the fix and test update, and all tests passed: `9 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995288171208326b4df47adde9c2108)