### PR TITLE
Revert unintended player_editor changes that landed on main

### DIFF
--- a/jupr_app/data/sb_write.py
+++ b/jupr_app/data/sb_write.py
@@ -36,16 +36,12 @@ def _enforce_rating_state_policy(*, table: str, payload: Dict, derived_from_matc
 
 
 def sb_insert(supabase: Any, table: str, payload: Dict) -> Any:
-    try:
-        return (
-            supabase
-            .table(table)
-            .insert(payload)
-            .execute()
-        )
-    except Exception as e:
-        print("SUPABASE WRITE FAILURE:", e)
-        raise
+    return (
+        supabase
+        .table(table)
+        .insert(payload)
+        .execute()
+    )
 
 
 def sb_upsert(
@@ -61,19 +57,15 @@ def sb_upsert(
         payload=payload,
         derived_from_match_history=derived_from_match_history,
     )
-    try:
-        return (
-            supabase
-            .table(table)
-            .upsert(
-                payload,
-                on_conflict=conflict,
-            )
-            .execute()
+    return (
+        supabase
+        .table(table)
+        .upsert(
+            payload,
+            on_conflict=conflict,
         )
-    except Exception as e:
-        print("SUPABASE WRITE FAILURE:", e)
-        raise
+        .execute()
+    )
 
 
 def sb_update(
@@ -94,11 +86,7 @@ def sb_update(
     for col, value in filters.items():
         query = query.eq(col, value)
 
-    try:
-        return query.execute()
-    except Exception as e:
-        print("SUPABASE WRITE FAILURE:", e)
-        raise
+    return query.execute()
 
 
 def sb_delete(
@@ -112,16 +100,8 @@ def sb_delete(
     for col, value in filters.items():
         query = query.eq(col, value)
 
-    try:
-        return query.execute()
-    except Exception as e:
-        print("SUPABASE WRITE FAILURE:", e)
-        raise
+    return query.execute()
 
 
 def sb_rpc(supabase: Any, name: str, payload: Dict) -> Any:
-    try:
-        return supabase.rpc(name, payload).execute()
-    except Exception as e:
-        print("SUPABASE WRITE FAILURE:", e)
-        raise
+    return supabase.rpc(name, payload).execute()

--- a/jupr_app/domain/player_ops.py
+++ b/jupr_app/domain/player_ops.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 
 from typing import Tuple
 
+from postgrest.exceptions import APIError
+
 
 def _normalized_player_name(name: str) -> str:
     return " ".join(str(name or "").strip().lower().split())
-
 
 def safe_add_player(
     *,
@@ -15,4 +16,71 @@ def safe_add_player(
     name: str,
     rating_jupr: float,
 ) -> Tuple[bool, str]:
-    raise Exception("SAFE_ADD_PLAYER WAS CALLED")
+    """
+    Idempotent player creation for JUPR.
+
+    Behavior:
+    - Inserts player using ON CONFLICT (club_id, normalized_name)
+    - Returns the upserted row id directly from the upsert response
+    - Deterministic and race-safe
+    """
+
+    clean_name = str(name or "").strip()
+    if not clean_name:
+        return False, "Blank name."
+
+    try:
+        elo = float(rating_jupr) * 400.0
+    except Exception:
+        return False, "Invalid rating."
+
+    normalized_name = _normalized_player_name(clean_name)
+
+    payload = {
+        "club_id": str(club_id),
+        "name": clean_name,
+        "normalized_name": normalized_name,
+        "active": True,
+        "rating": float(elo),
+        "starting_rating": float(elo),
+        "wins": 0,
+        "losses": 0,
+        "matches_played": 0,
+        "last_game_at": None,
+        "inactive_at": None,
+    }
+
+    try:
+        resp = (
+            supabase
+            .table("players")
+            .upsert(payload, on_conflict="club_id,normalized_name")
+            .execute()
+        )
+
+        if resp.data and len(resp.data) > 0 and resp.data[0].get("id"):
+            return True, resp.data[0]["id"]
+
+        existing = (
+            supabase
+            .table("players")
+            .select("id")
+            .eq("club_id", str(club_id))
+            .eq("normalized_name", normalized_name)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        if existing and existing[0].get("id"):
+            return True, existing[0]["id"]
+
+        return False, "Upsert did not return an id"
+
+    except APIError as e:
+        if getattr(e, "code", "") == "42P10":
+            return False, (
+                "Schema mismatch: players upsert requires a unique index or constraint on "
+                "(club_id, normalized_name)."
+            )
+        return False, str(e)

--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -3,10 +3,10 @@ import pandas as pd
 import time
 
 from jupr_app.ui.layout import page_shell
+from jupr_app.domain.player_ops import safe_add_player
 from jupr_app.domain.player_merge import merge_player_into
 
 def render(ctx):
-    st.write("BUILD MARKER: rebuild branch player_editor v1")
     mode_label = "Public" if bool(ctx.public_mode) else "Admin"
     page_shell("👥 Player Editor", "Edit player records and league ratings.", mode_label=mode_label)
     PICK_KEY = "player_editor_pick"
@@ -17,6 +17,7 @@ def render(ctx):
 
     supabase = ctx.supabase
     club_id = str(ctx.club_id)
+
     df_players_all = getattr(ctx, "df_players_all", pd.DataFrame())
 
     # -------------------------
@@ -26,13 +27,7 @@ def render(ctx):
         with st.form("add_player_form"):
             name = st.text_input("Name")
             rating = st.number_input("Starting JUPR", 1.0, 7.0, 3.5, step=0.1)
-            submit = st.form_submit_button("Add Player")
-            st.write("Submit value:", submit)
-
-            if submit:
-                st.write("Submit is TRUE")
-                st.write("DEBUG club_id:", club_id)
-                st.write("DEBUG name:", name)
+            if st.form_submit_button("Add Player"):
                 name_clean = name.strip()
                 if not name_clean:
                     st.error("Name required.")
@@ -52,14 +47,16 @@ def render(ctx):
                     st.session_state[PICK_KEY] = name_clean
                     time.sleep(0.1)
                     st.rerun()
-                resp = supabase.table("players").insert({
-                    "club_id": club_id,
-                    "name": "TEST_PLAYER_DIRECT",
-                    "normalized_name": "test_player_direct",
-                    "active": True,
-                }).execute()
-                st.write("DIRECT INSERT RESPONSE:", resp.data)
-                st.success("Direct insert attempted.")
+                ok, err = safe_add_player(
+                    supabase=supabase,
+                    club_id=club_id,
+                    name=name_clean,
+                    rating_jupr=float(rating),
+                )
+                if not ok:
+                    st.error(err or "Unable to add player.")
+                    st.stop()
+                st.success("Added.")
                 st.session_state[PICK_KEY] = name_clean
                 time.sleep(0.2)
                 st.rerun()


### PR DESCRIPTION
### Motivation
- Undo recent player-editor changes that were merged into `main` by mistake so the UI, domain logic, and write helpers return to the intended behavior without extra forensic instrumentation or debug output.

### Description
- Reverted the player-editor related changes and restored the prior implementations across the codebase.
- Restored `safe_add_player` behavior in `jupr_app/domain/player_ops.py` to perform an idempotent upsert with a lookup fallback and explicit APIError handling. 
- Removed debug/forensic instrumentation and direct insert experiments from `jupr_app/ui/pages/player_editor.py` and reintroduced the `safe_add_player` call in the add-player flow. 
- Cleaned up noisy try/except logging wrappers in `jupr_app/data/sb_write.py` so the helper functions are simple, policy-enforcing wrappers (`sb_insert`, `sb_upsert`, `sb_update`, `sb_delete`, `sb_rpc`).

### Testing
- Compiled the three modified modules with `python -m compileall jupr_app/data/sb_write.py jupr_app/domain/player_ops.py jupr_app/ui/pages/player_editor.py` and the compilation succeeded. 
- Inspected the resulting diffs to confirm the three target files were updated to the expected reverted implementations. 
- Opened a PR containing the reversion changes for review and merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699872d239008326a1920fe1333390f2)