### PR TITLE
Fix illegal add-player widget state mutation in player editor

### DIFF
--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -11,6 +11,11 @@ def render(ctx):
     page_shell("👥 Player Editor", "Edit player records and league ratings.", mode_label=mode_label)
     PICK_KEY = "player_editor_pick"
 
+    # Process reset before widgets are created
+    if st.session_state.get("_reset_add_player_form"):
+        st.session_state["add_player_name"] = ""
+        st.session_state["_reset_add_player_form"] = False
+
     def _normalize_name(raw: str) -> str:
         cleaned = re.sub(r"[^a-z0-9_]+", "", (raw or "").strip().lower().replace(" ", "_"))
         cleaned = re.sub(r"_+", "_", cleaned).strip("_")
@@ -68,7 +73,7 @@ def render(ctx):
                 st.success(f"Player created: {name_clean} (Starting JUPR {float(rating):.1f})")
                 st.session_state["_force_data_reload"] = True
                 st.session_state["_player_editor_pending_pick"] = name_clean
-                st.session_state["add_player_name"] = ""
+                st.session_state["_reset_add_player_form"] = True
                 st.rerun()
 
     st.divider()


### PR DESCRIPTION
### Motivation
- Prevent a `StreamlitAPIException` caused by mutating `st.session_state["add_player_name"]` after the widget was instantiated. 
- Ensure the add-player form clears deterministically after a successful create without breaking Streamlit widget lifecycle.

### Description
- Remove the direct post-submission mutation of `st.session_state["add_player_name"]` from the form submit block. 
- Set a reset flag `st.session_state["_reset_add_player_form"] = True` on successful player creation instead of clearing the field immediately. 
- Add pre-widget processing at the top of `render()` that clears `st.session_state["add_player_name"]` and unsets the flag before any widgets are created, and retain `st.text_input(..., key="add_player_name")` for keyed binding.

### Testing
- `python -m compileall jupr_app/ui/pages/player_editor.py` executed and the file compiled without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f4ce89a883269346ceeb88a1cf73)