### PR TITLE
Make playoff bracket generation idempotent via upsert

### DIFF
--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -414,7 +414,7 @@ def render(ctx):
 
                         supabase.table("tournament_games").upsert(
                             games_payload,
-                            on_conflict="tournament_id,stage,rr_round_number,rr_slot_number"
+                            on_conflict="tournament_id,stage,playoff_game_code,series_game_number"
                         ).execute()
 
                         st.success("Playoff bracket regenerated.")
@@ -440,7 +440,10 @@ def render(ctx):
                 # Explicit club_id for tenant isolation (RLS + multi-club safety)
                 game["club_id"] = str(club_id)
             _require_club_id_payload(games_payload)
-            sb_insert(supabase, "tournament_games", games_payload)
+            supabase.table("tournament_games").upsert(
+                games_payload,
+                on_conflict="tournament_id,stage,playoff_game_code,series_game_number"
+            ).execute()
             sb_update(
                 supabase,
                 "tournaments",


### PR DESCRIPTION
### Motivation
- Ensure playoff bracket generation and regeneration are idempotent and avoid duplicate rows by upserting generated playoff games with a stable conflict key (`playoff_game_code,series_game_number`).

### Description
- Replaced the initial `sb_insert` of generated playoff games and the previous `upsert` conflict target with `supabase.table("tournament_games").upsert(games_payload, on_conflict="tournament_id,stage,playoff_game_code,series_game_number").execute()` in `jupr_app/ui/pages/tournaments.py` so both generation paths use the same conflict keys.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/tournaments.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a76ea94fc83269343488240542f57)