### PR TITLE
refactor(playoffs): make dependency resolver series-aware

### DIFF
--- a/jupr_app/domain/tournaments/__init__.py
+++ b/jupr_app/domain/tournaments/__init__.py
@@ -631,20 +631,32 @@ def resolve_series_results(games: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 def resolve_playoff_dependencies(games: list[dict[str, Any]]) -> list[dict[str, Any]]:
     updates: dict[str, dict[str, Any]] = {}
-    by_code: dict[str, dict[str, Any]] = {}
 
+    # --- Collapse series rows into one logical row per playoff_game_code ---
+    series_map: dict[str, list[dict[str, Any]]] = {}
     for g in games:
         code = g.get("playoff_game_code")
         if not code:
             continue
+        series_map.setdefault(code, []).append(g)
 
-        existing = by_code.get(code)
+    by_code: dict[str, dict[str, Any]] = {}
 
-        # Prefer finalized game in best-of series
-        if g.get("finalized_at"):
-            by_code[code] = g
-        elif not existing:
-            by_code[code] = g
+    for code, series_games in series_map.items():
+        # Prefer finalized game in series
+        finalized_game = next((g for g in series_games if g.get("finalized_at")), None)
+
+        if finalized_game:
+            by_code[code] = finalized_game
+        else:
+            # No finalized game -> treat series as unresolved
+            # Use a representative row but clear winner/loser logically
+            representative = series_games[0]
+            rep_copy = dict(representative)
+            rep_copy["winner_team_id"] = None
+            rep_copy["loser_team_id"] = None
+            rep_copy["finalized_at"] = None
+            by_code[code] = rep_copy
 
     def resolve_source(source: Any) -> tuple[bool, str | None]:
         if not source:
@@ -665,20 +677,27 @@ def resolve_playoff_dependencies(games: list[dict[str, Any]]) -> list[dict[str, 
     local_games = [dict(g) for g in games]
     while changed:
         changed = False
-        by_code = {}
+        series_map = {}
 
         for g in local_games:
             code = g.get("playoff_game_code")
             if not code:
                 continue
+            series_map.setdefault(code, []).append(g)
 
-            existing = by_code.get(code)
+        by_code = {}
+        for code, series_games in series_map.items():
+            finalized_game = next((g for g in series_games if g.get("finalized_at")), None)
 
-            # Prefer finalized game in best-of series
-            if g.get("finalized_at"):
-                by_code[code] = g
-            elif not existing:
-                by_code[code] = g
+            if finalized_game:
+                by_code[code] = finalized_game
+            else:
+                representative = series_games[0]
+                rep_copy = dict(representative)
+                rep_copy["winner_team_id"] = None
+                rep_copy["loser_team_id"] = None
+                rep_copy["finalized_at"] = None
+                by_code[code] = rep_copy
         for game in local_games:
             if game.get("stage") != "PLAYOFF":
                 continue


### PR DESCRIPTION
### Motivation
- The playoff dependency resolver assumed one row per `playoff_game_code`, which fails for best-of-3 series where multiple physical rows share the same code and can cause downstream games to be cleared incorrectly.
- The intent is to treat an entire series as a single logical unit so downstream dependencies only see a definitive winner/loser when a series is finalized.

### Description
- Collapse multiple physical rows into a `series_map` and create a single `by_code` logical row per `playoff_game_code` in `resolve_playoff_dependencies()` in `jupr_app/domain/tournaments/__init__.py`.
- Prefer a finalized game within the series when present and use that game as the authoritative row for the series.
- When no game in the series is finalized, use a representative row with `winner_team_id`, `loser_team_id`, and `finalized_at` set to `None` so the series is treated as unresolved by downstream logic.
- Apply the same series-aware collapse on each iterative pass while preserving all existing dependency-resolution and update-application logic.

### Testing
- Ran `pytest -q tests/test_tournaments.py -k resolve_playoff_dependencies` and the targeted test passed.
- Test run reported `1 passed, 8 deselected` for the selected tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952f056e0c8326b8e02f4df73b1a3c)