### PR TITLE
Fix match pipeline to query leagues_metadata

### DIFF
--- a/jupr_app/domain/match_pipeline.py
+++ b/jupr_app/domain/match_pipeline.py
@@ -188,7 +188,7 @@ def _build_processing_context(*, supabase: Any, club_id: str) -> dict[str, Any]:
         or []
     )
     meta_rows = (
-        supabase.table("league_settings")
+        supabase.table("leagues_metadata")
         .select("league_name,k_factor")
         .eq("club_id", club_id)
         .execute()


### PR DESCRIPTION
### Motivation
- Match recording was failing because the processing context queried a non-existent table (`league_settings`) instead of the actual schema table, causing metadata lookups to fail.

### Description
- In `_build_processing_context()` of `jupr_app/domain/match_pipeline.py` replaced `supabase.table("league_settings")` with `supabase.table("leagues_metadata")` while leaving the `.select("league_name,k_factor")`, `.eq("club_id", club_id)`, and DataFrame construction unchanged.

### Testing
- Ran `python -m compileall jupr_app` and `python -c "import jupr_app.domain.match_pipeline as mp; print('ok')"`, and both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69976e0da278832686e95fd739280ba3)