### PR TITLE
Add baseline schema snapshot, tournament tenant hardening, and RLS (club_id propagation + UI guards)

### DIFF
--- a/jupr_app/domain/tournament_podium.py
+++ b/jupr_app/domain/tournament_podium.py
@@ -40,12 +40,15 @@ def upsert_tournament_podium(
 ) -> None:
     if supabase is None or not tournament_id or not payload:
         return
+    for row in payload:
+        if "club_id" not in row:
+            raise RuntimeError("Missing club_id in tournament write payload.")
     try:
         sb_upsert(
             supabase,
             "tournament_podium",
             payload,
-            conflict="tournament_id,placement",
+            conflict="club_id,tournament_id,placement",
         )
     except Exception:
         logger.exception("Failed to upsert tournament podium", extra={"tournament_id": tournament_id})

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -34,6 +34,13 @@ TOURNAMENT_CHARTS = [
 ]
 
 
+def _require_club_id_payload(payload):
+    rows = payload if isinstance(payload, list) else [payload]
+    for row in rows:
+        if "club_id" not in row:
+            raise RuntimeError("Missing club_id in tournament write payload.")
+
+
 def render(ctx):
     mode_label = "Public" if bool(ctx.public_mode) else "Admin"
     page_shell("🏆 Tournaments", "Admin-only tournament manager.", mode_label=mode_label)
@@ -237,6 +244,7 @@ def render(ctx):
             for _, row in editor_df.iterrows():
                 payload.append(
                     {
+                        "club_id": str(club_id),
                         "tournament_id": tournament_id,
                         "team_number": int(row.get("Team")),
                         "player1_id": name_to_id.get(row.get("Player 1")) if row.get("Player 1") else None,
@@ -244,7 +252,9 @@ def render(ctx):
                     }
                 )
 
-            sb_upsert(supabase, "tournament_teams", payload, conflict="tournament_id,team_number")
+            _require_club_id_payload(payload)
+
+            sb_upsert(supabase, "tournament_teams", payload, conflict="club_id,tournament_id,team_number")
             st.success("Teams saved.")
             st.session_state["force_data_refresh"] = True
 
@@ -259,6 +269,9 @@ def render(ctx):
         if st.button("Generate RR Schedule", disabled=bool(rr_games) or not ready_teams or is_complete):
             team_ids = {int(num): t["id"] for num, t in teams_by_number.items()}
             games_payload = build_round_robin_games(tournament_id=tournament_id, team_ids_by_number=team_ids)
+            for game in games_payload:
+                game["club_id"] = str(club_id)
+            _require_club_id_payload(games_payload)
             sb_insert(supabase, "tournament_games", games_payload)
             sb_update(supabase, "tournaments", {"status": "ROUND_ROBIN"}, filters={"club_id": str(club_id), "id": tournament_id})
             st.success("Round robin schedule generated.")
@@ -384,6 +397,10 @@ def render(ctx):
                             best_of=int(tournament.get("playoff_best_of", 1)),
                         )
 
+                        for game in games_payload:
+                            game["club_id"] = str(club_id)
+                        _require_club_id_payload(games_payload)
+
                         supabase.table("tournament_games").insert(games_payload).execute()
 
                         st.success("Playoff bracket regenerated.")
@@ -404,6 +421,9 @@ def render(ctx):
                 standings=standings,
                 best_of=int(tournament.get("playoff_best_of", 1)),
             )
+            for game in games_payload:
+                game["club_id"] = str(club_id)
+            _require_club_id_payload(games_payload)
             sb_insert(supabase, "tournament_games", games_payload)
             sb_update(
                 supabase,
@@ -601,7 +621,10 @@ def _render_podium_review(
             return
         try:
             payload = build_podium_payload(tournament_id, placements, source)
-        except ValueError as exc:
+            for row in payload:
+                row["club_id"] = str(ctx.club_id)
+            _require_club_id_payload(payload)
+        except (ValueError, RuntimeError) as exc:
             st.error(str(exc))
             return
         if not payload:

--- a/supabase/migrations/202602210000_baseline_schema.sql
+++ b/supabase/migrations/202602210000_baseline_schema.sql
@@ -1,0 +1,464 @@
+-- Baseline schema snapshot for new environments.
+-- Source: live schema export snapshot dated 2026-02-19.
+-- IMPORTANT: This migration is intended for fresh environments and should not be run on production.
+
+-- Live schema snapshot generated from provided export on 2026-02-19.
+-- Nullability was not provided in the source export; columns are marked NULL in this baseline.
+
+CREATE TABLE badge_eval_queue (
+  id uuid NULL,
+  created_at timestamp with time zone NULL,
+  club_id text NULL,
+  context_id text NULL,
+  event_type text NULL,
+  player_ids ARRAY NULL,
+  match_id text NULL,
+  payload_json jsonb NULL,
+  status text NULL,
+  attempts integer NULL,
+  last_error text NULL,
+  processed_at timestamp with time zone NULL
+);
+
+CREATE TABLE badge_eval_runs (
+  id uuid NULL,
+  created_at timestamp with time zone NULL,
+  created_by text NULL,
+  mode text NULL,
+  scope_json jsonb NULL,
+  status text NULL,
+  started_at timestamp with time zone NULL,
+  finished_at timestamp with time zone NULL,
+  summary_json jsonb NULL,
+  error text NULL
+);
+
+CREATE TABLE badge_events_v2 (
+  id uuid NULL,
+  user_id uuid NULL,
+  event_type text NULL,
+  event_ts timestamp with time zone NULL,
+  data jsonb NULL,
+  idempotency_key text NULL,
+  created_at timestamp with time zone NULL
+);
+
+CREATE TABLE badge_fact_registry (
+  fact_key text NULL,
+  description text NULL,
+  data_type text NULL,
+  allowed_scope text NULL
+);
+
+CREATE TABLE badge_rule_conditions (
+  id uuid NULL,
+  badge_id uuid NULL,
+  fact_key text NULL,
+  operator text NULL,
+  value_numeric numeric NULL,
+  created_at timestamp with time zone NULL
+);
+
+CREATE TABLE badge_rules_v2 (
+  id uuid NULL,
+  badge_id uuid NULL,
+  rule_type text NULL,
+  params jsonb NULL,
+  trigger_event text NULL,
+  evaluation_mode text NULL,
+  enabled boolean NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL
+);
+
+CREATE TABLE badges (
+  badge_id text NULL,
+  name text NULL,
+  prestige integer NULL,
+  category text NULL,
+  is_stackable boolean NULL,
+  is_active boolean NULL,
+  created_at timestamp with time zone NULL,
+  rarity text NULL,
+  tier integer NULL,
+  icon_key text NULL,
+  lore text NULL,
+  hint text NULL,
+  scope text NULL,
+  status text NULL,
+  is_locked boolean NULL,
+  award_count integer NULL,
+  published_at timestamp with time zone NULL,
+  archived_at timestamp with time zone NULL,
+  club_id text NULL,
+  is_system_badge boolean NULL,
+  created_by_admin_id text NULL
+);
+
+CREATE TABLE badges_v2 (
+  id uuid NULL,
+  slug text NULL,
+  name text NULL,
+  display_text text NULL,
+  description text NULL,
+  icon_url text NULL,
+  icon_emoji text NULL,
+  category text NULL,
+  rarity text NULL,
+  sort_order integer NULL,
+  is_active boolean NULL,
+  is_hidden boolean NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL,
+  status text NULL,
+  is_locked boolean NULL,
+  award_count integer NULL,
+  published_at timestamp with time zone NULL,
+  archived_at timestamp with time zone NULL,
+  club_id text NULL,
+  is_system_badge boolean NULL,
+  created_by_admin_id text NULL
+);
+
+CREATE TABLE club_user_roles (
+  club_id text NULL,
+  user_id uuid NULL,
+  role text NULL,
+  assigned_by uuid NULL,
+  assigned_at timestamp with time zone NULL
+);
+
+CREATE TABLE clubs (
+  id text NULL,
+  name text NULL,
+  status text NULL,
+  logo_url text NULL,
+  primary_color text NULL,
+  created_at timestamp with time zone NULL
+);
+
+CREATE TABLE events (
+  id uuid NULL,
+  club_id text NULL,
+  name text NULL,
+  event_type text NULL,
+  is_active boolean NULL,
+  created_at timestamp with time zone NULL,
+  starts_at timestamp with time zone NULL,
+  ends_at timestamp with time zone NULL,
+  notes text NULL
+);
+
+CREATE TABLE ladder_audit_log (
+  id bigint NULL,
+  club_id text NULL,
+  actor text NULL,
+  action_type text NULL,
+  entity_type text NULL,
+  entity_id text NULL,
+  before jsonb NULL,
+  after jsonb NULL,
+  created_at timestamp with time zone NULL
+);
+
+CREATE TABLE ladder_challenge_matches (
+  id bigint NULL,
+  club_id text NULL,
+  challenge_id bigint NULL,
+  match_no integer NULL,
+  def_partner_id bigint NULL,
+  chal_partner_id bigint NULL,
+  g1_def integer NULL,
+  g1_chal integer NULL,
+  g2_def integer NULL,
+  g2_chal integer NULL,
+  g3_def integer NULL,
+  g3_chal integer NULL,
+  verified boolean NULL,
+  verified_at timestamp with time zone NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL
+);
+
+CREATE TABLE ladder_challenges (
+  id bigint NULL,
+  club_id text NULL,
+  challenger_id bigint NULL,
+  defender_id bigint NULL,
+  challenger_rank_at_create integer NULL,
+  defender_rank_at_create integer NULL,
+  status text NULL,
+  ledger_ref text NULL,
+  created_by text NULL,
+  created_at timestamp with time zone NULL,
+  accept_by timestamp with time zone NULL,
+  accepted_at timestamp with time zone NULL,
+  play_by timestamp with time zone NULL,
+  scheduled_for timestamp with time zone NULL,
+  pass_used_by bigint NULL,
+  pass_used_at timestamp with time zone NULL,
+  forfeit_by bigint NULL,
+  forfeit_reason text NULL,
+  winner_id bigint NULL,
+  completed_at timestamp with time zone NULL,
+  resolution_notes text NULL,
+  tier_id text NULL,
+  notice_sent_at timestamp with time zone NULL
+);
+
+CREATE TABLE ladder_pass_usage (
+  id bigint NULL,
+  club_id text NULL,
+  player_id bigint NULL,
+  month_key text NULL,
+  used_at timestamp with time zone NULL,
+  challenge_id bigint NULL,
+  created_at timestamp with time zone NULL
+);
+
+CREATE TABLE ladder_player_flags (
+  club_id text NULL,
+  player_id bigint NULL,
+  vacation_until timestamp with time zone NULL,
+  reinstate_required boolean NULL,
+  reinstate_notes text NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL,
+  tier_move_flag boolean NULL,
+  tier_move_dest_tier text NULL,
+  tier_move_count integer NULL,
+  tier_move_triggered_at timestamp with time zone NULL,
+  tier_move_last_eval_at timestamp with time zone NULL
+);
+
+CREATE TABLE ladder_roster (
+  id bigint NULL,
+  club_id text NULL,
+  player_id bigint NULL,
+  rank integer NULL,
+  is_active boolean NULL,
+  joined_at timestamp with time zone NULL,
+  left_at timestamp with time zone NULL,
+  notes text NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL,
+  tier_id text NULL
+);
+
+CREATE TABLE ladder_settings (
+  club_id text NULL,
+  challenge_range integer NULL,
+  accept_window_hours integer NULL,
+  play_window_days integer NULL,
+  cooldown_hours integer NULL,
+  protected_hours integer NULL,
+  pass_hold_hours integer NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL
+);
+
+CREATE TABLE league_ratings (
+  id bigint NULL,
+  player_id bigint NULL,
+  club_id text NULL,
+  league_name text NULL,
+  rating numeric NULL,
+  matches_played integer NULL,
+  wins integer NULL,
+  losses integer NULL,
+  starting_rating numeric NULL,
+  is_active boolean NULL,
+  inactive_at timestamp with time zone NULL
+);
+
+CREATE TABLE leagues_metadata (
+  id bigint NULL,
+  club_id text NULL,
+  league_name text NULL,
+  league_type text NULL,
+  min_weeks integer NULL,
+  is_active boolean NULL,
+  created_at timestamp with time zone NULL,
+  min_games integer NULL,
+  description text NULL,
+  k_factor integer NULL,
+  ended_at timestamp with time zone NULL,
+  ended_by text NULL,
+  status text NULL,
+  end_awards jsonb NULL,
+  started_at timestamp with time zone NULL,
+  schedule_config jsonb NULL,
+  court_board_defaults jsonb NULL,
+  rules_config jsonb NULL,
+  awards_config jsonb NULL
+);
+
+CREATE TABLE matches (
+  id bigint NULL,
+  club_id text NULL,
+  date timestamp with time zone NULL,
+  league text NULL,
+  t1_p1 bigint NULL,
+  t1_p2 bigint NULL,
+  t2_p1 bigint NULL,
+  t2_p2 bigint NULL,
+  score_t1 integer NULL,
+  score_t2 integer NULL,
+  elo_delta numeric NULL,
+  match_type text NULL,
+  week_tag text NULL,
+  t1_p1_r numeric NULL,
+  t1_p2_r numeric NULL,
+  t2_p1_r numeric NULL,
+  t2_p2_r numeric NULL,
+  t1_p1_r_end numeric NULL,
+  t1_p2_r_end numeric NULL,
+  t2_p1_r_end numeric NULL,
+  t2_p2_r_end numeric NULL,
+  elo_delta_t1 double precision NULL,
+  elo_delta_t2 double precision NULL,
+  context_type text NULL,
+  context_id uuid NULL,
+  tournament_id uuid NULL,
+  tournament_game_id uuid NULL,
+  idempotency_key text NULL
+);
+
+CREATE TABLE player_badge_facts (
+  club_id text NULL,
+  player_id bigint NULL,
+  context_id text NULL,
+  fact_key text NULL,
+  fact_value_num double precision NULL,
+  updated_at timestamp with time zone NULL
+);
+
+CREATE TABLE player_badges (
+  id uuid NULL,
+  club_id text NULL,
+  player_id bigint NULL,
+  badge_id text NULL,
+  earned_at timestamp with time zone NULL,
+  context_type text NULL,
+  context_id text NULL,
+  match_id text NULL,
+  value_num numeric NULL,
+  value_json jsonb NULL,
+  awarded_by uuid NULL,
+  rule_version text NULL,
+  eval_run_id uuid NULL,
+  revoked_at timestamp with time zone NULL,
+  revoked_by uuid NULL,
+  revoked_reason text NULL,
+  revoke_reason text NULL
+);
+
+CREATE TABLE player_profiles (
+  club_id text NULL,
+  player_id bigint NULL,
+  preferred_channel text NULL,
+  email text NULL,
+  phone text NULL,
+  whatsapp text NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL
+);
+
+CREATE TABLE players (
+  id bigint NULL,
+  club_id text NULL,
+  name text NULL,
+  rating numeric NULL,
+  starting_rating numeric NULL,
+  matches_played integer NULL,
+  wins integer NULL,
+  losses integer NULL,
+  created_at timestamp with time zone NULL,
+  active boolean NULL,
+  last_game_at timestamp with time zone NULL,
+  inactive_at timestamp with time zone NULL,
+  normalized_name text NULL
+);
+
+CREATE TABLE processed_match_facts (
+  club_id text NULL,
+  match_id text NULL,
+  player_id bigint NULL
+);
+
+CREATE TABLE tournaments (
+  id uuid NULL,
+  club_id text NULL,
+  name text NULL,
+  status text NULL,
+  team_count integer NULL,
+  playoff_advance_count integer NULL,
+  created_by_admin_id text NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL,
+  playoff_best_of integer NULL
+);
+
+CREATE TABLE tournament_teams (
+  id uuid NULL,
+  tournament_id uuid NULL,
+  team_number integer NULL,
+  player1_id integer NULL,
+  player2_id integer NULL,
+  seed integer NULL
+);
+
+CREATE TABLE tournament_games (
+  id uuid NULL,
+  tournament_id uuid NULL,
+  stage text NULL,
+  rr_round_number integer NULL,
+  rr_slot_number integer NULL,
+  playoff_game_code text NULL,
+  playoff_round text NULL,
+  team_a_id uuid NULL,
+  team_b_id uuid NULL,
+  team_a_source jsonb NULL,
+  team_b_source jsonb NULL,
+  score_a integer NULL,
+  score_b integer NULL,
+  winner_team_id uuid NULL,
+  loser_team_id uuid NULL,
+  finalized_at timestamp with time zone NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL,
+  series_game_number integer NULL
+);
+
+CREATE TABLE tournament_podium (
+  id uuid NULL,
+  tournament_id uuid NULL,
+  placement integer NULL,
+  team_id uuid NULL,
+  source text NULL,
+  created_at timestamp with time zone NULL
+);
+
+CREATE TABLE user_badges_v2 (
+  user_id uuid NULL,
+  badge_id uuid NULL,
+  awarded_at timestamp with time zone NULL,
+  awarded_by uuid NULL,
+  reason text NULL,
+  metadata jsonb NULL
+);
+
+CREATE TABLE weekly_recaps (
+  id uuid NULL,
+  club_id text NULL,
+  week_start date NULL,
+  week_end date NULL,
+  status text NULL,
+  generated_json jsonb NULL,
+  edits_json jsonb NULL,
+  final_json jsonb NULL,
+  created_at timestamp with time zone NULL,
+  updated_at timestamp with time zone NULL,
+  published_at timestamp with time zone NULL,
+  published_by text NULL
+);

--- a/supabase/migrations/202602210000_baseline_schema.sql
+++ b/supabase/migrations/202602210000_baseline_schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE badge_eval_queue (
   club_id text NULL,
   context_id text NULL,
   event_type text NULL,
-  player_ids ARRAY NULL,
+  player_ids bigint[] NULL,
   match_id text NULL,
   payload_json jsonb NULL,
   status text NULL,

--- a/supabase/migrations/202602210010_tournament_schema_hardening.sql
+++ b/supabase/migrations/202602210010_tournament_schema_hardening.sql
@@ -1,0 +1,82 @@
+-- Tournament tenant hardening (safe for existing production data)
+
+ALTER TABLE public.tournament_teams
+  ADD COLUMN IF NOT EXISTS club_id text;
+
+ALTER TABLE public.tournament_games
+  ADD COLUMN IF NOT EXISTS club_id text;
+
+ALTER TABLE public.tournament_podium
+  ADD COLUMN IF NOT EXISTS club_id text;
+
+UPDATE public.tournament_teams tt
+SET club_id = t.club_id
+FROM public.tournaments t
+WHERE tt.tournament_id = t.id
+  AND tt.club_id IS NULL;
+
+UPDATE public.tournament_games tg
+SET club_id = t.club_id
+FROM public.tournaments t
+WHERE tg.tournament_id = t.id
+  AND tg.club_id IS NULL;
+
+UPDATE public.tournament_podium tp
+SET club_id = t.club_id
+FROM public.tournaments t
+WHERE tp.tournament_id = t.id
+  AND tp.club_id IS NULL;
+
+DO $$
+DECLARE
+  teams_missing bigint;
+  games_missing bigint;
+  podium_missing bigint;
+BEGIN
+  SELECT count(*) INTO teams_missing FROM public.tournament_teams WHERE club_id IS NULL;
+  SELECT count(*) INTO games_missing FROM public.tournament_games WHERE club_id IS NULL;
+  SELECT count(*) INTO podium_missing FROM public.tournament_podium WHERE club_id IS NULL;
+
+  IF teams_missing > 0 OR games_missing > 0 OR podium_missing > 0 THEN
+    RAISE EXCEPTION
+      'Tournament tenant hardening failed: null club_id remains (teams=%, games=%, podium=%)',
+      teams_missing, games_missing, podium_missing;
+  END IF;
+END $$;
+
+ALTER TABLE public.tournament_teams
+  ALTER COLUMN club_id SET NOT NULL;
+
+ALTER TABLE public.tournament_games
+  ALTER COLUMN club_id SET NOT NULL;
+
+ALTER TABLE public.tournament_podium
+  ALTER COLUMN club_id SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tournament_teams_club_id ON public.tournament_teams (club_id);
+CREATE INDEX IF NOT EXISTS idx_tournament_games_club_id ON public.tournament_games (club_id);
+CREATE INDEX IF NOT EXISTS idx_tournament_podium_club_id ON public.tournament_podium (club_id);
+
+ALTER TABLE public.tournament_teams
+  DROP CONSTRAINT IF EXISTS uq_tournament_team_number;
+ALTER TABLE public.tournament_teams
+  DROP CONSTRAINT IF EXISTS tournament_teams_club_tournament_team_number_uq;
+ALTER TABLE public.tournament_teams
+  ADD CONSTRAINT tournament_teams_club_tournament_team_number_uq
+  UNIQUE (club_id, tournament_id, team_number);
+
+ALTER TABLE public.tournament_podium
+  DROP CONSTRAINT IF EXISTS tournament_podium_unique_placement;
+ALTER TABLE public.tournament_podium
+  DROP CONSTRAINT IF EXISTS tournament_podium_club_tournament_placement_uq;
+ALTER TABLE public.tournament_podium
+  ADD CONSTRAINT tournament_podium_club_tournament_placement_uq
+  UNIQUE (club_id, tournament_id, placement);
+
+ALTER TABLE public.tournament_podium
+  DROP CONSTRAINT IF EXISTS tournament_podium_unique_team;
+ALTER TABLE public.tournament_podium
+  DROP CONSTRAINT IF EXISTS tournament_podium_club_tournament_team_uq;
+ALTER TABLE public.tournament_podium
+  ADD CONSTRAINT tournament_podium_club_tournament_team_uq
+  UNIQUE (club_id, tournament_id, team_id);

--- a/supabase/migrations/202602210020_tournament_rls.sql
+++ b/supabase/migrations/202602210020_tournament_rls.sql
@@ -1,0 +1,74 @@
+-- Tournament RLS policy pack keyed by JWT user_metadata.club_id
+
+ALTER TABLE public.tournaments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tournament_teams ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tournament_games ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tournament_podium ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tournaments_select_by_club ON public.tournaments;
+CREATE POLICY tournaments_select_by_club
+ON public.tournaments
+FOR SELECT
+USING (
+  club_id = (current_setting('request.jwt.claims', true)::jsonb -> 'user_metadata' ->> 'club_id')
+);
+
+DROP POLICY IF EXISTS tournaments_insert_by_club ON public.tournaments;
+CREATE POLICY tournaments_insert_by_club
+ON public.tournaments
+FOR INSERT
+WITH CHECK (
+  club_id = (current_setting('request.jwt.claims', true)::jsonb -> 'user_metadata' ->> 'club_id')
+);
+
+DROP POLICY IF EXISTS tournaments_update_by_club ON public.tournaments;
+CREATE POLICY tournaments_update_by_club
+ON public.tournaments
+FOR UPDATE
+USING (
+  club_id = (current_setting('request.jwt.claims', true)::jsonb -> 'user_metadata' ->> 'club_id')
+)
+WITH CHECK (
+  club_id = (current_setting('request.jwt.claims', true)::jsonb -> 'user_metadata' ->> 'club_id')
+);
+
+DROP POLICY IF EXISTS tournaments_delete_by_club ON public.tournaments;
+CREATE POLICY tournaments_delete_by_club
+ON public.tournaments
+FOR DELETE
+USING (
+  club_id = (current_setting('request.jwt.claims', true)::jsonb -> 'user_metadata' ->> 'club_id')
+);
+
+DROP POLICY IF EXISTS tournament_teams_all_by_club ON public.tournament_teams;
+CREATE POLICY tournament_teams_all_by_club
+ON public.tournament_teams
+FOR ALL
+USING (
+  club_id = (current_setting('request.jwt.claims', true)::jsonb -> 'user_metadata' ->> 'club_id')
+)
+WITH CHECK (
+  club_id = (current_setting('request.jwt.claims', true)::jsonb -> 'user_metadata' ->> 'club_id')
+);
+
+DROP POLICY IF EXISTS tournament_games_all_by_club ON public.tournament_games;
+CREATE POLICY tournament_games_all_by_club
+ON public.tournament_games
+FOR ALL
+USING (
+  club_id = (current_setting('request.jwt.claims', true)::jsonb -> 'user_metadata' ->> 'club_id')
+)
+WITH CHECK (
+  club_id = (current_setting('request.jwt.claims', true)::jsonb -> 'user_metadata' ->> 'club_id')
+);
+
+DROP POLICY IF EXISTS tournament_podium_all_by_club ON public.tournament_podium;
+CREATE POLICY tournament_podium_all_by_club
+ON public.tournament_podium
+FOR ALL
+USING (
+  club_id = (current_setting('request.jwt.claims', true)::jsonb -> 'user_metadata' ->> 'club_id')
+)
+WITH CHECK (
+  club_id = (current_setting('request.jwt.claims', true)::jsonb -> 'user_metadata' ->> 'club_id')
+);


### PR DESCRIPTION
### Motivation
- Provide a baseline schema snapshot for fresh environments and harden the tournament domain for multi-tenant safety by making child tables tenant-aware and enforcing tenant-scoped constraints and access.
- Ensure application code always writes tenant context (`club_id`) when creating/upserting tournament-related rows so RLS and new uniqueness constraints are safe in production.

### Description
- Add a baseline schema snapshot for new environments at `supabase/migrations/202602210000_baseline_schema.sql` (explicitly marked not to run on production). 
- Add a production-safe hardening migration at `supabase/migrations/202602210010_tournament_schema_hardening.sql` that adds `club_id` to `tournament_teams`, `tournament_games`, and `tournament_podium`, backfills from `tournaments.club_id`, fails fast if any NULLs remain, sets `NOT NULL`, creates indexes, and replaces unique constraints with tenant-scoped uniques (e.g. `UNIQUE (club_id, tournament_id, team_number)` and podium uniqueness including `club_id`).
- Add RLS policies in `supabase/migrations/202602210020_tournament_rls.sql` enabling RLS on `tournaments`, `tournament_teams`, `tournament_games`, and `tournament_podium` and scoping policies to the JWT `user_metadata.club_id` using `current_setting('request.jwt.claims', true)::jsonb -> 'user_metadata' ->> 'club_id'`.
- Update application code to include `club_id` on writes and enforce defensive guards: add `_require_club_id_payload()` and inject `club_id` into payloads in `jupr_app/ui/pages/tournaments.py`, and add a runtime guard and change the upsert conflict target in `jupr_app/domain/tournament_podium.py` to `club_id,tournament_id,placement`.

### Testing
- Compiled modified modules successfully with `python -m py_compile jupr_app/ui/pages/tournaments.py jupr_app/domain/tournament_podium.py` (succeeds).
- Migrations were added under `supabase/migrations/` but were not applied to a live database in this run; full migration application and data-preservation validation against a production-like DB were not executed here (recommended to run the hardening migration against a staging copy before production).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a29e3098083269c2d4e11a7f028ee)