### PR TITLE
Validate match context IDs before writing matches rows

### DIFF
--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -6,6 +6,7 @@ from jupr_app.data.sb_write import sb_insert, sb_update, sb_upsert
 
 import hashlib
 import json
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Callable
 
@@ -76,16 +77,29 @@ def process_matches(
             return "league"
         return "admin"
 
+    def parse_uuid(value: Any) -> str | None:
+        if value is None:
+            return None
+
+        normalized = str(value).strip()
+        if not normalized:
+            return None
+
+        try:
+            return str(uuid.UUID(normalized))
+        except (ValueError, TypeError, AttributeError):
+            return None
+
     def resolve_context_id(match_row: dict[str, Any], context_type: str, league_name: str) -> str | None:
         raw_context_id = match_row.get("context_id")
-        if raw_context_id is not None and str(raw_context_id).strip() != "":
-            return str(raw_context_id)
-        if context_type == "league" and league_name:
-            return str(league_name)
+        parsed_context_id = parse_uuid(raw_context_id)
+        if parsed_context_id:
+            return parsed_context_id
         if context_type == "tournament":
             tournament_id = match_row.get("tournament_id")
-            if tournament_id is not None and str(tournament_id).strip() != "":
-                return str(tournament_id)
+            parsed_tournament_id = parse_uuid(tournament_id)
+            if parsed_tournament_id:
+                return parsed_tournament_id
         return None
 
     def build_idempotency_key(match_row: dict[str, Any]) -> str:

--- a/services/match_pipeline.py
+++ b/services/match_pipeline.py
@@ -3,12 +3,27 @@
 from __future__ import annotations
 
 import os
+import uuid
 from typing import Any, Literal, Mapping
 
 from jupr_app.data.client import make_supabase
 from jupr_app.domain.match_pipeline import record_match
 
 _ALLOWED_CONTEXT_TYPES = {"league", "ladder", "tournament", "round_robin", "moneyball", "admin"}
+
+
+def _coerce_uuid(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    normalized = str(value).strip()
+    if not normalized:
+        return None
+
+    try:
+        return str(uuid.UUID(normalized))
+    except (ValueError, TypeError, AttributeError):
+        return None
 
 
 def get_supabase_client() -> Any:
@@ -40,7 +55,7 @@ def submit_match(
 
     payload = dict(match_payload or {})
     payload["context_type"] = context_type
-    payload["context_id"] = context_id
+    payload["context_id"] = _coerce_uuid(context_id)
     if idempotency_key is not None:
         payload["idempotency_key"] = idempotency_key
 


### PR DESCRIPTION
### Motivation
- Prevent non-UUID `context_id` values from being written into the `matches.context_id` UUID column to avoid insert failures.
- Preserve existing `context_type` selection while ensuring league matches remain discoverable via the `matches.league` text column instead of writing league names into `context_id`.

### Description
- Added `_coerce_uuid()` to `services/match_pipeline.py` and use it in `submit_match()` so `payload["context_id"]` is set to a canonical UUID string or `None` when input is invalid.
- Added `parse_uuid()` in `jupr_app/domain/match_processing.py` and updated `resolve_context_id()` to return the match `context_id` only if it is a valid UUID, or the `tournament_id` only if it is a valid UUID, otherwise `None` (removed the previous league-name fallback into `context_id`).
- Kept `resolve_context_type()` behavior unchanged so `context_type` selection remains the same.

### Testing
- Ran `python -m compileall services/match_pipeline.py jupr_app/domain/match_processing.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997791ae7d8832685818e61a90eac35)