### PR TITLE
Make badge eval queue idempotency key tenant-safe

### DIFF
--- a/jupr_app/domain/gamification/badge_queue.py
+++ b/jupr_app/domain/gamification/badge_queue.py
@@ -39,7 +39,7 @@ def enqueue_badge_eval(
     }
     try:
         if match_id:
-            sb_upsert(supabase, BADGE_QUEUE_TABLE, row, conflict="event_type,match_id")
+            sb_upsert(supabase, BADGE_QUEUE_TABLE, row, conflict="club_id,event_type,match_id")
         else:
             sb_insert(supabase, BADGE_QUEUE_TABLE, row)
     except APIError as exc:

--- a/migrations/20260706_badge_eval_queue_tenant_unique.sql
+++ b/migrations/20260706_badge_eval_queue_tenant_unique.sql
@@ -1,0 +1,5 @@
+drop index if exists public.badge_eval_queue_event_match_uidx;
+
+create unique index if not exists badge_eval_queue_club_event_match_uidx
+    on public.badge_eval_queue (club_id, event_type, match_id)
+    where match_id is not null;


### PR DESCRIPTION
### Motivation
- Prevent cross-club collisions when enqueueing match-based badge evaluation jobs by scoping idempotency to a tenant level using `club_id`.
- Replace the existing cross-tenant uniqueness constraint on `(event_type, match_id)` with a tenant-safe index so upserts are safe per club.

### Description
- Update `enqueue_badge_eval()` in `jupr_app/domain/gamification/badge_queue.py` to use `conflict="club_id,event_type,match_id"` when `match_id` is present.
- Add migration `migrations/20260706_badge_eval_queue_tenant_unique.sql` that drops the old index `badge_eval_queue_event_match_uidx` and creates `badge_eval_queue_club_event_match_uidx` as a unique index on `(club_id, event_type, match_id)` with `WHERE match_id IS NOT NULL`.

### Testing
- Ran `python -m compileall jupr_app` and the package compiled successfully.
- Reviewed the new migration SQL for the required statements and attempted parser validation but `pglast` was not available in the environment, and `psql` was not installed for runtime verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69976fc344548326862d4c1b8cd478bb)