### PR TITLE
Require idempotency_key and add idempotent pre-insert check to match pipeline

### DIFF
--- a/jupr_app/domain/match_pipeline.py
+++ b/jupr_app/domain/match_pipeline.py
@@ -177,6 +177,29 @@ def _coerce_match_payload(club_id: str, payload: Mapping[str, Any]) -> dict[str,
     return row
 
 
+def _require_idempotency_key(payload: Mapping[str, Any]) -> str:
+    key = str(payload.get("idempotency_key") or "").strip()
+    if not key:
+        raise ValueError("idempotency_key is required")
+    return key
+
+
+def _find_existing_match_by_idempotency_key(*, supabase: Any, club_id: str, idempotency_key: str) -> dict[str, Any] | None:
+    existing_rows = (
+        supabase.table("matches")
+        .select("*")
+        .eq("club_id", club_id)
+        .eq("idempotency_key", idempotency_key)
+        .limit(1)
+        .execute()
+        .data
+        or []
+    )
+    if not existing_rows:
+        return None
+    return dict(existing_rows[0])
+
+
 def _rebuild_state(*, supabase: Any, club_id: str) -> dict[str, int]:
     """Rebuild all match-derived projections for a single club deterministically."""
     players_rows = (
@@ -419,6 +442,38 @@ def record_match(*, supabase: Any, club_id: str, match_payload: Mapping[str, Any
     queue side-effects stay in sync.
     """
     scoped_club_id = _require_club_id(club_id)
+    scoped_idempotency_key = _require_idempotency_key(match_payload)
+
+    # Migration expectation: enforce DB uniqueness with
+    #   UNIQUE (club_id, idempotency_key)
+    # on matches to guarantee race-safe, cross-process idempotency.
+    existing_match = _find_existing_match_by_idempotency_key(
+        supabase=supabase,
+        club_id=scoped_club_id,
+        idempotency_key=scoped_idempotency_key,
+    )
+    if existing_match:
+        existing_match_id = _as_int(existing_match.get("id"))
+        log_event(
+            supabase=supabase,
+            club_id=scoped_club_id,
+            actor=str(match_payload.get("actor") or "match_pipeline"),
+            action_type="record_match",
+            payload={
+                "match_id": existing_match_id,
+                "success": True,
+                "idempotent_hit": True,
+                "match_payload": dict(match_payload),
+            },
+        )
+        return _pipeline_result(
+            success=True,
+            match_id=existing_match_id,
+            warnings=[],
+            existing=existing_match,
+            idempotent_hit=True,
+        )
+
     payload = _coerce_match_payload(scoped_club_id, match_payload)
     snapshot = _snapshot_ratings_state(supabase=supabase, club_id=scoped_club_id)
     inserted_rows: list[dict[str, Any]] = []

--- a/jupr_app/domain/tournaments/sync.py
+++ b/jupr_app/domain/tournaments/sync.py
@@ -1,8 +1,26 @@
 from __future__ import annotations
 # Match writes must go through match_pipeline.
+import hashlib
 from typing import Any
 
 from jupr_app.domain.match_pipeline import record_match, update_match
+
+
+def _build_tournament_match_idempotency_key(*, club_id: str, game_id: str, common_fields: dict[str, Any]) -> str:
+    seed = "|".join(
+        [
+            str(club_id).strip(),
+            str(game_id).strip(),
+            str(common_fields.get("tournament_id") or "").strip(),
+            str(common_fields.get("tournament_game_id") or "").strip(),
+            str(common_fields.get("t1_p1") or ""),
+            str(common_fields.get("t1_p2") or ""),
+            str(common_fields.get("t2_p1") or ""),
+            str(common_fields.get("t2_p2") or ""),
+        ]
+    )
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+    return f"tournament:{club_id}:{game_id}:{digest}"
 
 
 def sync_tournament_game_to_match(
@@ -53,6 +71,11 @@ def sync_tournament_game_to_match(
     }
 
     if not existing_rows:
+        idempotency_key = _build_tournament_match_idempotency_key(
+            club_id=str(club_id),
+            game_id=str(game_id),
+            common_fields=common_fields,
+        )
         record_match(
             supabase=supabase,
             club_id=str(club_id),
@@ -60,6 +83,7 @@ def sync_tournament_game_to_match(
                 **common_fields,
                 "context_type": "tournament",
                 "context_id": str(match_payload.get("tournament_id") or game.get("tournament_id") or ""),
+                "idempotency_key": idempotency_key,
             },
         )
         return

--- a/tests/test_match_pipeline_idempotency.py
+++ b/tests/test_match_pipeline_idempotency.py
@@ -5,114 +5,68 @@ from types import SimpleNamespace
 from jupr_app.domain import match_pipeline
 
 
-class DummyQuery:
-    def __init__(self, supabase: "DummySupabase", table_name: str) -> None:
-        self.supabase = supabase
-        self.table_name = table_name
-        self._filters: list[tuple[str, object, str]] = []
-        self._limit: int | None = None
-        self._payload = None
-        self._on_conflict = None
-        self._ignore_duplicates = False
+class _Query:
+    def __init__(self, rows):
+        self._rows = rows
 
     def select(self, _fields: str):
         return self
 
-    def eq(self, col: str, value):
-        self._filters.append((col, value, "eq"))
+    def eq(self, _col: str, _value):
         return self
 
-    def in_(self, col: str, values):
-        self._filters.append((col, list(values), "in"))
-        return self
-
-    def limit(self, value: int):
-        self._limit = int(value)
-        return self
-
-    def upsert(self, payload, on_conflict=None, ignore_duplicates=False):
-        self._payload = dict(payload)
-        self._on_conflict = on_conflict
-        self._ignore_duplicates = bool(ignore_duplicates)
+    def limit(self, _n: int):
         return self
 
     def execute(self):
-        if self._payload is not None:
-            return self._execute_upsert()
-        return self._execute_select()
-
-    def _execute_select(self):
-        rows = [dict(row) for row in self.supabase.tables[self.table_name]]
-        for col, value, mode in self._filters:
-            if mode == "eq":
-                rows = [row for row in rows if row.get(col) == value]
-            elif mode == "in":
-                rows = [row for row in rows if row.get(col) in value]
-        if self._limit is not None:
-            rows = rows[: self._limit]
-        return SimpleNamespace(data=rows)
-
-    def _execute_upsert(self):
-        if self.table_name != "matches":
-            raise AssertionError("unexpected upsert table")
-        key = self._payload.get("idempotency_key")
-        existing = None
-        for row in self.supabase.tables["matches"]:
-            if row.get(self._on_conflict) == key:
-                existing = row
-                break
-
-        if existing is not None and self._ignore_duplicates:
-            return SimpleNamespace(data=[])
-
-        if existing is not None:
-            existing.update(self._payload)
-            return SimpleNamespace(data=[dict(existing)])
-
-        inserted = dict(self._payload)
-        inserted.setdefault("id", f"m{len(self.supabase.tables['matches']) + 1}")
-        self.supabase.tables["matches"].append(inserted)
-        return SimpleNamespace(data=[dict(inserted)])
+        return SimpleNamespace(data=self._rows)
 
 
-class DummySupabase:
-    def __init__(self) -> None:
-        self.tables = {
-            "players": [
-                {"id": 1, "club_id": "club-1", "rating": 1200.0, "last_game_at": None},
-                {"id": 2, "club_id": "club-1", "rating": 1200.0, "last_game_at": None},
-            ],
-            "matches": [],
-        }
+class _Supabase:
+    def __init__(self, existing_rows=None):
+        self._existing_rows = existing_rows or []
 
     def table(self, name: str):
-        return DummyQuery(self, name)
+        assert name == "matches"
+        return _Query(self._existing_rows)
 
 
-def test_record_match_replay_is_idempotent(monkeypatch, capsys):
-    supabase = DummySupabase()
-    player_updates = []
+def test_record_match_idempotency_hit_returns_existing_and_skips_rebuild(monkeypatch):
+    supabase = _Supabase(existing_rows=[{"id": 9, "idempotency_key": "dup-1", "club_id": "club-1"}])
+    rebuild_calls = []
 
-    def fake_sb_update(_supabase, _table, payload, *, filters):
-        player_updates.append((dict(filters), dict(payload)))
-        return SimpleNamespace(data=[{"ok": True}])
+    monkeypatch.setattr(match_pipeline, "_rebuild_state", lambda **_: rebuild_calls.append(True))
+    monkeypatch.setattr(match_pipeline, "log_event", lambda **_: None)
 
-    monkeypatch.setattr(match_pipeline, "sb_update", fake_sb_update)
-    monkeypatch.setattr(match_pipeline, "sb_upsert", lambda *args, **kwargs: SimpleNamespace(data=[{"ok": True}]))
+    result = match_pipeline.record_match(
+        supabase=supabase,
+        club_id="club-1",
+        match_payload={"idempotency_key": "dup-1", "score_t1": 11, "score_t2": 9},
+    )
 
-    payload = {
-        "club_id": "club-1",
-        "team_a_player_ids": [1],
-        "team_b_player_ids": [2],
-        "score_a": 11,
-        "score_b": 9,
-        "played_at": "2026-01-01T00:00:00+00:00",
-    }
+    assert result["success"] is True
+    assert result["idempotent_hit"] is True
+    assert result["match_id"] == 9
+    assert rebuild_calls == []
 
-    first = match_pipeline.record_match(supabase, **payload)
-    second = match_pipeline.record_match(supabase, **payload)
 
-    assert first["status"] == "inserted"
-    assert second["status"] == "exists"
-    assert len(player_updates) == 2
-    assert "[PIPELINE] idempotent hit — skipping delta" in capsys.readouterr().out
+def test_record_match_new_idempotency_inserts_and_rebuilds(monkeypatch):
+    supabase = _Supabase(existing_rows=[])
+    rebuild_calls = []
+
+    monkeypatch.setattr(match_pipeline, "_run_write", lambda fn: fn())
+    monkeypatch.setattr(match_pipeline, "_snapshot_ratings_state", lambda **_: {"players": [], "league_ratings": []})
+    monkeypatch.setattr(match_pipeline, "sb_insert", lambda *_args, **_kwargs: SimpleNamespace(data=[{"id": 10}]))
+    monkeypatch.setattr(match_pipeline, "_rebuild_state", lambda **_: rebuild_calls.append(True) or {"matches_processed": 1})
+    monkeypatch.setattr(match_pipeline, "log_event", lambda **_: None)
+
+    result = match_pipeline.record_match(
+        supabase=supabase,
+        club_id="club-1",
+        match_payload={"idempotency_key": "new-1", "score_t1": 11, "score_t2": 9},
+    )
+
+    assert result["success"] is True
+    assert result.get("idempotent_hit") is not True
+    assert result["match_id"] == 10
+    assert rebuild_calls == [True]

--- a/tests/test_match_pipeline_transactional.py
+++ b/tests/test_match_pipeline_transactional.py
@@ -36,6 +36,7 @@ def test_record_match_rolls_back_and_returns_structured_error(monkeypatch):
     writes = []
 
     monkeypatch.setattr(match_pipeline, "_run_write", lambda fn: fn())
+    monkeypatch.setattr(match_pipeline, "_find_existing_match_by_idempotency_key", lambda **_: None)
     monkeypatch.setattr(match_pipeline, "_snapshot_ratings_state", lambda **_: {"players": [], "league_ratings": []})
     monkeypatch.setattr(match_pipeline, "_restore_ratings_state", lambda **_: writes.append("restore_ratings"))
     monkeypatch.setattr(match_pipeline, "sb_insert", lambda *_args, **_kwargs: SimpleNamespace(data=[{"id": 42}]))
@@ -49,7 +50,15 @@ def test_record_match_rolls_back_and_returns_structured_error(monkeypatch):
     result = match_pipeline.record_match(
         supabase=object(),
         club_id="club-1",
-        match_payload={"t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 9},
+        match_payload={
+            "idempotency_key": "key-1",
+            "t1_p1": 1,
+            "t1_p2": 2,
+            "t2_p1": 3,
+            "t2_p2": 4,
+            "score_t1": 11,
+            "score_t2": 9,
+        },
     )
 
     assert result["success"] is False
@@ -65,6 +74,7 @@ def test_update_match_rolls_back_patch_and_returns_structured_error(monkeypatch)
     supabase = _DummySupabase(match_rows=[{"id": 8, "score_t1": 11, "score_t2": 9, "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4}])
 
     monkeypatch.setattr(match_pipeline, "_run_write", lambda fn: fn())
+    monkeypatch.setattr(match_pipeline, "_find_existing_match_by_idempotency_key", lambda **_: None)
     monkeypatch.setattr(match_pipeline, "_snapshot_ratings_state", lambda **_: {"players": [], "league_ratings": []})
     monkeypatch.setattr(match_pipeline, "_restore_ratings_state", lambda **_: writes.append("restore_ratings"))
 
@@ -95,6 +105,7 @@ def test_record_match_logs_audit_event(monkeypatch):
     logged = []
 
     monkeypatch.setattr(match_pipeline, "_run_write", lambda fn: fn())
+    monkeypatch.setattr(match_pipeline, "_find_existing_match_by_idempotency_key", lambda **_: None)
     monkeypatch.setattr(match_pipeline, "_snapshot_ratings_state", lambda **_: {"players": [], "league_ratings": []})
     monkeypatch.setattr(match_pipeline, "sb_insert", lambda *_args, **_kwargs: SimpleNamespace(data=[{"id": 12}]))
     monkeypatch.setattr(match_pipeline, "_rebuild_state", lambda **_: {"matches_processed": 1})
@@ -103,10 +114,51 @@ def test_record_match_logs_audit_event(monkeypatch):
     result = match_pipeline.record_match(
         supabase=object(),
         club_id="club-1",
-        match_payload={"t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 9},
+        match_payload={
+            "idempotency_key": "key-1",
+            "t1_p1": 1,
+            "t1_p2": 2,
+            "t2_p1": 3,
+            "t2_p2": 4,
+            "score_t1": 11,
+            "score_t2": 9,
+        },
     )
 
     assert result["success"] is True
     assert logged
     assert logged[0]["action_type"] == "record_match"
     assert logged[0]["payload"]["match_id"] == 12
+
+
+def test_record_match_requires_idempotency_key():
+    try:
+        match_pipeline.record_match(
+            supabase=object(),
+            club_id="club-1",
+            match_payload={"score_t1": 11, "score_t2": 9},
+        )
+        assert False, "expected ValueError"
+    except ValueError as exc:
+        assert "idempotency_key is required" in str(exc)
+
+
+def test_record_match_returns_existing_on_idempotency_hit(monkeypatch):
+    existing = {"id": 55, "club_id": "club-1", "idempotency_key": "dup-key"}
+    rebuild_calls = []
+
+    monkeypatch.setattr(match_pipeline, "_find_existing_match_by_idempotency_key", lambda **_: existing)
+    monkeypatch.setattr(match_pipeline, "_rebuild_state", lambda **_: rebuild_calls.append(True))
+    monkeypatch.setattr(match_pipeline, "log_event", lambda **_: None)
+
+    result = match_pipeline.record_match(
+        supabase=object(),
+        club_id="club-1",
+        match_payload={"idempotency_key": "dup-key", "score_t1": 11, "score_t2": 9},
+    )
+
+    assert result["success"] is True
+    assert result["match_id"] == 55
+    assert result["idempotent_hit"] is True
+    assert result["existing"]["id"] == 55
+    assert rebuild_calls == []


### PR DESCRIPTION
### Motivation
- Prevent duplicate rating deltas and side-effects from replay/multi-click match submissions by enforcing idempotency at the canonical write path.  
- Make record-match writes deterministic and safe across processes by requiring callers to provide an idempotency signature and returning an existing match when present.  

### Description
- Require an idempotency key for `record_match` by adding `_require_idempotency_key` and raising `ValueError` when missing, so callers must provide `idempotency_key`. (`jupr_app/domain/match_pipeline.py`).
- Add `_find_existing_match_by_idempotency_key` and a pre-insert lookup scoped to `(club_id, idempotency_key)` that returns the existing match immediately and skips rebuild/rating delta work when a hit occurs; returned payload includes `idempotent_hit` and `existing`. (`jupr_app/domain/match_pipeline.py`).
- Document expected DB migration: enforce `UNIQUE (club_id, idempotency_key)` on `matches` to make idempotency race-safe across processes (comment in `record_match`).
- Generate and pass deterministic idempotency keys for tournament-sync submissions by adding `_build_tournament_match_idempotency_key` and wiring it into the tournament flow so that UI/admin/tournament paths are protected from duplicate inserts. (`jupr_app/domain/tournaments/sync.py`).
- Update tests to exercise the new requirement and behavior by modifying/adding assertions in `tests/test_match_pipeline_transactional.py` and `tests/test_match_pipeline_idempotency.py` to cover required idempotency key, idempotent-hit returns (no rebuild), and normal insert+rebuild paths. (`tests/...`).

### Testing
- Ran the focused unit tests: `pytest -q tests/test_match_pipeline_transactional.py tests/test_match_pipeline_idempotency.py`, and all tests passed (`7 passed`).
- The changes are covered by the updated tests which simulate existing-match lookup, insert rollback, and idempotency-hit behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699693c3d9c083268d546bccc5278368)