### PR TITLE
PHASE 2.4 — Bulk Match Editor Uses Pipeline

### DIFF
--- a/jupr_app/domain/bulk_match_editor.py
+++ b/jupr_app/domain/bulk_match_editor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from jupr_app.data.sb_write import sb_insert, sb_update, sb_upsert
+from jupr_app.data.sb_write import sb_insert
 
 from typing import Any, Dict, List, Optional, Set, Tuple
 import json
@@ -8,6 +8,7 @@ import json
 import pandas as pd
 
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
+from jupr_app.domain.match_pipeline import update_match
 
 def compute_recompute_scope(patches: List[Dict[str, Any]]) -> Dict[str, bool]:
     """
@@ -143,8 +144,6 @@ def apply_bulk_match_edits(
     affected_players: Set[int] = set()
 
     # For audit
-    audit_before: List[Dict[str, Any]] = []
-    audit_after: List[Dict[str, Any]] = []
     applied: List[Dict[str, Any]] = []
 
     warnings: List[str] = []
@@ -213,20 +212,26 @@ def apply_bulk_match_edits(
         if not update:
             continue
 
-        # audit snapshots (only changed fields + id)
-        b_snap = {"id": mid}
-        a_snap = {"id": mid}
-        for k, newv in update.items():
-            b_snap[k] = before.get(k)
-            a_snap[k] = newv
-
-        # Apply update
-        sb_update(supabase, "matches", update, filters={"club_id": club_id, "id": mid})
+        # Apply update via pipeline
+        update_match(
+            supabase,
+            match_id=str(mid),
+            club_id=str(club_id),
+            played_at=update.get("date"),
+            league=update.get("league"),
+            week_tag=update.get("week_tag"),
+            match_type=update.get("match_type"),
+            notes=update.get("notes"),
+            is_active=update.get("is_active"),
+            score_a=update.get("score_t1"),
+            score_b=update.get("score_t2"),
+            tournament_id=update.get("tournament_id"),
+            tournament_game_id=update.get("tournament_game_id"),
+            is_popup=update.get("is_popup"),
+        )
 
         updated_ids.append(mid)
         applied.append({"id": mid, **update})
-        audit_before.append(b_snap)
-        audit_after.append(a_snap)
 
     recompute_scope = compute_recompute_scope(patches)
 
@@ -242,8 +247,6 @@ def apply_bulk_match_edits(
             "updated_ids": updated_ids,
             "affected_leagues": sorted(affected_leagues),
             "recompute_scope": recompute_scope,
-            "before": audit_before,
-            "after": audit_after,
             "patches": applied,
             "warnings": warnings,
         },

--- a/jupr_app/domain/match_pipeline.py
+++ b/jupr_app/domain/match_pipeline.py
@@ -199,28 +199,40 @@ def update_match(
     supabase,
     *,
     match_id: str,
-    score_a: int,
-    score_b: int,
+    score_a: int | None = None,
+    score_b: int | None = None,
     played_at: str | None = None,
     league: str | None = None,
     week_tag: str | None = None,
+    match_type: str | None = None,
+    notes: str | None = None,
+    is_active: bool | None = None,
     tournament_id: str | None = None,
     tournament_game_id: str | None = None,
     is_popup: bool | None = None,
+    club_id: str | None = None,
 ) -> dict:
     normalized_match_id = str(match_id or "").strip()
     if not normalized_match_id:
         raise ValueError("match_id is required")
 
-    payload: dict[str, Any] = {
-        "score_t1": int(score_a),
-        "score_t2": int(score_b),
-        "date": _normalize_played_at(played_at),
-    }
+    payload: dict[str, Any] = {}
+    if score_a is not None:
+        payload["score_t1"] = int(score_a)
+    if score_b is not None:
+        payload["score_t2"] = int(score_b)
+    if played_at is not None:
+        payload["date"] = _normalize_played_at(played_at)
     if league is not None:
         payload["league"] = str(league)
     if week_tag is not None:
         payload["week_tag"] = str(week_tag)
+    if match_type is not None:
+        payload["match_type"] = str(match_type)
+    if notes is not None:
+        payload["notes"] = str(notes)
+    if is_active is not None:
+        payload["is_active"] = bool(is_active)
     if tournament_id is not None:
         payload["tournament_id"] = str(tournament_id)
     if tournament_game_id is not None:
@@ -228,7 +240,14 @@ def update_match(
     if is_popup is not None:
         payload["is_popup"] = bool(is_popup)
 
-    result = sb_update(supabase, "matches", payload, filters={"id": normalized_match_id})
+    if not payload:
+        raise ValueError("At least one field is required to update a match")
+
+    filters: dict[str, Any] = {"id": normalized_match_id}
+    if club_id is not None and str(club_id).strip():
+        filters["club_id"] = str(club_id).strip()
+
+    result = sb_update(supabase, "matches", payload, filters=filters)
     rows = getattr(result, "data", None) or []
     if not rows:
         raise RuntimeError(f"Failed to update matches row for id={normalized_match_id}")


### PR DESCRIPTION
### Motivation
- Route bulk match edits through the central match pipeline so updates follow the same validation/normalization/idempotency rules as other match writes and avoid direct table writes from the editor module.
- Remove duplicated per-row snapshot/delta maintenance in the editor and consolidate update logic in the pipeline to reduce drift and duplicate logic.
- No skills from the skills catalog were used for this change.

### Description
- Replaced direct `sb_update(..., "matches", ...)` calls in `jupr_app/domain/bulk_match_editor.py` with calls to `update_match(...)` from `jupr_app.domain.match_pipeline`, preserving auto-clear `week_tag` logic and patch-level audit/warning behavior.
- Removed per-row `before`/`after` snapshot construction from the bulk editor and kept the applied patch list in the audit payload to avoid duplicating snapshot logic.
- Extended `update_match(...)` in `jupr_app/domain/match_pipeline.py` to accept partial updates (`score_a`, `score_b`, `played_at`, `league`, `week_tag`, `match_type`, `notes`, `is_active`, `tournament_id`, `tournament_game_id`, `is_popup`) and an optional `club_id` filter, and validated that at least one field is present before issuing the update.

### Testing
- Compiled modified modules with `python -m compileall jupr_app/domain/bulk_match_editor.py jupr_app/domain/match_pipeline.py`, which succeeded.
- Ran `pytest -q tests/test_match_pipeline_idempotency.py`, which passed (1 passed).
- Changes were committed and verified with local diffs; no other automated tests were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996806b4d008326a55c944d05f8e860)