### PR TITLE
Unify match pipeline and remove duplicate rating mutation path

### DIFF
--- a/jupr_app/domain/match_pipeline.py
+++ b/jupr_app/domain/match_pipeline.py
@@ -20,16 +20,12 @@ from __future__ import annotations
 
 # Match writes must go through match_pipeline.
 
-from datetime import datetime, timezone
 from typing import Any, Mapping
 
 from jupr_app.data.retry import sb_retry
 from jupr_app.data.sb_write import sb_delete, sb_insert, sb_update, sb_upsert
 from jupr_app.domain.audit_logger import log_event
-from jupr_app.domain.constants import CAP_LOSER_GAIN_ELO, DEFAULT_K_FACTOR, MIN_WIN_DELTA_ELO
-from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
-from jupr_app.domain.player_activity import build_player_activity_update, coerce_utc_datetime, max_activity_time
-from jupr_app.domain.ratings import calculate_hybrid_elo
+from jupr_app.domain.replay_history import FULL_RESET_LABEL, replay_history
 
 _ALLOWED_MATCH_KEYS = {
     "date",
@@ -221,236 +217,17 @@ def _find_existing_match_by_idempotency_key(*, supabase: Any, club_id: str, idem
 
 
 def _rebuild_state(*, supabase: Any, club_id: str) -> dict[str, int]:
-    """Rebuild all match-derived projections for a single club deterministically."""
-    players_rows = (
-        supabase.table("players")
-        .select("id,rating,starting_rating,created_at,last_game_at")
-        .eq("club_id", club_id)
-        .execute()
-        .data
-        or []
+    """Replay historical matches to refresh snapshots and derived ratings."""
+    replay = replay_history(
+        supabase=supabase,
+        club_id=club_id,
+        df_meta=None,
+        target_reset=FULL_RESET_LABEL,
     )
-    matches = (
-        supabase.table("matches")
-        .select("id,date,league,match_type,score_t1,score_t2,t1_p1,t1_p2,t2_p1,t2_p2")
-        .eq("club_id", club_id)
-        .order("date", desc=False)
-        .order("id", desc=False)
-        .execute()
-        .data
-        or []
-    )
-
-    player_state: dict[int, dict[str, Any]] = {}
-    for row in players_rows:
-        pid = _as_int(row.get("id"))
-        if pid is None:
-            continue
-        base_rating = row.get("starting_rating")
-        if base_rating is None:
-            base_rating = row.get("rating", 1200.0)
-        player_state[pid] = {
-            "r": float(base_rating or 1200.0),
-            "base_rating": float(base_rating or 1200.0),
-            "w": 0,
-            "l": 0,
-            "mp": 0,
-            "created_at": row.get("created_at"),
-            "existing_last_game_at": row.get("last_game_at"),
-        }
-
-    league_state: dict[tuple[int, str], dict[str, Any]] = {}
-    match_snapshot_updates: list[tuple[int, dict[str, Any], dict[str, Any]]] = []
-
-    def ensure_player(pid: int) -> None:
-        if pid in player_state:
-            return
-        player_state[pid] = {
-            "r": 1200.0,
-            "base_rating": 1200.0,
-            "w": 0,
-            "l": 0,
-            "mp": 0,
-            "created_at": None,
-            "existing_last_game_at": None,
-        }
-
-    last_game_updates: dict[int, datetime] = {}
-
-    for row in matches:
-        mid = _as_int(row.get("id"))
-        if mid is None:
-            continue
-
-        slots = [_as_int(row.get(k)) for k in _SLOT_KEYS]
-        if any(pid is None for pid in slots):
-            continue
-        p1, p2, p3, p4 = (int(slots[0]), int(slots[1]), int(slots[2]), int(slots[3]))
-
-        s1 = int(row.get("score_t1") or 0)
-        s2 = int(row.get("score_t2") or 0)
-        if (s1 + s2) <= 0:
-            continue
-
-        for pid in (p1, p2, p3, p4):
-            ensure_player(pid)
-
-        sr1 = float(player_state[p1]["r"])
-        sr2 = float(player_state[p2]["r"])
-        sr3 = float(player_state[p3]["r"])
-        sr4 = float(player_state[p4]["r"])
-
-        do1, do2 = calculate_hybrid_elo(
-            (sr1 + sr2) / 2.0,
-            (sr3 + sr4) / 2.0,
-            s1,
-            s2,
-            k_factor=float(DEFAULT_K_FACTOR),
-            min_win_delta=float(MIN_WIN_DELTA_ELO),
-            cap_loser_gain=float(CAP_LOSER_GAIN_ELO),
-        )
-
-        t1_won = s1 > s2
-        t2_won = s2 > s1
-
-        for pid, delta, won in ((p1, do1, t1_won), (p2, do1, t1_won), (p3, do2, t2_won), (p4, do2, t2_won)):
-            player_state[pid]["r"] = float(player_state[pid]["r"]) + float(delta)
-            player_state[pid]["mp"] = int(player_state[pid]["mp"]) + 1
-            if s1 != s2:
-                if won:
-                    player_state[pid]["w"] = int(player_state[pid]["w"]) + 1
-                else:
-                    player_state[pid]["l"] = int(player_state[pid]["l"]) + 1
-
-        er1 = float(player_state[p1]["r"])
-        er2 = float(player_state[p2]["r"])
-        er3 = float(player_state[p3]["r"])
-        er4 = float(player_state[p4]["r"])
-
-        league_name = str(row.get("league") or "").strip()
-        is_popup = str(row.get("match_type") or "") == "PopUp"
-        if league_name and not is_popup:
-            for pid in (p1, p2, p3, p4):
-                key = (pid, league_name)
-                if key not in league_state:
-                    league_state[key] = {"r": float(player_state[pid]["r"]), "w": 0, "l": 0, "mp": 0}
-            li1, li2 = calculate_hybrid_elo(
-                (float(league_state[(p1, league_name)]["r"]) + float(league_state[(p2, league_name)]["r"])) / 2.0,
-                (float(league_state[(p3, league_name)]["r"]) + float(league_state[(p4, league_name)]["r"])) / 2.0,
-                s1,
-                s2,
-                k_factor=float(DEFAULT_K_FACTOR),
-                min_win_delta=float(MIN_WIN_DELTA_ELO),
-                cap_loser_gain=float(CAP_LOSER_GAIN_ELO),
-            )
-            for pid, delta, won in ((p1, li1, t1_won), (p2, li1, t1_won), (p3, li2, t2_won), (p4, li2, t2_won)):
-                key = (pid, league_name)
-                league_state[key]["r"] = float(league_state[key]["r"]) + float(delta)
-                league_state[key]["mp"] = int(league_state[key]["mp"]) + 1
-                if s1 != s2:
-                    if won:
-                        league_state[key]["w"] = int(league_state[key]["w"]) + 1
-                    else:
-                        league_state[key]["l"] = int(league_state[key]["l"]) + 1
-
-        match_dt = coerce_utc_datetime(row.get("date")) or datetime.fromtimestamp(0, timezone.utc)
-        for pid in (p1, p2, p3, p4):
-            last_game_updates[pid] = max_activity_time(last_game_updates.get(pid), match_dt) or match_dt
-
-        snapshot = {
-            "elo_delta": float(abs(do1) if t1_won else abs(do2)),
-            "t1_p1_r": sr1,
-            "t1_p2_r": sr2,
-            "t2_p1_r": sr3,
-            "t2_p2_r": sr4,
-            "t1_p1_r_end": er1,
-            "t1_p2_r_end": er2,
-            "t2_p1_r_end": er3,
-            "t2_p2_r_end": er4,
-        }
-        badge_payload = {
-            "match_id": str(mid),
-            "score_t1": s1,
-            "score_t2": s2,
-            "t1_p1": p1,
-            "t1_p2": p2,
-            "t2_p1": p3,
-            "t2_p2": p4,
-            "t1_p1_r": sr1,
-            "t1_p2_r": sr2,
-            "t2_p1_r": sr3,
-            "t2_p2_r": sr4,
-        }
-        match_snapshot_updates.append((mid, snapshot, badge_payload))
-
-    for match_id, snapshot, badge_payload in match_snapshot_updates:
-        _run_write(lambda match_id=match_id, snapshot=snapshot: sb_update(
-            supabase,
-            "matches",
-            snapshot,
-            filters=_scoped_filters(club_id, {"club_id": club_id, "id": int(match_id)}),
-        ))
-        _run_write(lambda badge_payload=badge_payload: enqueue_badge_eval(
-            supabase,
-            club_id=club_id,
-            event_type="match_recorded",
-            player_ids=[
-                int(badge_payload["t1_p1"]),
-                int(badge_payload["t1_p2"]),
-                int(badge_payload["t2_p1"]),
-                int(badge_payload["t2_p2"]),
-            ],
-            context_id="overall",
-            match_id=str(badge_payload["match_id"]),
-            payload=badge_payload,
-        ))
-
-    for pid, state in player_state.items():
-        latest_match = last_game_updates.get(pid)
-        activity_update = build_player_activity_update(state.get("existing_last_game_at"), latest_match)
-        payload = {
-            "rating": float(state["r"]),
-            "wins": int(state["w"]),
-            "losses": int(state["l"]),
-            "matches_played": int(state["mp"]),
-        }
-        payload.update(activity_update)
-        _run_write(lambda pid=pid, payload=payload: sb_update(
-            supabase,
-            "players",
-            payload,
-            filters=_scoped_filters(club_id, {"club_id": club_id, "id": int(pid)}),
-        ))
-
-    _run_write(lambda: sb_delete(
-        supabase,
-        "league_ratings",
-        filters=_scoped_filters(club_id, {"club_id": club_id}),
-    ))
-    for (pid, league_name), state in league_state.items():
-        payload = {
-            "club_id": club_id,
-            "player_id": int(pid),
-            "league_name": str(league_name),
-            "rating": float(state["r"]),
-            "wins": int(state["w"]),
-            "losses": int(state["l"]),
-            "matches_played": int(state["mp"]),
-            "starting_rating": float(player_state.get(pid, {}).get("base_rating", 1200.0)),
-            "is_active": True,
-            "inactive_at": None,
-        }
-        _run_write(lambda payload=payload: sb_upsert(
-            supabase,
-            "league_ratings",
-            _scoped_payload(club_id, payload),
-            conflict="club_id,player_id,league_name",
-        ))
-
     return {
-        "matches_processed": len(match_snapshot_updates),
-        "players_updated": len(player_state),
-        "league_rows_upserted": len(league_state),
+        "matches_processed": int(replay.get("matches_rewritten") or 0),
+        "players_updated": int(replay.get("players_updated") or 0),
+        "league_rows_upserted": int(replay.get("league_ratings_rows") or 0),
     }
 
 

--- a/services/match_pipeline.py
+++ b/services/match_pipeline.py
@@ -1,23 +1,12 @@
-"""Canonical match submission pipeline (infrastructure stub only).
-
-This module provides a single future-facing entry point (`submit_match`) for
-consolidating match write logic across league, ladder, tournament, and admin
-contexts.
-
-Constraints for this initial infrastructure PR:
-- Additive only: no integration with existing flows.
-- No behavior changes to current application paths beyond canonical match insert.
-- Non-insert helpers remain explicit stubs.
-"""
+"""Compatibility wrapper around the canonical domain match pipeline."""
 
 from __future__ import annotations
 
-from jupr_app.data.sb_write import sb_insert, sb_update, sb_upsert
-
 import os
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Literal, Mapping
 
 from jupr_app.data.client import make_supabase
+from jupr_app.domain.match_pipeline import record_match
 
 _ALLOWED_CONTEXT_TYPES = {"league", "ladder", "tournament", "round_robin", "moneyball", "admin"}
 
@@ -25,9 +14,7 @@ _ALLOWED_CONTEXT_TYPES = {"league", "ladder", "tournament", "round_robin", "mone
 def get_supabase_client() -> Any:
     """Build a Supabase client from environment credentials."""
     supabase_url = os.getenv("SUPABASE_URL", "")
-    supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "") or os.getenv(
-        "SUPABASE_KEY", ""
-    )
+    supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "") or os.getenv("SUPABASE_KEY", "")
 
     if not supabase_url or not supabase_key:
         raise ValueError(
@@ -40,273 +27,27 @@ def get_supabase_client() -> Any:
 def submit_match(
     club_id: str,
     context_type: Literal["league", "ladder", "tournament", "round_robin", "moneyball", "admin"],
-    context_id: Optional[str],
-    match_payload: Dict[str, Any],
-    idempotency_key: Optional[str] = None,
+    context_id: str | None,
+    match_payload: Mapping[str, Any],
+    idempotency_key: str | None = None,
     run_context_hooks: bool = True,
-) -> Dict[str, Any]:
-    """Validate input and route to canonical pipeline steps.
-
-    The canonical insert step writes to Supabase and enforces idempotency when
-    an idempotency key is provided. Other downstream stages remain no-op stubs.
-    """
-    if not club_id or not isinstance(club_id, str):
-        raise ValueError("club_id must be a non-empty string")
-
+) -> dict[str, Any]:
+    """Delegate legacy service entrypoint to `jupr_app.domain.match_pipeline.record_match`."""
     if context_type not in _ALLOWED_CONTEXT_TYPES:
         raise ValueError(
             "context_type must be one of: league, ladder, tournament, round_robin, moneyball, admin"
         )
 
-    if not isinstance(match_payload, dict):
-        raise ValueError("match_payload must be a dict")
-
-    insert_result = _insert_match_record(
-        club_id=club_id,
-        context_type=context_type,
-        context_id=context_id,
-        match_payload=match_payload,
-        idempotency_key=idempotency_key,
-    )
-    rating_result = _apply_rating_engine_stub(match_payload=match_payload)
-    hooks_result: Dict[str, Any]
-    if run_context_hooks:
-        hooks_result = _run_context_hooks(
-            club_id=club_id,
-            context_type=context_type,
-            context_id=context_id,
-            match_payload=match_payload,
-            rating_result=rating_result,
-        )
-    else:
-        hooks_result = {
-            "stub": True,
-            "name": "run_context_hooks",
-            "action": "skipped_by_flag",
-        }
-
-    return {
-        "ok": True,
-        "status": "inserted_with_stubbed_post_steps",
-        "message": "Canonical submit_match pipeline executed. Insert is live; downstream steps are currently stubs.",
-        "club_id": club_id,
-        "context_type": context_type,
-        "context_id": context_id,
-        "idempotency_key": idempotency_key,
-        "insert": insert_result,
-        "rating": rating_result,
-        "hooks": hooks_result,
-    }
-
-
-def _insert_match_record(
-    club_id: str,
-    context_type: str,
-    context_id: Optional[str],
-    match_payload: Dict[str, Any],
-    idempotency_key: Optional[str],
-) -> Dict[str, Any]:
-    """Insert a match row, returning the existing row when idempotency matches.
-
-    This function checks for an existing `(club_id, idempotency_key)` match
-    before insert. If one exists, it is returned directly and no insert is
-    performed.
-    """
-    supabase = get_supabase_client()
-
-    if idempotency_key:
-        existing_response = (
-            supabase.table("matches")
-            .select("*")
-            .eq("club_id", club_id)
-            .eq("idempotency_key", idempotency_key)
-            .limit(1)
-            .execute()
-        )
-        existing_rows = getattr(existing_response, "data", None) or []
-        if existing_rows:
-            return dict(existing_rows[0])
-
-    ALLOWED_MATCH_COLUMNS = {
-        "t1_p1", "t1_p2", "t2_p1", "t2_p2",
-        "score_t1", "score_t2",
-        "elo_delta", "elo_delta_t1", "elo_delta_t2",
-        "t1_p1_r", "t1_p1_r_end",
-        "t1_p2_r", "t1_p2_r_end",
-        "t2_p1_r", "t2_p1_r_end",
-        "t2_p2_r", "t2_p2_r_end",
-        "league", "match_type", "week_tag",
-        "tournament_id", "tournament_game_id",
-        "date",
-    }
-
-    payload: Dict[str, Any] = {
-        k: v for k, v in match_payload.items()
-        if k in ALLOWED_MATCH_COLUMNS
-    }
-
-    payload["club_id"] = club_id
+    payload = dict(match_payload or {})
     payload["context_type"] = context_type
     payload["context_id"] = context_id
-
-    if idempotency_key:
+    if idempotency_key is not None:
         payload["idempotency_key"] = idempotency_key
 
-    matches_table = supabase.table("matches")
-    print("===== DEBUG: MATCH INSERT =====")
-    print("FINAL INSERT PAYLOAD KEYS:", list(payload.keys()))
-    print("FINAL INSERT PAYLOAD:", payload)
-    print("================================")
-    insert_response = matches_table.insert(payload).execute()
-    inserted_rows = getattr(insert_response, "data", None) or []
-    if not inserted_rows:
-        raise RuntimeError("Supabase insert returned no row data for matches insert")
-
-    return dict(inserted_rows[0])
-
-
-def _apply_rating_engine_stub(match_payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Stub: placeholder for future rating engine application (currently no-op)."""
-    participants: list[dict[str, Any]] = []
-    for slot in ("t1_p1", "t1_p2", "t2_p1", "t2_p2"):
-        pid = match_payload.get(slot)
-        if pid is None:
-            continue
-        end_key = f"{slot}_r_end"
-        start_key = f"{slot}_r"
-        participants.append(
-            {
-                "player_id": int(pid),
-                "new_rating": match_payload.get(end_key),
-                "starting_rating": match_payload.get(start_key),
-            }
-        )
-    return {
-        "stub": True,
-        "name": "apply_rating_engine",
-        "action": "noop",
-        "details": "No rating changes applied.",
-        "participants": participants,
-    }
-
-
-def _run_context_hooks(
-    club_id: str,
-    context_type: str,
-    context_id: Optional[str],
-    match_payload: Dict[str, Any],
-    rating_result: Dict[str, Any],
-) -> Dict[str, Any]:
-    """Run context-specific hooks after insert + rating stages."""
-    if context_type == "league":
-        return _league_hook(
-            club_id=club_id,
-            league_id=str(context_id or match_payload.get("league") or "").strip(),
-            match_payload=match_payload,
-            rating_result=rating_result,
-        )
-
-    _ = (context_id, match_payload, rating_result)
-    return {
-        "stub": True,
-        "name": "run_context_hooks",
-        "context_type": context_type,
-        "action": "noop",
-        "details": "No context hook executed.",
-    }
-
-
-def _league_hook(
-    club_id: str,
-    league_id: str,
-    match_payload: Dict[str, Any],
-    rating_result: Dict[str, Any],
-) -> Dict[str, Any]:
-    """Update league standings rows from pipeline-produced rating_result."""
-    if not league_id:
-        return {
-            "stub": True,
-            "name": "league_hook",
-            "action": "skipped",
-            "details": "League context_id was empty.",
-        }
-
-    participants = rating_result.get("participants") or []
-    if not participants:
-        return {
-            "stub": True,
-            "name": "league_hook",
-            "action": "skipped",
-            "details": "No participants in rating_result.",
-        }
-
-    score_t1 = int(match_payload.get("score_t1", 0) or 0)
-    score_t2 = int(match_payload.get("score_t2", 0) or 0)
-    winner_team = None
-    if score_t1 != score_t2:
-        winner_team = 1 if score_t1 > score_t2 else 2
-
-    team_for_slot = {"t1_p1": 1, "t1_p2": 1, "t2_p1": 2, "t2_p2": 2}
     supabase = get_supabase_client()
-    updated_rows = 0
+    result = record_match(supabase=supabase, club_id=club_id, match_payload=payload)
+    result["run_context_hooks"] = bool(run_context_hooks)
+    return result
 
-    for slot, team in team_for_slot.items():
-        pid = match_payload.get(slot)
-        if pid is None:
-            continue
-        participant = next((p for p in participants if int(p.get("player_id", -1)) == int(pid)), None)
-        if not participant or participant.get("new_rating") is None:
-            continue
 
-        existing = (
-            supabase.table("league_ratings")
-            .select("id,wins,losses,matches_played,starting_rating")
-            .eq("club_id", club_id)
-            .eq("league_name", league_id)
-            .eq("player_id", int(pid))
-            .limit(1)
-            .execute()
-        )
-        existing_row = ((getattr(existing, "data", None) or [None])[0])
-
-        wins_add = int(winner_team == team)
-        losses_add = int(winner_team is not None and winner_team != team)
-
-        if existing_row:
-            payload = {
-                "rating": float(participant["new_rating"]),
-                "wins": int(existing_row.get("wins", 0) or 0) + wins_add,
-                "losses": int(existing_row.get("losses", 0) or 0) + losses_add,
-                "matches_played": int(existing_row.get("matches_played", 0) or 0) + 1,
-                "is_active": True,
-                "inactive_at": None,
-            }
-            sb_update(supabase, "league_ratings", payload, filters={"id": int(existing_row["id"]), "club_id": club_id})
-            updated_rows += 1
-            continue
-
-        start_rating = participant.get("starting_rating")
-        if start_rating is None:
-            start_rating = participant["new_rating"]
-        payload = {
-            "club_id": club_id,
-            "league_name": league_id,
-            "player_id": int(pid),
-            "rating": float(participant["new_rating"]),
-            "starting_rating": float(start_rating),
-            "wins": wins_add,
-            "losses": losses_add,
-            "matches_played": 1,
-            "is_active": True,
-            "inactive_at": None,
-        }
-        sb_insert(supabase, "league_ratings", payload)
-        updated_rows += 1
-
-    return {
-        "stub": False,
-        "name": "league_hook",
-        "action": "updated",
-        "league_id": league_id,
-        "rows_updated": int(updated_rows),
-    }
+__all__ = ["submit_match", "get_supabase_client"]


### PR DESCRIPTION
### Motivation
- Consolidate match write logic so there is a single authoritative entrypoint for match mutations and projection rebuilds.
- Eliminate a parallel rating/mutation code path that duplicated rating math outside of the domain processing modules.
- Keep rating math and replay logic centralized in the domain modules (`match_processing.py` / `replay_history.py`) to avoid inconsistent mutations.

### Description
- Replaced `services/match_pipeline.py` implementation with a thin compatibility wrapper that validates context, prepares payload/idempotency fields, and delegates to `jupr_app.domain.match_pipeline.record_match` via `submit_match`.
- Removed inline rating/snapshot/league rebuild code from `jupr_app/domain/match_pipeline.py` and made `_rebuild_state` call `jupr_app.domain.replay_history.replay_history` (using `FULL_RESET_LABEL`) to perform replay-based rebuilds.
- Removed imports of rating constants and `calculate_hybrid_elo` from the service path so no rating math remains in `services/match_pipeline.py` and the domain pipeline delegates replay work to the single replay implementation.
- Preserved `record_match`, `update_match`, `delete_match`, and related domain APIs as the canonical write path and kept idempotency and retry semantics intact.

### Testing
- Ran `pytest -q tests/test_match_pipeline_transactional.py tests/test_match_pipeline_idempotency.py tests/test_badge_v3_pipeline.py`, which resulted in 1 failing test (`tests/test_badge_v3_pipeline.py::test_badge_v3_pipeline_updates_facts_before_enqueue_and_award`) due to the test harness requiring a service-role-like Supabase client in that scenario.
- Re-ran `pytest -q tests/test_match_pipeline_transactional.py tests/test_match_pipeline_idempotency.py` and both test files passed (`9 passed`).
- Verified via search that rating math and constants are no longer present in `services/match_pipeline.py` and that rebuild/rating work is routed through `replay_history` and `match_processing`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699697ead7408326bfaf730db9fc1fd3)