### PR TITLE
Phase 3.3 — Add replay lock mechanism

### DIFF
--- a/jupr_app/cli/replay_ratings.py
+++ b/jupr_app/cli/replay_ratings.py
@@ -4,40 +4,16 @@ import argparse
 import json
 import os
 import sys
-from contextlib import contextmanager
-from pathlib import Path
 
 import pandas as pd
 
 from jupr_app.data.client import make_supabase
 from jupr_app.domain.replay_history import FULL_RESET_LABEL, replay_history
-
-
-@contextmanager
-def _replay_lock(club_id: str, force: bool = False):
-    lock_path = Path(f"/tmp/jupr_replay_{club_id}.lock")
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-
-    with lock_path.open("a+") as lock_file:
-        try:
-            import fcntl
-
-            lock_mode = fcntl.LOCK_EX | (0 if force else fcntl.LOCK_NB)
-            fcntl.flock(lock_file.fileno(), lock_mode)
-        except BlockingIOError as exc:
-            raise RuntimeError(
-                f"Replay lock is already held for club_id={club_id}. Use --force to wait for lock release."
-            ) from exc
-
-        try:
-            yield
-        finally:
-            try:
-                import fcntl
-
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-            except Exception:
-                pass
+from jupr_app.domain.replay_lock import (
+    ReplayAlreadyRunningError,
+    acquire_replay_lock_with_wait,
+    release_replay_lock,
+)
 
 
 def _load_df_meta(supabase, club_id: str) -> pd.DataFrame:
@@ -90,8 +66,11 @@ def main() -> int:
         print(json.dumps({"club_id": args.club_id, "dry_run": True, "status": "validated"}, indent=2))
         return 0
 
+    summary: dict = {}
+
     try:
-        with _replay_lock(args.club_id, force=args.force):
+        acquire_replay_lock_with_wait(supabase, str(args.club_id), wait=bool(args.force))
+        try:
             df_meta = _load_df_meta(supabase, args.club_id)
             summary = replay_history(
                 supabase=supabase,
@@ -101,6 +80,11 @@ def main() -> int:
                 progress_cb=None,
             )
             _record_run(supabase, str(args.club_id), "success", summary)
+        finally:
+            release_replay_lock(supabase, str(args.club_id))
+    except ReplayAlreadyRunningError as exc:
+        print(f"Replay failed: {exc}", file=sys.stderr)
+        return 1
     except Exception as exc:
         _record_run(supabase, str(args.club_id), "failed", {"error": str(exc)})
         print(f"Replay failed: {exc}", file=sys.stderr)

--- a/jupr_app/domain/replay_lock.py
+++ b/jupr_app/domain/replay_lock.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import sleep
+from typing import Any
+
+from postgrest.exceptions import APIError
+
+
+class ReplayAlreadyRunningError(RuntimeError):
+    """Raised when a replay is already running for a club."""
+
+
+@dataclass(frozen=True)
+class ReplayLockInfo:
+    club_id: str
+    started_at: str | None
+    status: str | None
+
+
+def _get_api_error_code(exc: APIError) -> str | None:
+    code = getattr(exc, "code", None)
+    if code:
+        return code
+    if exc.args and isinstance(exc.args[0], dict):
+        return exc.args[0].get("code")
+    return None
+
+
+def acquire_replay_lock(supabase: Any, club_id: str) -> None:
+    payload = {"club_id": str(club_id), "status": "running"}
+    try:
+        supabase.table("replay_lock").insert(payload).execute()
+    except APIError as exc:
+        if _get_api_error_code(exc) == "23505":
+            raise ReplayAlreadyRunningError(f"Replay already running for club_id={club_id}.") from exc
+        raise
+
+
+def acquire_replay_lock_with_wait(supabase: Any, club_id: str, *, wait: bool = False, poll_seconds: float = 1.0) -> None:
+    while True:
+        try:
+            acquire_replay_lock(supabase, club_id)
+            return
+        except ReplayAlreadyRunningError:
+            if not wait:
+                raise
+            sleep(max(poll_seconds, 0.1))
+
+
+def release_replay_lock(supabase: Any, club_id: str) -> None:
+    supabase.table("replay_lock").delete().eq("club_id", str(club_id)).execute()
+
+
+def is_replay_running(supabase: Any, club_id: str) -> ReplayLockInfo | None:
+    response = (
+        supabase.table("replay_lock")
+        .select("club_id,started_at,status")
+        .eq("club_id", str(club_id))
+        .limit(1)
+        .execute()
+    )
+    rows = response.data or []
+    if not rows:
+        return None
+    row = rows[0]
+    return ReplayLockInfo(
+        club_id=str(row.get("club_id") or club_id),
+        started_at=row.get("started_at"),
+        status=row.get("status"),
+    )

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -7,6 +7,7 @@ from postgrest.exceptions import APIError
 from jupr_app.domain.gamification.ensure_badges import ensure_badges
 from jupr_app.domain.gamification.badge_state import ALLOWED_BADGE_STATES, can_transition_badge_state
 from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
+from jupr_app.domain.replay_lock import is_replay_running
 from jupr_app.ui.layout import page_shell
 
 
@@ -148,6 +149,18 @@ def render(ctx):
         latest = replay_runs.data[0]
         st.caption("Last replay run (read-only)")
         st.json(latest)
+
+    replay_lock_info = None
+    try:
+        replay_lock_info = is_replay_running(supabase, club_id)
+    except Exception:
+        replay_lock_info = None
+
+    if replay_lock_info is None:
+        st.caption("Replay lock: not running")
+    else:
+        st.caption("Replay lock: running")
+        st.json({"club_id": replay_lock_info.club_id, "started_at": replay_lock_info.started_at, "status": replay_lock_info.status})
 
     st.divider()
 

--- a/migrations/20260219_add_replay_lock.sql
+++ b/migrations/20260219_add_replay_lock.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS replay_lock (
+  club_id text PRIMARY KEY,
+  started_at timestamptz NOT NULL DEFAULT now(),
+  status text NOT NULL DEFAULT 'running'
+);


### PR DESCRIPTION
### Motivation
- Prevent concurrent replay runs per club to avoid duplicate CPU work and rating duplication.
- Provide a durable, inspectable lock so a failed process can be investigated via admin UI and logs.
- Surface lock state in the Admin Tools so operators can see when a replay is active for a club.

### Description
- Added migration `migrations/20260219_add_replay_lock.sql` which creates a `replay_lock` table keyed by `club_id` with `started_at` and `status` columns.
- New helper module `jupr_app/domain/replay_lock.py` implementing `acquire_replay_lock(...)`, `acquire_replay_lock_with_wait(...)`, `release_replay_lock(...)`, `is_replay_running(...)`, and `ReplayAlreadyRunningError` for DB-backed locking and optional wait (`--force`) semantics.
- Updated `jupr_app/cli/replay_ratings.py` to acquire the DB lock before starting the replay, release the lock in a `finally` block after the run, and return a clear error when a lock already exists for the club.
- Updated Admin Tools `jupr_app/ui/pages/admin_tools.py` to show the replay lock state and lock metadata (`club_id`, `started_at`, `status`) for the current club.

### Testing
- Compiled modified modules with `python -m compileall jupr_app/domain/replay_lock.py jupr_app/cli/replay_ratings.py jupr_app/ui/pages/admin_tools.py` and compilation succeeded.
- Verified CLI flags and help output with `python -m jupr_app.cli.replay_ratings --help`, which printed usage successfully.
- Attempted to capture a UI screenshot but the local Streamlit app was not reachable (`ERR_EMPTY_RESPONSE`), so live UI verification was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996838d10908326bde0003c48f85226)