### PR TITLE
Add additive schema alignment phase 1 migration

### DIFF
--- a/migrations/20260219_schema_alignment_phase1.sql
+++ b/migrations/20260219_schema_alignment_phase1.sql
@@ -1,0 +1,69 @@
+-- SCHEMA ALIGNMENT PHASE 1
+-- Deterministic alignment to rebuild branch expectations
+-- Additive only
+
+-- Type-aligned companion columns for badge_eval_queue.
+-- TODO: Backfill from legacy columns and switch application reads/writes before deprecating legacy fields.
+ALTER TABLE IF EXISTS public.badge_eval_queue
+    ADD COLUMN IF NOT EXISTS attempts_v2 integer NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS club_id_v2 text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS created_at_v2 timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS event_type_v2 text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS payload_json_v2 jsonb NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS player_ids_v2 bigint[] NOT NULL DEFAULT '{}'::bigint[],
+    ADD COLUMN IF NOT EXISTS processed_at_v2 timestamptz NULL,
+    ADD COLUMN IF NOT EXISTS status_v2 text NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS badge_eval_queue_status_v2_created_v2_idx
+    ON public.badge_eval_queue (status_v2, created_at_v2);
+
+-- Type-aligned companion columns for badge_eval_runs.
+-- TODO: Backfill from legacy columns and switch application reads/writes before deprecating legacy fields.
+ALTER TABLE IF EXISTS public.badge_eval_runs
+    ADD COLUMN IF NOT EXISTS created_at_v2 timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS finished_at_v2 timestamptz NULL,
+    ADD COLUMN IF NOT EXISTS mode_v2 text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS scope_json_v2 jsonb NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS started_at_v2 timestamptz NULL,
+    ADD COLUMN IF NOT EXISTS status_v2 text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS summary_json_v2 jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE INDEX IF NOT EXISTS badge_eval_runs_status_v2_created_v2_idx
+    ON public.badge_eval_runs (status_v2, created_at_v2);
+
+-- Missing columns and type-aligned companion columns for badges.
+-- TODO: Backfill *_v2 columns from legacy columns and migrate reads/writes before cleanup.
+ALTER TABLE IF EXISTS public.badges
+    ADD COLUMN IF NOT EXISTS category_v2 text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS created_at_v2 timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS hint_v2 text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS is_active_v2 boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS is_stackable_v2 boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS lore_v2 text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS name_v2 text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS prestige_v2 integer NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS scope_v2 text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS state text,
+    ADD COLUMN IF NOT EXISTS state_change_reason text,
+    ADD COLUMN IF NOT EXISTS state_changed_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS badges_state_idx
+    ON public.badges (state);
+
+-- Type-aligned companion columns for player_badges.
+-- TODO: Backfill *_v2 columns from legacy columns and migrate reads/writes before cleanup.
+ALTER TABLE IF EXISTS public.player_badges
+    ADD COLUMN IF NOT EXISTS badge_id_v2 text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS club_id_v2 text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS context_type_v2 text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS earned_at_v2 timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS player_id_v2 bigint NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS player_badges_club_player_badge_v2_idx
+    ON public.player_badges (club_id_v2, player_id_v2, badge_id_v2);
+
+-- Type-aligned companion columns for players.
+-- TODO: Backfill *_v2 columns from legacy columns and migrate reads/writes before cleanup.
+ALTER TABLE IF EXISTS public.players
+    ADD COLUMN IF NOT EXISTS last_game_at_v2 timestamptz,
+    ADD COLUMN IF NOT EXISTS inactive_at_v2 timestamptz;


### PR DESCRIPTION
### Motivation
- Align the database schema for tables flagged in the alignment plan so branch expectations from PR2 match the live schema snapshot. 
- Follow an additive-only approach to avoid destructive changes and preserve existing migration history. 

### Description
- Add new migration `migrations/20260219_schema_alignment_phase1.sql` with the required Phase 1 header and additive-only intent. 
- Introduce type-aligned companion `_v2` columns for `badge_eval_queue`, `badge_eval_runs`, `badges`, `player_badges`, and `players` to address type mismatches while leaving legacy columns intact. 
- Add missing `badges` state columns (`state`, `state_change_reason`, `state_changed_at`) and create indexes for `badge_eval_queue`, `badge_eval_runs`, `badges`, and `player_badges` using `CREATE INDEX IF NOT EXISTS`. 
- Leave TODO notes in the migration to indicate later safe backfill and cutover from legacy columns to the new `_v2` columns. 

### Testing
- Ran schema comparison with `python tools/schema_diff.py` and used `python tools/schema_diff.py 2>&1 | rg "table=(players|matches|league_ratings|leagues_metadata|badges|player_badges|badge_eval_queue|badge_eval_runs|admin_audit_events)"` to review relevant discrepancies. 
- Verified the new migration file is present with `git status --short` and committed the change with `git show --stat --oneline` to confirm the addition. 
- All automated checks and commands executed during the rollout completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967000e3a8832697a7dd9235f2530d)