### PR TITLE
Remove temporary Player Editor debug instrumentation

### DIFF
--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -7,7 +7,6 @@ from jupr_app.ui.layout import page_shell
 from jupr_app.domain.player_merge import merge_player_into
 
 def render(ctx):
-    st.write("BUILD MARKER: rebuild branch player_editor v1")
     mode_label = "Public" if bool(ctx.public_mode) else "Admin"
     page_shell("👥 Player Editor", "Edit player records and league ratings.", mode_label=mode_label)
     PICK_KEY = "player_editor_pick"
@@ -33,12 +32,8 @@ def render(ctx):
             name = st.text_input("Name", key="add_player_name")
             rating = st.number_input("Starting JUPR", 1.0, 7.0, 3.5, step=0.1, key="add_player_starting_jupr")
             submit = st.form_submit_button("Add Player")
-            st.write("Submit value:", submit)
 
             if submit:
-                st.write("Submit is TRUE")
-                st.write("DEBUG club_id:", club_id)
-                st.write("DEBUG name:", name)
                 name_clean = name.strip()
                 normalized_name = _normalize_name(name_clean)
                 if not name_clean:
@@ -69,10 +64,8 @@ def render(ctx):
                     "active": True,
                     "rating": int(round(float(rating) * 400.0)),
                 }
-                st.write("Supabase client session:", supabase.auth.get_session())
-                resp = supabase.table("players").insert(payload).execute()
-                st.write("DIRECT INSERT RESPONSE:", resp.data)
-                st.success("Direct insert attempted.")
+                supabase.table("players").insert(payload).execute()
+                st.success(f"Player created: {name_clean} (Starting JUPR {float(rating):.1f})")
                 st.session_state["_force_data_reload"] = True
                 st.session_state["_player_editor_pending_pick"] = name_clean
                 st.session_state["add_player_name"] = ""


### PR DESCRIPTION
### Motivation

- Remove temporary debug scaffolding and noisy `st.write` prints introduced during Player Editor stabilization while keeping functional behavior unchanged.
- Ensure the admin UI is clean and production-ready without altering insert logic, session-driven navigation, or service-role separation.

### Description

- Deleted debug-only lines including the `BUILD MARKER` and `st.write(...)` calls around the add-player submit flow and Supabase session/response prints in `jupr_app/ui/pages/player_editor.py`.
- Kept the insert `payload = {"club_id": club_id, "name": name_clean, "normalized_name": normalized_name, "active": True, "rating": int(round(float(rating) * 400.0)),}` intact and executing as before.
- Replaced the temporary debug insert message with the intended success message `st.success(f"Player created: {name_clean} (Starting JUPR {float(rating):.1f})")` and preserved the post-insert state updates `st.session_state["_force_data_reload"]`, `st.session_state["_player_editor_pending_pick"]`, clearing `add_player_name`, and `st.rerun()`.
- No changes were made to navigation logic, Supabase client separation, cache invalidation flags, replay logic, or RLS-related code.

### Testing

- Searched the repository for the debug markers with `rg` and confirmed no matches remained for the specified debug strings; the search succeeded.
- Verified syntax by compiling the updated module with `python -m py_compile jupr_app/ui/pages/player_editor.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998bc1f732c8326bee2dbf83e0610a9)