### PR TITLE
Add structured audit logging for match pipeline operations

### DIFF
--- a/jupr_app/domain/audit_logger.py
+++ b/jupr_app/domain/audit_logger.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from jupr_app.data.sb_write import sb_insert
+
+
+def log_event(
+    *,
+    supabase: Any,
+    club_id: str,
+    actor: str,
+    action_type: str,
+    payload: Mapping[str, Any] | None = None,
+) -> None:
+    """Best-effort structured audit logging.
+
+    Audit failures must never block the primary write operation.
+    """
+    try:
+        sb_insert(
+            supabase,
+            "admin_audit_events",
+            {
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "club_id": str(club_id or "").strip(),
+                "actor": str(actor or "system"),
+                "action_type": str(action_type or "unknown"),
+                "payload_json": dict(payload or {}),
+            },
+        )
+    except Exception:
+        return
+
+
+__all__ = ["log_event"]

--- a/jupr_app/domain/bulk_match_editor.py
+++ b/jupr_app/domain/bulk_match_editor.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 # Match writes must go through match_pipeline.
 
-from jupr_app.data.sb_write import sb_insert
-
 from typing import Any, Dict, List, Optional, Set, Tuple
 import json
 
 import pandas as pd
 
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
+from jupr_app.domain.audit_logger import log_event
 from jupr_app.domain.match_pipeline import update_match
 
 def compute_recompute_scope(patches: List[Dict[str, Any]]) -> Dict[str, bool]:
@@ -55,29 +54,6 @@ def _normalize_blank_to_none(v: Any) -> Any:
     return v
 
 
-def _safe_insert_audit_event(
-    supabase,
-    payload: Dict[str, Any],
-) -> None:
-    """
-    Best-effort: if the table doesn't exist, do not fail the admin operation.
-    Recommended table shape (optional):
-      admin_audit_events(created_at timestamptz default now(), club_id text, actor text, action_type text, payload_json jsonb)
-    """
-    try:
-        sb_insert(
-            supabase,
-            "admin_audit_events",
-            {
-                "club_id": payload.get("club_id"),
-                "actor": payload.get("actor"),
-                "action_type": payload.get("action_type", "bulk_match_edit"),
-                "payload_json": payload,
-            },
-        )
-    except Exception:
-        # Intentionally swallow errors (table may not exist in some deployments)
-        return
 
 
 def apply_bulk_match_edits(
@@ -228,12 +204,14 @@ def apply_bulk_match_edits(
     recompute_scope = compute_recompute_scope(patches)
 
     # Audit event (best effort)
-    _safe_insert_audit_event(
-        supabase,
-        {
+    log_event(
+        supabase=supabase,
+        club_id=str(club_id),
+        actor=actor,
+        action_type="bulk_match_edit",
+        payload={
             "club_id": club_id,
             "actor": actor,
-            "action_type": "bulk_match_edit",
             "source": source,
             "updated_count": len(updated_ids),
             "updated_ids": updated_ids,

--- a/jupr_app/domain/match_pipeline.py
+++ b/jupr_app/domain/match_pipeline.py
@@ -25,6 +25,7 @@ from typing import Any, Mapping
 
 from jupr_app.data.retry import sb_retry
 from jupr_app.data.sb_write import sb_delete, sb_insert, sb_update, sb_upsert
+from jupr_app.domain.audit_logger import log_event
 from jupr_app.domain.constants import CAP_LOSER_GAIN_ELO, DEFAULT_K_FACTOR, MIN_WIN_DELTA_ELO
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
 from jupr_app.domain.player_activity import build_player_activity_update, coerce_utc_datetime, max_activity_time
@@ -423,12 +424,14 @@ def record_match(*, supabase: Any, club_id: str, match_payload: Mapping[str, Any
     inserted_rows: list[dict[str, Any]] = []
     inserted_match_id: int | None = None
     warnings: list[str] = []
+    operation_success = False
 
     try:
         inserted = _run_write(lambda: sb_insert(supabase, "matches", payload))
         inserted_rows = getattr(inserted, "data", None) or []
         inserted_match_id = _as_int((inserted_rows[0] or {}).get("id")) if inserted_rows else None
         rebuild = _rebuild_state(supabase=supabase, club_id=scoped_club_id)
+        operation_success = True
         return _pipeline_result(
             success=True,
             match_id=inserted_match_id,
@@ -452,6 +455,18 @@ def record_match(*, supabase: Any, club_id: str, match_payload: Mapping[str, Any
             match_id=inserted_match_id,
             warnings=warnings,
             error=str(err),
+        )
+    finally:
+        log_event(
+            supabase=supabase,
+            club_id=scoped_club_id,
+            actor=str(match_payload.get("actor") or "match_pipeline"),
+            action_type="record_match",
+            payload={
+                "match_id": inserted_match_id,
+                "success": operation_success,
+                "match_payload": dict(match_payload),
+            },
         )
 
 
@@ -478,6 +493,7 @@ def update_match(*, supabase: Any, club_id: str, match_id: int, patch: Mapping[s
     )
     match_before = dict(match_before_rows[0]) if match_before_rows else None
     warnings: list[str] = []
+    operation_success = False
 
     try:
         updated = _run_write(lambda: sb_update(
@@ -488,6 +504,7 @@ def update_match(*, supabase: Any, club_id: str, match_id: int, patch: Mapping[s
         ))
         updated_rows = getattr(updated, "data", None) or []
         rebuild = _rebuild_state(supabase=supabase, club_id=scoped_club_id)
+        operation_success = True
         return _pipeline_result(
             success=True,
             match_id=target_match_id,
@@ -514,6 +531,18 @@ def update_match(*, supabase: Any, club_id: str, match_id: int, patch: Mapping[s
             warnings=warnings,
             error=str(err),
         )
+    finally:
+        log_event(
+            supabase=supabase,
+            club_id=scoped_club_id,
+            actor=str(patch.get("actor") or "match_pipeline"),
+            action_type="update_match",
+            payload={
+                "match_id": target_match_id,
+                "success": operation_success,
+                "patch": dict(patch),
+            },
+        )
 
 
 def delete_match(*, supabase: Any, club_id: str, match_id: int) -> dict[str, Any]:
@@ -524,6 +553,7 @@ def delete_match(*, supabase: Any, club_id: str, match_id: int) -> dict[str, Any
     """
     scoped_club_id = _require_club_id(club_id)
     target_match_id = int(match_id)
+    operation_success = False
     try:
         deleted = _run_write(lambda: sb_delete(
             supabase,
@@ -531,6 +561,7 @@ def delete_match(*, supabase: Any, club_id: str, match_id: int) -> dict[str, Any
             filters={"club_id": scoped_club_id, "id": target_match_id},
         ))
         rebuild = _rebuild_state(supabase=supabase, club_id=scoped_club_id)
+        operation_success = True
         return _pipeline_result(
             success=True,
             match_id=target_match_id,
@@ -541,6 +572,14 @@ def delete_match(*, supabase: Any, club_id: str, match_id: int) -> dict[str, Any
     except Exception as exc:
         err = MatchPipelineError(f"delete_match failed: {exc}")
         return _pipeline_result(success=False, match_id=target_match_id, warnings=[], error=str(err))
+    finally:
+        log_event(
+            supabase=supabase,
+            club_id=scoped_club_id,
+            actor="match_pipeline",
+            action_type="delete_match",
+            payload={"match_id": target_match_id, "success": operation_success},
+        )
 
 
 def delete_matches(*, supabase: Any, club_id: str, match_ids: list[int]) -> dict[str, Any]:
@@ -576,6 +615,8 @@ def merge_player_into(*, supabase: Any, club_id: str, source_player_id: int, tar
     if src == dst:
         raise ValueError("source_player_id and target_player_id must differ")
 
+    operation_success = False
+    rewritten = 0
     try:
         matches = (
             supabase.table("matches")
@@ -587,7 +628,6 @@ def merge_player_into(*, supabase: Any, club_id: str, source_player_id: int, tar
             or []
         )
 
-        rewritten = 0
         for row in matches:
             match_id = int(row["id"])
             patch: dict[str, int] = {}
@@ -605,10 +645,19 @@ def merge_player_into(*, supabase: Any, club_id: str, source_player_id: int, tar
             rewritten += 1
 
         rebuild = _rebuild_state(supabase=supabase, club_id=scoped_club_id)
+        operation_success = True
         return _pipeline_result(success=True, match_id=None, warnings=[], matches_rewritten=rewritten, rebuild=rebuild)
     except Exception as exc:
         err = MatchPipelineError(f"merge_player_into failed: {exc}")
         return _pipeline_result(success=False, match_id=None, warnings=[], error=str(err))
+    finally:
+        log_event(
+            supabase=supabase,
+            club_id=scoped_club_id,
+            actor="match_pipeline",
+            action_type="merge_player",
+            payload={"source_player_id": src, "target_player_id": dst, "matches_rewritten": rewritten, "success": operation_success},
+        )
 
 
 def reassign_match_players(

--- a/tests/test_audit_logger.py
+++ b/tests/test_audit_logger.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from jupr_app.domain import audit_logger
+
+
+def test_log_event_swallows_insert_errors(monkeypatch):
+    monkeypatch.setattr(audit_logger, "sb_insert", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("no table")))
+
+    audit_logger.log_event(
+        supabase=object(),
+        club_id="club-1",
+        actor="tester",
+        action_type="record_match",
+        payload={"id": 1},
+    )
+
+
+def test_log_event_includes_required_fields(monkeypatch):
+    inserted = {}
+
+    def _fake_insert(_supabase, table, payload):
+        inserted["table"] = table
+        inserted["payload"] = payload
+
+    monkeypatch.setattr(audit_logger, "sb_insert", _fake_insert)
+
+    audit_logger.log_event(
+        supabase=object(),
+        club_id="club-1",
+        actor="tester",
+        action_type="update_match",
+        payload={"id": 2},
+    )
+
+    assert inserted["table"] == "admin_audit_events"
+    assert inserted["payload"]["club_id"] == "club-1"
+    assert inserted["payload"]["actor"] == "tester"
+    assert inserted["payload"]["action_type"] == "update_match"
+    assert inserted["payload"]["payload_json"] == {"id": 2}
+    assert inserted["payload"]["created_at"]

--- a/tests/test_match_pipeline_transactional.py
+++ b/tests/test_match_pipeline_transactional.py
@@ -89,3 +89,24 @@ def test_update_match_rolls_back_patch_and_returns_structured_error(monkeypatch)
     assert "restore_ratings" in writes
     assert writes[0][1] == {"score_t1": 1, "score_t2": 11}
     assert writes[1][2] == {"club_id": "club-1", "id": 8}
+
+
+def test_record_match_logs_audit_event(monkeypatch):
+    logged = []
+
+    monkeypatch.setattr(match_pipeline, "_run_write", lambda fn: fn())
+    monkeypatch.setattr(match_pipeline, "_snapshot_ratings_state", lambda **_: {"players": [], "league_ratings": []})
+    monkeypatch.setattr(match_pipeline, "sb_insert", lambda *_args, **_kwargs: SimpleNamespace(data=[{"id": 12}]))
+    monkeypatch.setattr(match_pipeline, "_rebuild_state", lambda **_: {"matches_processed": 1})
+    monkeypatch.setattr(match_pipeline, "log_event", lambda **payload: logged.append(payload))
+
+    result = match_pipeline.record_match(
+        supabase=object(),
+        club_id="club-1",
+        match_payload={"t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 9},
+    )
+
+    assert result["success"] is True
+    assert logged
+    assert logged[0]["action_type"] == "record_match"
+    assert logged[0]["payload"]["match_id"] == 12


### PR DESCRIPTION
### Motivation
- Provide a single, best-effort, non-blocking audit path for admin and match write operations so auditing does not interfere with match writes. 
- Ensure all key match write operations are consistently logged for observability and later analysis. 
- Replace ad-hoc `_safe_insert_audit_event` usage with a shared utility to reduce duplication and centralize behavior.

### Description
- Add a new module `jupr_app.domain.audit_logger` exposing `log_event(*, supabase, club_id, actor, action_type, payload)` which writes to `admin_audit_events` with an auto-generated UTC `created_at` timestamp and swallows errors. 
- Instrument `match_pipeline` to emit audit events for `record_match`, `update_match`, `delete_match`, and `merge_player_into` (logged as `merge_player`) using `finally` blocks so logging always runs and never blocks the primary write. 
- Refactor `jupr_app.domain.bulk_match_editor` to call `log_event` instead of maintaining its own `_safe_insert_audit_event`. 
- Add tests `tests/test_audit_logger.py` and extend `tests/test_match_pipeline_transactional.py` to assert logger behavior and that `record_match` emits an audit invocation.

### Testing
- Ran Python compilation check with `python -m py_compile jupr_app/domain/audit_logger.py jupr_app/domain/match_pipeline.py jupr_app/domain/bulk_match_editor.py tests/test_match_pipeline_transactional.py tests/test_audit_logger.py` and it succeeded. 
- Ran unit tests with `pytest -q tests/test_match_pipeline_transactional.py tests/test_audit_logger.py` which passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699692ebd440832699569de09b73e2e5)