### PR TITLE
Gate replay behind schema version validation

### DIFF
--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -16,6 +16,9 @@ from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
 from jupr_app.ui.layout import page_shell
 
 
+REQUIRED_SCHEMA_VERSION = "rebuild_phase1_alignment"
+
+
 def _get_api_error_code(exc: APIError) -> str | None:
     code = getattr(exc, "code", None)
     if code:
@@ -23,6 +26,20 @@ def _get_api_error_code(exc: APIError) -> str | None:
     if exc.args and isinstance(exc.args[0], dict):
         return exc.args[0].get("code")
     return None
+
+
+def _is_replay_schema_valid(supabase) -> bool:
+    try:
+        response = (
+            supabase.table("schema_version")
+            .select("version")
+            .eq("version", REQUIRED_SCHEMA_VERSION)
+            .limit(1)
+            .execute()
+        )
+    except Exception:
+        return False
+    return bool(response.data)
 
 
 def render(ctx):
@@ -117,6 +134,10 @@ def render(ctx):
     target_reset = st.selectbox("Replay scope", league_opts)
 
     if st.button(f"⚠️ Replay History for: {target_reset}"):
+        if not _is_replay_schema_valid(supabase):
+            st.error("Schema mismatch detected.\nRun migrations before replay.")
+            st.stop()
+
         bar = st.progress(0.0)
         with st.spinner("Crunching..."):
             result = replay_history(


### PR DESCRIPTION
### Motivation
- Prevent replay from running against a database with an incompatible schema and force operators to apply migrations first.
- Surface a clear, visible error and abort the UI action rather than attempting a replay with unknown schema state.

### Description
- Added a required replay schema version constant `REQUIRED_SCHEMA_VERSION` in `jupr_app/ui/pages/admin_tools.py`.
- Implemented `_is_replay_schema_valid(supabase)` which queries `schema_version` for the required version and returns false on missing row or query error.
- Guarded the Replay flow to call `_is_replay_schema_valid` before starting `replay_history`, and abort with the visible error `Schema mismatch detected.` followed by `Run migrations before replay.` when the check fails.
- Changes are localized to `jupr_app/ui/pages/admin_tools.py` and introduce no fallback behavior.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/admin_tools.py` which succeeded.
- Launched the app with `streamlit run streamlit_app.py --server.port 8501 --server.headless true` for visual verification which started successfully.
- Captured a Playwright screenshot of the updated Streamlit page to validate the UI gating visually (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996725204a48326b55a9ad1ab4cd545)