### PR TITLE
Revert player_editor backport changes

### DIFF
--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -5,76 +5,76 @@ from datetime import datetime, timezone
 
 from jupr_app.ui.layout import page_shell
 from jupr_app.domain.player_ops import safe_add_player
-st.header("FORM TEST")
 
-with st.form("test_form"):
-    name = st.text_input("Name")
-    submit = st.form_submit_button("Add Player")
-
-st.write("Submit value:", submit)
-
-if submit:
-    st.success("FORM WORKS")
 def render(ctx):
-    import streamlit as st
-    st.write("STATIC PAGE")
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("👥 Player Editor", "Edit player records and league ratings.", mode_label=mode_label)
+    PICK_KEY = "player_editor_pick"
 
-    with st.form("static_form"):
-        submit = st.form_submit_button("Click Me")
+    if not bool(getattr(ctx, "admin_logged_in", False)):
+        st.error("Admin login required.")
+        st.stop()
 
-    st.write("Submit:", submit)
+    supabase = ctx.supabase
+    club_id = str(ctx.club_id)
 
-    if submit:
-        st.success("IT WORKS")
+    df_players_all = getattr(ctx, "df_players_all", pd.DataFrame())
+    df_meta = getattr(ctx, "df_meta", pd.DataFrame())
+
     # -------------------------
     # Add New Player
     # -------------------------
     with st.expander("➕ Add New Player", expanded=False):
-    
-        with st.form("add_player_form", clear_on_submit=True):
+        with st.form("add_player_form"):
             name = st.text_input("Name")
             rating = st.number_input("Starting JUPR", 1.0, 7.0, 3.5, step=0.1)
-            submit = st.form_submit_button("Add Player")
-    
-        if submit:
-            name_clean = name.strip()
-    
-            if not name_clean:
-                st.error("Name required.")
-                st.stop()
-    
-            existing = (
-                supabase.table("players")
-                .select("id,name")
-                .eq("club_id", club_id)
-                .eq("name", name_clean)
-                .limit(1)
-                .execute()
-                .data
-                or []
-            )
-    
-            if existing:
-                st.info("Player already exists — opening existing record.")
+            if st.form_submit_button("Add Player"):
+                name_clean = name.strip()
+                if not name_clean:
+                    st.error("Name required.")
+                    st.stop()
+                existing = (
+                    supabase.table("players")
+                    .select("id,name")
+                    .eq("club_id", club_id)
+                    .eq("name", name_clean)
+                    .limit(1)
+                    .execute()
+                    .data
+                    or []
+                )
+                if existing:
+                    st.info("Player already exists — opening existing record.")
+                    st.session_state[PICK_KEY] = name_clean
+                    time.sleep(0.1)
+                    st.rerun()
+                payload = {
+                    "club_id": club_id,
+                    "name": name_clean,
+                    "rating": float(rating) * 400.0,
+                    "starting_rating": float(rating) * 400.0,
+                    "wins": 0,
+                    "losses": 0,
+                    "matches_played": 0,
+                    "active": True,
+                    "inactive_at": None,
+                }
+                ok, err = safe_add_player(
+                    supabase=supabase,
+                    club_id=club_id,
+                    name=name_clean,
+                    rating_jupr=float(rating),
+                )
+                if not ok:
+                    st.error(err or "Unable to add player.")
+                    st.stop()
+                st.success("Added.")
                 st.session_state[PICK_KEY] = name_clean
+                time.sleep(0.2)
                 st.rerun()
-    
-            ok, err = safe_add_player(
-                supabase=supabase,
-                club_id=club_id,
-                name=name_clean,
-                rating_jupr=float(rating),
-            )
-    
-            if not ok:
-                st.error(err or "Unable to add player.")
-                st.stop()
-    
-            st.success("Added.")
-            st.session_state[PICK_KEY] = name_clean
-            st.rerun()
-    
+
     st.divider()
+
     # -------------------------
     # Select Player
     # -------------------------


### PR DESCRIPTION
### Motivation
- Undo a recent backport that introduced temporary form/test scaffolding and altered the admin player editor behavior in `jupr_app/ui/pages/player_editor.py` to restore the intended player management UX.

### Description
- Restores the original admin-check flow and removes the temporary form/test UI scaffolding from `jupr_app/ui/pages/player_editor.py`.
- Restores the Add Player form behavior to use `safe_add_player`, re-enable duplicate checks, set session pick state, and rerun after successful additions.
- Reconciles UI layout changes including the page shell, pick key usage, and preserves edit, league ratings, and merge-account functionality.
- Consolidates the undo into a single revert change that updates only `jupr_app/ui/pages/player_editor.py`.

### Testing
- Verified working tree and repository state with `git status --short` and review commands; all checks completed successfully.
- Confirmed the consolidated revert is present at HEAD and the target file `jupr_app/ui/pages/player_editor.py` reflects the restored logic using repository inspection commands such as `git log --oneline -n 6` and `git show --stat` which all succeeded.
- Per-file content was inspected with `nl -ba jupr_app/ui/pages/player_editor.py | sed -n '1,260p'` to confirm the expected UI and flow were restored.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987483b4cc8326b815c5375cb86da7)