### PR TITLE
fix(auth): non-destructive session validation to prevent admin logout on rerun

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -274,26 +274,29 @@ def main():
                 st.stop()
         
         # --------------------------------------------
-        # SESSION VALIDATION (non-destructive)
+        # SESSION VALIDATION (NON-DESTRUCTIVE)
         # --------------------------------------------
 
         session = st.session_state.get("sb_session")
 
         if session:
             try:
-                current = supabase.auth.get_session()
-                current_session = getattr(current, "session", current)
+                current_obj = supabase.auth.get_session()
+                current_session = getattr(current_obj, "session", current_obj)
 
                 if current_session:
+                    # Update session if Supabase refreshed it internally
                     st.session_state["sb_session"] = current_session
-                else:
-                    # Only clear if Supabase truly has no session
-                    st.session_state.pop("sb_session", None)
-                    st.session_state["entry_mode"] = None
-                    st.rerun()
+
+                # IMPORTANT:
+                # Do NOT clear session on transient failure.
+                # Do NOT reset entry_mode here.
+                # Only explicit logout should clear session.
 
             except Exception:
-                # Do NOT wipe session on transient failure
+                # Never wipe session automatically.
+                # Streamlit reruns or minor Supabase hiccups
+                # should not log out admin.
                 pass
         
         # --------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent unintended admin logout caused by the previous aggressive session refresh logic by making the session validation non-destructive in `streamlit_app.py`.

### Description
- Replace the existing SESSION REFRESH / VALIDATION block with a non-destructive validation that only updates `st.session_state["sb_session"]` when `supabase.auth.get_session()` returns a session and remove automatic clearing of the session and `entry_mode`, while preserving the existing login flow, redirect handling, JWT claim extraction, public mode, and explicit logout behavior.

### Testing
- Ran `python -m py_compile streamlit_app.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699667f13b38832682ed2b901ffdb94e)