### PR TITLE
PHASE 2.3 — Tournament Save Delegates to Match Pipeline

### DIFF
--- a/jupr_app/domain/match_pipeline.py
+++ b/jupr_app/domain/match_pipeline.py
@@ -19,7 +19,13 @@ def record_match(
     score_b: int,
     played_at: str | None = None,
     context_id: str | None = None,
+    context_type: str | None = None,
     source: str = "manual",
+    league: str | None = None,
+    week_tag: str | None = None,
+    tournament_id: str | None = None,
+    tournament_game_id: str | None = None,
+    is_popup: bool | None = None,
 ) -> dict:
     if not str(club_id or "").strip():
         raise ValueError("club_id is required")
@@ -34,6 +40,7 @@ def record_match(
     score_b = int(score_b)
     played_at_iso = _normalize_played_at(played_at)
     normalized_context_id = _normalize_optional_str(context_id)
+    normalized_context_type = _normalize_optional_str(context_type)
     source = _normalize_optional_str(source) or "manual"
 
     all_player_ids = sorted(set(normalized_team_a + normalized_team_b))
@@ -84,6 +91,19 @@ def record_match(
         "idempotency_key": idempotency_key,
         "match_type": source,
     }
+
+    if normalized_context_type:
+        match_payload["context_type"] = normalized_context_type
+    if league is not None:
+        match_payload["league"] = str(league)
+    if week_tag is not None:
+        match_payload["week_tag"] = str(week_tag)
+    if tournament_id is not None:
+        match_payload["tournament_id"] = str(tournament_id)
+    if tournament_game_id is not None:
+        match_payload["tournament_game_id"] = str(tournament_game_id)
+    if is_popup is not None:
+        match_payload["is_popup"] = bool(is_popup)
 
     inserted_match_resp = (
         supabase.table("matches")
@@ -175,8 +195,48 @@ def record_match(
     }
 
 
-def update_match(*args: Any, **kwargs: Any) -> dict:
-    raise NotImplementedError("update_match will be implemented in a future phase")
+def update_match(
+    supabase,
+    *,
+    match_id: str,
+    score_a: int,
+    score_b: int,
+    played_at: str | None = None,
+    league: str | None = None,
+    week_tag: str | None = None,
+    tournament_id: str | None = None,
+    tournament_game_id: str | None = None,
+    is_popup: bool | None = None,
+) -> dict:
+    normalized_match_id = str(match_id or "").strip()
+    if not normalized_match_id:
+        raise ValueError("match_id is required")
+
+    payload: dict[str, Any] = {
+        "score_t1": int(score_a),
+        "score_t2": int(score_b),
+        "date": _normalize_played_at(played_at),
+    }
+    if league is not None:
+        payload["league"] = str(league)
+    if week_tag is not None:
+        payload["week_tag"] = str(week_tag)
+    if tournament_id is not None:
+        payload["tournament_id"] = str(tournament_id)
+    if tournament_game_id is not None:
+        payload["tournament_game_id"] = str(tournament_game_id)
+    if is_popup is not None:
+        payload["is_popup"] = bool(is_popup)
+
+    result = sb_update(supabase, "matches", payload, filters={"id": normalized_match_id})
+    rows = getattr(result, "data", None) or []
+    if not rows:
+        raise RuntimeError(f"Failed to update matches row for id={normalized_match_id}")
+
+    return {
+        "status": "updated",
+        "match": dict(rows[0]),
+    }
 
 
 def void_match(*args: Any, **kwargs: Any) -> dict:

--- a/jupr_app/domain/tournaments/sync.py
+++ b/jupr_app/domain/tournaments/sync.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Any
-from jupr_app.data.supabase_admin import get_service_supabase
-from jupr_app.domain.match_processing import process_matches
+
+from jupr_app.domain.match_pipeline import record_match, update_match
 
 
 def sync_tournament_game_to_match(
@@ -15,31 +15,57 @@ def sync_tournament_game_to_match(
     df_leagues,
     df_meta,
 ) -> None:
-    """
-    Idempotent sync:
-    - Deletes any existing match row for this tournament game
-    - Rebuilds canonical match entry
-    """
+    """Persist tournament game scores through the canonical match pipeline."""
 
     game_id = game.get("id")
     if not game_id:
         return
 
-    supabase_admin = get_service_supabase()
+    _ = (name_to_id, df_players_all, df_leagues, df_meta)
 
-    # Delete existing canonical match
-    supabase_admin.table("matches") \
-        .delete() \
-        .eq("tournament_game_id", game_id) \
+    team_a_player_ids = [pid for pid in [match_payload.get("t1_p1"), match_payload.get("t1_p2")] if pid is not None]
+    team_b_player_ids = [pid for pid in [match_payload.get("t2_p1"), match_payload.get("t2_p2")] if pid is not None]
+
+    existing_resp = (
+        supabase.table("matches")
+        .select("id,score_t1,score_t2")
+        .eq("club_id", str(club_id))
+        .eq("tournament_game_id", str(game_id))
+        .limit(1)
         .execute()
+    )
+    existing_rows = getattr(existing_resp, "data", None) or []
 
-    # Insert fresh canonical match
-    process_matches(
-        [match_payload],
-        supabase_admin=supabase_admin,
-        club_id=str(club_id),
-        name_to_id=name_to_id,
-        df_players_all=df_players_all,
-        df_leagues=df_leagues,
-        df_meta=df_meta,
+    common_fields = {
+        "score_a": int(match_payload.get("s1") or 0),
+        "score_b": int(match_payload.get("s2") or 0),
+        "played_at": match_payload.get("date"),
+        "league": match_payload.get("league"),
+        "week_tag": match_payload.get("week_tag"),
+        "tournament_id": match_payload.get("tournament_id"),
+        "tournament_game_id": match_payload.get("tournament_game_id"),
+        "is_popup": bool(match_payload.get("is_popup", True)),
+    }
+
+    if not existing_rows:
+        record_match(
+            supabase,
+            club_id=str(club_id),
+            team_a_player_ids=team_a_player_ids,
+            team_b_player_ids=team_b_player_ids,
+            context_type="tournament",
+            context_id=str(match_payload.get("tournament_id") or game.get("tournament_id") or ""),
+            source="tournament",
+            **common_fields,
+        )
+        return
+
+    existing = existing_rows[0]
+    if int(existing.get("score_t1") or 0) == common_fields["score_a"] and int(existing.get("score_t2") or 0) == common_fields["score_b"]:
+        return
+
+    update_match(
+        supabase,
+        match_id=str(existing.get("id")),
+        **common_fields,
     )


### PR DESCRIPTION
### Motivation
- Centralize all tournament match persistence behind the canonical match pipeline to avoid ad-hoc writes and duplicated rating logic.
- Replace direct Supabase `matches` delete/insert behavior in the tournament sync helper with pipeline calls to ensure consistent idempotency and rating updates.

### Description
- Added metadata-aware parameters to `record_match` (`context_type`, `league`, `week_tag`, `tournament_id`, `tournament_game_id`, `is_popup`) so tournament saves can flow through the canonical pipeline.`
- Implemented `update_match` in `jupr_app.domain.match_pipeline` to support in-place updates of existing canonical match rows.`
- Reworked `sync_tournament_game_to_match` to delegate persistence to `record_match` (when no canonical match exists) or `update_match` (when a canonical match exists and the score changed) and removed the previous direct delete/insert logic.`
- Removed dependency on the admin service insert flow in the tournament sync helper and preserved a no-op when the canonical match score is unchanged.`

### Testing
- Ran a code search to verify tournament sync now delegates to pipeline and that there are no direct `matches` table write chains in the tournament sync helper (`rg` checks); the search confirmed the intended changes.`
- Compiled modified modules with `python -m py_compile jupr_app/domain/match_pipeline.py jupr_app/domain/tournaments/sync.py jupr_app/ui/pages/tournaments.py` and the compilation succeeded with no syntax errors.`
- Basic runtime sanity validated by invoking the updated `sync_tournament_game_to_match` logic paths locally (insert, update, no-op) during development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967fb32cd48326a97af1ab2e4847d4)