### PR TITLE
Persist admin sidebar page selection to query params

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -67,7 +67,7 @@ def render_public_top_nav(*, labels_in_order: list[str], current_label: str) -> 
     )
 
 
-def render_admin_sidebar_nav(*, current_label: str, admin_logged_in: bool) -> str:
+def render_admin_sidebar_nav(*, current_label: str, admin_logged_in: bool, label_to_page_key: dict[str, str]) -> str:
     taxonomy = [
         ("Command Center", ["🧭 Command Center"]),
         ("Competitions", ["🪜 Challenge Ladder", "🏆 Tournaments", "🏆 Tournament Manager", "🏆 Division Manager", "💰 Moneyball"]),
@@ -93,6 +93,14 @@ def render_admin_sidebar_nav(*, current_label: str, admin_logged_in: bool) -> st
             prefix = "👉 " if label == selected else ""
             if st.sidebar.button(f"{prefix}{label}", key=f"nav_btn_{label}", use_container_width=True):
                 selected = label
+                try:
+                    from streamlit.runtime.scriptrunner import get_script_run_ctx
+                except Exception:
+                    pass
+                # Persist selection into query params
+                page_key = label_to_page_key.get(label)
+                if page_key:
+                    st.query_params["page"] = page_key
         st.sidebar.markdown(" ")
 
     return selected
@@ -500,7 +508,11 @@ def main():
                     clear_requirements_cache()
                 except Exception:
                     pass
-            sel = render_admin_sidebar_nav(current_label=sel, admin_logged_in=admin_logged_in)
+            sel = render_admin_sidebar_nav(
+                current_label=sel,
+                admin_logged_in=admin_logged_in,
+                label_to_page_key=LABEL_TO_PAGE_KEY,
+            )
             if sel not in visible_labels:
                 sel = visible_labels[0]
 


### PR DESCRIPTION
### Motivation
- Reruns were resetting the admin navigation to "🧭 Command Center" because the admin sidebar selection was not persisted to `st.query_params`, causing form submissions (e.g. Player Editor) to land on the wrong page.

### Description
- Add a `label_to_page_key` parameter to `render_admin_sidebar_nav()` and thread `LABEL_TO_PAGE_KEY` into the call site to avoid new globals.
- When an admin sidebar button is clicked, write the matching page key into `st.query_params["page"]` (with the guarded import of `get_script_run_ctx` as requested). 
- No changes were made to `render_public_top_nav()` or the `resolve_route()` deep-link logic, so public navigation behavior is unchanged.

### Testing
- Ran `python -m py_compile streamlit_app.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997f4e4e28883269f40930584e5486c)