### PR TITLE
Fix Add Player upsert failure by aligning normalized_name conflict contract

### DIFF
--- a/jupr_app/domain/player_ops.py
+++ b/jupr_app/domain/player_ops.py
@@ -5,6 +5,10 @@ from typing import Tuple
 
 from postgrest.exceptions import APIError
 
+
+def _normalized_player_name(name: str) -> str:
+    return " ".join(str(name or "").strip().lower().split())
+
 def safe_add_player(
     *,
     supabase,
@@ -30,9 +34,12 @@ def safe_add_player(
     except Exception:
         return False, "Invalid rating."
 
+    normalized_name = _normalized_player_name(clean_name)
+
     payload = {
         "club_id": str(club_id),
         "name": clean_name,
+        "normalized_name": normalized_name,
         "active": True,
         "rating": float(elo),
         "starting_rating": float(elo),
@@ -54,7 +61,26 @@ def safe_add_player(
         if resp.data and len(resp.data) > 0 and resp.data[0].get("id"):
             return True, resp.data[0]["id"]
 
+        existing = (
+            supabase
+            .table("players")
+            .select("id")
+            .eq("club_id", str(club_id))
+            .eq("normalized_name", normalized_name)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        if existing and existing[0].get("id"):
+            return True, existing[0]["id"]
+
         return False, "Upsert did not return an id"
 
     except APIError as e:
+        if getattr(e, "code", "") == "42P10":
+            return False, (
+                "Schema mismatch: players upsert requires a unique index or constraint on "
+                "(club_id, normalized_name)."
+            )
         return False, str(e)

--- a/supabase/migrations/202602200003_players_normalized_name_unique.sql
+++ b/supabase/migrations/202602200003_players_normalized_name_unique.sql
@@ -1,8 +1,18 @@
 -- Ensure ON CONFLICT (club_id, normalized_name) can be inferred by Postgres.
 -- The previous partial unique index (where normalized_name is not null) cannot
 -- be inferred by a plain ON CONFLICT (club_id, normalized_name) clause.
+-- Guard for environments where legacy core tables are provisioned outside this
+-- migration chain and public.players may not yet exist.
 
-drop index if exists public.players_club_id_normalized_name_uq;
+do $$
+begin
+  if to_regclass('public.players') is not null then
+    execute 'drop index if exists public.players_club_id_normalized_name_uq';
 
-create unique index if not exists players_club_id_normalized_name_uq
-  on public.players (club_id, normalized_name);
+    execute $sql$
+      create unique index if not exists players_club_id_normalized_name_uq
+        on public.players (club_id, normalized_name)
+    $sql$;
+  end if;
+end;
+$$;

--- a/supabase/migrations/202602200003_players_normalized_name_unique.sql
+++ b/supabase/migrations/202602200003_players_normalized_name_unique.sql
@@ -1,0 +1,8 @@
+-- Ensure ON CONFLICT (club_id, normalized_name) can be inferred by Postgres.
+-- The previous partial unique index (where normalized_name is not null) cannot
+-- be inferred by a plain ON CONFLICT (club_id, normalized_name) clause.
+
+drop index if exists public.players_club_id_normalized_name_uq;
+
+create unique index if not exists players_club_id_normalized_name_uq
+  on public.players (club_id, normalized_name);

--- a/tests/test_player_ops.py
+++ b/tests/test_player_ops.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from postgrest.exceptions import APIError
+
+from jupr_app.domain.player_ops import safe_add_player
+
+
+class _Query:
+    def __init__(self, supabase, table_name: str):
+        self.supabase = supabase
+        self.table_name = table_name
+        self._filters: list[tuple[str, object]] = []
+
+    def upsert(self, payload, on_conflict=None):
+        self.supabase.last_payload = dict(payload)
+        self.supabase.last_on_conflict = on_conflict
+        return self
+
+    def select(self, _fields: str):
+        return self
+
+    def eq(self, col: str, value):
+        self._filters.append((col, value))
+        return self
+
+    def limit(self, _n: int):
+        return self
+
+    def execute(self):
+        if self.supabase.raise_api_error is not None:
+            raise self.supabase.raise_api_error
+        if self.supabase.upsert_data is not None:
+            data = self.supabase.upsert_data
+            self.supabase.upsert_data = None
+            return SimpleNamespace(data=data)
+
+        rows = self.supabase.rows.get(self.table_name, [])
+        for col, value in self._filters:
+            rows = [row for row in rows if str(row.get(col)) == str(value)]
+        return SimpleNamespace(data=rows)
+
+
+class _Supabase:
+    def __init__(self):
+        self.rows = {"players": []}
+        self.upsert_data = None
+        self.raise_api_error = None
+        self.last_payload = None
+        self.last_on_conflict = None
+
+    def table(self, name: str):
+        return _Query(self, name)
+
+
+def test_safe_add_player_sets_normalized_name_and_conflict_target():
+    supabase = _Supabase()
+    supabase.upsert_data = [{"id": 17}]
+
+    ok, player_id = safe_add_player(
+        supabase=supabase,
+        club_id="club-1",
+        name="  Alice   Smith ",
+        rating_jupr=3.5,
+    )
+
+    assert ok is True
+    assert player_id == 17
+    assert supabase.last_on_conflict == "club_id,normalized_name"
+    assert supabase.last_payload["normalized_name"] == "alice smith"
+
+
+def test_safe_add_player_falls_back_to_lookup_when_upsert_returns_empty_data():
+    supabase = _Supabase()
+    supabase.upsert_data = []
+    supabase.rows["players"].append({"id": 99, "club_id": "club-1", "normalized_name": "alice smith"})
+
+    ok, player_id = safe_add_player(
+        supabase=supabase,
+        club_id="club-1",
+        name="Alice Smith",
+        rating_jupr=3.5,
+    )
+
+    assert ok is True
+    assert player_id == 99
+
+
+def test_safe_add_player_surfaces_schema_mismatch_for_on_conflict():
+    supabase = _Supabase()
+    supabase.raise_api_error = APIError(
+        {
+            "code": "42P10",
+            "message": "there is no unique or exclusion constraint matching the ON CONFLICT specification",
+            "hint": None,
+            "details": None,
+        }
+    )
+
+    ok, err = safe_add_player(
+        supabase=supabase,
+        club_id="club-1",
+        name="Alice Smith",
+        rating_jupr=3.5,
+    )
+
+    assert ok is False
+    assert "Schema mismatch" in err


### PR DESCRIPTION
### Motivation
- The Add Player flow failed because `safe_add_player` used `upsert(..., on_conflict="club_id,normalized_name")` while the repo had a partial unique index (`WHERE normalized_name IS NOT NULL`) so Postgres could not infer the `ON CONFLICT` target and raised `42P10` (unique constraint mismatch).
- The change ensures the code and DB contract agree and that errors are actionable rather than silent.

### Description
- Compute and include `normalized_name` in the player payload by adding `_normalized_player_name` and writing `"normalized_name"` in `safe_add_player` so the upsert conflict target is provided explicitly (`jupr_app/domain/player_ops.py`).
- Add a deterministic fallback lookup after an upsert that returns no row data to retrieve an existing `id` when PostgREST returns empty response data (`safe_add_player`).
- Surface a clear schema-mismatch error for the Postgres `42P10` case so the UI shows an actionable message instead of an opaque failure (`safe_add_player`).
- Add a migration `supabase/migrations/202602200003_players_normalized_name_unique.sql` that replaces the partial index with a full unique index on `(club_id, normalized_name)` so `ON CONFLICT (club_id, normalized_name)` can be inferred by Postgres.
- Add focused unit tests in `tests/test_player_ops.py` covering normalized-name payload population, fallback lookup, and explicit schema-mismatch messaging.

### Testing
- Ran `pytest -q tests/test_player_ops.py` which executed the new focused tests and reported `3 passed`.
- Verified that `safe_add_player` now attaches `normalized_name` to `payload` and that an empty upsert response triggers the fallback lookup in the mocked tests which succeeded. 
- Confirmed explicit `42P10` handling returns a schema-mismatch message in the failing mocked case.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997dfa575c88326bc74041b89f6e768)