### PR TITLE
Add schema version lock migration and schema_diff guard

### DIFF
--- a/migrations/20260810_schema_version_lock.sql
+++ b/migrations/20260810_schema_version_lock.sql
@@ -1,0 +1,8 @@
+create table if not exists schema_version (
+  version text primary key,
+  applied_at timestamptz not null default now()
+);
+
+insert into schema_version (version)
+values ('rebuild_phase1_alignment')
+on conflict do nothing;

--- a/tools/schema_diff.py
+++ b/tools/schema_diff.py
@@ -268,6 +268,35 @@ def _migration_files() -> list[Path]:
     return files
 
 
+def _extract_schema_version(sql_text: str) -> str | None:
+    match = re.search(
+        r"""\bINSERT\s+INTO\s+(?:\w+\.)?schema_version\s*\(\s*version\s*\)\s*\n?\s*VALUES\s*\(\s*'([^']+)'\s*\)""",
+        sql_text,
+        flags=re.IGNORECASE | re.VERBOSE,
+    )
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def _validate_latest_schema_version(migration_files: list[Path]) -> list[str]:
+    failures: list[str] = []
+    expected_state = _build_state(migration_files)
+    if "schema_version" not in expected_state:
+        failures.append("SCHEMA_VERSION_MISMATCH missing schema_version table in migration state")
+
+    latest_migration = migration_files[-1]
+    latest_sql = _strip_comments(latest_migration.read_text(encoding="utf-8"))
+    latest_version = _extract_schema_version(latest_sql)
+    if latest_version is None:
+        failures.append(
+            "SCHEMA_VERSION_MISMATCH "
+            f"latest migration {latest_migration.name} must insert into schema_version(version)"
+        )
+
+    return failures
+
+
 def _compare_schemas(live: SchemaState, expected: SchemaState) -> list[dict[str, str]]:
     diffs: list[dict[str, str]] = []
     for table in sorted(expected):
@@ -315,12 +344,16 @@ def main() -> int:
     live_snapshot = _latest_live_snapshot()
     migration_files = _migration_files()
 
+    version_failures = _validate_latest_schema_version(migration_files)
+    for failure in version_failures:
+        print(failure)
+
     live_state = _build_state([live_snapshot])
     expected_state = _build_state(migration_files)
     diffs = _compare_schemas(live_state, expected_state)
     _print_diffs(diffs)
 
-    return 1 if diffs else 0
+    return 1 if diffs or version_failures else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Ensure migrations can stamp a schema version to lock a particular alignment and detect when the codebase has not applied that stamp. 
- Fail fast in the schema comparison tool when the latest migration does not include the required schema-version insert or when the migration-derived state omits the `schema_version` table.

### Description
- Add `migrations/20260810_schema_version_lock.sql` which creates a `schema_version` table and inserts the `rebuild_phase1_alignment` version using `on conflict do nothing` for idempotence. 
- Extend `tools/schema_diff.py` with `_extract_schema_version` to parse `INSERT INTO schema_version(version)` statements from SQL. 
- Add `_validate_latest_schema_version` which verifies the migration-derived schema includes `schema_version` and that the latest migration file inserts a version row, returning validation failures. 
- Wire the validator into `main()` so failures are printed and cause a non-zero exit code alongside existing schema diffs.

### Testing
- Ran `python -m py_compile tools/schema_diff.py` and it completed successfully. 
- Ran `python tools/schema_diff.py` which executed the new validation and printed schema diffs and returned a non-zero exit code (expected given current live snapshot vs migrations). 
- The new validation path was exercised during the run and will surface `SCHEMA_VERSION_MISMATCH` failures when the latest migration lacks the version stamp or the migration-derived state lacks the `schema_version` table.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699670f3354083268937f0f3e2e8454b)