### PR TITLE
Persist entry_mode after successful admin login

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -221,6 +221,7 @@ def main():
 
                             if session:
                                 st.session_state["sb_session"] = session
+                                st.session_state["entry_mode"] = "login"
                                 st.success("Logged in successfully.")
                                 st.rerun()
                             else:


### PR DESCRIPTION
### Motivation
- After a successful admin login the app could return to the gateway because `entry_mode` was not persisted across the `st.rerun()` that follows authentication, causing the gateway to render again despite a valid `sb_session`.

### Description
- Set `st.session_state["entry_mode"] = "login"` in the successful login branch of `streamlit_app.py` so the login mode is preserved before calling `st.rerun()`; the gateway `setdefault` and the logout reset behavior were left unchanged.

### Testing
- Ran `python -m py_compile streamlit_app.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699645751cd0832686039b71ad88c875)