### PR TITLE
docs: add deterministic schema audit baseline snapshot

### DIFF
--- a/docs/schema/SCHEMA_ALIGNMENT_PLAN.md
+++ b/docs/schema/SCHEMA_ALIGNMENT_PLAN.md
@@ -1,0 +1,19 @@
+# Schema Alignment Plan
+
+## Tables under audit
+- players
+- matches
+- league_ratings
+- leagues_metadata
+- badges
+- player_badges
+- badge_eval_queue
+- badge_eval_runs
+- admin_audit_events
+
+## Explicit comparison checklist
+- Missing columns
+- Type mismatches
+- Missing unique constraints
+- Missing foreign keys
+- Missing composite indexes

--- a/docs/schema/live_schema_snapshot_20260219.sql
+++ b/docs/schema/live_schema_snapshot_20260219.sql
@@ -1,0 +1,460 @@
+-- Live schema snapshot generated from provided export on 2026-02-19.
+-- Nullability was not provided in the source export; columns are marked NULL in this baseline.
+
+CREATE TABLE badge_eval_queue (
+  id uuid NULL,
+  created_at timestamp with time zone NULL,
+  club_id text NULL,
+  context_id text NULL,
+  event_type text NULL,
+  player_ids ARRAY NULL,
+  match_id text NULL,
+  payload_json jsonb NULL,
+  status text NULL,
+  attempts integer NULL,
+  last_error text NULL,
+  processed_at timestamp with time zone NULL
+);
+
+CREATE TABLE badge_eval_runs (
+  id uuid NULL,
+  created_at timestamp with time zone NULL,
+  created_by text NULL,
+  mode text NULL,
+  scope_json jsonb NULL,
+  status text NULL,
+  started_at timestamp with time zone NULL,
+  finished_at timestamp with time zone NULL,
+  summary_json jsonb NULL,
+  error text NULL
+);
+
+CREATE TABLE badge_events_v2 (
+  id uuid NULL,
+  user_id uuid NULL,
+  event_type text NULL,
+  event_ts timestamp with time zone NULL,
+  data jsonb NULL,
+  idempotency_key text NULL,
+  created_at timestamp with time zone NULL
+);
+
+CREATE TABLE badge_fact_registry (
+  fact_key text NULL,
+  description text NULL,
+  data_type text NULL,
+  allowed_scope text NULL
+);
+
+CREATE TABLE badge_rule_conditions (
+  id uuid NULL,
+  badge_id uuid NULL,
+  fact_key text NULL,
+  operator text NULL,
+  value_numeric numeric NULL,
+  created_at timestamp with time zone NULL
+);
+
+CREATE TABLE badge_rules_v2 (
+  id uuid NULL,
+  badge_id uuid NULL,
+  rule_type text NULL,
+  params jsonb NULL,
+  trigger_event text NULL,
+  evaluation_mode text NULL,
+  enabled boolean NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL
+);
+
+CREATE TABLE badges (
+  badge_id text NULL,
+  name text NULL,
+  prestige integer NULL,
+  category text NULL,
+  is_stackable boolean NULL,
+  is_active boolean NULL,
+  created_at timestamp with time zone NULL,
+  rarity text NULL,
+  tier integer NULL,
+  icon_key text NULL,
+  lore text NULL,
+  hint text NULL,
+  scope text NULL,
+  status text NULL,
+  is_locked boolean NULL,
+  award_count integer NULL,
+  published_at timestamp with time zone NULL,
+  archived_at timestamp with time zone NULL,
+  club_id text NULL,
+  is_system_badge boolean NULL,
+  created_by_admin_id text NULL
+);
+
+CREATE TABLE badges_v2 (
+  id uuid NULL,
+  slug text NULL,
+  name text NULL,
+  display_text text NULL,
+  description text NULL,
+  icon_url text NULL,
+  icon_emoji text NULL,
+  category text NULL,
+  rarity text NULL,
+  sort_order integer NULL,
+  is_active boolean NULL,
+  is_hidden boolean NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL,
+  status text NULL,
+  is_locked boolean NULL,
+  award_count integer NULL,
+  published_at timestamp with time zone NULL,
+  archived_at timestamp with time zone NULL,
+  club_id text NULL,
+  is_system_badge boolean NULL,
+  created_by_admin_id text NULL
+);
+
+CREATE TABLE club_user_roles (
+  club_id text NULL,
+  user_id uuid NULL,
+  role text NULL,
+  assigned_by uuid NULL,
+  assigned_at timestamp with time zone NULL
+);
+
+CREATE TABLE clubs (
+  id text NULL,
+  name text NULL,
+  status text NULL,
+  logo_url text NULL,
+  primary_color text NULL,
+  created_at timestamp with time zone NULL
+);
+
+CREATE TABLE events (
+  id uuid NULL,
+  club_id text NULL,
+  name text NULL,
+  event_type text NULL,
+  is_active boolean NULL,
+  created_at timestamp with time zone NULL,
+  starts_at timestamp with time zone NULL,
+  ends_at timestamp with time zone NULL,
+  notes text NULL
+);
+
+CREATE TABLE ladder_audit_log (
+  id bigint NULL,
+  club_id text NULL,
+  actor text NULL,
+  action_type text NULL,
+  entity_type text NULL,
+  entity_id text NULL,
+  before jsonb NULL,
+  after jsonb NULL,
+  created_at timestamp with time zone NULL
+);
+
+CREATE TABLE ladder_challenge_matches (
+  id bigint NULL,
+  club_id text NULL,
+  challenge_id bigint NULL,
+  match_no integer NULL,
+  def_partner_id bigint NULL,
+  chal_partner_id bigint NULL,
+  g1_def integer NULL,
+  g1_chal integer NULL,
+  g2_def integer NULL,
+  g2_chal integer NULL,
+  g3_def integer NULL,
+  g3_chal integer NULL,
+  verified boolean NULL,
+  verified_at timestamp with time zone NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL
+);
+
+CREATE TABLE ladder_challenges (
+  id bigint NULL,
+  club_id text NULL,
+  challenger_id bigint NULL,
+  defender_id bigint NULL,
+  challenger_rank_at_create integer NULL,
+  defender_rank_at_create integer NULL,
+  status text NULL,
+  ledger_ref text NULL,
+  created_by text NULL,
+  created_at timestamp with time zone NULL,
+  accept_by timestamp with time zone NULL,
+  accepted_at timestamp with time zone NULL,
+  play_by timestamp with time zone NULL,
+  scheduled_for timestamp with time zone NULL,
+  pass_used_by bigint NULL,
+  pass_used_at timestamp with time zone NULL,
+  forfeit_by bigint NULL,
+  forfeit_reason text NULL,
+  winner_id bigint NULL,
+  completed_at timestamp with time zone NULL,
+  resolution_notes text NULL,
+  tier_id text NULL,
+  notice_sent_at timestamp with time zone NULL
+);
+
+CREATE TABLE ladder_pass_usage (
+  id bigint NULL,
+  club_id text NULL,
+  player_id bigint NULL,
+  month_key text NULL,
+  used_at timestamp with time zone NULL,
+  challenge_id bigint NULL,
+  created_at timestamp with time zone NULL
+);
+
+CREATE TABLE ladder_player_flags (
+  club_id text NULL,
+  player_id bigint NULL,
+  vacation_until timestamp with time zone NULL,
+  reinstate_required boolean NULL,
+  reinstate_notes text NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL,
+  tier_move_flag boolean NULL,
+  tier_move_dest_tier text NULL,
+  tier_move_count integer NULL,
+  tier_move_triggered_at timestamp with time zone NULL,
+  tier_move_last_eval_at timestamp with time zone NULL
+);
+
+CREATE TABLE ladder_roster (
+  id bigint NULL,
+  club_id text NULL,
+  player_id bigint NULL,
+  rank integer NULL,
+  is_active boolean NULL,
+  joined_at timestamp with time zone NULL,
+  left_at timestamp with time zone NULL,
+  notes text NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL,
+  tier_id text NULL
+);
+
+CREATE TABLE ladder_settings (
+  club_id text NULL,
+  challenge_range integer NULL,
+  accept_window_hours integer NULL,
+  play_window_days integer NULL,
+  cooldown_hours integer NULL,
+  protected_hours integer NULL,
+  pass_hold_hours integer NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL
+);
+
+CREATE TABLE league_ratings (
+  id bigint NULL,
+  player_id bigint NULL,
+  club_id text NULL,
+  league_name text NULL,
+  rating numeric NULL,
+  matches_played integer NULL,
+  wins integer NULL,
+  losses integer NULL,
+  starting_rating numeric NULL,
+  is_active boolean NULL,
+  inactive_at timestamp with time zone NULL
+);
+
+CREATE TABLE leagues_metadata (
+  id bigint NULL,
+  club_id text NULL,
+  league_name text NULL,
+  league_type text NULL,
+  min_weeks integer NULL,
+  is_active boolean NULL,
+  created_at timestamp with time zone NULL,
+  min_games integer NULL,
+  description text NULL,
+  k_factor integer NULL,
+  ended_at timestamp with time zone NULL,
+  ended_by text NULL,
+  status text NULL,
+  end_awards jsonb NULL,
+  started_at timestamp with time zone NULL,
+  schedule_config jsonb NULL,
+  court_board_defaults jsonb NULL,
+  rules_config jsonb NULL,
+  awards_config jsonb NULL
+);
+
+CREATE TABLE matches (
+  id bigint NULL,
+  club_id text NULL,
+  date timestamp with time zone NULL,
+  league text NULL,
+  t1_p1 bigint NULL,
+  t1_p2 bigint NULL,
+  t2_p1 bigint NULL,
+  t2_p2 bigint NULL,
+  score_t1 integer NULL,
+  score_t2 integer NULL,
+  elo_delta numeric NULL,
+  match_type text NULL,
+  week_tag text NULL,
+  t1_p1_r numeric NULL,
+  t1_p2_r numeric NULL,
+  t2_p1_r numeric NULL,
+  t2_p2_r numeric NULL,
+  t1_p1_r_end numeric NULL,
+  t1_p2_r_end numeric NULL,
+  t2_p1_r_end numeric NULL,
+  t2_p2_r_end numeric NULL,
+  elo_delta_t1 double precision NULL,
+  elo_delta_t2 double precision NULL,
+  context_type text NULL,
+  context_id uuid NULL,
+  tournament_id uuid NULL,
+  tournament_game_id uuid NULL,
+  idempotency_key text NULL
+);
+
+CREATE TABLE player_badge_facts (
+  club_id text NULL,
+  player_id bigint NULL,
+  context_id text NULL,
+  fact_key text NULL,
+  fact_value_num double precision NULL,
+  updated_at timestamp with time zone NULL
+);
+
+CREATE TABLE player_badges (
+  id uuid NULL,
+  club_id text NULL,
+  player_id bigint NULL,
+  badge_id text NULL,
+  earned_at timestamp with time zone NULL,
+  context_type text NULL,
+  context_id text NULL,
+  match_id text NULL,
+  value_num numeric NULL,
+  value_json jsonb NULL,
+  awarded_by uuid NULL,
+  rule_version text NULL,
+  eval_run_id uuid NULL,
+  revoked_at timestamp with time zone NULL,
+  revoked_by uuid NULL,
+  revoked_reason text NULL,
+  revoke_reason text NULL
+);
+
+CREATE TABLE player_profiles (
+  club_id text NULL,
+  player_id bigint NULL,
+  preferred_channel text NULL,
+  email text NULL,
+  phone text NULL,
+  whatsapp text NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL
+);
+
+CREATE TABLE players (
+  id bigint NULL,
+  club_id text NULL,
+  name text NULL,
+  rating numeric NULL,
+  starting_rating numeric NULL,
+  matches_played integer NULL,
+  wins integer NULL,
+  losses integer NULL,
+  created_at timestamp with time zone NULL,
+  active boolean NULL,
+  last_game_at timestamp with time zone NULL,
+  inactive_at timestamp with time zone NULL,
+  normalized_name text NULL
+);
+
+CREATE TABLE processed_match_facts (
+  club_id text NULL,
+  match_id text NULL,
+  player_id bigint NULL
+);
+
+CREATE TABLE tournament_games (
+  id uuid NULL,
+  tournament_id uuid NULL,
+  stage text NULL,
+  rr_round_number integer NULL,
+  rr_slot_number integer NULL,
+  playoff_game_code text NULL,
+  playoff_round text NULL,
+  team_a_id uuid NULL,
+  team_b_id uuid NULL,
+  team_a_source jsonb NULL,
+  team_b_source jsonb NULL,
+  score_a integer NULL,
+  score_b integer NULL,
+  winner_team_id uuid NULL,
+  loser_team_id uuid NULL,
+  finalized_at timestamp with time zone NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL,
+  series_game_number integer NULL
+);
+
+CREATE TABLE tournament_podium (
+  id uuid NULL,
+  tournament_id uuid NULL,
+  placement integer NULL,
+  team_id uuid NULL,
+  source text NULL,
+  created_at timestamp with time zone NULL
+);
+
+CREATE TABLE tournament_teams (
+  id uuid NULL,
+  tournament_id uuid NULL,
+  team_number integer NULL,
+  player1_id integer NULL,
+  player2_id integer NULL,
+  seed integer NULL
+);
+
+CREATE TABLE tournaments (
+  id uuid NULL,
+  club_id text NULL,
+  name text NULL,
+  status text NULL,
+  team_count integer NULL,
+  playoff_advance_count integer NULL,
+  created_by_admin_id text NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL,
+  playoff_best_of integer NULL
+);
+
+CREATE TABLE user_badges_v2 (
+  user_id uuid NULL,
+  badge_id uuid NULL,
+  awarded_at timestamp with time zone NULL,
+  awarded_by uuid NULL,
+  reason text NULL,
+  metadata jsonb NULL
+);
+
+CREATE TABLE weekly_recaps (
+  id uuid NULL,
+  club_id text NULL,
+  week_start date NULL,
+  week_end date NULL,
+  status text NULL,
+  generated_json jsonb NULL,
+  edits_json jsonb NULL,
+  final_json jsonb NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL,
+  published_at timestamp with time zone NULL,
+  published_by text NULL
+);

--- a/docs/schema/live_schema_snapshot_raw.csv
+++ b/docs/schema/live_schema_snapshot_raw.csv
@@ -1,0 +1,1812 @@
+[
+  {
+    "table_name": "badge_eval_queue",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "badge_eval_queue",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badge_eval_queue",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_eval_queue",
+    "column_name": "context_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_eval_queue",
+    "column_name": "event_type",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_eval_queue",
+    "column_name": "player_ids",
+    "data_type": "ARRAY"
+  },
+  {
+    "table_name": "badge_eval_queue",
+    "column_name": "match_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_eval_queue",
+    "column_name": "payload_json",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "badge_eval_queue",
+    "column_name": "status",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_eval_queue",
+    "column_name": "attempts",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "badge_eval_queue",
+    "column_name": "last_error",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_eval_queue",
+    "column_name": "processed_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badge_eval_runs",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "badge_eval_runs",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badge_eval_runs",
+    "column_name": "created_by",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_eval_runs",
+    "column_name": "mode",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_eval_runs",
+    "column_name": "scope_json",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "badge_eval_runs",
+    "column_name": "status",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_eval_runs",
+    "column_name": "started_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badge_eval_runs",
+    "column_name": "finished_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badge_eval_runs",
+    "column_name": "summary_json",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "badge_eval_runs",
+    "column_name": "error",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_events_v2",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "badge_events_v2",
+    "column_name": "user_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "badge_events_v2",
+    "column_name": "event_type",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_events_v2",
+    "column_name": "event_ts",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badge_events_v2",
+    "column_name": "data",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "badge_events_v2",
+    "column_name": "idempotency_key",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_events_v2",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badge_fact_registry",
+    "column_name": "fact_key",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_fact_registry",
+    "column_name": "description",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_fact_registry",
+    "column_name": "data_type",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_fact_registry",
+    "column_name": "allowed_scope",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_rule_conditions",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "badge_rule_conditions",
+    "column_name": "badge_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "badge_rule_conditions",
+    "column_name": "fact_key",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_rule_conditions",
+    "column_name": "operator",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_rule_conditions",
+    "column_name": "value_numeric",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "badge_rule_conditions",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badge_rules_v2",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "badge_rules_v2",
+    "column_name": "badge_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "badge_rules_v2",
+    "column_name": "rule_type",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_rules_v2",
+    "column_name": "params",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "badge_rules_v2",
+    "column_name": "trigger_event",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_rules_v2",
+    "column_name": "evaluation_mode",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badge_rules_v2",
+    "column_name": "enabled",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "badge_rules_v2",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badge_rules_v2",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "badge_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "name",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "prestige",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "category",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "is_stackable",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "is_active",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "rarity",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "tier",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "icon_key",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "lore",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "hint",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "scope",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "status",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "is_locked",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "award_count",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "published_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "archived_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "is_system_badge",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "badges",
+    "column_name": "created_by_admin_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "slug",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "name",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "display_text",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "description",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "icon_url",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "icon_emoji",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "category",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "rarity",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "sort_order",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "is_active",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "is_hidden",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "status",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "is_locked",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "award_count",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "published_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "archived_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "is_system_badge",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "badges_v2",
+    "column_name": "created_by_admin_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "club_user_roles",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "club_user_roles",
+    "column_name": "user_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "club_user_roles",
+    "column_name": "role",
+    "data_type": "text"
+  },
+  {
+    "table_name": "club_user_roles",
+    "column_name": "assigned_by",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "club_user_roles",
+    "column_name": "assigned_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "clubs",
+    "column_name": "id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "clubs",
+    "column_name": "name",
+    "data_type": "text"
+  },
+  {
+    "table_name": "clubs",
+    "column_name": "status",
+    "data_type": "text"
+  },
+  {
+    "table_name": "clubs",
+    "column_name": "logo_url",
+    "data_type": "text"
+  },
+  {
+    "table_name": "clubs",
+    "column_name": "primary_color",
+    "data_type": "text"
+  },
+  {
+    "table_name": "clubs",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "events",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "events",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "events",
+    "column_name": "name",
+    "data_type": "text"
+  },
+  {
+    "table_name": "events",
+    "column_name": "event_type",
+    "data_type": "text"
+  },
+  {
+    "table_name": "events",
+    "column_name": "is_active",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "events",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "events",
+    "column_name": "starts_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "events",
+    "column_name": "ends_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "events",
+    "column_name": "notes",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_audit_log",
+    "column_name": "id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_audit_log",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_audit_log",
+    "column_name": "actor",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_audit_log",
+    "column_name": "action_type",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_audit_log",
+    "column_name": "entity_type",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_audit_log",
+    "column_name": "entity_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_audit_log",
+    "column_name": "before",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "ladder_audit_log",
+    "column_name": "after",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "ladder_audit_log",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "challenge_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "match_no",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "def_partner_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "chal_partner_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "g1_def",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "g1_chal",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "g2_def",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "g2_chal",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "g3_def",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "g3_chal",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "verified",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "verified_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_challenge_matches",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "challenger_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "defender_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "challenger_rank_at_create",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "defender_rank_at_create",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "status",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "ledger_ref",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "created_by",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "accept_by",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "accepted_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "play_by",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "scheduled_for",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "pass_used_by",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "pass_used_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "forfeit_by",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "forfeit_reason",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "winner_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "completed_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "resolution_notes",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "tier_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_challenges",
+    "column_name": "notice_sent_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_pass_usage",
+    "column_name": "id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_pass_usage",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_pass_usage",
+    "column_name": "player_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_pass_usage",
+    "column_name": "month_key",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_pass_usage",
+    "column_name": "used_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_pass_usage",
+    "column_name": "challenge_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_pass_usage",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_player_flags",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_player_flags",
+    "column_name": "player_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_player_flags",
+    "column_name": "vacation_until",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_player_flags",
+    "column_name": "reinstate_required",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "ladder_player_flags",
+    "column_name": "reinstate_notes",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_player_flags",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_player_flags",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_player_flags",
+    "column_name": "tier_move_flag",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "ladder_player_flags",
+    "column_name": "tier_move_dest_tier",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_player_flags",
+    "column_name": "tier_move_count",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_player_flags",
+    "column_name": "tier_move_triggered_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_player_flags",
+    "column_name": "tier_move_last_eval_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_roster",
+    "column_name": "id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_roster",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_roster",
+    "column_name": "player_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "ladder_roster",
+    "column_name": "rank",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_roster",
+    "column_name": "is_active",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "ladder_roster",
+    "column_name": "joined_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_roster",
+    "column_name": "left_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_roster",
+    "column_name": "notes",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_roster",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_roster",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_roster",
+    "column_name": "tier_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_settings",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "ladder_settings",
+    "column_name": "challenge_range",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_settings",
+    "column_name": "accept_window_hours",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_settings",
+    "column_name": "play_window_days",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_settings",
+    "column_name": "cooldown_hours",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_settings",
+    "column_name": "protected_hours",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_settings",
+    "column_name": "pass_hold_hours",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "ladder_settings",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "ladder_settings",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "league_ratings",
+    "column_name": "id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "league_ratings",
+    "column_name": "player_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "league_ratings",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "league_ratings",
+    "column_name": "league_name",
+    "data_type": "text"
+  },
+  {
+    "table_name": "league_ratings",
+    "column_name": "rating",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "league_ratings",
+    "column_name": "matches_played",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "league_ratings",
+    "column_name": "wins",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "league_ratings",
+    "column_name": "losses",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "league_ratings",
+    "column_name": "starting_rating",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "league_ratings",
+    "column_name": "is_active",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "league_ratings",
+    "column_name": "inactive_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "league_name",
+    "data_type": "text"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "league_type",
+    "data_type": "text"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "min_weeks",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "is_active",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "min_games",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "description",
+    "data_type": "text"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "k_factor",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "ended_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "ended_by",
+    "data_type": "text"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "status",
+    "data_type": "text"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "end_awards",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "started_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "schedule_config",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "court_board_defaults",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "rules_config",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "leagues_metadata",
+    "column_name": "awards_config",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "date",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "league",
+    "data_type": "text"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "t1_p1",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "t1_p2",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "t2_p1",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "t2_p2",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "score_t1",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "score_t2",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "elo_delta",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "match_type",
+    "data_type": "text"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "week_tag",
+    "data_type": "text"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "t1_p1_r",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "t1_p2_r",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "t2_p1_r",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "t2_p2_r",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "t1_p1_r_end",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "t1_p2_r_end",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "t2_p1_r_end",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "t2_p2_r_end",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "elo_delta_t1",
+    "data_type": "double precision"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "elo_delta_t2",
+    "data_type": "double precision"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "context_type",
+    "data_type": "text"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "context_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "tournament_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "tournament_game_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "matches",
+    "column_name": "idempotency_key",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_badge_facts",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_badge_facts",
+    "column_name": "player_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "player_badge_facts",
+    "column_name": "context_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_badge_facts",
+    "column_name": "fact_key",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_badge_facts",
+    "column_name": "fact_value_num",
+    "data_type": "double precision"
+  },
+  {
+    "table_name": "player_badge_facts",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "player_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "badge_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "earned_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "context_type",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "context_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "match_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "value_num",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "value_json",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "awarded_by",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "rule_version",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "eval_run_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "revoked_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "revoked_by",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "revoked_reason",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_badges",
+    "column_name": "revoke_reason",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_profiles",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_profiles",
+    "column_name": "player_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "player_profiles",
+    "column_name": "preferred_channel",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_profiles",
+    "column_name": "email",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_profiles",
+    "column_name": "phone",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_profiles",
+    "column_name": "whatsapp",
+    "data_type": "text"
+  },
+  {
+    "table_name": "player_profiles",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "player_profiles",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "players",
+    "column_name": "id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "players",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "players",
+    "column_name": "name",
+    "data_type": "text"
+  },
+  {
+    "table_name": "players",
+    "column_name": "rating",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "players",
+    "column_name": "starting_rating",
+    "data_type": "numeric"
+  },
+  {
+    "table_name": "players",
+    "column_name": "matches_played",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "players",
+    "column_name": "wins",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "players",
+    "column_name": "losses",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "players",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "players",
+    "column_name": "active",
+    "data_type": "boolean"
+  },
+  {
+    "table_name": "players",
+    "column_name": "last_game_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "players",
+    "column_name": "inactive_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "players",
+    "column_name": "normalized_name",
+    "data_type": "text"
+  },
+  {
+    "table_name": "processed_match_facts",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "processed_match_facts",
+    "column_name": "match_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "processed_match_facts",
+    "column_name": "player_id",
+    "data_type": "bigint"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "tournament_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "stage",
+    "data_type": "text"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "rr_round_number",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "rr_slot_number",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "playoff_game_code",
+    "data_type": "text"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "playoff_round",
+    "data_type": "text"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "team_a_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "team_b_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "team_a_source",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "team_b_source",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "score_a",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "score_b",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "winner_team_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "loser_team_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "finalized_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "tournament_games",
+    "column_name": "series_game_number",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "tournament_podium",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "tournament_podium",
+    "column_name": "tournament_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "tournament_podium",
+    "column_name": "placement",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "tournament_podium",
+    "column_name": "team_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "tournament_podium",
+    "column_name": "source",
+    "data_type": "text"
+  },
+  {
+    "table_name": "tournament_podium",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "tournament_teams",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "tournament_teams",
+    "column_name": "tournament_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "tournament_teams",
+    "column_name": "team_number",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "tournament_teams",
+    "column_name": "player1_id",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "tournament_teams",
+    "column_name": "player2_id",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "tournament_teams",
+    "column_name": "seed",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "tournaments",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "tournaments",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "tournaments",
+    "column_name": "name",
+    "data_type": "text"
+  },
+  {
+    "table_name": "tournaments",
+    "column_name": "status",
+    "data_type": "text"
+  },
+  {
+    "table_name": "tournaments",
+    "column_name": "team_count",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "tournaments",
+    "column_name": "playoff_advance_count",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "tournaments",
+    "column_name": "created_by_admin_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "tournaments",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "tournaments",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "tournaments",
+    "column_name": "playoff_best_of",
+    "data_type": "integer"
+  },
+  {
+    "table_name": "user_badges_v2",
+    "column_name": "user_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "user_badges_v2",
+    "column_name": "badge_id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "user_badges_v2",
+    "column_name": "awarded_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "user_badges_v2",
+    "column_name": "awarded_by",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "user_badges_v2",
+    "column_name": "reason",
+    "data_type": "text"
+  },
+  {
+    "table_name": "user_badges_v2",
+    "column_name": "metadata",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "weekly_recaps",
+    "column_name": "id",
+    "data_type": "uuid"
+  },
+  {
+    "table_name": "weekly_recaps",
+    "column_name": "club_id",
+    "data_type": "text"
+  },
+  {
+    "table_name": "weekly_recaps",
+    "column_name": "week_start",
+    "data_type": "date"
+  },
+  {
+    "table_name": "weekly_recaps",
+    "column_name": "week_end",
+    "data_type": "date"
+  },
+  {
+    "table_name": "weekly_recaps",
+    "column_name": "status",
+    "data_type": "text"
+  },
+  {
+    "table_name": "weekly_recaps",
+    "column_name": "generated_json",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "weekly_recaps",
+    "column_name": "edits_json",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "weekly_recaps",
+    "column_name": "final_json",
+    "data_type": "jsonb"
+  },
+  {
+    "table_name": "weekly_recaps",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "weekly_recaps",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "weekly_recaps",
+    "column_name": "published_at",
+    "data_type": "timestamp with time zone"
+  },
+  {
+    "table_name": "weekly_recaps",
+    "column_name": "published_by",
+    "data_type": "text"
+  }
+]


### PR DESCRIPTION
### Motivation
- Create a reproducible, literal baseline of the Supabase schema export to support deterministic schema audits and alignment work.
- Preserve the exact exported column order and data types from the provided CSV without inferring constraints, indexes, or nullability. 

### Description
- Added the raw export payload verbatim at `docs/schema/live_schema_snapshot_raw.csv` as the source baseline artifact.
- Generated a canonical DDL snapshot at `docs/schema/live_schema_snapshot_20260219.sql` containing `CREATE TABLE` statements for every exported table with columns in original ordinal order and data types preserved, and with columns marked `NULL` because nullability was not provided.
- Added `docs/schema/SCHEMA_ALIGNMENT_PLAN.md` listing the tables under audit and an explicit comparison checklist (`Missing columns`, `Type mismatches`, `Missing unique constraints`, `Missing foreign keys`, `Missing composite indexes`).
- This change is documentation-only and introduces no migrations or runtime code changes.

### Testing
- Ran the generation script (`python` inline script that reads `docs/schema/live_schema_snapshot_raw.csv` and writes `docs/schema/live_schema_snapshot_20260219.sql`) which completed successfully and wrote `32` tables to the SQL snapshot.
- Executed a verification script that loads `docs/schema/live_schema_snapshot_raw.csv` and asserts every table from the raw export appears as a `CREATE TABLE` in `docs/schema/live_schema_snapshot_20260219.sql`, and the check succeeded.
- Performed basic file checks (file existence and line counts for `docs/schema/live_schema_snapshot_20260219.sql`, `docs/schema/live_schema_snapshot_raw.csv`, and `docs/schema/SCHEMA_ALIGNMENT_PLAN.md`) to confirm the artifacts were produced as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69966d23bee883269828d1894951b5a5)