### PR TITLE
Remove pg_indexes fallback and enforce strict assert_app_invariants preflight

### DIFF
--- a/jupr_app/data/load.py
+++ b/jupr_app/data/load.py
@@ -5,10 +5,7 @@ from jupr_app.domain.player_activity import add_activity_columns
 from jupr_app.domain.gamification.badge_descriptions import BADGE_DESCRIPTIONS_MD
 from jupr_app.domain.gamification.badge_registry import badge_schema_by_id
 from jupr_app.domain.gamification.requirements import load_requirements_map
-from jupr_app.data.schema_preflight import (
-    check_required_upsert_indexes,
-    ensure_badge_schema_preflight,
-)
+from jupr_app.data.schema_preflight import ensure_badge_schema_preflight
 from jupr_app.domain.idempotency import build_match_idempotency_key_v1
 from services.match_pipeline import submit_match
 
@@ -150,7 +147,7 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
     """
     club_id = str(club_id)
     ensure_badge_schema_preflight(supabase)
-    schema_degraded, schema_degraded_reason = check_required_upsert_indexes(supabase)
+    schema_degraded, schema_degraded_reason = False, None
 
     max_retries = 3
     last_err = None

--- a/jupr_app/data/schema_preflight.py
+++ b/jupr_app/data/schema_preflight.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 from typing import Any
 
 from postgrest.exceptions import APIError
@@ -35,30 +34,6 @@ _MISSING_COLUMN_CODES = {"PGRST204"}
 _MISSING_TABLE_CODES = {"PGRST205", "42P01"}
 
 logger = logging.getLogger(__name__)
-
-REQUIRED_UPSERT_INDEXES = (
-    {
-        "index_name": "badge_eval_queue_club_event_eventkey_uidx",
-        "table": "badge_eval_queue",
-        "columns": ["club_id", "event_type", "event_key"],
-        "predicate": None,
-        "create_sql": (
-            "CREATE UNIQUE INDEX badge_eval_queue_club_event_eventkey_uidx ON public.badge_eval_queue "
-            "(club_id,event_type,event_key);"
-        ),
-    },
-    {
-        "index_name": "league_ratings_club_player_league_uidx",
-        "table": "league_ratings",
-        "columns": ["club_id", "player_id", "league_name"],
-        "predicate": None,
-        "create_sql": (
-            "CREATE UNIQUE INDEX league_ratings_club_player_league_uidx ON public.league_ratings "
-            "(club_id,player_id,league_name);"
-        ),
-    },
-)
-
 
 def ensure_badge_schema_preflight(supabase: Any) -> bool:
     if _should_skip_preflight():
@@ -109,19 +84,6 @@ def _ensure_required_write_indexes(supabase: Any) -> None:
                 "Database write preflight failed. assert_app_invariants rejected schema invariants. "
                 f"(code={code} message={message})"
             ) from exc
-        if code == "PGRST202" and "assert_app_invariants" in message:
-            degraded, _ = check_required_upsert_indexes(supabase)
-            if degraded:
-                raise RuntimeError(
-                    "Database write preflight failed. Required unique indexes are missing. "
-                    "Apply supabase/migrations/202602200001_enforce_uniques_and_preflight.sql "
-                    "and reload PostgREST schema cache."
-                ) from exc
-            logger.warning(
-                "PostgREST schema cache is stale for assert_app_invariants RPC; "
-                "validated indexes via pg_indexes fallback. Reload schema cache."
-            )
-            return
         raise RuntimeError(
             "Database write preflight failed while executing assert_app_invariants. "
             f"(code={code} message={message})"
@@ -131,41 +93,6 @@ def _ensure_required_write_indexes(supabase: Any) -> None:
             "Database write preflight failed while executing assert_app_invariants. "
             f"(error={exc})"
         ) from exc
-
-
-def check_required_upsert_indexes(supabase: Any) -> tuple[bool, str | None]:
-    """Read-only check for unique indexes required by PostgREST upserts."""
-    if _should_skip_preflight():
-        return False, None
-
-    try:
-        resp = (
-            supabase.table("pg_indexes")
-            .select("schemaname,tablename,indexname,indexdef")
-            .eq("schemaname", "public")
-            .in_("tablename", [spec["table"] for spec in REQUIRED_UPSERT_INDEXES])
-            .execute()
-        )
-    except Exception as exc:
-        reason = (
-            "Failed to run upsert index preflight; app will run read-only. "
-            "Apply required unique indexes and reload PostgREST schema cache."
-        )
-        logger.warning(reason, exc_info=exc)
-        return True, reason
-
-    rows = resp.data or []
-    missing_specs = [spec for spec in REQUIRED_UPSERT_INDEXES if not _has_matching_index(rows, spec)]
-    if not missing_specs:
-        return False, None
-
-    missing_names = ", ".join(spec["index_name"] for spec in missing_specs)
-    sql_block = "\n".join(spec["create_sql"] for spec in missing_specs)
-    reason = (
-        "Missing required unique indexes for PostgREST upserts: "
-        f"{missing_names}. Apply SQL:\n{sql_block}"
-    )
-    return True, reason
 
 
 def _ensure_required_schema_version(supabase: Any) -> None:
@@ -230,50 +157,6 @@ def _probe_column(supabase: Any, table: str, column: str) -> bool:
             f"PostgREST error while checking {table}.{column} (code={code} message={message})."
         ) from exc
     return True
-
-
-def _has_matching_index(rows: list[dict[str, Any]], spec: dict[str, Any]) -> bool:
-    expected_columns = [str(col).strip().lower() for col in spec["columns"]]
-    expected_predicate = _normalize_expression(spec.get("predicate") or "")
-
-    for row in rows:
-        if str(row.get("tablename") or "") != spec["table"]:
-            continue
-        if str(row.get("indexname") or "") != spec["index_name"]:
-            continue
-
-        indexdef = str(row.get("indexdef") or "")
-        if "UNIQUE" not in indexdef.upper():
-            continue
-        if _extract_index_columns(indexdef) != expected_columns:
-            continue
-
-        actual_predicate = _extract_predicate(indexdef)
-        if expected_predicate != _normalize_expression(actual_predicate):
-            continue
-        return True
-
-    return False
-
-
-def _extract_index_columns(indexdef: str) -> list[str]:
-    match = re.search(r"\(([^)]+)\)", indexdef)
-    if not match:
-        return []
-    return [part.strip().strip('"').lower() for part in match.group(1).split(",") if part.strip()]
-
-
-def _extract_predicate(indexdef: str) -> str:
-    marker = " WHERE "
-    upper = indexdef.upper()
-    idx = upper.find(marker)
-    if idx < 0:
-        return ""
-    return indexdef[idx + len(marker) :].strip().rstrip(";")
-
-
-def _normalize_expression(value: str) -> str:
-    return " ".join(str(value).replace("(", " ").replace(")", " ").lower().split())
 
 
 def _probe_table(supabase: Any, table: str) -> bool:


### PR DESCRIPTION
### Motivation
- Supabase does not expose `pg_indexes` via PostgREST, causing the previous `pg_indexes`-based fallback to trigger a PostgREST error and silently degrade the app to read-only even when required indexes exist.
- The intent is to remove the brittle PostgREST index probing and rely exclusively on the `assert_app_invariants` RPC so preflight either passes or raises an explicit error.

### Description
- Deleted the `REQUIRED_UPSERT_INDEXES` constant and the `check_required_upsert_indexes()` helper from `jupr_app/data/schema_preflight.py` so no `pg_indexes` queries are attempted.
- Removed the `PGRST202` fallback branch inside `_ensure_required_write_indexes()`; preflight now calls `sb_rpc("assert_app_invariants", {"payload": {}})` and fails fast.
- `_ensure_required_write_indexes()` preserves explicit handling for API error code `P0001` by raising a `RuntimeError` that indicates invariant rejection, and for all other `APIError`s it raises a `RuntimeError` containing the raw code/message.
- Updated `jupr_app/data/load.py` to stop importing/calling the removed fallback checker and set `schema_degraded, schema_degraded_reason = False, None` after preflight.

### Testing
- Ran `python -m compileall jupr_app/data/schema_preflight.py jupr_app/data/load.py` and compilation succeeded.
- Searched repository for removed symbols (`check_required_upsert_indexes`, `REQUIRED_UPSERT_INDEXES`) with `rg` and confirmed no remaining references.
- Verified the modified files compile and the code paths now rely solely on `sb_rpc("assert_app_invariants", {"payload": {}})` for write-invariant checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997dd88af148326b1fa346e12a7edcb)