### PR TITLE
Phase 3.2b — Add Postgres RPC for deterministic replay replace

### DIFF
--- a/jupr_app/data/sb_write.py
+++ b/jupr_app/data/sb_write.py
@@ -46,3 +46,7 @@ def sb_update(
         query = query.eq(col, value)
 
     return query.execute()
+
+
+def sb_rpc(supabase: Any, name: str, payload: Dict) -> Any:
+    return supabase.rpc(name, payload).execute()

--- a/jupr_app/domain/replay_history.py
+++ b/jupr_app/domain/replay_history.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from jupr_app.data.sb_write import sb_insert, sb_update, sb_upsert
+from jupr_app.data.sb_write import sb_rpc, sb_update
 
+import json
 import random
 import time
 from typing import Any, Callable, Dict, Optional
@@ -25,6 +26,39 @@ def _exec_with_retry(fn, *, retries: int = 6, base_sleep: float = 0.5):
                 raise
             delay = base_sleep * (2**attempt) + random.uniform(0.0, 0.2)
             time.sleep(delay)
+
+
+def _json_size_bytes(payload: Any) -> int:
+    return len(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+
+
+def _chunk_rows_by_payload_limit(rows: list[Dict[str, Any]], *, max_payload_bytes: int) -> list[list[Dict[str, Any]]]:
+    if not rows:
+        return []
+
+    chunks: list[list[Dict[str, Any]]] = []
+    current: list[Dict[str, Any]] = []
+    current_size = 2  # []
+
+    for row in rows:
+        row_size = _json_size_bytes(row)
+        if row_size + 2 > max_payload_bytes:
+            raise RuntimeError("replace_league_ratings row exceeds max payload size")
+
+        delim = 1 if current else 0
+        if current and current_size + delim + row_size > max_payload_bytes:
+            chunks.append(current)
+            current = [row]
+            current_size = 2 + row_size
+            continue
+
+        current.append(row)
+        current_size += delim + row_size
+
+    if current:
+        chunks.append(current)
+
+    return chunks
 
 
 def replay_history(
@@ -198,11 +232,6 @@ def replay_history(
             )
 
     # Rebuild league_ratings
-    if str(target_reset).strip() != FULL_RESET_LABEL:
-        supabase.table("league_ratings").delete().eq("club_id", club_id).eq("league_name", str(target_reset)).execute()
-    else:
-        supabase.table("league_ratings").delete().eq("club_id", club_id).execute()
-
     new_rows = []
     for (pid, lg), s in island_map.items():
         if str(target_reset).strip() == FULL_RESET_LABEL or str(lg).strip() == str(target_reset).strip():
@@ -229,9 +258,27 @@ def replay_history(
                 }
             )
 
-    for i in range(0, len(new_rows), 1000):
-        chunk = new_rows[i : i + 1000]
-        _exec_with_retry(lambda chunk=chunk: sb_insert(supabase, "league_ratings", chunk))
+    new_rows = sorted(new_rows, key=lambda row: (str(row.get("league_name") or ""), int(row.get("player_id") or 0)))
+    payload_chunks = _chunk_rows_by_payload_limit(new_rows, max_payload_bytes=5 * 1024 * 1024)
+
+    if not payload_chunks:
+        if str(target_reset).strip() != FULL_RESET_LABEL:
+            supabase.table("league_ratings").delete().eq("club_id", club_id).eq("league_name", str(target_reset)).execute()
+        else:
+            supabase.table("league_ratings").delete().eq("club_id", club_id).execute()
+    else:
+        for idx, chunk in enumerate(payload_chunks):
+            _exec_with_retry(
+                lambda chunk=chunk, idx=idx: sb_rpc(
+                    supabase,
+                    "replace_league_ratings",
+                    {
+                        "p_club_id": club_id,
+                        "p_rows": chunk,
+                        "p_reset": bool(idx == 0),
+                    },
+                )
+            )
 
     # Rewrite match snapshots (in-place updates on existing match rows)
     snapshot_columns = {

--- a/migrations/20260812_replace_league_ratings_rpc.sql
+++ b/migrations/20260812_replace_league_ratings_rpc.sql
@@ -1,0 +1,47 @@
+CREATE OR REPLACE FUNCTION public.replace_league_ratings(
+    p_club_id text,
+    p_rows jsonb,
+    p_reset boolean DEFAULT true
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF p_reset THEN
+        DELETE FROM league_ratings WHERE club_id = p_club_id;
+    END IF;
+
+    IF p_rows IS NULL OR jsonb_typeof(p_rows) <> 'array' OR jsonb_array_length(p_rows) = 0 THEN
+        RETURN;
+    END IF;
+
+    INSERT INTO league_ratings (
+        club_id,
+        league_name,
+        player_id,
+        rating,
+        wins,
+        losses,
+        matches_played,
+        starting_rating
+    )
+    SELECT
+        p_club_id,
+        x.league_name,
+        x.player_id,
+        x.rating,
+        x.wins,
+        x.losses,
+        x.matches_played,
+        x.starting_rating
+    FROM jsonb_to_recordset(p_rows) AS x(
+        league_name text,
+        player_id bigint,
+        rating numeric,
+        wins integer,
+        losses integer,
+        matches_played integer,
+        starting_rating numeric
+    );
+END;
+$$;

--- a/tests/test_replay_history_rpc.py
+++ b/tests/test_replay_history_rpc.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+from jupr_app.domain import replay_history
+
+
+class _Query:
+    def __init__(self, supabase: "_Supabase", table: str):
+        self.supabase = supabase
+        self.table = table
+        self.filters: list[tuple[str, object]] = []
+
+    def select(self, _fields: str):
+        return self
+
+    def eq(self, col: str, value):
+        self.filters.append((col, value))
+        return self
+
+    def order(self, *_args, **_kwargs):
+        return self
+
+    def execute(self):
+        rows = [dict(row) for row in self.supabase.tables[self.table]]
+        for col, val in self.filters:
+            rows = [r for r in rows if r.get(col) == val]
+        return SimpleNamespace(data=rows)
+
+
+class _Supabase:
+    def __init__(self):
+        self.tables = {
+            "players": [
+                {"id": 2, "club_id": "club-1", "starting_rating": 1200.0, "rating": 1200.0},
+                {"id": 1, "club_id": "club-1", "starting_rating": 1200.0, "rating": 1200.0},
+                {"id": 3, "club_id": "club-1", "starting_rating": 1200.0, "rating": 1200.0},
+                {"id": 4, "club_id": "club-1", "starting_rating": 1200.0, "rating": 1200.0},
+            ],
+            "matches": [
+                {
+                    "id": 10,
+                    "club_id": "club-1",
+                    "date": "2026-01-01T00:00:00+00:00",
+                    "league": "B League",
+                    "match_type": "League",
+                    "t1_p1": 2,
+                    "t1_p2": 1,
+                    "t2_p1": 4,
+                    "t2_p2": 3,
+                    "score_t1": 11,
+                    "score_t2": 8,
+                }
+            ],
+        }
+        self.rpc_calls: list[tuple[str, dict]] = []
+
+    def table(self, name: str):
+        return _Query(self, name)
+
+    def rpc(self, name: str, payload: dict):
+        self.rpc_calls.append((name, payload))
+        return SimpleNamespace(execute=lambda: SimpleNamespace(data=[]))
+
+
+def test_chunk_rows_by_payload_limit_splits_large_payload():
+    rows = [
+        {"league_name": "A", "player_id": 1, "rating": 1200.0, "wins": 0, "losses": 0, "matches_played": 1, "starting_rating": 1200.0},
+        {"league_name": "A", "player_id": 2, "rating": 1201.0, "wins": 1, "losses": 0, "matches_played": 1, "starting_rating": 1200.0},
+    ]
+
+    chunks = replay_history._chunk_rows_by_payload_limit(rows, max_payload_bytes=150)
+
+    assert len(chunks) == 2
+    assert chunks[0][0]["player_id"] == 1
+    assert chunks[1][0]["player_id"] == 2
+
+
+def test_replay_history_uses_replace_league_ratings_rpc(monkeypatch):
+    supabase = _Supabase()
+
+    monkeypatch.setattr(replay_history, "sb_update", lambda *args, **kwargs: SimpleNamespace(data=[]))
+
+    replay_history.replay_history(
+        supabase=supabase,
+        club_id="club-1",
+        df_meta=pd.DataFrame([{"league_name": "B League", "k_factor": 24}]),
+        target_reset="B League",
+    )
+
+    assert len(supabase.rpc_calls) == 1
+    rpc_name, payload = supabase.rpc_calls[0]
+    assert rpc_name == "replace_league_ratings"
+    assert payload["p_club_id"] == "club-1"
+    assert payload["p_reset"] is True
+    assert [row["player_id"] for row in payload["p_rows"]] == [1, 2, 3, 4]


### PR DESCRIPTION
### Motivation
- Replace Python batched inserts for `league_ratings` with a single-server Postgres RPC to dramatically reduce replay HTTP calls and avoid connection/termination errors during large replays.
- Ensure deterministic ordering of rebuilt rows and control JSON payload size to make multi-chunk uploads safe and repeatable.

### Description
- Added a new SQL migration `migrations/20260812_replace_league_ratings_rpc.sql` which defines `public.replace_league_ratings(p_club_id text, p_rows jsonb, p_reset boolean DEFAULT true)` that optionally deletes a club's existing `league_ratings` and inserts replacements via `jsonb_to_recordset`.
- Added `sb_rpc` helper in `jupr_app/data/sb_write.py` and updated `jupr_app/domain/replay_history.py` to call the RPC instead of doing Python-side batched `INSERT`s for `league_ratings`.
- Enforced deterministic ordering of rebuilt rows with `new_rows = sorted(..., key=(league_name, player_id))` and implemented payload chunking with `_json_size_bytes` and `_chunk_rows_by_payload_limit` to split JSON into <= 5MB chunks; the first chunk is sent with `p_reset=true` to clear existing rows.
- Added `tests/test_replay_history_rpc.py` to validate chunking behavior and that `replace_league_ratings` is invoked with the expected payload and ordering.

### Testing
- Ran unit tests with `pytest -q tests/test_replay_history_rpc.py tests/test_match_pipeline_idempotency.py` which resulted in `3 passed`.
- The new tests validate payload chunking and RPC invocation, and the existing idempotency test continues to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69968466acd0832692b961a7f9f4334d)