### PR TITLE
Fix schema preflight RPC binding and preserve invariant errors

### DIFF
--- a/jupr_app/data/schema_preflight.py
+++ b/jupr_app/data/schema_preflight.py
@@ -97,11 +97,18 @@ def ensure_app_write_invariants(supabase: Any) -> bool:
 
 def _ensure_required_write_indexes(supabase: Any) -> None:
     try:
-        sb_rpc(supabase, "assert_app_invariants", {})
+        # Bind the jsonb argument by name so PostgREST selects the
+        # assert_app_invariants(payload jsonb) signature deterministically.
+        sb_rpc(supabase, "assert_app_invariants", {"payload": {}})
         return
     except APIError as exc:
         code = _get_api_error_code(exc)
         message = _get_api_error_message(exc)
+        if code == "P0001":
+            raise RuntimeError(
+                "Database write preflight failed. assert_app_invariants rejected schema invariants. "
+                f"(code={code} message={message})"
+            ) from exc
         if code == "PGRST202" and "assert_app_invariants" in message:
             degraded, _ = check_required_upsert_indexes(supabase)
             if degraded:
@@ -116,15 +123,13 @@ def _ensure_required_write_indexes(supabase: Any) -> None:
             )
             return
         raise RuntimeError(
-            "Database write preflight failed. Required unique indexes are missing. "
-            "Apply supabase/migrations/202602200001_enforce_uniques_and_preflight.sql "
-            "and reload PostgREST schema cache."
+            "Database write preflight failed while executing assert_app_invariants. "
+            f"(code={code} message={message})"
         ) from exc
     except Exception as exc:
         raise RuntimeError(
-            "Database write preflight failed. Required unique indexes are missing. "
-            "Apply supabase/migrations/202602200001_enforce_uniques_and_preflight.sql "
-            "and reload PostgREST schema cache."
+            "Database write preflight failed while executing assert_app_invariants. "
+            f"(error={exc})"
         ) from exc
 
 

--- a/tests/test_schema_preflight.py
+++ b/tests/test_schema_preflight.py
@@ -93,11 +93,13 @@ class _FakeSupabase:
         self.rpc_error_code = rpc_error_code
         self.rpc_error_message = rpc_error_message
         self.pg_indexes_rows = pg_indexes_rows or []
+        self.last_rpc_payload = None
 
     def table(self, name: str):
         return _FakeTableQuery(self, name)
 
-    def rpc(self, name: str, _payload: dict):
+    def rpc(self, name: str, payload: dict):
+        self.last_rpc_payload = payload
         return _FakeRpcQuery(self, name)
 
 
@@ -183,7 +185,27 @@ def test_ensure_app_write_invariants_raises_for_missing_unique_indexes():
     supabase = _FakeSupabase({"schema_version": {"version"}}, rpc_invariants_ok=False)
     with pytest.raises(RuntimeError) as excinfo:
         ensure_app_write_invariants(supabase)
-    assert "Database write preflight failed" in str(excinfo.value)
+    assert "assert_app_invariants rejected schema invariants" in str(excinfo.value)
+
+
+def test_preflight_calls_assert_invariants_with_named_payload():
+    supabase = _FakeSupabase(
+        {
+            "schema_version": {"version"},
+            "player_badges": {
+                "awarded_by",
+                "rule_version",
+                "eval_run_id",
+                "revoked_at",
+                "revoked_by",
+                "revoke_reason",
+            },
+            "badge_eval_runs": {"id"},
+        }
+    )
+
+    assert ensure_badge_schema_preflight(supabase) is True
+    assert supabase.last_rpc_payload == {"payload": {}}
 
 
 def test_preflight_uses_index_fallback_when_rpc_is_missing_and_indexes_exist(monkeypatch):
@@ -247,3 +269,28 @@ def test_preflight_raises_when_rpc_is_missing_and_indexes_are_missing(monkeypatc
     with pytest.raises(RuntimeError) as excinfo:
         ensure_badge_schema_preflight(supabase)
     assert "Database write preflight failed" in str(excinfo.value)
+
+
+def test_preflight_does_not_mask_unrelated_rpc_errors(monkeypatch):
+    monkeypatch.delenv("JUPR_SKIP_BADGE_SCHEMA_PREFLIGHT", raising=False)
+    supabase = _FakeSupabase(
+        {
+            "schema_version": {"version"},
+            "player_badges": {
+                "awarded_by",
+                "rule_version",
+                "eval_run_id",
+                "revoked_at",
+                "revoked_by",
+                "revoke_reason",
+            },
+            "badge_eval_runs": {"id"},
+        },
+        rpc_error_code="PGRST301",
+        rpc_error_message="JWT expired",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        ensure_badge_schema_preflight(supabase)
+    assert "while executing assert_app_invariants" in str(excinfo.value)
+    assert "JWT expired" in str(excinfo.value)


### PR DESCRIPTION
### Motivation
- The preflight RPC call used an empty/unnamed param object which can make PostgREST resolve the wrong `assert_app_invariants` signature when the schema cache contains both a no-arg and a `jsonb` variant. 
- The preflight error path collapsed all `APIError` cases into a generic "required unique indexes missing" message, masking real invariant failures and unrelated RPC errors and forcing degraded mode incorrectly.

### Description
- Call `assert_app_invariants` with a named JSONB parameter via `sb_rpc(..., {"payload": {}})` so PostgREST deterministically binds to the `payload jsonb` signature. 
- Tighten `_ensure_required_write_indexes()` error handling to re-raise an explicit invariant rejection for Postgres error code `P0001` and to surface other API errors with their actual code/message instead of always mapping to missing-index diagnostics. 
- Preserve the existing `PGRST202` (schema cache miss) fallback that validates indexes by reading `pg_indexes`. 
- Add and update unit tests to assert the named payload is sent and that unrelated RPC errors are not masked; update the test fake supabase to capture the last RPC payload.

### Testing
- Ran `pytest -q tests/test_schema_preflight.py` and all tests passed (9 passed). 
- New tests cover named payload binding, explicit `P0001` invariant reporting, and that unrelated RPC errors surface their real messages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997dabaaa5083269b5b512592565743)