### PR TITLE
Fix Supabase session persistence across refresh via token rehydration

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -111,10 +111,15 @@ def render_admin_sidebar_nav(*, current_label: str, admin_logged_in: bool) -> st
 
 
 def resolve_auth_session(supabase):
-    params = st.query_params
+    try:
+        session_obj = supabase.auth.get_session()
+        session = getattr(session_obj, "session", session_obj)
+        if session:
+            return session
+    except Exception:
+        pass
 
-    if "sb_session" in st.session_state:
-        return st.session_state["sb_session"]
+    params = st.query_params
 
     access_token = params.get("access_token")
     refresh_token = params.get("refresh_token")
@@ -130,7 +135,6 @@ def resolve_auth_session(supabase):
             session_obj = supabase.auth.get_session()
             session = getattr(session_obj, "session", session_obj)
             if session:
-                st.session_state["sb_session"] = session
                 st.query_params.clear()
                 return session
         except Exception:
@@ -222,9 +226,25 @@ def main():
         supabase_auth = get_supabase_auth()
         assert_schema_health(supabase_service)
 
+        # Attempt token rehydration before resolving session
+        if (
+            "sb_access_token" in st.session_state
+            and "sb_refresh_token" in st.session_state
+        ):
+            try:
+                supabase_auth.auth.set_session(
+                    {
+                        "access_token": st.session_state["sb_access_token"],
+                        "refresh_token": st.session_state["sb_refresh_token"],
+                    }
+                )
+            except Exception:
+                # If token invalid or expired, clear them
+                st.session_state.pop("sb_access_token", None)
+                st.session_state.pop("sb_refresh_token", None)
+
         session = resolve_auth_session(supabase_auth)
         st.write("DEBUG — resolve_auth_session:", bool(session))
-        st.write("DEBUG — session_state sb_session:", bool(st.session_state.get("sb_session")))    
         if session is not None:
             st.session_state["auth"]["mode"] = "user"
             st.session_state["auth"]["supabase_session"] = session
@@ -260,15 +280,21 @@ def main():
 
             if submitted:
                 try:
-                    session = supabase_auth.auth.sign_in_with_password(
+                    auth_response = supabase_auth.auth.sign_in_with_password(
                         {
                             "email": email.strip(),
                             "password": password,
                         }
                     )
+                    session_obj = getattr(auth_response, "session", auth_response)
+
+                    # Persist raw tokens
+                    st.session_state["sb_access_token"] = session_obj.access_token
+                    st.session_state["sb_refresh_token"] = session_obj.refresh_token
+
+                    # Update layered auth state
                     st.session_state["auth"]["mode"] = "user"
-                    st.session_state["auth"]["supabase_session"] = session
-                    st.session_state["sb_session"] = getattr(session, "session", session)
+                    st.session_state["auth"]["supabase_session"] = session_obj
                     st.session_state["entry_mode"] = "auth"
                 except Exception as e:
                     st.error(f"Login exception: {e}")
@@ -284,13 +310,12 @@ def main():
                         st.error("Unable to send magic link.")
             return
 
-        session = st.session_state.get("sb_session")
+        session = st.session_state["auth"].get("supabase_session")
         if session:
             try:
                 current_obj = supabase_auth.auth.get_session()
                 current_session = getattr(current_obj, "session", current_obj)
                 if current_session:
-                    st.session_state["sb_session"] = current_session
                     st.session_state["auth"]["supabase_session"] = current_session
                     session = current_session
             except Exception:
@@ -346,7 +371,8 @@ def main():
                 "supabase_session": None,
                 "admin_override": False,
             }
-            st.session_state.pop("sb_session", None)
+            st.session_state.pop("sb_access_token", None)
+            st.session_state.pop("sb_refresh_token", None)
             st.session_state["entry_mode"] = "gateway"
 
         if st.session_state["auth"]["mode"] != "public":


### PR DESCRIPTION
### Motivation
- Streamlit reruns were losing Supabase auth because the Supabase Python client does not persist sessions across reruns, causing `resolve_auth_session()` to return `None` after refresh.
- The goal is to persist raw `access_token`/`refresh_token` across reruns and rehydrate the Supabase auth client each run so login survives refresh/hard-refresh while preserving layered auth semantics.

### Description
- Updated `resolve_auth_session()` to first call `supabase.auth.get_session()` and return a valid session if present, otherwise fall back to the existing URL token resolution logic using query params, and removed reliance on legacy `sb_session` state.
- On successful password login the code now stores the raw tokens in `st.session_state` under `sb_access_token` and `sb_refresh_token`, extracts the canonical session object, and writes it to `st.session_state["auth"]["supabase_session"]` (the canonical layered auth source).
- On each run, before resolving the session the app attempts to rehydrate the Supabase client by calling `supabase_auth.auth.set_session(...)` with persisted tokens and clears them if the operation fails.
- Logout now clears the persisted `sb_access_token` and `sb_refresh_token` in addition to resetting the layered `auth` object, and all remaining references to `sb_session` were removed and replaced by `auth["supabase_session"]` where appropriate.

### Testing
- Compiled `streamlit_app.py` with `python -m py_compile streamlit_app.py` and the compilation succeeded.
- Verified no remaining legacy `sb_session` references via repository search (`rg -n "sb_session"`) which returned none.
- Basic static diff inspection confirms the new token persistence, rehydration, session resolution order, and logout cleanup were applied to `streamlit_app.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a12dae4948326a210ee0ee58a47ee)