### PR TITLE
Fix Player Editor crash from missing AppContext field

### DIFF
--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -17,8 +17,6 @@ def render(ctx):
 
     supabase = ctx.supabase
     club_id = str(ctx.club_id)
-    st.write("SUPABASE URL:", ctx.supabase_url)
-
     df_players_all = getattr(ctx, "df_players_all", pd.DataFrame())
 
     # -------------------------


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash in the Player Editor page caused by reading a non-existent attribute `ctx.supabase_url` from the `AppContext` during `render()`.

### Description
- Remove the stray debug `st.write("SUPABASE URL:", ctx.supabase_url)` from `jupr_app/ui/pages/player_editor.py` so the page only accesses fields that are defined on `AppContext` (e.g. `supabase`, `club_id`, `df_players_all`).

### Testing
- Compiled the modified file with `python -m py_compile jupr_app/ui/pages/player_editor.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997e74707b08326b9d11fb1a4c3b657)