### PR TITLE
Replace invalid ctx.sb_update with supabase update in podium finalization

### DIFF
--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -607,7 +607,10 @@ def _render_podium_review(
 
         upsert_tournament_podium(ctx.supabase, tournament_id, payload)
         award_tournament_trophies_from_podium(ctx, tournament_id, tournament_name)
-        ctx.sb_update(supabase, "tournaments", {"status": "COMPLETE"}, filters={"id": tournament_id})
+        supabase.table("tournaments") \
+            .update({"status": "COMPLETE"}) \
+            .eq("id", tournament_id) \
+            .execute()
         st.success("Tournament completed and podium locked.")
         st.session_state.pop(f"podium_review_open_{tournament_id}", None)
         st.rerun()


### PR DESCRIPTION
### Motivation
- Fix a crash caused by calling the non-existent `AppContext.sb_update` method inside `_render_podium_review()` by using the Supabase client directly to update tournament status.

### Description
- Replaced the single line `ctx.sb_update(supabase, "tournaments", {"status": "COMPLETE"}, filters={"id": tournament_id})` with `supabase.table("tournaments").update({"status": "COMPLETE"}).eq("id", tournament_id).execute()` and did not modify any other logic.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/tournaments.py` which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995309179808326840d9da3d47da112)