### PR TITLE
Add uniqueness constraints for tournament round robin and playoff games

### DIFF
--- a/supabase/migrations/20260221_tournament_playoff_unique.sql
+++ b/supabase/migrations/20260221_tournament_playoff_unique.sql
@@ -1,0 +1,21 @@
+-- Prevent duplicate round robin slots
+CREATE UNIQUE INDEX IF NOT EXISTS
+tournament_rr_unique_slot
+ON tournament_games (
+    tournament_id,
+    stage,
+    rr_round_number,
+    rr_slot_number
+)
+WHERE stage = 'ROUND_ROBIN';
+
+-- Prevent duplicate playoff games
+CREATE UNIQUE INDEX IF NOT EXISTS
+tournament_playoff_unique_slot
+ON tournament_games (
+    tournament_id,
+    stage,
+    playoff_game_code,
+    COALESCE(series_game_number, 1)
+)
+WHERE stage = 'PLAYOFF';


### PR DESCRIPTION
### Motivation
- Ensure data integrity by preventing duplicate round robin slots and duplicate playoff games for the same tournament and slot identifiers. 
- Avoid ambiguous playoff entries by treating a NULL `series_game_number` as `1` when enforcing uniqueness for playoff series games.

### Description
- Add a new Supabase migration file at `supabase/migrations/20260221_tournament_playoff_unique.sql` that defines the index changes. 
- Create a partial unique index `tournament_rr_unique_slot` on `tournament_games(tournament_id, stage, rr_round_number, rr_slot_number)` with `WHERE stage = 'ROUND_ROBIN'`. 
- Create a partial unique index `tournament_playoff_unique_slot` on `tournament_games(tournament_id, stage, playoff_game_code, COALESCE(series_game_number, 1))` with `WHERE stage = 'PLAYOFF'`.

### Testing
- Confirmed the migration file was created in the `supabase/migrations` directory and reviewed its contents with `nl -ba supabase/migrations/20260221_tournament_playoff_unique.sql`. 
- Performed repository status checks to ensure the file is present in the working tree. 
- No database migration or runtime tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a7632a8a8832693497d5e209afe2d)