### PR TITLE
PHASE 2.5: enforce match_pipeline as sole match write entrypoint

### DIFF
--- a/jupr_app/domain/match_pipeline.py
+++ b/jupr_app/domain/match_pipeline.py
@@ -1,3 +1,8 @@
+"""
+THIS IS THE ONLY MATCH WRITE ENTRYPOINT.
+All match writes must pass through this module.
+"""
+
 from __future__ import annotations
 
 import hashlib


### PR DESCRIPTION
### Motivation
- Ensure all writes to the `matches` table are centralized and enforced through a single pipeline module (`jupr_app/domain/match_pipeline.py`).

### Description
- Added a module-level enforcement banner at the top of `jupr_app/domain/match_pipeline.py` declaring it the only match-write entrypoint and committed the change.

### Testing
- Ran a repository-wide scan using `rg` and a Python verification script which reported 1 total direct write (inside `jupr_app/domain/match_pipeline.py`) and 0 occurrences outside the allowed module before the change and 0 occurrences outside after the change, and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996811ad32c8326b315b5eba7d30314)