### PR TITLE
Fix NameError in Admin Tools badge state controls

### DIFF
--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -8,6 +8,7 @@ from jupr_app.domain.gamification.ensure_badges import ensure_badges
 from jupr_app.domain.gamification.badge_state import ALLOWED_BADGE_STATES, can_transition_badge_state
 from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
 from jupr_app.domain.replay_lock import is_replay_running
+from jupr_app.data.sb_write import sb_update
 from jupr_app.ui.layout import page_shell
 
 


### PR DESCRIPTION
### Motivation
- The Admin Tools page called `sb_update(...)` in the Badge State Controls section but did not import it, causing a `NameError`; this patch adds the missing import to restore functionality.

### Description
- Added the import `from jupr_app.data.sb_write import sb_update` near the other imports in `jupr_app/ui/pages/admin_tools.py` as a minimal, localized change.

### Testing
- Ran `python -m compileall jupr_app` and the project compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699770651de0832696277bbcd3366bb5)