### PR TITLE
Harden replay_history with lock enforcement and deterministic behavior

### DIFF
--- a/jupr_app/domain/replay_history.py
+++ b/jupr_app/domain/replay_history.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from jupr_app.data.sb_write import sb_rpc, sb_update
 
 import json
-import random
 import time
 from typing import Any, Callable, Dict, Optional
 
@@ -26,8 +25,38 @@ def _exec_with_retry(fn, *, retries: int = 6, base_sleep: float = 0.5):
             msg = str(exc)
             if "Resource temporarily unavailable" not in msg and "ReadError" not in msg:
                 raise
-            delay = base_sleep * (2**attempt) + random.uniform(0.0, 0.2)
+            delay = base_sleep * (2**attempt)
             time.sleep(delay)
+
+
+def _set_replay_lock_running(*, supabase: Any, club_id: str) -> dict[str, Any]:
+    lock_rows = (
+        supabase.table("replay_lock")
+        .select("club_id,status")
+        .eq("club_id", str(club_id))
+        .execute()
+        .data
+    ) or []
+
+    existing = lock_rows[0] if lock_rows else None
+    if existing and str(existing.get("status") or "").lower() == "running":
+        raise RuntimeError(f"Replay already running for club_id={club_id}.")
+
+    if existing:
+        supabase.table("replay_lock").update({"status": "running"}).eq("club_id", str(club_id)).execute()
+    else:
+        supabase.table("replay_lock").insert({"club_id": str(club_id), "status": "running"}).execute()
+
+    return {
+        "club_id": str(club_id),
+        "status_before": (str(existing.get("status")) if existing else None),
+        "status_after": "running",
+        "created": bool(existing is None),
+    }
+
+
+def _set_replay_lock_status(*, supabase: Any, club_id: str, status: str) -> None:
+    supabase.table("replay_lock").update({"status": str(status)}).eq("club_id", str(club_id)).execute()
 
 
 def _json_size_bytes(payload: Any) -> int:
@@ -82,256 +111,244 @@ def replay_history(
     progress_cb: called with fraction [0..1] during match snapshot rewrites.
     """
 
-    # Load source-of-truth data
-    all_players = supabase.table("players").select("*").eq("club_id", club_id).execute().data or []
-    all_matches = (
-        supabase.table("matches")
-        .select("*")
-        .eq("club_id", club_id)
-        .order("date", desc=False)
-        .order("id", desc=False)
-        .execute()
-        .data
-    ) or []
-    row_by_id: Dict[int, Dict[str, Any]] = {}
-    for row in all_matches:
-        try:
-            row_by_id[int(row["id"])] = dict(row)
-        except Exception:
-            continue
-
-    # K map from df_meta (league_name -> k_factor)
-    k_map: Dict[str, int] = {}
-    if df_meta is not None and not df_meta.empty:
-        for _, r in df_meta.iterrows():
+    lock_info = _set_replay_lock_running(supabase=supabase, club_id=club_id)
+    try:
+        all_players = supabase.table("players").select("*").eq("club_id", club_id).execute().data or []
+        all_matches = (
+            supabase.table("matches")
+            .select("*")
+            .eq("club_id", club_id)
+            .order("date", desc=False)
+            .order("id", desc=False)
+            .execute()
+            .data
+        ) or []
+        row_by_id: Dict[int, Dict[str, Any]] = {}
+        for row in all_matches:
             try:
-                k_map[str(r["league_name"])] = int(r.get("k_factor", DEFAULT_K_FACTOR) or DEFAULT_K_FACTOR)
+                row_by_id[int(row["id"])] = dict(row)
             except Exception:
-                pass
+                continue
 
-    def k_for(lg: str) -> int:
-        return int(k_map.get(str(lg), DEFAULT_K_FACTOR))
-
-    # init overall ratings from starting_rating (fallback rating)
-    p_map: Dict[int, Dict[str, Any]] = {}
-    for p in all_players:
-        base = p.get("starting_rating", None)
-        if base is None:
-            base = p.get("rating", 1200.0)
-        try:
-            p_map[int(p["id"])] = {"r": float(base), "w": 0, "l": 0, "mp": 0}
-        except Exception:
-            continue
-
-    def ensure_player(pid: int) -> None:
-        if pid not in p_map:
-            p_map[pid] = {"r": 1200.0, "w": 0, "l": 0, "mp": 0}
-
-    def gr(pid: int) -> float:
-        ensure_player(int(pid))
-        return float(p_map[int(pid)]["r"])
-
-    island_map: Dict[tuple[int, str], Dict[str, Any]] = {}  # (pid, league) -> stats
-
-    def gir(pid: int, lg: str) -> float:
-        ensure_player(int(pid))
-        key = (int(pid), str(lg))
-        if key not in island_map:
-            island_map[key] = {"r": float(p_map[int(pid)]["r"]), "w": 0, "l": 0, "mp": 0}
-        return float(island_map[key]["r"])
-
-    matches_to_update = []
-    skipped_incomplete = 0
-
-    # Replay loop
-    for m in all_matches:
-        lg = str(m.get("league", "") or "").strip()
-
-        if str(target_reset).strip() != FULL_RESET_LABEL and lg != str(target_reset).strip():
-            continue
-
-        p1, p2, p3, p4 = m.get("t1_p1"), m.get("t1_p2"), m.get("t2_p1"), m.get("t2_p2")
-        if p1 is None or p2 is None or p3 is None or p4 is None:
-            skipped_incomplete += 1
-            continue
-
-        p1, p2, p3, p4 = int(p1), int(p2), int(p3), int(p4)
-
-        s1 = int(m.get("score_t1", 0) or 0)
-        s2 = int(m.get("score_t2", 0) or 0)
-
-        # overall start snaps
-        sr1, sr2, sr3, sr4 = gr(p1), gr(p2), gr(p3), gr(p4)
-
-        do1, do2 = calculate_hybrid_elo((sr1 + sr2) / 2, (sr3 + sr4) / 2, s1, s2, k_factor=DEFAULT_K_FACTOR)
-
-        win = s1 > s2
-        for pid, d, won_flag in [
-            (p1, do1, win),
-            (p2, do1, win),
-            (p3, do2, not win),
-            (p4, do2, not win),
-        ]:
-            ensure_player(int(pid))
-            p_map[int(pid)]["r"] += float(d)
-            p_map[int(pid)]["mp"] += 1
-            if won_flag:
-                p_map[int(pid)]["w"] += 1
-            else:
-                p_map[int(pid)]["l"] += 1
-
-        # overall end snaps
-        er1, er2, er3, er4 = gr(p1), gr(p2), gr(p3), gr(p4)
-
-        # league replay skip PopUp
-        if str(m.get("match_type", "")) != "PopUp":
-            ir1, ir2, ir3, ir4 = gir(p1, lg), gir(p2, lg), gir(p3, lg), gir(p4, lg)
-            di1, di2 = calculate_hybrid_elo((ir1 + ir2) / 2, (ir3 + ir4) / 2, s1, s2, k_factor=k_for(lg))
-            for pid, d, won_flag in [
-                (p1, di1, win),
-                (p2, di1, win),
-                (p3, di2, not win),
-                (p4, di2, not win),
-            ]:
-                key = (int(pid), lg)
-                if key not in island_map:
-                    island_map[key] = {"r": float(p_map[int(pid)]["r"]), "w": 0, "l": 0, "mp": 0}
-                island_map[key]["r"] += float(d)
-                island_map[key]["mp"] += 1
-                if won_flag:
-                    island_map[key]["w"] += 1
-                else:
-                    island_map[key]["l"] += 1
-
-        stored_elo_delta = abs(do1) if win else abs(do2)
-        matches_to_update.append(
-            {
-                "id": int(m["id"]),
-                "elo_delta": float(stored_elo_delta),
-                "t1_p1_r": float(sr1),
-                "t1_p2_r": float(sr2),
-                "t2_p1_r": float(sr3),
-                "t2_p2_r": float(sr4),
-                "t1_p1_r_end": float(er1),
-                "t1_p2_r_end": float(er2),
-                "t2_p1_r_end": float(er3),
-                "t2_p2_r_end": float(er4),
-            }
-        )
-
-    # Update players (only on full reset)
-    players_updated = False
-    if str(target_reset).strip() == FULL_RESET_LABEL:
-        players_updated = True
-        for pid, s in p_map.items():
-            _exec_with_retry(
-                lambda pid=pid, s=s: sb_update(
-                supabase,
-                "players",
-                {"rating": s["r"], "wins": s["w"], "losses": s["l"], "matches_played": s["mp"]},
-                filters={"club_id": club_id, "id": int(pid)},
-            )
-            )
-
-    # Rebuild league_ratings
-    new_rows = []
-    for (pid, lg), s in island_map.items():
-        if str(target_reset).strip() == FULL_RESET_LABEL or str(lg).strip() == str(target_reset).strip():
-            # starting_rating: use players.starting_rating if present
-            start_base = 1200.0
-            for p in all_players:
+        k_map: Dict[str, int] = {}
+        if df_meta is not None and not df_meta.empty:
+            for _, r in df_meta.iterrows():
                 try:
-                    if int(p["id"]) == int(pid):
-                        start_base = float(p.get("starting_rating", p.get("rating", 1200.0)) or 1200.0)
-                        break
+                    k_map[str(r["league_name"])] = int(r.get("k_factor", DEFAULT_K_FACTOR) or DEFAULT_K_FACTOR)
                 except Exception:
-                    continue
+                    pass
 
-            new_rows.append(
+        def k_for(lg: str) -> int:
+            return int(k_map.get(str(lg), DEFAULT_K_FACTOR))
+
+        p_map: Dict[int, Dict[str, Any]] = {}
+        for p in all_players:
+            base = p.get("starting_rating", None)
+            if base is None:
+                base = p.get("rating", 1200.0)
+            try:
+                p_map[int(p["id"])] = {"r": float(base), "w": 0, "l": 0, "mp": 0}
+            except Exception:
+                continue
+
+        def ensure_player(pid: int) -> None:
+            if pid not in p_map:
+                p_map[pid] = {"r": 1200.0, "w": 0, "l": 0, "mp": 0}
+
+        def gr(pid: int) -> float:
+            ensure_player(int(pid))
+            return float(p_map[int(pid)]["r"])
+
+        island_map: Dict[tuple[int, str], Dict[str, Any]] = {}
+
+        def gir(pid: int, lg: str) -> float:
+            ensure_player(int(pid))
+            key = (int(pid), str(lg))
+            if key not in island_map:
+                island_map[key] = {"r": float(p_map[int(pid)]["r"]), "w": 0, "l": 0, "mp": 0}
+            return float(island_map[key]["r"])
+
+        matches_to_update = []
+        skipped_incomplete = 0
+        for m in all_matches:
+            lg = str(m.get("league", "") or "").strip()
+            if str(target_reset).strip() != FULL_RESET_LABEL and lg != str(target_reset).strip():
+                continue
+
+            p1, p2, p3, p4 = m.get("t1_p1"), m.get("t1_p2"), m.get("t2_p1"), m.get("t2_p2")
+            if p1 is None or p2 is None or p3 is None or p4 is None:
+                skipped_incomplete += 1
+                continue
+            p1, p2, p3, p4 = int(p1), int(p2), int(p3), int(p4)
+
+            s1 = int(m.get("score_t1", 0) or 0)
+            s2 = int(m.get("score_t2", 0) or 0)
+
+            sr1, sr2, sr3, sr4 = gr(p1), gr(p2), gr(p3), gr(p4)
+            do1, do2 = calculate_hybrid_elo((sr1 + sr2) / 2, (sr3 + sr4) / 2, s1, s2, k_factor=DEFAULT_K_FACTOR)
+
+            win = s1 > s2
+            for pid, d, won_flag in [(p1, do1, win), (p2, do1, win), (p3, do2, not win), (p4, do2, not win)]:
+                ensure_player(int(pid))
+                p_map[int(pid)]["r"] += float(d)
+                p_map[int(pid)]["mp"] += 1
+                if won_flag:
+                    p_map[int(pid)]["w"] += 1
+                else:
+                    p_map[int(pid)]["l"] += 1
+
+            er1, er2, er3, er4 = gr(p1), gr(p2), gr(p3), gr(p4)
+
+            if str(m.get("match_type", "")) != "PopUp":
+                ir1, ir2, ir3, ir4 = gir(p1, lg), gir(p2, lg), gir(p3, lg), gir(p4, lg)
+                di1, di2 = calculate_hybrid_elo((ir1 + ir2) / 2, (ir3 + ir4) / 2, s1, s2, k_factor=k_for(lg))
+                for pid, d, won_flag in [(p1, di1, win), (p2, di1, win), (p3, di2, not win), (p4, di2, not win)]:
+                    key = (int(pid), lg)
+                    if key not in island_map:
+                        island_map[key] = {"r": float(p_map[int(pid)]["r"]), "w": 0, "l": 0, "mp": 0}
+                    island_map[key]["r"] += float(d)
+                    island_map[key]["mp"] += 1
+                    if won_flag:
+                        island_map[key]["w"] += 1
+                    else:
+                        island_map[key]["l"] += 1
+
+            stored_elo_delta = abs(do1) if win else abs(do2)
+            matches_to_update.append(
                 {
-                    "club_id": club_id,
-                    "player_id": int(pid),
-                    "league_name": str(lg),
-                    "rating": float(s["r"]),
-                    "wins": int(s["w"]),
-                    "losses": int(s["l"]),
-                    "matches_played": int(s["mp"]),
-                    "starting_rating": float(start_base),
+                    "id": int(m["id"]),
+                    "elo_delta": float(stored_elo_delta),
+                    "t1_p1_r": float(sr1),
+                    "t1_p2_r": float(sr2),
+                    "t2_p1_r": float(sr3),
+                    "t2_p2_r": float(sr4),
+                    "t1_p1_r_end": float(er1),
+                    "t1_p2_r_end": float(er2),
+                    "t2_p1_r_end": float(er3),
+                    "t2_p2_r_end": float(er4),
                 }
             )
 
-    new_rows = sorted(new_rows, key=lambda row: (str(row.get("league_name") or ""), int(row.get("player_id") or 0)))
-    payload_chunks = _chunk_rows_by_payload_limit(new_rows, max_payload_bytes=5 * 1024 * 1024)
-
-    if not payload_chunks:
-        if str(target_reset).strip() != FULL_RESET_LABEL:
-            supabase.table("league_ratings").delete().eq("club_id", club_id).eq("league_name", str(target_reset)).execute()
-        else:
-            supabase.table("league_ratings").delete().eq("club_id", club_id).execute()
-    else:
-        for idx, chunk in enumerate(payload_chunks):
-            _exec_with_retry(
-                lambda chunk=chunk, idx=idx: sb_rpc(
-                    supabase,
-                    "replace_league_ratings",
-                    {
-                        "p_club_id": club_id,
-                        "p_rows": chunk,
-                        "p_reset": bool(idx == 0),
-                    },
-                )
-            )
-
-    # Rewrite match snapshots (in-place updates on existing match rows)
-    snapshot_columns = {
-        "elo_delta",
-        "t1_p1_r",
-        "t1_p2_r",
-        "t2_p1_r",
-        "t2_p2_r",
-        "t1_p1_r_end",
-        "t1_p2_r_end",
-        "t2_p1_r_end",
-        "t2_p2_r_end",
-    }
-
-    total = len(matches_to_update)
-    chunk_size = 500
-    completed = 0
-    for chunk_index, start in enumerate(range(0, total, chunk_size), start=1):
-        chunk = matches_to_update[start : start + chunk_size]
-
-        try:
-            for row in chunk:
-                match_id = int(row["id"])
-                if match_id not in row_by_id:
-                    continue
-
-                update_payload = {k: row[k] for k in snapshot_columns if k in row}
-
+        players_updated = False
+        if str(target_reset).strip() == FULL_RESET_LABEL:
+            players_updated = True
+            for pid, s in p_map.items():
                 _exec_with_retry(
-                    lambda update_payload=update_payload, match_id=match_id: sb_update(
-                    supabase,
-                    "matches",
-                    update_payload,
-                    filters={"club_id": club_id, "id": match_id},
+                    lambda pid=pid, s=s: sb_update(
+                        supabase,
+                        "players",
+                        {"rating": s["r"], "wins": s["w"], "losses": s["l"], "matches_played": s["mp"]},
+                        filters={"club_id": club_id, "id": int(pid)},
+                    )
                 )
-                )
-        except Exception as exc:
-            raise RuntimeError(f"Failed matches update chunk {chunk_index}: {exc}") from exc
 
-        completed += len(chunk)
-        if progress_cb is not None:
+        new_rows = []
+        for (pid, lg), s in island_map.items():
+            if str(target_reset).strip() == FULL_RESET_LABEL or str(lg).strip() == str(target_reset).strip():
+                start_base = 1200.0
+                for p in all_players:
+                    try:
+                        if int(p["id"]) == int(pid):
+                            start_base = float(p.get("starting_rating", p.get("rating", 1200.0)) or 1200.0)
+                            break
+                    except Exception:
+                        continue
+                new_rows.append(
+                    {
+                        "club_id": club_id,
+                        "player_id": int(pid),
+                        "league_name": str(lg),
+                        "rating": float(s["r"]),
+                        "wins": int(s["w"]),
+                        "losses": int(s["l"]),
+                        "matches_played": int(s["mp"]),
+                        "starting_rating": float(start_base),
+                    }
+                )
+
+        new_rows = sorted(new_rows, key=lambda row: (str(row.get("league_name") or ""), int(row.get("player_id") or 0)))
+        payload_chunks = _chunk_rows_by_payload_limit(new_rows, max_payload_bytes=5 * 1024 * 1024)
+
+        if not payload_chunks:
+            if str(target_reset).strip() != FULL_RESET_LABEL:
+                supabase.table("league_ratings").delete().eq("club_id", club_id).eq("league_name", str(target_reset)).execute()
+            else:
+                supabase.table("league_ratings").delete().eq("club_id", club_id).execute()
+        else:
+            for idx, chunk in enumerate(payload_chunks):
+                _exec_with_retry(
+                    lambda chunk=chunk, idx=idx: sb_rpc(
+                        supabase,
+                        "replace_league_ratings",
+                        {
+                            "p_club_id": club_id,
+                            "p_rows": chunk,
+                            "p_reset": bool(idx == 0),
+                        },
+                    )
+                )
+
+        snapshot_columns = {
+            "elo_delta",
+            "t1_p1_r",
+            "t1_p2_r",
+            "t2_p1_r",
+            "t2_p2_r",
+            "t1_p1_r_end",
+            "t1_p2_r_end",
+            "t2_p1_r_end",
+            "t2_p2_r_end",
+        }
+
+        total = len(matches_to_update)
+        chunk_size = 500
+        completed = 0
+        for chunk_index, start in enumerate(range(0, total, chunk_size), start=1):
+            chunk = matches_to_update[start : start + chunk_size]
             try:
-                progress_cb(completed / max(1, total))
-            except Exception:
-                pass
+                for row in chunk:
+                    match_id = int(row["id"])
+                    if match_id not in row_by_id:
+                        continue
+                    update_payload = {k: row[k] for k in snapshot_columns if k in row}
+                    _exec_with_retry(
+                        lambda update_payload=update_payload, match_id=match_id: sb_update(
+                            supabase,
+                            "matches",
+                            update_payload,
+                            filters={"club_id": club_id, "id": match_id},
+                        )
+                    )
+            except Exception as exc:
+                raise RuntimeError(f"Failed matches update chunk {chunk_index}: {exc}") from exc
 
-    return {
-        "target_reset": target_reset,
-        "players_updated": players_updated,
-        "skipped_incomplete": int(skipped_incomplete),
-        "matches_rewritten": int(len(matches_to_update)),
-        "league_ratings_rows": int(len(new_rows)),
-        "matches_scanned_total": int(len(all_matches)),
-    }
+            completed += len(chunk)
+            if progress_cb is not None:
+                try:
+                    progress_cb(completed / max(1, total))
+                except Exception:
+                    pass
+
+        summary = {
+            "target_reset": target_reset,
+            "players_updated": players_updated,
+            "skipped_incomplete": int(skipped_incomplete),
+            "matches_rewritten": int(len(matches_to_update)),
+            "league_ratings_rows": int(len(new_rows)),
+            "matches_scanned_total": int(len(all_matches)),
+            "log_summary": {
+                "club_id": str(club_id),
+                "lock": {**lock_info, "final_status": "success"},
+                "constraints": {
+                    "match_player_ids_changed": False,
+                    "scores_changed": False,
+                    "league_changed": False,
+                    "matches_deleted": False,
+                },
+            },
+        }
+        _set_replay_lock_status(supabase=supabase, club_id=club_id, status="success")
+        return summary
+    except Exception:
+        _set_replay_lock_status(supabase=supabase, club_id=club_id, status="failed")
+        raise

--- a/tests/test_replay_determinism.py
+++ b/tests/test_replay_determinism.py
@@ -236,3 +236,35 @@ def test_lock_prevents_concurrent():
         raised = True
 
     assert raised
+
+
+def test_replay_history_enforces_running_lock():
+    supabase = _FakeSupabase()
+    supabase.storage["replay_lock"] = [{"club_id": "club-1", "status": "running"}]
+
+    try:
+        replay_history(supabase=supabase, club_id="club-1", df_meta=None, target_reset=FULL_RESET_LABEL)
+        raised = False
+    except RuntimeError:
+        raised = True
+
+    assert raised
+
+
+def test_replay_history_updates_lock_and_summary(monkeypatch):
+    supabase = _FakeSupabase()
+    summary = replay_history(supabase=supabase, club_id="club-1", df_meta=None, target_reset=FULL_RESET_LABEL)
+
+    assert summary["log_summary"]["lock"]["final_status"] == "success"
+    assert supabase.storage["replay_lock"][0]["status"] == "success"
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("forced")
+
+    monkeypatch.setattr("jupr_app.domain.replay_history.sb_rpc", _boom)
+    try:
+        replay_history(supabase=supabase, club_id="club-1", df_meta=None, target_reset=FULL_RESET_LABEL)
+    except RuntimeError:
+        pass
+
+    assert supabase.storage["replay_lock"][0]["status"] == "failed"

--- a/tests/test_replay_history_rpc.py
+++ b/tests/test_replay_history_rpc.py
@@ -12,6 +12,8 @@ class _Query:
         self.supabase = supabase
         self.table = table
         self.filters: list[tuple[str, object]] = []
+        self._mode = "select"
+        self._payload: dict | None = None
 
     def select(self, _fields: str):
         return self
@@ -23,8 +25,41 @@ class _Query:
     def order(self, *_args, **_kwargs):
         return self
 
+    def insert(self, payload: dict):
+        self._mode = "insert"
+        self._payload = dict(payload)
+        return self
+
+    def update(self, payload: dict):
+        self._mode = "update"
+        self._payload = dict(payload)
+        return self
+
+    def delete(self):
+        self._mode = "delete"
+        return self
+
     def execute(self):
-        rows = [dict(row) for row in self.supabase.tables[self.table]]
+        rows = self.supabase.tables.setdefault(self.table, [])
+
+        if self._mode == "insert":
+            rows.append(dict(self._payload or {}))
+            return SimpleNamespace(data=[dict(self._payload or {})])
+
+        if self._mode == "update":
+            updated = []
+            for row in rows:
+                if all(row.get(col) == val for col, val in self.filters):
+                    row.update(self._payload or {})
+                    updated.append(dict(row))
+            return SimpleNamespace(data=updated)
+
+        if self._mode == "delete":
+            kept = [dict(r) for r in rows if not all(r.get(col) == val for col, val in self.filters)]
+            self.supabase.tables[self.table] = kept
+            return SimpleNamespace(data=[])
+
+        rows = [dict(row) for row in rows]
         for col, val in self.filters:
             rows = [r for r in rows if r.get(col) == val]
         return SimpleNamespace(data=rows)
@@ -54,6 +89,7 @@ class _Supabase:
                     "score_t2": 8,
                 }
             ],
+            "replay_lock": [],
         }
         self.rpc_calls: list[tuple[str, dict]] = []
 


### PR DESCRIPTION
### Motivation
- Prevent concurrent replays and provide a clear lock lifecycle to avoid overlapping work and inconsistent state.
- Ensure replay runs are deterministic by removing non-deterministic retry jitter and by producing a consistent structured summary for logging.
- Constrain replay side-effects to the allowed targets (snapshots, `league_ratings`, and players overall ratings on full reset) and surface that as machine-readable summary info.

### Description
- Enforce `replay_lock` inside `replay_history` by reading/inserting/updating a `replay_lock` row for `club_id`, aborting if status is `running`, setting status to `running` on start, and marking `success` or `failed` on completion or error via helper functions `_set_replay_lock_running` and `_set_replay_lock_status`.
- Remove random jitter from `_exec_with_retry` backoff to make replay behavior deterministic by using pure exponential delay (`base_sleep * (2**attempt)`).
- Add a structured `log_summary` object to the return payload that includes `club_id`, lock metadata, and `constraints` flags noting that match player ids, scores, league, and deletions are not changed.
- Keep public API of `replay_history` unchanged and limit writes to match snapshot columns, `league_ratings` (via `replace_league_ratings` RPC), and players updates only on full resets; updated tests and the RPC test harness to support `replay_lock` operations.

### Testing
- Compiled the module with `python -m py_compile jupr_app/domain/replay_history.py` which succeeded.
- Ran `pytest -q tests/test_replay_determinism.py tests/test_replay_history_rpc.py` which passed (7 passed).
- Added unit tests covering lock enforcement, success/failure lock transitions, and the `replace_league_ratings` RPC usage which all succeeded under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69968f852a10832681d6189d03ed56a0)