### PR TITLE
Add RPC fallback when Supabase client doesn't support upsert on_conflict

### DIFF
--- a/jupr_app/domain/player_ops.py
+++ b/jupr_app/domain/player_ops.py
@@ -48,14 +48,20 @@ def safe_add_player(
     }
 
     try:
-        resp = sb_upsert(
-            supabase,
-            "players",
-            payload,
-            conflict="club_id,normalized_name",
-        )
+        try:
+            resp = sb_upsert(
+                supabase,
+                "players",
+                payload,
+                conflict="club_id,normalized_name",
+            )
+        except TypeError:
+            # Fallback for older supabase-py clients that do not support
+            # upsert(..., on_conflict="...").
+            supabase.rpc("upsert_player_safe", {"p_payload": payload}).execute()
+            resp = None
 
-        if resp.data and len(resp.data) > 0:
+        if resp and resp.data and len(resp.data) > 0:
             return True, resp.data[0]["id"]
 
         existing = (

--- a/migrations/20260220_upsert_player_safe_rpc.sql
+++ b/migrations/20260220_upsert_player_safe_rpc.sql
@@ -1,0 +1,51 @@
+create or replace function public.upsert_player_safe(p_payload jsonb)
+returns void
+language sql
+as $$
+insert into public.players (
+  club_id,
+  name,
+  active,
+  rating,
+  starting_rating,
+  wins,
+  losses,
+  matches_played,
+  last_game_at,
+  inactive_at
+)
+select
+  r.club_id,
+  r.name,
+  coalesce(r.active, true),
+  r.rating,
+  r.starting_rating,
+  coalesce(r.wins, 0),
+  coalesce(r.losses, 0),
+  coalesce(r.matches_played, 0),
+  r.last_game_at,
+  r.inactive_at
+from jsonb_to_record(p_payload) as r(
+  club_id text,
+  name text,
+  active boolean,
+  rating numeric,
+  starting_rating numeric,
+  wins integer,
+  losses integer,
+  matches_played integer,
+  last_game_at timestamptz,
+  inactive_at timestamptz
+)
+on conflict (club_id, normalized_name)
+do update set
+  name = excluded.name,
+  active = excluded.active,
+  rating = excluded.rating,
+  starting_rating = excluded.starting_rating,
+  wins = excluded.wins,
+  losses = excluded.losses,
+  matches_played = excluded.matches_played,
+  last_game_at = excluded.last_game_at,
+  inactive_at = excluded.inactive_at;
+$$;


### PR DESCRIPTION
### Motivation
- Keep idempotent player writes while removing reliance on a chained `.on_conflict()` call path that some Python Supabase clients do not support. 
- Provide compatibility across client versions by falling back to a server-side RPC when the `upsert(..., on_conflict=...)` argument is unsupported.

### Description
- Update `safe_add_player` in `jupr_app/domain/player_ops.py` to call `sb_upsert(..., conflict="club_id,normalized_name")` normally and catch `TypeError` to fallback to `supabase.rpc("upsert_player_safe", {"p_payload": payload}).execute()` if the client does not accept `on_conflict`.
- Adjust the response check to handle the fallback path (`resp` may be `None`) before falling back to the existing lookup logic.
- Add a new SQL migration `migrations/20260220_upsert_player_safe_rpc.sql` which creates `public.upsert_player_safe(p_payload jsonb)` implementing `INSERT ... ON CONFLICT (club_id, normalized_name) DO UPDATE` semantics.

### Testing
- Ran `python -m py_compile jupr_app/domain/player_ops.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699687a9e8608326b3d8acef72e1f1e8)