### PR TITLE
Instrument player creation path and switch to raw insert diagnostics

### DIFF
--- a/jupr_app/domain/player_ops.py
+++ b/jupr_app/domain/player_ops.py
@@ -51,36 +51,11 @@ def safe_add_player(
     }
 
     try:
-        resp = (
-            supabase
-            .table("players")
-            .upsert(payload, on_conflict="club_id,normalized_name")
-            .execute()
-        )
-
+        resp = supabase.table("players").insert(payload).execute()
+        print("DEBUG INSERT RESPONSE:", resp.data)
         if resp.data and len(resp.data) > 0 and resp.data[0].get("id"):
             return True, resp.data[0]["id"]
-
-        existing = (
-            supabase
-            .table("players")
-            .select("id")
-            .eq("club_id", str(club_id))
-            .eq("normalized_name", normalized_name)
-            .limit(1)
-            .execute()
-            .data
-            or []
-        )
-        if existing and existing[0].get("id"):
-            return True, existing[0]["id"]
-
-        return False, "Upsert did not return an id"
-
+        return False, "Insert did not return an id"
     except APIError as e:
-        if getattr(e, "code", "") == "42P10":
-            return False, (
-                "Schema mismatch: players upsert requires a unique index or constraint on "
-                "(club_id, normalized_name)."
-            )
-        return False, str(e)
+        print("DEBUG INSERT ERROR:", e)
+        raise

--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -28,6 +28,9 @@ def render(ctx):
             name = st.text_input("Name")
             rating = st.number_input("Starting JUPR", 1.0, 7.0, 3.5, step=0.1)
             if st.form_submit_button("Add Player"):
+                st.write("DEBUG: Add Player form submitted")
+                st.write("DEBUG club_id:", club_id)
+                st.write("DEBUG name:", name)
                 name_clean = name.strip()
                 if not name_clean:
                     st.error("Name required.")
@@ -47,12 +50,18 @@ def render(ctx):
                     st.session_state[PICK_KEY] = name_clean
                     time.sleep(0.1)
                     st.rerun()
-                ok, err = safe_add_player(
-                    supabase=supabase,
-                    club_id=club_id,
-                    name=name_clean,
-                    rating_jupr=float(rating),
-                )
+                try:
+                    ok, err = safe_add_player(
+                        supabase=supabase,
+                        club_id=club_id,
+                        name=name_clean,
+                        rating_jupr=float(rating),
+                    )
+                    st.write("DEBUG safe_add_player returned:", ok, err)
+                except Exception as e:
+                    st.error("safe_add_player crashed")
+                    st.exception(e)
+                    raise
                 if not ok:
                     st.error(err or "Unable to add player.")
                     st.stop()


### PR DESCRIPTION
### Motivation
- Add targeted instrumentation to determine whether the UI submit path fires, whether `safe_add_player()` is invoked, and whether Supabase/RLS or client compatibility is blocking player creation.
- Make diagnostics minimal and reversible so the investigation can classify the root cause without refactoring application flow.

### Description
- Added UI-level debug output in `jupr_app/ui/pages/player_editor.py` to log form submission and input values and wrapped the `safe_add_player()` call in a `try/except` to surface exceptions with `st.exception` and re-raise.
- Replaced the `.upsert(..., on_conflict=...)` path in `jupr_app/domain/player_ops.py` with a raw `.insert(...).execute()` and added `print` diagnostics for insert responses and `APIError` so insert-time errors are visible.
- Changes are intentionally minimal and diagnostic-only and affect only the add-player submit handler and the `safe_add_player()` insert path.

### Testing
- Compiled the modified files with `python -m compileall jupr_app/ui/pages/player_editor.py jupr_app/domain/player_ops.py`, and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997e2f251c48326940d941e8b9ef7af)