### PR TITLE
Handle missing preflight RPC via pg_indexes fallback

### DIFF
--- a/jupr_app/data/schema_preflight.py
+++ b/jupr_app/data/schema_preflight.py
@@ -98,6 +98,28 @@ def ensure_app_write_invariants(supabase: Any) -> bool:
 def _ensure_required_write_indexes(supabase: Any) -> None:
     try:
         sb_rpc(supabase, "assert_app_invariants", {})
+        return
+    except APIError as exc:
+        code = _get_api_error_code(exc)
+        message = _get_api_error_message(exc)
+        if code == "PGRST202" and "assert_app_invariants" in message:
+            degraded, _ = check_required_upsert_indexes(supabase)
+            if degraded:
+                raise RuntimeError(
+                    "Database write preflight failed. Required unique indexes are missing. "
+                    "Apply supabase/migrations/202602200001_enforce_uniques_and_preflight.sql "
+                    "and reload PostgREST schema cache."
+                ) from exc
+            logger.warning(
+                "PostgREST schema cache is stale for assert_app_invariants RPC; "
+                "validated indexes via pg_indexes fallback. Reload schema cache."
+            )
+            return
+        raise RuntimeError(
+            "Database write preflight failed. Required unique indexes are missing. "
+            "Apply supabase/migrations/202602200001_enforce_uniques_and_preflight.sql "
+            "and reload PostgREST schema cache."
+        ) from exc
     except Exception as exc:
         raise RuntimeError(
             "Database write preflight failed. Required unique indexes are missing. "

--- a/tests/test_schema_preflight.py
+++ b/tests/test_schema_preflight.py
@@ -21,8 +21,16 @@ class _FakeRpcQuery:
         self.name = name
 
     def execute(self):
-        if self.name == "assert_app_invariants" and not self.supabase.rpc_invariants_ok:
-            raise APIError({"code": "P0001", "message": "missing required unique indexes"})
+        if self.name == "assert_app_invariants":
+            if self.supabase.rpc_error_code:
+                raise APIError(
+                    {
+                        "code": self.supabase.rpc_error_code,
+                        "message": self.supabase.rpc_error_message,
+                    }
+                )
+            if not self.supabase.rpc_invariants_ok:
+                raise APIError({"code": "P0001", "message": "missing required unique indexes"})
         return _FakeResponse([])
 
 
@@ -55,6 +63,8 @@ class _FakeTableQuery:
             )
         if self.table_name == "schema_version":
             return _FakeResponse([{"version": self.supabase.schema_version}])
+        if self.table_name == "pg_indexes":
+            return _FakeResponse(self.supabase.pg_indexes_rows)
         if self.selected:
             column = self.selected.split(",")[0].strip()
             if column not in self.supabase.tables[self.table_name]:
@@ -68,10 +78,21 @@ class _FakeTableQuery:
 
 
 class _FakeSupabase:
-    def __init__(self, tables, *, rpc_invariants_ok: bool = True):
+    def __init__(
+        self,
+        tables,
+        *,
+        rpc_invariants_ok: bool = True,
+        rpc_error_code: str | None = None,
+        rpc_error_message: str = "",
+        pg_indexes_rows=None,
+    ):
         self.tables = tables
         self.schema_version = REQUIRED_SCHEMA_VERSION
         self.rpc_invariants_ok = rpc_invariants_ok
+        self.rpc_error_code = rpc_error_code
+        self.rpc_error_message = rpc_error_message
+        self.pg_indexes_rows = pg_indexes_rows or []
 
     def table(self, name: str):
         return _FakeTableQuery(self, name)
@@ -162,4 +183,67 @@ def test_ensure_app_write_invariants_raises_for_missing_unique_indexes():
     supabase = _FakeSupabase({"schema_version": {"version"}}, rpc_invariants_ok=False)
     with pytest.raises(RuntimeError) as excinfo:
         ensure_app_write_invariants(supabase)
+    assert "Database write preflight failed" in str(excinfo.value)
+
+
+def test_preflight_uses_index_fallback_when_rpc_is_missing_and_indexes_exist(monkeypatch):
+    monkeypatch.delenv("JUPR_SKIP_BADGE_SCHEMA_PREFLIGHT", raising=False)
+    supabase = _FakeSupabase(
+        {
+            "schema_version": {"version"},
+            "player_badges": {
+                "awarded_by",
+                "rule_version",
+                "eval_run_id",
+                "revoked_at",
+                "revoked_by",
+                "revoke_reason",
+            },
+            "badge_eval_runs": {"id"},
+            "pg_indexes": {"schemaname", "tablename", "indexname", "indexdef"},
+        },
+        rpc_error_code="PGRST202",
+        rpc_error_message="Could not find the function public.assert_app_invariants without parameters in the schema cache",
+        pg_indexes_rows=[
+            {
+                "schemaname": "public",
+                "tablename": "badge_eval_queue",
+                "indexname": "badge_eval_queue_club_event_eventkey_uidx",
+                "indexdef": "CREATE UNIQUE INDEX badge_eval_queue_club_event_eventkey_uidx ON public.badge_eval_queue USING btree (club_id, event_type, event_key)",
+            },
+            {
+                "schemaname": "public",
+                "tablename": "league_ratings",
+                "indexname": "league_ratings_club_player_league_uidx",
+                "indexdef": "CREATE UNIQUE INDEX league_ratings_club_player_league_uidx ON public.league_ratings USING btree (club_id, player_id, league_name)",
+            },
+        ],
+    )
+
+    assert ensure_badge_schema_preflight(supabase) is True
+
+
+def test_preflight_raises_when_rpc_is_missing_and_indexes_are_missing(monkeypatch):
+    monkeypatch.delenv("JUPR_SKIP_BADGE_SCHEMA_PREFLIGHT", raising=False)
+    supabase = _FakeSupabase(
+        {
+            "schema_version": {"version"},
+            "player_badges": {
+                "awarded_by",
+                "rule_version",
+                "eval_run_id",
+                "revoked_at",
+                "revoked_by",
+                "revoke_reason",
+            },
+            "badge_eval_runs": {"id"},
+            "pg_indexes": {"schemaname", "tablename", "indexname", "indexdef"},
+        },
+        rpc_error_code="PGRST202",
+        rpc_error_message="Could not find the function public.assert_app_invariants without parameters in the schema cache",
+        pg_indexes_rows=[],
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        ensure_badge_schema_preflight(supabase)
     assert "Database write preflight failed" in str(excinfo.value)


### PR DESCRIPTION
### Motivation
- Avoid crashing when PostgREST schema cache does not expose the `assert_app_invariants` RPC (PostgREST `PGRST202`) by providing a read-only fallback check against `pg_indexes` so the app can validate required unique indexes.
- Provide a clearer recovery path: if indexes exist but the RPC is missing, log a stale-schema-cache warning instead of failing; if indexes are missing, continue to raise the existing migration/cache-reload error.

### Description
- Updated `_ensure_required_write_indexes` to return on success, and to catch `APIError` specifically; when the error code is `PGRST202` and the message references `assert_app_invariants`, the code now calls `check_required_upsert_indexes` as a fallback and either raises the same runtime error if indexes are missing or logs a stale-schema-cache warning and continues when indexes are present.  
- Kept the original behavior for other exceptions, still raising the same actionable runtime error instructing application of the migration and PostgREST schema reload.  
- Extended test doubles and added tests in `tests/test_schema_preflight.py` to simulate RPC errors via `rpc_error_code`/`rpc_error_message` and to return `pg_indexes` rows; added tests for both fallback outcomes (indexes present -> pass, indexes absent -> raise).  
- Files changed: `jupr_app/data/schema_preflight.py` and `tests/test_schema_preflight.py`.

### Testing
- Ran `pytest -q tests/test_schema_preflight.py` and all tests passed (`7 passed`).
- New tests verify both successful fallback (RPC missing but indexes present) and failure (RPC missing and indexes missing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997d3c2a46c832684eff647d2d69c83)