### PR TITLE
Upgrade Streamlit Supabase auth flow to production-grade state machine

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 import os
 import traceback
 import re
+import base64
+
+import jwt
 
 import streamlit as st
 import pandas as pd  # noqa: F401  # kept because pages may rely on it
@@ -134,6 +137,7 @@ def main():
         from jupr_app.ui.url import qp_get
 
         st.session_state.setdefault("entry_mode", None)
+        st.session_state.setdefault("auth_initialized", False)
 
         st.set_page_config(
             page_title="JUPR Leagues",
@@ -143,7 +147,30 @@ def main():
         )
         apply_clean_theme(accent_hex="#2F6FED")  # pick your accent once (can later be club-specific)
 
-        if st.session_state["entry_mode"] is None:
+        # Make base_url available to all pages (leaderboards uses this for share links)
+        # Use session_state because ctx is a frozen-ish dataclass and you don't want to refactor it mid-stream.
+        # Fly env vars required in production/staging: PUBLIC_BASE_URL, SUPABASE_URL,
+        # and SUPABASE_ANON_KEY.
+        base_url = os.getenv("PUBLIC_BASE_URL", LOCAL_PUBLIC_BASE_URL_DEFAULT)
+        st.session_state["base_url"] = str(base_url)
+
+        # -------------------------
+        # Authentication handling
+        # -------------------------
+        params = st.experimental_get_query_params()
+        access_token = params.get("access_token", [None])[0]
+        refresh_token = params.get("refresh_token", [None])[0]
+        flow_type = params.get("type", [None])[0]
+
+        if flow_type == "signup":
+            st.success("Email confirmed successfully.")
+            st.stop()
+
+        if (
+            st.session_state["entry_mode"] is None
+            and not (access_token and refresh_token)
+            and flow_type != "recovery"
+        ):
             st.markdown("# JUPR Leagues 🌵")
 
             col1, col2 = st.columns(2)
@@ -160,24 +187,52 @@ def main():
 
             st.stop()
 
-        # ---- Public mode ----
-        PUBLIC_MODE = st.session_state["entry_mode"] == "public"
-
-        # Make base_url available to all pages (leaderboards uses this for share links)
-        # Use session_state because ctx is a frozen-ish dataclass and you don't want to refactor it mid-stream.
-        # Fly env vars required in production/staging: PUBLIC_BASE_URL, SUPABASE_URL,
-        # and SUPABASE_ANON_KEY.
-        base_url = os.getenv("PUBLIC_BASE_URL", LOCAL_PUBLIC_BASE_URL_DEFAULT)
-        st.session_state["base_url"] = str(base_url)
-
         # -------------------------
         # Supabase initialization
         # -------------------------
         supabase = get_supabase()
 
-        # -------------------------
-        # Authentication handling
-        # -------------------------
+        if access_token and refresh_token:
+            try:
+                supabase.auth.set_session(
+                    {
+                        "access_token": access_token,
+                        "refresh_token": refresh_token,
+                    }
+                )
+                session_response = supabase.auth.get_session()
+                session = getattr(session_response, "session", session_response)
+                if session:
+                    st.session_state["sb_session"] = session
+                    st.session_state["entry_mode"] = "auth"
+                    st.session_state["auth_initialized"] = True
+            except Exception:
+                st.error("Unable to complete authentication redirect flow.")
+                st.stop()
+
+            st.experimental_set_query_params()
+            st.rerun()
+
+        if flow_type == "recovery":
+            st.subheader("Set New Password")
+
+            new_password = st.text_input("New Password", type="password")
+            confirm_password = st.text_input("Confirm Password", type="password")
+
+            if st.button("Update Password"):
+                if new_password != confirm_password:
+                    st.error("Passwords do not match.")
+                else:
+                    supabase.auth.update_user({"password": new_password})
+                    st.success("Password updated successfully.")
+                    st.session_state.pop("recovery_mode", None)
+                    st.rerun()
+
+            st.stop()
+
+        # ---- Public mode ----
+        PUBLIC_MODE = st.session_state["entry_mode"] == "public"
+
         entry_mode = st.session_state.get("entry_mode")
         if entry_mode == "login":
             if not st.session_state.get("sb_session"):
@@ -195,25 +250,67 @@ def main():
                         )
                         if getattr(auth_response, "session", None):
                             st.session_state["sb_session"] = auth_response.session
+                            st.session_state["entry_mode"] = "auth"
+                            st.session_state["auth_initialized"] = True
                             st.rerun()
                         else:
                             st.error("Login failed")
                     except Exception:
                         st.error("Login failed")
+
+                if st.button("Send Magic Link", use_container_width=True):
+                    if not email:
+                        st.error("Email is required for magic link login.")
+                    else:
+                        try:
+                            supabase.auth.sign_in_with_otp({"email": email})
+                            st.success("Magic link sent. Check your email.")
+                            st.stop()
+                        except Exception:
+                            st.error("Unable to send magic link.")
                 return
 
+        session = st.session_state.get("sb_session")
+        if session:
             try:
-                supabase.auth.set_session(st.session_state["sb_session"])
+                session_payload = {
+                    "access_token": getattr(session, "access_token", None),
+                    "refresh_token": getattr(session, "refresh_token", None),
+                }
+                if session_payload["access_token"] and session_payload["refresh_token"]:
+                    supabase.auth.set_session(session_payload)
+                refreshed_response = supabase.auth.get_session()
+                refreshed = getattr(refreshed_response, "session", refreshed_response)
+
+                if refreshed:
+                    st.session_state["sb_session"] = refreshed
+                    st.session_state["entry_mode"] = "auth"
+                    st.session_state["auth_initialized"] = True
             except Exception:
                 st.session_state.pop("sb_session", None)
-                st.error("Login failed")
-                return
+                st.session_state["entry_mode"] = None
+                st.session_state["auth_initialized"] = False
+                st.rerun()
+
+        if st.session_state.get("sb_session"):
+            try:
+                token = st.session_state["sb_session"].access_token
+                base64.urlsafe_b64decode(token.split(".")[1] + "===")
+                payload = jwt.decode(token, options={"verify_signature": False})
+                st.session_state["jwt_payload"] = payload
+
+                if "club_id" not in payload.get("user_metadata", {}):
+                    st.error("JWT missing club_id claim.")
+                    st.stop()
+            except Exception as e:
+                st.error(f"JWT validation failed: {e}")
+                st.stop()
 
         # -------------------------
         # Resolve club_id dynamically
         # -------------------------
         club_id = None
-        if entry_mode == "login":
+        if st.session_state.get("sb_session"):
             session = st.session_state.get("sb_session")
             user = getattr(session, "user", None)
             user_metadata = getattr(user, "user_metadata", {}) if user else {}
@@ -241,10 +338,15 @@ def main():
                     pass
                 st.session_state.pop("sb_session", None)
                 st.session_state["entry_mode"] = None
+                st.session_state["auth_initialized"] = False
                 st.rerun()
 
         # Canonical admin flag (never true in public mode)
-        admin_logged_in = bool(st.session_state.get("sb_session"))
+        if st.session_state.get("sb_session"):
+            st.session_state["entry_mode"] = "auth"
+            admin_logged_in = True
+        else:
+            admin_logged_in = False
 
         # Optional: allow pages to request a refresh of cached data
         if bool(st.session_state.get("force_data_refresh", False)):


### PR DESCRIPTION
### Motivation
- Replace ad-hoc login handling with a deterministic auth state model to make the app behave reliably across redirects and reloads. 
- Support SaaS-grade Supabase flows: email confirmation, magic-link sign-in, and password recovery so users can self-serve authentication flows. 
- Improve resiliency by automatically refreshing sessions and defensively validating JWTs to detect missing tenant claims early.

### Description
- Introduced centralized auth state keys `entry_mode` and `auth_initialized` and enforced a gateway → login/public/auth deterministic flow using `st.session_state`. 
- Implemented unified redirect handling that reads `st.experimental_get_query_params()` for `access_token`, `refresh_token`, and `type`, sets the Supabase session, clears query params, and `st.rerun()`s when appropriate. 
- Added `type=signup` email confirmation messaging, `type=recovery` password reset UI that calls `supabase.auth.update_user`, and a magic-link path in the login UI via `supabase.auth.sign_in_with_otp`. 
- Added session auto-refresh logic using `supabase.auth.set_session()`/`get_session()` and defensive reset + rerun on refresh failure, plus JWT decode logging (`jwt.decode(..., options={"verify_signature": False})`) and a hard-stop when `club_id` is missing from `user_metadata`. 
- Enforced tenant isolation by resolving `club_id` from authenticated session metadata with a public fallback via `DEFAULT_PUBLIC_CLUB_ID`, and ensured logout clears `sb_session` and `auth_initialized` and reruns the app. 

### Testing
- Ran `python -m py_compile streamlit_app.py`, which succeeded. 
- Ran the full test suite with `pytest -q`; results were 159 passed and 2 failures, where the failing tests were `tests/test_badge_v3_pipeline.py::test_badge_v3_pipeline_updates_facts_before_enqueue_and_award` and `tests/test_ui_color_tokens.py::test_ui_files_do_not_use_hardcoded_colors`. 
- The test failures appear unrelated to the auth flow changes (pre-existing expectations about a service-role client and UI color tokenization) and did not indicate syntax/runtime errors in the modified `streamlit_app.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69965f986d608326a2de12678ccec3fe)