### PR TITLE
Enforce strict badge schema mode in fact + recompute paths

### DIFF
--- a/jupr_app/cli/badge_recompute.py
+++ b/jupr_app/cli/badge_recompute.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+# SCHEMA STRICT MODE ENABLED
+# All environments must match migrations
+
 import argparse
 import json
 import os

--- a/jupr_app/data/sb_write.py
+++ b/jupr_app/data/sb_write.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+# SCHEMA STRICT MODE ENABLED
+# All environments must match migrations
+
 from typing import Any, Dict
 
 

--- a/jupr_app/domain/gamification/fact_engine.py
+++ b/jupr_app/domain/gamification/fact_engine.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+# SCHEMA STRICT MODE ENABLED
+# All environments must match migrations
+
 from datetime import datetime, timezone
 from typing import Any
 
@@ -65,7 +68,7 @@ def update_match_facts_for_players(
         _set_numeric_fact(supabase, str(club_id), int(pid), context_id, "best_win_streak", best_streak, now_iso)
 
         current_rating = _read_player_rating(supabase, str(club_id), int(pid))
-        starting_rating = _read_player_starting_rating(supabase, str(club_id), int(pid), fallback=current_rating)
+        starting_rating = _read_player_starting_rating(supabase, str(club_id), int(pid))
         _set_numeric_fact(
             supabase,
             str(club_id),
@@ -257,10 +260,10 @@ def _read_player_rating(supabase: Any, club_id: str, player_id: int) -> float:
     return float(rows[0].get("rating") or 1200.0)
 
 
-def _read_player_starting_rating(supabase: Any, club_id: str, player_id: int, *, fallback: float) -> float:
+def _read_player_starting_rating(supabase: Any, club_id: str, player_id: int) -> float:
     resp = (
         supabase.table("players")
-        .select("starting_rating,rating")
+        .select("starting_rating")
         .eq("club_id", club_id)
         .eq("id", int(player_id))
         .limit(1)
@@ -268,13 +271,13 @@ def _read_player_starting_rating(supabase: Any, club_id: str, player_id: int, *,
     )
     rows = resp.data or []
     if not rows:
-        return float(fallback)
+        raise RuntimeError(f"Missing players row for club_id={club_id} player_id={player_id}")
     row = rows[0]
     starting = row.get("starting_rating")
     if starting is None:
-        starting = row.get("rating")
-    if starting is None:
-        return float(fallback)
+        raise RuntimeError(
+            f"Missing required players.starting_rating for club_id={club_id} player_id={player_id}"
+        )
     return float(starting)
 
 

--- a/jupr_app/domain/gamification/fact_replay.py
+++ b/jupr_app/domain/gamification/fact_replay.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+# SCHEMA STRICT MODE ENABLED
+# All environments must match migrations
+
 from typing import Any
 
 from jupr_app.domain.gamification.fact_engine import update_match_facts_for_players

--- a/jupr_app/domain/gamification/recompute.py
+++ b/jupr_app/domain/gamification/recompute.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+# SCHEMA STRICT MODE ENABLED
+# All environments must match migrations
+
 from jupr_app.data.sb_write import sb_insert, sb_update, sb_upsert
 
 from dataclasses import asdict
@@ -58,6 +61,7 @@ def run_badge_recompute(
     try:
         if ctx is None:
             ctx = _load_ctx(supabase, club_id, match_limit)
+        _require_strict_schema(ctx)
         ctx = _apply_match_filters(ctx, since=since, until=until)
 
         computed = list(
@@ -178,6 +182,14 @@ def _load_ctx(supabase: Any, club_id: str, match_limit: int) -> Any:
         schema_degraded=schema_degraded,
         schema_degraded_reason=schema_degraded_reason,
     )
+
+
+def _require_strict_schema(ctx: Any) -> None:
+    if getattr(ctx, "schema_degraded", False):
+        raise RuntimeError(
+            "Schema degraded mode is not supported. "
+            f"Apply required migrations: {getattr(ctx, 'schema_degraded_reason', 'unknown reason')}"
+        )
 
 
 def _apply_match_filters(ctx: Any, *, since: str | None, until: str | None) -> Any:


### PR DESCRIPTION
### Motivation
- Remove legacy degraded-schema fallbacks now that the badge schema is expected to be aligned with migrations and ensure runtime errors surface missing columns.
- Prevent silent behavior where missing optional columns would be quietly substituted or recompute would run in a degraded mode.

### Description
- Added a schema-strict header comment to `jupr_app/domain/gamification/fact_engine.py`, `jupr_app/domain/gamification/fact_replay.py`, `jupr_app/data/sb_write.py`, and `jupr_app/cli/badge_recompute.py` to mark these modules as migration-locked.
- Removed fallback logic for `players.starting_rating` in `jupr_app/domain/gamification/fact_engine.py` by changing `_read_player_starting_rating` to only select `starting_rating` and raise a `RuntimeError` when the player row or `starting_rating` is missing, and updated callers accordingly to perform strict writes for `rating_delta`.
- Enforced strict schema behavior in recompute by adding `_require_strict_schema(ctx)` to `jupr_app/domain/gamification/recompute.py` and invoking it after `ctx` is loaded so recompute fails fast if `load_data` indicates a degraded schema.

### Testing
- Ran `pytest -q tests/test_fact_engine.py tests/test_badge_recompute.py` and the tests passed: `8 passed in 1.79s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699671acc3b883269da2a71a16686d2d)