### PR TITLE
Include round_robin and moneyball as allowed context types in match processing

### DIFF
--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -64,7 +64,7 @@ def process_matches(
     skipped_incomplete = 0
     skipped_empty = 0
     has_non_popup_match = False
-    allowed_context_types = {"league", "ladder", "tournament", "admin"}
+    allowed_context_types = {"league", "ladder", "tournament", "round_robin", "moneyball", "admin"}
 
     def resolve_context_type(match_row: dict[str, Any], league_name: str) -> str:
         raw_context_type = str(match_row.get("context_type", "") or "").strip().lower()


### PR DESCRIPTION
### Motivation
- Align `process_matches` context validation with upstream services so `round_robin` and `moneyball` are treated as valid context types and not silently coerced to other types.

### Description
- Updated `allowed_context_types` in `jupr_app/domain/match_processing.py` from `{"league","ladder","tournament","admin"}` to `{"league","ladder","tournament","round_robin","moneyball","admin"}` and made no other behavioral changes.

### Testing
- Ran `python -m compileall jupr_app` which completed successfully and produced no compilation errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69976f3ab9288326acd8922f76201e7a)