### PR TITLE
PHASE 4.3 — Strict Schema Enforcement

### DIFF
--- a/jupr_app/data/load.py
+++ b/jupr_app/data/load.py
@@ -9,8 +9,6 @@ from jupr_app.domain.gamification.badge_registry import badge_schema_by_id
 from jupr_app.domain.gamification.requirements import load_requirements_map
 from jupr_app.data.schema_preflight import ensure_badge_schema_preflight
 from services.match_pipeline import submit_match
-import re
-from postgrest.exceptions import APIError
 
 
 PLAYER_BADGES_BASE_COLUMNS = [
@@ -112,15 +110,6 @@ def submit_matches_from_loader(supabase, club_id: str, matches: list[dict], chun
     return submitted
 
 
-def _missing_player_badges_columns(exc: APIError) -> set[str]:
-    message = str(exc)
-    missing = {col for col in PLAYER_BADGES_OPTIONAL_COLUMNS if col in message}
-    if missing:
-        return missing
-    matches = re.findall(r"player_badges\\.([a-zA-Z0-9_]+)", message)
-    return {col for col in matches if col in PLAYER_BADGES_OPTIONAL_COLUMNS}
-
-
 def _ensure_player_badges_columns(df: pd.DataFrame) -> pd.DataFrame:
     defaults = {
         "awarded_by": "engine",
@@ -136,38 +125,17 @@ def _ensure_player_badges_columns(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def _fetch_player_badges(supabase, club_id: str) -> tuple[pd.DataFrame, bool, str | None]:
-    schema_degraded = False
-    schema_degraded_reason = None
+def _fetch_player_badges(supabase, club_id: str) -> pd.DataFrame:
     select_cols = ",".join(PLAYER_BADGES_BASE_COLUMNS + PLAYER_BADGES_OPTIONAL_COLUMNS)
-    try:
-        pb_resp = (
-            supabase.table("player_badges")
-            .select(select_cols)
-            .eq("club_id", club_id)
-            .execute()
-        )
-    except APIError as exc:
-        missing = _missing_player_badges_columns(exc)
-        if getattr(exc, "code", None) == "42703" and missing:
-            schema_degraded = True
-            schema_degraded_reason = (
-                "player_badges missing columns "
-                f"{', '.join(sorted(missing))}; apply migrations/20260625_badge_recompute_runs.sql and "
-                "migrations/20260630_player_badges_revocation.sql."
-            )
-            legacy_select = ",".join(PLAYER_BADGES_BASE_COLUMNS)
-            pb_resp = (
-                supabase.table("player_badges")
-                .select(legacy_select)
-                .eq("club_id", club_id)
-                .execute()
-            )
-        else:
-            raise
+    pb_resp = (
+        supabase.table("player_badges")
+        .select(select_cols)
+        .eq("club_id", club_id)
+        .execute()
+    )
     df_player_badges = pd.DataFrame(pb_resp.data or [])
     df_player_badges = _ensure_player_badges_columns(df_player_badges)
-    return df_player_badges, schema_degraded, schema_degraded_reason
+    return df_player_badges
 
 
 def _drop_merged_players(df: pd.DataFrame) -> pd.DataFrame:
@@ -200,8 +168,6 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
 
     for attempt in range(max_retries):
         try:
-            schema_degraded = False
-            schema_degraded_reason = None
             # Players
             p_resp = (
                 supabase.table("players")
@@ -253,35 +219,20 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
             df_meta = pd.DataFrame(meta_resp.data or [])
 
             # Badges (global definitions)
-            try:
-                # Support older badge schema variants that lack state-related columns.
-                badges_resp = (
-                    supabase.table("badges")
-                    .select(
-                        "badge_id,name,prestige,category,is_stackable,is_active,rarity,"
-                        "tier,icon_key,scope,state,state_changed_at,state_change_reason,eval_triggers,created_at"
-                    )
-                    .execute()
+            badges_resp = (
+                supabase.table("badges")
+                .select(
+                    "badge_id,name,prestige,category,is_stackable,is_active,rarity,"
+                    "tier,icon_key,scope,state,state_changed_at,state_change_reason,eval_triggers,created_at"
                 )
-            except APIError as exc:
-                message = str(exc)
-                if getattr(exc, "code", None) == "42703" or "badges.state does not exist" in message:
-                    badges_resp = (
-                        supabase.table("badges")
-                        .select(
-                            "badge_id,name,prestige,category,is_stackable,is_active,rarity,"
-                            "tier,icon_key,scope,created_at"
-                        )
-                        .execute()
-                    )
-                else:
-                    raise
+                .execute()
+            )
             df_badges = pd.DataFrame(badges_resp.data or [])
             if not df_badges.empty and "badge_id" in df_badges.columns:
                 if "state" not in df_badges.columns:
-                    df_badges["state"] = "live"
+                    raise RuntimeError("Schema mismatch: badges.state missing.")
                 if "eval_triggers" not in df_badges.columns:
-                    df_badges["eval_triggers"] = [["match_recorded", "match_updated"]] * len(df_badges)
+                    raise RuntimeError("Schema mismatch: badges.eval_triggers missing.")
                 requirements_map = load_requirements_map()
                 df_badges["requirements"] = (
                     df_badges["badge_id"].astype(str).map(requirements_map).fillna("Requirements TBD")
@@ -301,7 +252,7 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
                 )
 
             # Player badges (club-scoped)
-            df_player_badges, schema_degraded, schema_degraded_reason = _fetch_player_badges(
+            df_player_badges = _fetch_player_badges(
                 supabase,
                 club_id,
             )
@@ -357,8 +308,8 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
                 df_player_badges,
                 name_to_id,
                 id_to_name,
-                schema_degraded,
-                schema_degraded_reason,
+                False,
+                None,
             )
 
         except Exception as e:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -38,6 +38,20 @@ def get_supabase():
     return create_client(url, service_key)
 
 
+def assert_schema_health(supabase):
+    required_tables = [
+        "players",
+        "matches",
+        "league_ratings",
+        "badges",
+        "player_badges",
+    ]
+    for table in required_tables:
+        resp = supabase.table(table).select("id").limit(1).execute()
+        if resp is None:
+            raise RuntimeError(f"Schema validation failed for table: {table}")
+
+
 @st.cache_data(ttl=30)
 def get_data(club_id: str):
     from jupr_app.data.load import load_data
@@ -144,6 +158,7 @@ def main():
         st.session_state.setdefault("entry_mode", None)
         
         supabase = get_supabase()
+        assert_schema_health(get_supabase())
         
         # --------------------------------------------
         # HANDLE SUPABASE REDIRECT FLOWS

--- a/tests/test_load_data_degraded_schema.py
+++ b/tests/test_load_data_degraded_schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import pandas as pd
+import pytest
 from postgrest.exceptions import APIError
 
 from jupr_app.data.load import load_data
@@ -61,35 +61,10 @@ class _FakeSupabase:
         return _FakeTableQuery(self, name)
 
 
-def test_load_data_degrades_player_badges_schema(monkeypatch):
+def test_load_data_fails_on_missing_player_badges_columns(monkeypatch):
     monkeypatch.setenv("JUPR_SKIP_BADGE_SCHEMA_PREFLIGHT", "1")
     supabase = _FakeSupabase()
 
-    (
-        df_players_all,
-        df_players_active,
-        df_leagues,
-        df_matches,
-        df_meta,
-        df_badges,
-        df_player_badges,
-        name_to_id,
-        id_to_name,
-        schema_degraded,
-        schema_degraded_reason,
-    ) = load_data(supabase, "club123", match_limit=5)
+    with pytest.raises(APIError):
+        load_data(supabase, "club123", match_limit=5)
 
-    assert schema_degraded is True
-    assert schema_degraded_reason is not None
-    assert "migrations/20260625_badge_recompute_runs.sql" in schema_degraded_reason
-    assert "migrations/20260630_player_badges_revocation.sql" in schema_degraded_reason
-    assert isinstance(df_player_badges, pd.DataFrame)
-    for col in [
-        "awarded_by",
-        "rule_version",
-        "eval_run_id",
-        "revoked_at",
-        "revoked_by",
-        "revoke_reason",
-    ]:
-        assert col in df_player_badges.columns


### PR DESCRIPTION
### Motivation
- Remove silent degraded-schema fallbacks so the app fails fast when DB schema is out of date after Phase 1 alignment.
- Ensure runtime behavior is strictly aligned with the expected schema to avoid hidden errors and divergent behavior.

### Description
- Removed fallback logic for `player_badges` missing columns by deleting `_missing_player_badges_columns` and the alternate legacy `select` path, and made `_fetch_player_badges` always request the full required column set (`jupr_app/data/load.py`).
- Removed badge-select fallback and added explicit guards that raise `RuntimeError` if `badges.state` or `badges.eval_triggers` are missing, instead of silently populating defaults (`jupr_app/data/load.py`).
- Added a startup schema guard `assert_schema_health(supabase)` and invoked it right after creating the Supabase client so required tables are sanity-checked at app start (`streamlit_app.py`).
- Updated the degraded-schema test to expect fail-fast behavior by asserting the loader raises when required columns are missing (`tests/test_load_data_degraded_schema.py`).

### Testing
- Ran `pytest -q tests/test_load_data_degraded_schema.py tests/test_schema_preflight.py` and the suite completed: `3 passed`.
- Ran `pytest -q tests/test_load_data_leagues_metadata.py` and it completed: `1 passed`.
- Existing tests that validated degraded/fallback behavior were updated to assert the new fail-fast behavior and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699689a994a083268fe977ac5dba1a31)