### PR TITLE
fix(tournaments): use ctx.supabase when completing tournament

### DIFF
--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -607,7 +607,7 @@ def _render_podium_review(
 
         upsert_tournament_podium(ctx.supabase, tournament_id, payload)
         award_tournament_trophies_from_podium(ctx, tournament_id, tournament_name)
-        supabase.table("tournaments") \
+        ctx.supabase.table("tournaments") \
             .update({"status": "COMPLETE"}) \
             .eq("id", tournament_id) \
             .execute()


### PR DESCRIPTION
### Motivation
- Fix a `NameError` in `_render_podium_review()` caused by an undefined `supabase` variable when marking a tournament as complete.

### Description
- Replace the single incorrect reference in `jupr_app/ui/pages/tournaments.py` from `supabase.table("tournaments")...` to `ctx.supabase.table("tournaments")...` and leave all other logic unchanged.

### Testing
- Verified the replacement with `rg -n 'ctx\.supabase\.table("tournaments")' jupr_app/ui/pages/tournaments.py` and inspected the change with `git diff -- jupr_app/ui/pages/tournaments.py`, both confirming the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953199f4bc83268a7f83a6ce028ebd)