### PR TITLE
Remove Manual Rerun From Player Editor

### DIFF
--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -11,10 +11,15 @@ def render(ctx):
     page_shell("👥 Player Editor", "Edit player records and league ratings.", mode_label=mode_label)
     PICK_KEY = "player_editor_pick"
 
-    # Process reset before widgets are created
+    # Process form reset
     if st.session_state.get("_reset_add_player_form"):
         st.session_state["add_player_name"] = ""
         st.session_state["_reset_add_player_form"] = False
+
+    # Process refresh
+    if st.session_state.get("_refresh_players"):
+        ctx.reload_players()
+        st.session_state["_refresh_players"] = False
 
     def _normalize_name(raw: str) -> str:
         cleaned = re.sub(r"[^a-z0-9_]+", "", (raw or "").strip().lower().replace(" ", "_"))
@@ -59,9 +64,9 @@ def render(ctx):
                 )
                 if existing:
                     st.info("Player already exists — opening existing record.")
-                    st.session_state["_force_data_reload"] = True
+                    st.session_state["_refresh_players"] = True
                     st.session_state["_player_editor_pending_pick"] = name_clean
-                    st.rerun()
+                    st.stop()
                 payload = {
                     "club_id": club_id,
                     "name": name_clean,
@@ -71,10 +76,9 @@ def render(ctx):
                 }
                 supabase.table("players").insert(payload).execute()
                 st.success(f"Player created: {name_clean} (Starting JUPR {float(rating):.1f})")
-                st.session_state["_force_data_reload"] = True
+                st.session_state["_refresh_players"] = True
                 st.session_state["_player_editor_pending_pick"] = name_clean
                 st.session_state["_reset_add_player_form"] = True
-                st.rerun()
 
     st.divider()
 
@@ -208,7 +212,7 @@ def render(ctx):
         )
         if result.get("success"):
             st.success("Merge completed. Replay was suggested for downstream recalculation.")
+            st.session_state["_refresh_players"] = True
         else:
             st.error(result.get("error") or "Merge failed.")
         time.sleep(0.4)
-        st.rerun()


### PR DESCRIPTION
### Motivation

- Remove ad-hoc `st.rerun()` usage that caused fragment-scoped rerun exceptions and double-click navigation glitches, and make page behavior deterministic via session-state flags. 
- Stabilize form reset and player-list refresh so the page updates through the existing reload mechanism instead of forced reruns.

### Description

- Replaced `st.rerun()` calls in `jupr_app/ui/pages/player_editor.py` with deterministic session-state flags and pre-widget processing. 
- Added top-of-`render()` handling to process `_reset_add_player_form` by clearing `add_player_name` and `_refresh_players` by calling `ctx.reload_players()` and clearing the flag. 
- Updated the add-player flow so the "existing player" branch sets `_refresh_players` and `_player_editor_pending_pick` then calls `st.stop()` instead of rerunning. 
- Updated successful create and successful merge flows to set `_refresh_players` and `_reset_add_player_form` (where appropriate) without invoking `st.rerun()`.

### Testing

- Ran `python -m py_compile jupr_app/ui/pages/player_editor.py` and it completed without errors. 
- Verified no remaining `st.rerun(` occurrences in `jupr_app/ui/pages/player_editor.py` via a code search, with zero matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f6193fb883269d4ff78ee60e5197)