### PR TITLE
Default PRODUCTION_MODE to false and clarify rating-state enforcement

### DIFF
--- a/jupr_app/config.py
+++ b/jupr_app/config.py
@@ -2,4 +2,4 @@ import os
 
 USE_BADGE_ENGINE_V3 = True
 DEBUG_MODE = os.getenv("DEBUG_MODE", "false").lower() == "true"
-PRODUCTION_MODE = os.getenv("PRODUCTION_MODE", "true").lower() == "true"
+PRODUCTION_MODE = os.getenv("PRODUCTION_MODE", "false").lower() == "true"

--- a/jupr_app/data/sb_write.py
+++ b/jupr_app/data/sb_write.py
@@ -11,6 +11,10 @@ from jupr_app.config import PRODUCTION_MODE
 
 
 RATING_STATE_DERIVATION_NOTE = "Rating state is derived from match history only."
+RATING_STATE_POLICY_GUIDANCE = (
+    "Set derived_from_match_history=True only for writes produced by match replay/pipeline "
+    "from canonical match history; manual edits to rating-state fields stay blocked in production."
+)
 
 
 def _enforce_rating_state_policy(*, table: str, payload: Dict, derived_from_match_history: bool) -> None:
@@ -26,7 +30,8 @@ def _enforce_rating_state_policy(*, table: str, payload: Dict, derived_from_matc
     if any(field in payload for field in forbidden_fields):
         kind = "league rating" if str(table) == "league_ratings" else "rating"
         raise RuntimeError(
-            f"Manual {kind} edits are disabled in PRODUCTION_MODE. {RATING_STATE_DERIVATION_NOTE}"
+            f"Manual {kind} edits are disabled in PRODUCTION_MODE. "
+            f"{RATING_STATE_DERIVATION_NOTE} {RATING_STATE_POLICY_GUIDANCE}"
         )
 
 

--- a/tests/test_sb_write.py
+++ b/tests/test_sb_write.py
@@ -1,9 +1,10 @@
-from jupr_app.data.sb_write import _enforce_rating_state_policy
+from jupr_app.data import sb_write
 
 
 def test_manual_player_rating_edit_blocked_in_production():
+    sb_write.PRODUCTION_MODE = True
     try:
-        _enforce_rating_state_policy(
+        sb_write._enforce_rating_state_policy(
             table="players",
             payload={"rating": 1200.0},
             derived_from_match_history=False,
@@ -11,11 +12,13 @@ def test_manual_player_rating_edit_blocked_in_production():
         assert False, "Expected RuntimeError"
     except RuntimeError as exc:
         assert "Manual rating edits are disabled in PRODUCTION_MODE" in str(exc)
+        assert "Set derived_from_match_history=True" in str(exc)
 
 
 def test_manual_league_rating_edit_blocked_in_production():
+    sb_write.PRODUCTION_MODE = True
     try:
-        _enforce_rating_state_policy(
+        sb_write._enforce_rating_state_policy(
             table="league_ratings",
             payload={"rating": 1200.0},
             derived_from_match_history=False,
@@ -26,7 +29,8 @@ def test_manual_league_rating_edit_blocked_in_production():
 
 
 def test_derived_rating_edit_allowed_in_production():
-    _enforce_rating_state_policy(
+    sb_write.PRODUCTION_MODE = True
+    sb_write._enforce_rating_state_policy(
         table="players",
         payload={"rating": 1210.0, "wins": 1},
         derived_from_match_history=True,


### PR DESCRIPTION
### Motivation
- Local and development runs should default to non-production behavior unless `PRODUCTION_MODE` is explicitly set to `true`.
- The rating-state enforcement needs clearer guidance in its error message so callers understand why manual edits are blocked and how to allow pipeline-derived writes.
- Preserve existing production deployments that already set `PRODUCTION_MODE=true` so their behavior remains unchanged.

### Description
- Change `jupr_app.config.PRODUCTION_MODE` default to `os.getenv("PRODUCTION_MODE", "false").lower() == "true"` so unset environments evaluate to `False`.
- Add `RATING_STATE_POLICY_GUIDANCE` to `jupr_app/data/sb_write.py` and include it in the raised `RuntimeError` to explain that manual rating edits are blocked and that `derived_from_match_history=True` is the way to allow pipeline/replay writes.
- Update `tests/test_sb_write.py` to set `sb_write.PRODUCTION_MODE = True` in tests and assert the new guidance appears in the error message for player rating edits.

### Testing
- Ran `pytest -q tests/test_sb_write.py` and all tests passed (`3 passed`).
- Verified importing `jupr_app.config` with `PRODUCTION_MODE` unset yields `False` during an automated import check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69977aa9b5e08326b33811ed2af6c22f)