### PR TITLE
Add league_ratings unique index migration for upsert conflict target

### DIFF
--- a/migrations/20260219_league_ratings_unique.sql
+++ b/migrations/20260219_league_ratings_unique.sql
@@ -1,0 +1,4 @@
+-- Required for sb_upsert(... conflict="club_id,player_id,league_name") in jupr_app/domain/match_processing.py.
+CREATE UNIQUE INDEX IF NOT EXISTS league_ratings_club_player_league_uidx
+ON public.league_ratings (club_id, player_id, league_name)
+WHERE club_id IS NOT NULL AND player_id IS NOT NULL;


### PR DESCRIPTION
### Motivation
- Provide the partial unique index required by PostgREST upserts driven by `sb_upsert(... conflict="club_id,player_id,league_name")` in `jupr_app/domain/match_processing.py` so the database enforces the conflict target.

### Description
- Add `migrations/20260219_league_ratings_unique.sql` which includes a top-line comment referencing the `sb_upsert` usage and creates the index `league_ratings_club_player_league_uidx`.
- The migration executes: `CREATE UNIQUE INDEX IF NOT EXISTS league_ratings_club_player_league_uidx ON public.league_ratings (club_id, player_id, league_name) WHERE club_id IS NOT NULL AND player_id IS NOT NULL;`.
- No application code was changed in this patch.

### Testing
- Verified the migration file contents with `sed -n '1,120p' migrations/20260219_league_ratings_unique.sql` and `nl -ba migrations/20260219_league_ratings_unique.sql`; both showed the expected comment and SQL and succeeded.
- Confirmed repository status with `git status --short` which listed the new migration file and `git show --stat --oneline HEAD` which showed the created file; both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699778b893e88326bf1818ec7742877a)