### PR TITLE
Startup stabilization: reduce preflight startup fragility

### DIFF
--- a/jupr_app/data/load.py
+++ b/jupr_app/data/load.py
@@ -5,7 +5,6 @@ from jupr_app.domain.player_activity import add_activity_columns
 from jupr_app.domain.gamification.badge_descriptions import BADGE_DESCRIPTIONS_MD
 from jupr_app.domain.gamification.badge_registry import badge_schema_by_id
 from jupr_app.domain.gamification.requirements import load_requirements_map
-from jupr_app.data.schema_preflight import ensure_badge_schema_preflight
 from jupr_app.domain.idempotency import build_match_idempotency_key_v1
 from services.match_pipeline import submit_match
 
@@ -146,7 +145,7 @@ def load_data(supabase, club_id: str, match_limit: int = 5000):
     No Streamlit calls here. Raise exceptions to be handled by UI.
     """
     club_id = str(club_id)
-    ensure_badge_schema_preflight(supabase)
+    # Preflight runs once at app startup in main(); do not duplicate here.
     schema_degraded, schema_degraded_reason = False, None
 
     max_retries = 3

--- a/jupr_app/data/schema_preflight.py
+++ b/jupr_app/data/schema_preflight.py
@@ -4,6 +4,7 @@ import logging
 import os
 from typing import Any
 
+import httpx
 from postgrest.exceptions import APIError
 
 from jupr_app.data.sb_write import sb_rpc
@@ -30,34 +31,40 @@ MIGRATION_HINT = (
 REQUIRED_BADGE_TABLES = {"badge_eval_runs"}
 OPTIONAL_BADGE_TABLES = {"badge_eval_queue"}
 SKIP_PREFLIGHT_ENV = "JUPR_SKIP_BADGE_SCHEMA_PREFLIGHT"
-_MISSING_COLUMN_CODES = {"PGRST204"}
 _MISSING_TABLE_CODES = {"PGRST205", "42P01"}
 
 logger = logging.getLogger(__name__)
 
 def ensure_badge_schema_preflight(supabase: Any) -> bool:
-    if _should_skip_preflight():
+    try:
+        if _should_skip_preflight():
+            return True
+        _ensure_required_schema_version(supabase)
+        _ensure_required_write_indexes(supabase)
+        missing_columns = _find_missing_player_badges_columns(supabase)
+        missing_tables = _find_missing_tables(supabase, REQUIRED_BADGE_TABLES)
+        missing_optional_tables = _find_missing_tables(supabase, OPTIONAL_BADGE_TABLES)
+        if missing_columns or missing_tables:
+            message_parts = [MIGRATION_HINT + "."]
+            if missing_columns:
+                missing_all = ", ".join(sorted(missing_columns))
+                message_parts.append(f"Missing player_badges columns: {missing_all}.")
+            if missing_tables:
+                missing_tables_list = ", ".join(sorted(missing_tables))
+                message_parts.append(f"Missing tables: {missing_tables_list}.")
+            raise RuntimeError(" ".join(message_parts))
+        if missing_optional_tables:
+            logger.warning(
+                "Optional badge tables missing: %s. Badge queue processing will be disabled until applied.",
+                ", ".join(sorted(missing_optional_tables)),
+            )
         return True
-    _ensure_required_schema_version(supabase)
-    _ensure_required_write_indexes(supabase)
-    missing_columns = _find_missing_player_badges_columns(supabase)
-    missing_tables = _find_missing_tables(supabase, REQUIRED_BADGE_TABLES)
-    missing_optional_tables = _find_missing_tables(supabase, OPTIONAL_BADGE_TABLES)
-    if missing_columns or missing_tables:
-        message_parts = [MIGRATION_HINT + "."]
-        if missing_columns:
-            missing_all = ", ".join(sorted(missing_columns))
-            message_parts.append(f"Missing player_badges columns: {missing_all}.")
-        if missing_tables:
-            missing_tables_list = ", ".join(sorted(missing_tables))
-            message_parts.append(f"Missing tables: {missing_tables_list}.")
-        raise RuntimeError(" ".join(message_parts))
-    if missing_optional_tables:
-        logger.warning(
-            "Optional badge tables missing: %s. Badge queue processing will be disabled until applied.",
-            ", ".join(sorted(missing_optional_tables)),
-        )
-    return True
+    except (APIError, httpx.RemoteProtocolError) as e:
+        print("Preflight transport warning:", str(e))
+        return True
+    except Exception as e:
+        print("Preflight unexpected warning:", str(e))
+        raise
 
 
 
@@ -122,12 +129,39 @@ def _ensure_required_schema_version(supabase: Any) -> None:
         )
 
 
-def _find_missing_player_badges_columns(supabase: Any) -> set[str]:
-    missing = set()
-    for column in sorted(REQUIRED_PLAYER_BADGES_COLUMNS | REQUIRED_REVOKED_COLUMNS):
-        if not _probe_column(supabase, "player_badges", column):
-            missing.add(column)
-    return missing
+def _get_table_columns(supabase: Any, table_name: str) -> set[str]:
+    """
+    Deterministically fetch column names from information_schema.
+    Single round-trip. Transport-safe.
+    """
+    try:
+        resp = (
+            supabase
+            .table("information_schema.columns")
+            .select("column_name")
+            .eq("table_schema", "public")
+            .eq("table_name", table_name)
+            .execute()
+        )
+
+        if resp.data:
+            return {row["column_name"] for row in resp.data}
+
+        return set()
+
+    except (APIError, httpx.RemoteProtocolError, Exception) as e:
+        print("Schema inspection failed:", str(e))
+        return set()
+
+
+def _find_missing_player_badges_columns(supabase: Any) -> list[str]:
+    expected_columns = sorted(
+        REQUIRED_PLAYER_BADGES_COLUMNS | REQUIRED_REVOKED_COLUMNS
+    )
+
+    existing_columns = _get_table_columns(supabase, "player_badges")
+
+    return [c for c in expected_columns if c not in existing_columns]
 
 
 def _find_missing_tables(supabase: Any, tables: set[str]) -> set[str]:
@@ -136,27 +170,6 @@ def _find_missing_tables(supabase: Any, tables: set[str]) -> set[str]:
         if not _probe_table(supabase, table):
             missing.add(table)
     return missing
-
-
-def _probe_column(supabase: Any, table: str, column: str) -> bool:
-    try:
-        supabase.table(table).select(column).limit(1).execute()
-    except APIError as exc:
-        code = _get_api_error_code(exc)
-        message = _get_api_error_message(exc)
-        logger.warning(
-            "PostgREST error while checking %s.%s (code=%s message=%s)",
-            table,
-            column,
-            code,
-            message,
-        )
-        if code in _MISSING_COLUMN_CODES:
-            return False
-        raise RuntimeError(
-            f"PostgREST error while checking {table}.{column} (code={code} message={message})."
-        ) from exc
-    return True
 
 
 def _probe_table(supabase: Any, table: str) -> bool:


### PR DESCRIPTION
### Motivation
- Reduce Streamlit startup failures by making badge schema preflight idempotent and resilient to transport instability.
- Eliminate many small HTTP probes during startup to cut down network round-trips and flakiness.

### Description
- Removed the duplicate `ensure_badge_schema_preflight(supabase)` call from `jupr_app/data/load.py` and added a comment noting preflight runs once at app startup in `main()`.
- Replaced the per-column probe loop in `jupr_app/data/schema_preflight.py` with a deterministic single-query helper ` _get_table_columns()` that reads `information_schema.columns` and rewrote `_find_missing_player_badges_columns()` to diff expected vs existing columns.
- Deleted the unused `_probe_column()` logic and its related per-column probing artifacts.
- Added `httpx` import and wrapped `ensure_badge_schema_preflight()` in transport-safe handlers that catch `APIError` and `httpx.RemoteProtocolError`, printing a warning and preventing transport errors from crashing startup while still surfacing unexpected exceptions.

### Testing
- Ran `python -m compileall jupr_app/data/load.py jupr_app/data/schema_preflight.py` which completed successfully.
- Verified code patterns and removal with `rg "_MISSING_COLUMN_CODES|_probe_column|ensure_badge_schema_preflight\("` showing the probe loop was removed and preflight call adjusted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c4165a248326a00e6dc04c722773)