### PR TITLE
Fix admin navigation persistence and one-click data refresh

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -278,13 +278,30 @@ def main():
         PUBLIC_MODE = st.session_state["entry_mode"] == "public"
         admin_logged_in = bool(st.session_state.get("sb_session"))
 
-        if admin_logged_in and st.sidebar.button("Log Out"):
+        def _clear_app_caches():
+            get_data.clear()
+            try:
+                from jupr_app.domain.gamification.requirements import clear_requirements_cache
+
+                clear_requirements_cache()
+            except Exception:
+                pass
+
+        if admin_logged_in and st.sidebar.button("Log Out", key="logout_btn"):
             try:
                 supabase.auth.sign_out()
             except Exception:
                 pass
             st.session_state.clear()
             st.stop()
+
+        if st.session_state.pop("_force_data_reload", False):
+            _clear_app_caches()
+
+        if (not PUBLIC_MODE) and admin_logged_in:
+            if st.sidebar.button("🔄 Refresh data", key="refresh_data_btn"):
+                _clear_app_caches()
+                st.rerun()
 
         (
             df_players_all,
@@ -492,21 +509,21 @@ def main():
         if PUBLIC_MODE:
             sel = render_public_top_nav(labels_in_order=public_labels_in_order, current_label=sel)
         else:
-            if admin_logged_in and st.sidebar.button("🔄 Refresh data"):
-                get_data.clear()
-                try:
-                    from jupr_app.domain.gamification.requirements import clear_requirements_cache
-
-                    clear_requirements_cache()
-                except Exception:
-                    pass
             sel = render_admin_sidebar_nav(current_label=sel, admin_logged_in=admin_logged_in)
             if sel not in visible_labels:
                 sel = visible_labels[0]
+            try:
+                page_key = LABEL_TO_PAGE_KEY.get(sel)
+                if page_key and st.query_params.get("page") != page_key:
+                    st.query_params["page"] = page_key
+            except Exception:
+                pass
 
         if PUBLIC_MODE:
             try:
-                st.query_params["page"] = LABEL_TO_PAGE_KEY.get(sel, "leaderboards")
+                page_key = LABEL_TO_PAGE_KEY.get(sel, "leaderboards")
+                if st.query_params.get("page") != page_key:
+                    st.query_params["page"] = page_key
             except Exception:
                 pass
 


### PR DESCRIPTION
### Motivation
- Ensure admin UI selection is persisted to the URL so deep-linking/bookmarks work for admin pages.
- Make the sidebar "🔄 Refresh data" button actually reload data on a single click by clearing caches and rerunning the app.
- Allow pages to request a data/cache invalidation via a session flag so background or page actions can force a fresh load.

### Description
- Added a `_clear_app_caches()` helper inside `main()` that clears `get_data` cache and attempts to clear gamification requirements cache in `jupr_app.domain.gamification.requirements`.
- Honor an explicit cache invalidation request from pages via `st.session_state.pop("_force_data_reload", False)` immediately before calling `get_data(club_id)`.
- Added an admin-only pre-load sidebar button (`🔄 Refresh data`, key `refresh_data_btn`) that calls `_clear_app_caches()` and then `st.rerun()` so the reload occurs on the same click.
- Gave the Log Out button a stable key (`logout_btn`) to avoid transient widget key issues.
- Removed the old later refresh block and added admin-side URL persistence after admin selection by setting `st.query_params["page"]` to the selected page key only when it differs, and guarded the public-mode `?page=` write to avoid redundant writes.

### Testing
- Ran `python -m py_compile streamlit_app.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ad83ac9883268c52d4532860e7e4)