### PR TITLE
Delegate rating updates to match_processing; make match_pipeline orchestration-only

### DIFF
--- a/jupr_app/domain/match_pipeline.py
+++ b/jupr_app/domain/match_pipeline.py
@@ -22,9 +22,12 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+import pandas as pd
+
 from jupr_app.data.retry import sb_retry
-from jupr_app.data.sb_write import sb_delete, sb_insert, sb_update, sb_upsert
+from jupr_app.data.sb_write import sb_delete, sb_insert, sb_update
 from jupr_app.domain.audit_logger import log_event
+from jupr_app.domain.match_processing import process_matches
 from jupr_app.domain.replay_history import FULL_RESET_LABEL, replay_history
 
 _ALLOWED_MATCH_KEYS = {
@@ -79,76 +82,6 @@ def _pipeline_result(
     }
     payload.update(extra)
     return payload
-
-
-def _snapshot_ratings_state(*, supabase: Any, club_id: str) -> dict[str, list[dict[str, Any]]]:
-    players_rows = (
-        supabase.table("players")
-        .select("id,rating,wins,losses,matches_played,last_game_at,is_active,inactive_at")
-        .eq("club_id", club_id)
-        .execute()
-        .data
-        or []
-    )
-    league_rows = (
-        supabase.table("league_ratings")
-        .select("club_id,player_id,league_name,rating,wins,losses,matches_played,starting_rating,is_active,inactive_at")
-        .eq("club_id", club_id)
-        .execute()
-        .data
-        or []
-    )
-    return {
-        "players": [dict(r) for r in players_rows],
-        "league_ratings": [dict(r) for r in league_rows],
-    }
-
-
-def _restore_ratings_state(*, supabase: Any, club_id: str, snapshot: Mapping[str, Any]) -> None:
-    for row in snapshot.get("players", []):
-        pid = _as_int(row.get("id"))
-        if pid is None:
-            continue
-        payload = {
-            "rating": row.get("rating"),
-            "wins": row.get("wins"),
-            "losses": row.get("losses"),
-            "matches_played": row.get("matches_played"),
-            "last_game_at": row.get("last_game_at"),
-            "is_active": row.get("is_active"),
-            "inactive_at": row.get("inactive_at"),
-        }
-        _run_write(lambda pid=pid, payload=payload: sb_update(
-            supabase,
-            "players",
-            payload,
-            filters=_scoped_filters(club_id, {"club_id": club_id, "id": int(pid)}),
-        ))
-
-    _run_write(lambda: sb_delete(
-        supabase,
-        "league_ratings",
-        filters=_scoped_filters(club_id, {"club_id": club_id}),
-    ))
-    for row in snapshot.get("league_ratings", []):
-        payload = {
-            "club_id": club_id,
-            "player_id": int(row["player_id"]),
-            "league_name": str(row.get("league_name") or ""),
-            "rating": row.get("rating"),
-            "wins": row.get("wins"),
-            "losses": row.get("losses"),
-            "matches_played": row.get("matches_played"),
-            "starting_rating": row.get("starting_rating"),
-            "is_active": row.get("is_active"),
-            "inactive_at": row.get("inactive_at"),
-        }
-        _run_write(lambda payload=payload: sb_upsert(
-            supabase,
-            "league_ratings",
-            _scoped_payload(club_id, payload),
-            conflict="club_id,player_id,league_name",
-        ))
 
 
 def _run_write(fn):
@@ -231,6 +164,44 @@ def _rebuild_state(*, supabase: Any, club_id: str) -> dict[str, int]:
     }
 
 
+def _build_processing_context(*, supabase: Any, club_id: str) -> dict[str, Any]:
+    players_rows = (
+        supabase.table("players")
+        .select("id,name,rating,wins,losses,matches_played,last_game_at")
+        .eq("club_id", club_id)
+        .execute()
+        .data
+        or []
+    )
+    leagues_rows = (
+        supabase.table("league_ratings")
+        .select("player_id,league_name,rating,wins,losses,matches_played,starting_rating")
+        .eq("club_id", club_id)
+        .execute()
+        .data
+        or []
+    )
+    meta_rows = (
+        supabase.table("league_settings")
+        .select("league_name,k_factor")
+        .eq("club_id", club_id)
+        .execute()
+        .data
+        or []
+    )
+    name_to_id = {
+        str(row.get("name") or "").strip(): int(row["id"])
+        for row in players_rows
+        if str(row.get("name") or "").strip() and _as_int(row.get("id")) is not None
+    }
+    return {
+        "name_to_id": name_to_id,
+        "df_players_all": pd.DataFrame(players_rows),
+        "df_leagues": pd.DataFrame(leagues_rows),
+        "df_meta": pd.DataFrame(meta_rows),
+    }
+
+
 def record_match(*, supabase: Any, club_id: str, match_payload: Mapping[str, Any]) -> dict[str, Any]:
     """Create one match for `club_id` and rebuild all dependent projections.
 
@@ -272,24 +243,46 @@ def record_match(*, supabase: Any, club_id: str, match_payload: Mapping[str, Any
         )
 
     payload = _coerce_match_payload(scoped_club_id, match_payload)
-    snapshot = _snapshot_ratings_state(supabase=supabase, club_id=scoped_club_id)
     inserted_rows: list[dict[str, Any]] = []
     inserted_match_id: int | None = None
     warnings: list[str] = []
     operation_success = False
 
     try:
-        inserted = _run_write(lambda: sb_insert(supabase, "matches", _scoped_payload(scoped_club_id, payload)))
-        inserted_rows = getattr(inserted, "data", None) or []
-        inserted_match_id = _as_int((inserted_rows[0] or {}).get("id")) if inserted_rows else None
-        rebuild = _rebuild_state(supabase=supabase, club_id=scoped_club_id)
+        processing_ctx = _build_processing_context(supabase=supabase, club_id=scoped_club_id)
+
+        def _write_match(match_row: dict[str, Any], context_id: str | None, context_type: str, idempotency_key: str):
+            nonlocal inserted_match_id
+            insert_payload = dict(match_row)
+            insert_payload["context_id"] = context_id
+            insert_payload["context_type"] = context_type
+            insert_payload["idempotency_key"] = idempotency_key
+            inserted = _run_write(lambda: sb_insert(supabase, "matches", _scoped_payload(scoped_club_id, insert_payload)))
+            rows = getattr(inserted, "data", None) or []
+            inserted_rows.extend(rows)
+            if rows and inserted_match_id is None:
+                inserted_match_id = _as_int((rows[0] or {}).get("id"))
+            return inserted
+
+        process_matches(
+            [payload],
+            supabase_admin=supabase,
+            supabase=supabase,
+            club_id=scoped_club_id,
+            name_to_id=processing_ctx["name_to_id"],
+            df_players_all=processing_ctx["df_players_all"],
+            df_leagues=processing_ctx["df_leagues"],
+            df_meta=processing_ctx["df_meta"],
+            sb_retry=_run_write,
+            match_writer=_write_match,
+        )
+        inserted_match_id = inserted_match_id or (_as_int((inserted_rows[0] or {}).get("id")) if inserted_rows else None)
         operation_success = True
         return _pipeline_result(
             success=True,
             match_id=inserted_match_id,
             warnings=warnings,
             inserted=inserted_rows,
-            rebuild=rebuild,
         )
     except Exception as exc:
         if inserted_match_id is not None:
@@ -299,8 +292,6 @@ def record_match(*, supabase: Any, club_id: str, match_payload: Mapping[str, Any
                 filters=_scoped_filters(scoped_club_id, {"club_id": scoped_club_id, "id": int(inserted_match_id)}),
             ))
             warnings.append("rolled_back_inserted_match")
-        _restore_ratings_state(supabase=supabase, club_id=scoped_club_id, snapshot=snapshot)
-        warnings.append("ratings_restored_from_snapshot")
         err = MatchPipelineError(f"record_match failed: {exc}")
         return _pipeline_result(
             success=False,
@@ -332,7 +323,6 @@ def update_match(*, supabase: Any, club_id: str, match_id: int, patch: Mapping[s
     target_match_id = int(match_id)
     safe_patch = _coerce_match_payload(scoped_club_id, patch)
     safe_patch.pop("club_id", None)
-    snapshot = _snapshot_ratings_state(supabase=supabase, club_id=scoped_club_id)
     match_before_rows = (
         supabase.table("matches")
         .select("*")
@@ -374,8 +364,6 @@ def update_match(*, supabase: Any, club_id: str, match_id: int, patch: Mapping[s
                 filters=_scoped_filters(scoped_club_id, {"club_id": scoped_club_id, "id": target_match_id}),
             ))
             warnings.append("rolled_back_match_patch")
-        _restore_ratings_state(supabase=supabase, club_id=scoped_club_id, snapshot=snapshot)
-        warnings.append("ratings_restored_from_snapshot")
         err = MatchPipelineError(f"update_match failed: {exc}")
         return _pipeline_result(
             success=False,

--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -16,7 +16,6 @@ from jupr_app.domain.player_activity import (
     max_activity_time,
 )
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
-from services.match_pipeline import submit_match
 
 
 def process_matches(
@@ -33,6 +32,7 @@ def process_matches(
     default_k_factor: int = 32,
     min_win_delta_elo: float = 1.0,
     cap_loser_gain_elo: float | None = 16.0,
+    match_writer: Callable[[dict[str, Any], str | None, str, str], Any] | None = None,
 ) -> dict[str, int]:
     """
     - Applies overall rating updates to players table
@@ -325,6 +325,20 @@ def process_matches(
     # -------------------------
     # Write match rows
     # -------------------------
+    if match_writer is None:
+        from services.match_pipeline import submit_match
+
+        def match_writer(match_row: dict[str, Any], context_id: str | None, context_type: str, idempotency_key: str):
+            return submit_match(
+                club_id=str(club_id),
+                context_type=context_type,
+                context_id=context_id,
+                match_payload=match_row,
+                idempotency_key=idempotency_key,
+                # match_processing already persists league_ratings; avoid pipeline hook double writes.
+                run_context_hooks=False,
+            )
+
     queued_badge_events: list[dict[str, Any]] = []
     if db_matches:
         CHUNK_M = 300
@@ -334,17 +348,7 @@ def process_matches(
                 context_type = resolve_context_type(match_row, str(match_row.get("league") or "").strip())
                 context_id = resolve_context_id(match_row, context_type, str(match_row.get("league") or "").strip())
                 idempotency_key = build_idempotency_key(match_row)
-                sb_retry(
-                    lambda match_row=match_row, context_type=context_type, context_id=context_id, idempotency_key=idempotency_key: submit_match(
-                        club_id=str(club_id),
-                        context_type=context_type,
-                        context_id=context_id,
-                        match_payload=match_row,
-                        idempotency_key=idempotency_key,
-                        # match_processing already persists league_ratings; avoid pipeline hook double writes.
-                        run_context_hooks=False,
-                    )
-                )
+                sb_retry(lambda match_row=match_row, context_id=context_id, context_type=context_type, idempotency_key=idempotency_key: match_writer(match_row, context_id, context_type, idempotency_key))
                 queued_badge_events.append({
                     "context_id": str(context_id or "overall"),
                     "match_id": str(idempotency_key),

--- a/tests/test_match_pipeline_idempotency.py
+++ b/tests/test_match_pipeline_idempotency.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
+import pandas as pd
 
 from jupr_app.domain import match_pipeline
 
@@ -19,7 +19,10 @@ class _Query:
         return self
 
     def execute(self):
-        return SimpleNamespace(data=self._rows)
+        class _Resp:
+            data = self._rows
+
+        return _Resp()
 
 
 class _Supabase:
@@ -27,15 +30,16 @@ class _Supabase:
         self._existing_rows = existing_rows or []
 
     def table(self, name: str):
-        assert name == "matches"
-        return _Query(self._existing_rows)
+        if name == "matches":
+            return _Query(self._existing_rows)
+        return _Query([])
 
 
-def test_record_match_idempotency_hit_returns_existing_and_skips_rebuild(monkeypatch):
+def test_record_match_idempotency_hit_returns_existing_and_skips_processing(monkeypatch):
     supabase = _Supabase(existing_rows=[{"id": 9, "idempotency_key": "dup-1", "club_id": "club-1"}])
-    rebuild_calls = []
+    process_calls = []
 
-    monkeypatch.setattr(match_pipeline, "_rebuild_state", lambda **_: rebuild_calls.append(True))
+    monkeypatch.setattr(match_pipeline, "process_matches", lambda *_args, **_kwargs: process_calls.append(True))
     monkeypatch.setattr(match_pipeline, "log_event", lambda **_: None)
 
     result = match_pipeline.record_match(
@@ -47,17 +51,28 @@ def test_record_match_idempotency_hit_returns_existing_and_skips_rebuild(monkeyp
     assert result["success"] is True
     assert result["idempotent_hit"] is True
     assert result["match_id"] == 9
-    assert rebuild_calls == []
+    assert process_calls == []
 
 
-def test_record_match_new_idempotency_inserts_and_rebuilds(monkeypatch):
+def test_record_match_new_idempotency_processes_matches(monkeypatch):
     supabase = _Supabase(existing_rows=[])
-    rebuild_calls = []
 
+    monkeypatch.setattr(match_pipeline, "_build_processing_context", lambda **_: {
+        "name_to_id": {},
+        "df_players_all": pd.DataFrame([]),
+        "df_leagues": pd.DataFrame([]),
+        "df_meta": pd.DataFrame([]),
+    })
+
+    def fake_process(match_list, **kwargs):
+        row = dict(match_list[0])
+        row["club_id"] = "club-1"
+        kwargs["match_writer"](row, None, "admin", "new-1")
+        return {"inserted": 1}
+
+    monkeypatch.setattr(match_pipeline, "process_matches", fake_process)
     monkeypatch.setattr(match_pipeline, "_run_write", lambda fn: fn())
-    monkeypatch.setattr(match_pipeline, "_snapshot_ratings_state", lambda **_: {"players": [], "league_ratings": []})
-    monkeypatch.setattr(match_pipeline, "sb_insert", lambda *_args, **_kwargs: SimpleNamespace(data=[{"id": 10}]))
-    monkeypatch.setattr(match_pipeline, "_rebuild_state", lambda **_: rebuild_calls.append(True) or {"matches_processed": 1})
+    monkeypatch.setattr(match_pipeline, "sb_insert", lambda *_args, **_kwargs: type("R", (), {"data": [{"id": 10}]})())
     monkeypatch.setattr(match_pipeline, "log_event", lambda **_: None)
 
     result = match_pipeline.record_match(
@@ -69,4 +84,3 @@ def test_record_match_new_idempotency_inserts_and_rebuilds(monkeypatch):
     assert result["success"] is True
     assert result.get("idempotent_hit") is not True
     assert result["match_id"] == 10
-    assert rebuild_calls == [True]

--- a/tests/test_match_pipeline_transactional.py
+++ b/tests/test_match_pipeline_transactional.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pandas as pd
+
 from jupr_app.domain import match_pipeline
 
 
@@ -37,15 +39,24 @@ def test_record_match_rolls_back_and_returns_structured_error(monkeypatch):
 
     monkeypatch.setattr(match_pipeline, "_run_write", lambda fn: fn())
     monkeypatch.setattr(match_pipeline, "_find_existing_match_by_idempotency_key", lambda **_: None)
-    monkeypatch.setattr(match_pipeline, "_snapshot_ratings_state", lambda **_: {"players": [], "league_ratings": []})
-    monkeypatch.setattr(match_pipeline, "_restore_ratings_state", lambda **_: writes.append("restore_ratings"))
+    monkeypatch.setattr(match_pipeline, "_build_processing_context", lambda **_: {
+        "name_to_id": {},
+        "df_players_all": pd.DataFrame([]),
+        "df_leagues": pd.DataFrame([]),
+        "df_meta": pd.DataFrame([]),
+    })
+
+    def fake_process(_match_list, **kwargs):
+        kwargs["match_writer"]({"club_id": "club-1", "score_t1": 11, "score_t2": 9}, None, "admin", "key-1")
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(match_pipeline, "process_matches", fake_process)
     monkeypatch.setattr(match_pipeline, "sb_insert", lambda *_args, **_kwargs: SimpleNamespace(data=[{"id": 42}]))
     monkeypatch.setattr(
         match_pipeline,
         "sb_delete",
         lambda *_args, **kwargs: writes.append(("delete", kwargs["filters"])) or SimpleNamespace(data=[{"id": 42}]),
     )
-    monkeypatch.setattr(match_pipeline, "_rebuild_state", lambda **_: (_ for _ in ()).throw(RuntimeError("boom")))
 
     result = match_pipeline.record_match(
         supabase=object(),
@@ -64,9 +75,7 @@ def test_record_match_rolls_back_and_returns_structured_error(monkeypatch):
     assert result["success"] is False
     assert result["match_id"] == 42
     assert result["error"] is not None
-    assert "ratings_restored_from_snapshot" in result["warnings"]
     assert ("delete", {"club_id": "club-1", "id": 42}) in writes
-    assert "restore_ratings" in writes
 
 
 def test_update_match_rolls_back_patch_and_returns_structured_error(monkeypatch):
@@ -74,9 +83,6 @@ def test_update_match_rolls_back_patch_and_returns_structured_error(monkeypatch)
     supabase = _DummySupabase(match_rows=[{"id": 8, "score_t1": 11, "score_t2": 9, "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4}])
 
     monkeypatch.setattr(match_pipeline, "_run_write", lambda fn: fn())
-    monkeypatch.setattr(match_pipeline, "_find_existing_match_by_idempotency_key", lambda **_: None)
-    monkeypatch.setattr(match_pipeline, "_snapshot_ratings_state", lambda **_: {"players": [], "league_ratings": []})
-    monkeypatch.setattr(match_pipeline, "_restore_ratings_state", lambda **_: writes.append("restore_ratings"))
 
     def fake_sb_update(_supabase, table, payload, *, filters):
         writes.append((table, dict(payload), dict(filters)))
@@ -96,7 +102,6 @@ def test_update_match_rolls_back_patch_and_returns_structured_error(monkeypatch)
     assert result["match_id"] == 8
     assert result["error"] is not None
     assert "rolled_back_match_patch" in result["warnings"]
-    assert "restore_ratings" in writes
     assert writes[0][1] == {"score_t1": 1, "score_t2": 11}
     assert writes[1][2] == {"club_id": "club-1", "id": 8}
 
@@ -106,9 +111,21 @@ def test_record_match_logs_audit_event(monkeypatch):
 
     monkeypatch.setattr(match_pipeline, "_run_write", lambda fn: fn())
     monkeypatch.setattr(match_pipeline, "_find_existing_match_by_idempotency_key", lambda **_: None)
-    monkeypatch.setattr(match_pipeline, "_snapshot_ratings_state", lambda **_: {"players": [], "league_ratings": []})
+    monkeypatch.setattr(match_pipeline, "_build_processing_context", lambda **_: {
+        "name_to_id": {},
+        "df_players_all": pd.DataFrame([]),
+        "df_leagues": pd.DataFrame([]),
+        "df_meta": pd.DataFrame([]),
+    })
+
+    def fake_process(match_list, **kwargs):
+        row = dict(match_list[0])
+        row["club_id"] = "club-1"
+        kwargs["match_writer"](row, None, "admin", "key-1")
+        return {"inserted": 1}
+
+    monkeypatch.setattr(match_pipeline, "process_matches", fake_process)
     monkeypatch.setattr(match_pipeline, "sb_insert", lambda *_args, **_kwargs: SimpleNamespace(data=[{"id": 12}]))
-    monkeypatch.setattr(match_pipeline, "_rebuild_state", lambda **_: {"matches_processed": 1})
     monkeypatch.setattr(match_pipeline, "log_event", lambda **payload: logged.append(payload))
 
     result = match_pipeline.record_match(
@@ -145,10 +162,10 @@ def test_record_match_requires_idempotency_key():
 
 def test_record_match_returns_existing_on_idempotency_hit(monkeypatch):
     existing = {"id": 55, "club_id": "club-1", "idempotency_key": "dup-key"}
-    rebuild_calls = []
+    process_calls = []
 
     monkeypatch.setattr(match_pipeline, "_find_existing_match_by_idempotency_key", lambda **_: existing)
-    monkeypatch.setattr(match_pipeline, "_rebuild_state", lambda **_: rebuild_calls.append(True))
+    monkeypatch.setattr(match_pipeline, "process_matches", lambda *_args, **_kwargs: process_calls.append(True))
     monkeypatch.setattr(match_pipeline, "log_event", lambda **_: None)
 
     result = match_pipeline.record_match(
@@ -161,7 +178,7 @@ def test_record_match_returns_existing_on_idempotency_hit(monkeypatch):
     assert result["match_id"] == 55
     assert result["idempotent_hit"] is True
     assert result["existing"]["id"] == 55
-    assert rebuild_calls == []
+    assert process_calls == []
 
 
 def test_require_club_scope_rejects_missing_club_id_in_payload():


### PR DESCRIPTION
### Motivation
- Ensure rating authority is centralized so only `jupr_app.domain.match_processing` and `jupr_app.domain.replay_history` perform rating calculations and writes.  
- Simplify `match_pipeline` so it acts as an orchestration layer (validation, idempotency, audit, enqueue) and avoid duplicate or conflicting rating writes.

### Description
- Refactored `jupr_app.domain.match_pipeline.record_match` to delegate match persistence and rating updates to `process_matches(...)` instead of locally recalculating or restoring ratings, and removed pipeline-local rating snapshot/restore logic.  
- Added `_build_processing_context(...)` in `match_pipeline` to load `players`, `league_ratings`, and league meta into DataFrame/mapping inputs consumed by `process_matches`.  
- Extended `jupr_app.domain.match_processing.process_matches` with an injectable `match_writer` callback and made `submit_match` a lazy import fallback so the pipeline can inject the write behavior and avoid circular imports.  
- Updated tests to assert the new orchestration flow (idempotency short-circuit, delegated processing, rollback behavior) and removed direct pipeline-level league/player write expectations.

### Testing
- Ran `pytest -q tests/test_match_pipeline_idempotency.py tests/test_match_pipeline_transactional.py`, and all tests passed (`9 passed`).  
- Unit tests were adjusted to mock `process_matches` and `_build_processing_context` to validate orchestration and rollback semantics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996990aebe4832691106810088c1a62)