### PR TITLE
Fix player editor refresh via cache invalidation

### DIFF
--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -5,6 +5,7 @@ import re
 
 from jupr_app.ui.layout import page_shell
 from jupr_app.domain.player_merge import merge_player_into
+from streamlit_app import get_data
 
 def render(ctx):
     mode_label = "Public" if bool(ctx.public_mode) else "Admin"
@@ -15,11 +16,6 @@ def render(ctx):
     if st.session_state.get("_reset_add_player_form"):
         st.session_state["add_player_name"] = ""
         st.session_state["_reset_add_player_form"] = False
-
-    # Process refresh
-    if st.session_state.get("_refresh_players"):
-        ctx.reload_players()
-        st.session_state["_refresh_players"] = False
 
     def _normalize_name(raw: str) -> str:
         cleaned = re.sub(r"[^a-z0-9_]+", "", (raw or "").strip().lower().replace(" ", "_"))
@@ -64,7 +60,7 @@ def render(ctx):
                 )
                 if existing:
                     st.info("Player already exists — opening existing record.")
-                    st.session_state["_refresh_players"] = True
+                    get_data.clear()
                     st.session_state["_player_editor_pending_pick"] = name_clean
                     st.stop()
                 payload = {
@@ -76,7 +72,7 @@ def render(ctx):
                 }
                 supabase.table("players").insert(payload).execute()
                 st.success(f"Player created: {name_clean} (Starting JUPR {float(rating):.1f})")
-                st.session_state["_refresh_players"] = True
+                get_data.clear()
                 st.session_state["_player_editor_pending_pick"] = name_clean
                 st.session_state["_reset_add_player_form"] = True
 
@@ -212,7 +208,7 @@ def render(ctx):
         )
         if result.get("success"):
             st.success("Merge completed. Replay was suggested for downstream recalculation.")
-            st.session_state["_refresh_players"] = True
+            get_data.clear()
         else:
             st.error(result.get("error") or "Merge failed.")
         time.sleep(0.4)


### PR DESCRIPTION
### Motivation
- The player editor previously attempted to call `ctx.reload_players()` driven by a session flag, which no longer exists after deterministic navigation refactors.
- Rerunning or mutating context from a page is fragile; cache invalidation is the correct mechanism to force a fresh context build.

### Description
- Removed the `_refresh_players` session-flag refresh path and the call to `ctx.reload_players()` from `jupr_app/ui/pages/player_editor.py`.
- Imported the shared cached loader with `from streamlit_app import get_data` so the page can explicitly invalidate app-level cached data.
- Replaced usages of `st.session_state["_refresh_players"] = True` with `get_data.clear()` in the existing-player branch, after successful player creation, and after a successful merge.
- Kept the pending-pick and form-reset behavior intact while removing any logic depending on the `_refresh_players` flag.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/player_editor.py` which succeeded with no syntax errors.
- Searched the codebase for remaining refresh/mutation patterns with `rg -n "_refresh_players|ctx\.reload_|ctx\.refresh_|ctx\.update_" jupr_app streamlit_app.py` which returned no matches.
- Verified the modified file compiles and the page logic now invalidates the cached loader instead of mutating context.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ffa617bc8326a0815d9c2f904c88)