### PR TITLE
Use ClientOptions for Supabase client initialization

### DIFF
--- a/jupr_app/data/client.py
+++ b/jupr_app/data/client.py
@@ -1,12 +1,15 @@
-from supabase import Client, create_client
+from supabase import create_client, Client
+from supabase.lib.client_options import ClientOptions
 
 
 def make_supabase(url: str, key: str) -> Client:
+    options = ClientOptions(
+        persist_session=True,
+        auto_refresh_token=True,
+    )
+
     return create_client(
         url,
         key,
-        options={
-            "persist_session": True,
-            "auto_refresh_token": True,
-        },
+        options=options,
     )


### PR DESCRIPTION
### Motivation
- Ensure compatibility with the current Supabase Python SDK by constructing a `ClientOptions` instance for session persistence and token auto-refresh instead of passing a raw dict.

### Description
- Replace the raw `options` dict with a `ClientOptions` object and import it from `supabase.lib.client_options` in `jupr_app/data/client.py`, then pass `options=options` into `create_client`.

### Testing
- Ran `python -m compileall jupr_app/data/client.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699665fcea18832688f6455f8ab4c9fc)