### PR TITLE
Schema preflight stabilization: use SECURITY DEFINER RPC for column introspection

### DIFF
--- a/jupr_app/data/schema_preflight.py
+++ b/jupr_app/data/schema_preflight.py
@@ -131,26 +131,25 @@ def _ensure_required_schema_version(supabase: Any) -> None:
 
 def _get_table_columns(supabase: Any, table_name: str) -> set[str]:
     """
-    Deterministically fetch column names from information_schema.
+    Deterministically fetch column names using SECURITY DEFINER RPC.
     Single round-trip. Transport-safe.
     """
     try:
-        resp = (
-            supabase
-            .table("information_schema.columns")
-            .select("column_name")
-            .eq("table_schema", "public")
-            .eq("table_name", table_name)
-            .execute()
-        )
+        resp = supabase.rpc(
+            "get_public_table_columns",
+            {"p_table": table_name}
+        ).execute()
 
         if resp.data:
             return {row["column_name"] for row in resp.data}
 
         return set()
 
-    except (APIError, httpx.RemoteProtocolError, Exception) as e:
-        print("Schema inspection failed:", str(e))
+    except (APIError, httpx.RemoteProtocolError) as e:
+        print("Schema inspection transport warning:", str(e))
+        return set()
+    except Exception as e:
+        print("Schema inspection unexpected warning:", str(e))
         return set()
 
 

--- a/supabase/migrations/20260701_get_public_table_columns_rpc.sql
+++ b/supabase/migrations/20260701_get_public_table_columns_rpc.sql
@@ -1,0 +1,13 @@
+-- Expose safe column introspection via SECURITY DEFINER RPC
+-- Required because PostgREST does not expose information_schema directly.
+
+create or replace function public.get_public_table_columns(p_table text)
+returns table(column_name text)
+language sql
+security definer
+as $$
+    select column_name
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = p_table;
+$$;


### PR DESCRIPTION
### Motivation
- Fix schema introspection failures caused by PostgREST not exposing `information_schema` by moving to a secure RPC that exposes only public-table column names.
- Ensure the preflight remains transport-safe so transient network/transport errors do not crash startup.
- Avoid any behavior changes to schema version enforcement, RPC invariants, RLS, auth, replay engine, or match pipeline.

### Description
- Add new migration `supabase/migrations/20260701_get_public_table_columns_rpc.sql` which creates `public.get_public_table_columns(p_table text)` as a `SECURITY DEFINER` SQL RPC returning `column_name` from `information_schema.columns` for `public` tables.
- Replace the previous `information_schema` REST query in `jupr_app/data/schema_preflight.py` by updating `_get_table_columns()` to call `supabase.rpc("get_public_table_columns", {"p_table": table_name}).execute()` in a single round-trip.
- Split exception handling so transport-level errors (`APIError`, `httpx.RemoteProtocolError`) are treated as transport warnings and return an empty set, while non-transport exceptions are logged as unexpected and still return an empty set, preserving schema-mismatch `RuntimeError` behavior elsewhere.
- No other application logic, RLS, or invariant code paths were modified.

### Testing
- Ran `python -m compileall jupr_app/data/schema_preflight.py` and the module compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ca100298832694de3475218a76bc)