### PR TITLE
Add global uniqueness constraints for tournaments, playoffs, and match idempotency

### DIFF
--- a/supabase/migrations/20260221_global_match_uniques.sql
+++ b/supabase/migrations/20260221_global_match_uniques.sql
@@ -1,0 +1,58 @@
+-- ========================================
+-- TOURNAMENT ROUND ROBIN UNIQUENESS
+-- ========================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+tournament_rr_unique_slot
+ON tournament_games (
+    tournament_id,
+    stage,
+    rr_round_number,
+    rr_slot_number
+)
+WHERE stage = 'ROUND_ROBIN';
+
+
+-- ========================================
+-- TOURNAMENT PLAYOFF UNIQUENESS
+-- ========================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+tournament_playoff_unique_slot
+ON tournament_games (
+    tournament_id,
+    stage,
+    playoff_game_code,
+    COALESCE(series_game_number, 1)
+)
+WHERE stage = 'PLAYOFF';
+
+
+-- ========================================
+-- LEAGUE MATCH UNIQUENESS
+-- (Prevent duplicate league match entries)
+-- ========================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+league_match_unique
+ON matches (
+    club_id,
+    context_type,
+    context_id,
+    tournament_game_id
+)
+WHERE context_type = 'TOURNAMENT';
+
+
+-- ========================================
+-- GENERIC MATCH IDEMPOTENCY
+-- (Prevents double-submit of same match payload)
+-- ========================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+matches_idempotency_unique
+ON matches (
+    club_id,
+    idempotency_key
+)
+WHERE idempotency_key IS NOT NULL;


### PR DESCRIPTION
### Motivation
- Prevent duplicate or conflicting tournament and match records at the database level by enforcing unique constraints for round-robin and playoff slots. 
- Prevent duplicate league match entries that reference the same tournament game. 
- Provide idempotency protection for match submissions to avoid double-submit hazards.

### Description
- Add a new Supabase migration file at `supabase/migrations/20260221_global_match_uniques.sql` containing four `CREATE UNIQUE INDEX IF NOT EXISTS` statements. 
- Add `tournament_rr_unique_slot` partial index on `tournament_games(tournament_id, stage, rr_round_number, rr_slot_number)` with `WHERE stage = 'ROUND_ROBIN'`. 
- Add `tournament_playoff_unique_slot` partial index on `tournament_games(tournament_id, stage, playoff_game_code, COALESCE(series_game_number, 1))` with `WHERE stage = 'PLAYOFF'`. 
- Add `league_match_unique` partial index on `matches(club_id, context_type, context_id, tournament_game_id)` with `WHERE context_type = 'TOURNAMENT'` and `matches_idempotency_unique` partial index on `matches(club_id, idempotency_key)` with `WHERE idempotency_key IS NOT NULL`.

### Testing
- Created the migration file and inspected it with `nl -ba supabase/migrations/20260221_global_match_uniques.sql`, which displayed the expected content. 
- Ran `git status --short` to verify the new file is untracked and then ran `git commit -m "Add global uniqueness constraints for tournaments, playoffs, and match idempotency"`, and the commit succeeded. 
- No database migration was applied in this rollout, so migration execution and runtime DB validation were not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a77b3b7108326915bfb557ad0fa84)