### PR TITLE
Fix Supabase auth response handling for admin login flow

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -206,20 +206,34 @@ def main():
                                     "password": password,
                                 }
                             )
-                            auth_session = getattr(auth_response, "session", None)
-                            if auth_session:
-                                st.session_state["sb_session"] = auth_session
-                                st.success("Logged in.")
+
+                            # Defensive handling of response
+                            if not auth_response:
+                                st.error("Login failed: no response from Supabase.")
+                                st.stop()
+
+                            # Try direct attribute access first
+                            session = getattr(auth_response, "session", None)
+
+                            # If attribute missing, try dict-style fallback
+                            if not session and isinstance(auth_response, dict):
+                                session = auth_response.get("session")
+
+                            if session:
+                                st.session_state["sb_session"] = session
+                                st.success("Logged in successfully.")
                                 st.rerun()
                             else:
-                                st.error("Login failed. No session returned.")
+                                st.error("Login failed: session not returned.")
+                                st.write("DEBUG auth_response:", auth_response)
                         except Exception as exc:
-                            st.error(f"Login failed: {exc}")
+                            st.error(f"Login exception: {exc}")
                 return
 
-            if not club_id:
-                st.error("Authenticated user missing club_id in metadata.")
-                return
+            if not PUBLIC_MODE and st.session_state.get("sb_session"):
+                if not club_id:
+                    st.error("Authenticated user missing club_id in metadata.")
+                    st.stop()
         else:
             club_id = os.getenv("DEFAULT_PUBLIC_CLUB_ID", "tres_palapas")
 


### PR DESCRIPTION
### Motivation
- The login flow was not handling the `auth_response` returned by `supabase.auth.sign_in_with_password()` correctly, causing successful authentication to not persist a session.
- Ensure the session returned by Supabase is captured whether the response is an object or a dict and that the app resumes after successful login.
- Avoid clearing global session state and only enforce `club_id` metadata checks after authentication in non-public mode.

### Description
- Replaced the `if st.button("Login")` handler in `streamlit_app.py` with defensive processing of `auth_response`, including an empty-response check and attribute-style then dict-style `session` extraction.
- Persist successful sessions to `st.session_state["sb_session"]`, call `st.rerun()` only on success, and surface a debug dump `DEBUG auth_response` when no session is returned.
- Updated login exception messaging to `Login exception: ...` for clarity.
- Changed the `club_id` guard to run only when `not PUBLIC_MODE` and `st.session_state.get("sb_session")` is present, and use `st.stop()` when metadata is missing; ensured logout only pops `sb_session` and did not introduce any `st.session_state.clear()` calls.

### Testing
- Ran `python -m py_compile /workspace/JUPR/streamlit_app.py` and it succeeded with no syntax errors.
- Verified there are no uses of `st.session_state.clear()` in the repository via `rg -n "st.session_state.clear\("`, and the search returned no matches.
- Verified the updated handler is present in `streamlit_app.py` and compiles cleanly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996435bdd5483269f33927613de5a7d)