### PR TITLE
Add forensic instrumentation for player creation path

### DIFF
--- a/jupr_app/data/sb_write.py
+++ b/jupr_app/data/sb_write.py
@@ -36,12 +36,16 @@ def _enforce_rating_state_policy(*, table: str, payload: Dict, derived_from_matc
 
 
 def sb_insert(supabase: Any, table: str, payload: Dict) -> Any:
-    return (
-        supabase
-        .table(table)
-        .insert(payload)
-        .execute()
-    )
+    try:
+        return (
+            supabase
+            .table(table)
+            .insert(payload)
+            .execute()
+        )
+    except Exception as e:
+        print("SUPABASE WRITE FAILURE:", e)
+        raise
 
 
 def sb_upsert(
@@ -57,15 +61,19 @@ def sb_upsert(
         payload=payload,
         derived_from_match_history=derived_from_match_history,
     )
-    return (
-        supabase
-        .table(table)
-        .upsert(
-            payload,
-            on_conflict=conflict,
+    try:
+        return (
+            supabase
+            .table(table)
+            .upsert(
+                payload,
+                on_conflict=conflict,
+            )
+            .execute()
         )
-        .execute()
-    )
+    except Exception as e:
+        print("SUPABASE WRITE FAILURE:", e)
+        raise
 
 
 def sb_update(
@@ -86,7 +94,11 @@ def sb_update(
     for col, value in filters.items():
         query = query.eq(col, value)
 
-    return query.execute()
+    try:
+        return query.execute()
+    except Exception as e:
+        print("SUPABASE WRITE FAILURE:", e)
+        raise
 
 
 def sb_delete(
@@ -100,8 +112,16 @@ def sb_delete(
     for col, value in filters.items():
         query = query.eq(col, value)
 
-    return query.execute()
+    try:
+        return query.execute()
+    except Exception as e:
+        print("SUPABASE WRITE FAILURE:", e)
+        raise
 
 
 def sb_rpc(supabase: Any, name: str, payload: Dict) -> Any:
-    return supabase.rpc(name, payload).execute()
+    try:
+        return supabase.rpc(name, payload).execute()
+    except Exception as e:
+        print("SUPABASE WRITE FAILURE:", e)
+        raise

--- a/jupr_app/domain/player_ops.py
+++ b/jupr_app/domain/player_ops.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 
 from typing import Tuple
 
-from postgrest.exceptions import APIError
-
 
 def _normalized_player_name(name: str) -> str:
     return " ".join(str(name or "").strip().lower().split())
+
 
 def safe_add_player(
     *,
@@ -16,46 +15,4 @@ def safe_add_player(
     name: str,
     rating_jupr: float,
 ) -> Tuple[bool, str]:
-    """
-    Idempotent player creation for JUPR.
-
-    Behavior:
-    - Inserts player using ON CONFLICT (club_id, normalized_name)
-    - Returns the upserted row id directly from the upsert response
-    - Deterministic and race-safe
-    """
-
-    clean_name = str(name or "").strip()
-    if not clean_name:
-        return False, "Blank name."
-
-    try:
-        elo = float(rating_jupr) * 400.0
-    except Exception:
-        return False, "Invalid rating."
-
-    normalized_name = _normalized_player_name(clean_name)
-
-    payload = {
-        "club_id": str(club_id),
-        "name": clean_name,
-        "normalized_name": normalized_name,
-        "active": True,
-        "rating": float(elo),
-        "starting_rating": float(elo),
-        "wins": 0,
-        "losses": 0,
-        "matches_played": 0,
-        "last_game_at": None,
-        "inactive_at": None,
-    }
-
-    try:
-        resp = supabase.table("players").insert(payload).execute()
-        print("DEBUG INSERT RESPONSE:", resp.data)
-        if resp.data and len(resp.data) > 0 and resp.data[0].get("id"):
-            return True, resp.data[0]["id"]
-        return False, "Insert did not return an id"
-    except APIError as e:
-        print("DEBUG INSERT ERROR:", e)
-        raise
+    raise Exception("SAFE_ADD_PLAYER WAS CALLED")

--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -3,10 +3,10 @@ import pandas as pd
 import time
 
 from jupr_app.ui.layout import page_shell
-from jupr_app.domain.player_ops import safe_add_player
 from jupr_app.domain.player_merge import merge_player_into
 
 def render(ctx):
+    st.write("BUILD MARKER: rebuild branch player_editor v1")
     mode_label = "Public" if bool(ctx.public_mode) else "Admin"
     page_shell("👥 Player Editor", "Edit player records and league ratings.", mode_label=mode_label)
     PICK_KEY = "player_editor_pick"
@@ -17,6 +17,7 @@ def render(ctx):
 
     supabase = ctx.supabase
     club_id = str(ctx.club_id)
+    st.write("SUPABASE URL:", ctx.supabase_url)
 
     df_players_all = getattr(ctx, "df_players_all", pd.DataFrame())
 
@@ -27,8 +28,11 @@ def render(ctx):
         with st.form("add_player_form"):
             name = st.text_input("Name")
             rating = st.number_input("Starting JUPR", 1.0, 7.0, 3.5, step=0.1)
-            if st.form_submit_button("Add Player"):
-                st.write("DEBUG: Add Player form submitted")
+            submit = st.form_submit_button("Add Player")
+            st.write("Submit value:", submit)
+
+            if submit:
+                st.write("Submit is TRUE")
                 st.write("DEBUG club_id:", club_id)
                 st.write("DEBUG name:", name)
                 name_clean = name.strip()
@@ -50,22 +54,14 @@ def render(ctx):
                     st.session_state[PICK_KEY] = name_clean
                     time.sleep(0.1)
                     st.rerun()
-                try:
-                    ok, err = safe_add_player(
-                        supabase=supabase,
-                        club_id=club_id,
-                        name=name_clean,
-                        rating_jupr=float(rating),
-                    )
-                    st.write("DEBUG safe_add_player returned:", ok, err)
-                except Exception as e:
-                    st.error("safe_add_player crashed")
-                    st.exception(e)
-                    raise
-                if not ok:
-                    st.error(err or "Unable to add player.")
-                    st.stop()
-                st.success("Added.")
+                resp = supabase.table("players").insert({
+                    "club_id": club_id,
+                    "name": "TEST_PLAYER_DIRECT",
+                    "normalized_name": "test_player_direct",
+                    "active": True,
+                }).execute()
+                st.write("DIRECT INSERT RESPONSE:", resp.data)
+                st.success("Direct insert attempted.")
                 st.session_state[PICK_KEY] = name_clean
                 time.sleep(0.2)
                 st.rerun()


### PR DESCRIPTION
### Motivation
- Provide deterministic, deployable instrumentation to prove where player creation fails end-to-end (UI → domain → DB) without refactoring, using explicit markers, forced failures, and direct DB writes. 

### Description
- Added a Streamlit build marker `BUILD MARKER: rebuild branch player_editor v1` and `SUPABASE URL:` output to `jupr_app/ui/pages/player_editor.py` to verify deployed code and target project.  
- Replaced the Add Player submit handling to expose `Submit value:` and `Submit is TRUE` and temporarily route the submit path to a direct Supabase insert of `TEST_PLAYER_DIRECT` with `DIRECT INSERT RESPONSE` logging.  
- Replaced `safe_add_player` implementation in `jupr_app/domain/player_ops.py` with a hard failure `raise Exception("SAFE_ADD_PLAYER WAS CALLED")` to verify whether the UI reaches the domain layer.  
- Wrapped Supabase write helpers in `jupr_app/data/sb_write.py` (`sb_insert`, `sb_upsert`, `sb_update`, `sb_delete`, `sb_rpc`) with try/except that prints `SUPABASE WRITE FAILURE: ...` and re-raises to surface raw API errors.

### Testing
- Ran `pytest -q tests/test_sb_write.py` and it passed (`3 passed`).
- Ran `python -m py_compile jupr_app/ui/pages/player_editor.py jupr_app/domain/player_ops.py jupr_app/data/sb_write.py` and compilation succeeded.  
- An automated Playwright attempt to capture the running app at `http://localhost:8501` failed with `ERR_EMPTY_RESPONSE`, indicating the app was not reachable from this environment (no UI screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997e4db29c08326bcedafff9ffc3262)