### PR TITLE
Add tournament game dedupe RPC and Python cleanup utility

### DIFF
--- a/jupr_app/domain/tournaments/sync.py
+++ b/jupr_app/domain/tournaments/sync.py
@@ -49,3 +49,8 @@ def sync_tournament_game_to_match(
         },
         conflict="club_id,tournament_game_id",
     )
+
+
+def cleanup_duplicate_tournament_games(supabase: Any, tournament_id: str) -> Any:
+    """Delete duplicate tournament games for a single tournament via SQL RPC."""
+    return supabase.rpc("dedupe_tournament_games", {"t_id": str(tournament_id)}).execute()

--- a/supabase/migrations/20260813_dedupe_tournament_games.sql
+++ b/supabase/migrations/20260813_dedupe_tournament_games.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE FUNCTION public.dedupe_tournament_games(t_id text)
+RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    deleted_count integer := 0;
+BEGIN
+    WITH ranked_games AS (
+        SELECT
+            id,
+            row_number() OVER (
+                PARTITION BY club_id, tournament_id, stage, rr_round_number, rr_slot_number
+                ORDER BY created_at ASC, id ASC
+            ) AS row_num
+        FROM public.tournament_games
+        WHERE tournament_id = t_id
+    ),
+    deleted AS (
+        DELETE FROM public.tournament_games tg
+        USING ranked_games rg
+        WHERE tg.id = rg.id
+          AND rg.row_num > 1
+        RETURNING 1
+    )
+    SELECT count(*) INTO deleted_count FROM deleted;
+
+    RETURN deleted_count;
+END;
+$$;

--- a/tests/test_tournament_sync_cleanup.py
+++ b/tests/test_tournament_sync_cleanup.py
@@ -1,0 +1,30 @@
+from jupr_app.domain.tournaments.sync import cleanup_duplicate_tournament_games
+
+
+class _RpcCall:
+    def __init__(self):
+        self.executed = False
+
+    def execute(self):
+        self.executed = True
+        return {"status": "ok"}
+
+
+class _Supabase:
+    def __init__(self):
+        self.calls = []
+        self.rpc_call = _RpcCall()
+
+    def rpc(self, name, payload):
+        self.calls.append((name, payload))
+        return self.rpc_call
+
+
+def test_cleanup_duplicate_tournament_games_calls_expected_rpc():
+    supabase = _Supabase()
+
+    result = cleanup_duplicate_tournament_games(supabase, 123)
+
+    assert result == {"status": "ok"}
+    assert supabase.calls == [("dedupe_tournament_games", {"t_id": "123"})]
+    assert supabase.rpc_call.executed is True


### PR DESCRIPTION
### Motivation
- Provide an admin-safe way to remove duplicate `tournament_games` rows for a given tournament and ensure upstream schema/migration support for the cleanup operation.

### Description
- Added `cleanup_duplicate_tournament_games(supabase, tournament_id)` in `jupr_app/domain/tournaments/sync.py` which calls the `dedupe_tournament_games` RPC and executes it. 
- Added SQL migration `supabase/migrations/20260813_dedupe_tournament_games.sql` that creates `public.dedupe_tournament_games(t_id text)` and deletes duplicates by ranking rows per `(club_id, tournament_id, stage, rr_round_number, rr_slot_number)`, keeping the earliest (`ORDER BY created_at ASC, id ASC`) and returning the deleted count. 
- Added unit test `tests/test_tournament_sync_cleanup.py` that mocks a Supabase RPC call and verifies the RPC name/payload and that `execute()` is called.

### Testing
- Ran `pytest -q tests/test_tournament_sync_cleanup.py` which passed: `1 passed in 0.04s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a7a7c4f308326add013cc26fb1ed0)