### PR TITLE
Enforce matches idempotency, add deterministic replay verification and write-guards

### DIFF
--- a/docs/write_path_audit_report.md
+++ b/docs/write_path_audit_report.md
@@ -1,0 +1,45 @@
+# Write-Path Audit Report
+
+## Scope
+Tables audited:
+- `matches`
+- `tournament_games`
+- `league_ratings`
+- related write paths participating in match creation / tournament generation
+
+Search patterns used:
+- `.insert(`
+- `.upsert(`
+- `.update(`
+- `.delete(`
+- `supabase.table("matches")`
+- `supabase.table("tournament_games")`
+
+## Structured summary
+
+| File | Function | Table written | Bypasses `record_match()`? | `idempotency_key` used | `club_id` included | `on_conflict` defined |
+|---|---|---|---|---|---|---|
+| `jupr_app/domain/match_pipeline.py` | `record_match` | `matches` (`sb_insert`) | No (canonical pipeline) | Yes (required) | Yes | N/A (`insert`) |
+| `jupr_app/domain/match_pipeline.py` | `update_match` | `matches` (`sb_update`) | No (pipeline mutation) | N/A | Yes | N/A |
+| `jupr_app/domain/match_pipeline.py` | `delete_match` | `matches` (`sb_delete`) | No (pipeline mutation) | N/A | Yes | N/A |
+| `jupr_app/domain/replay_history.py` | `replay_history` | `matches` (`sb_update` snapshots) | No raw insert; post-processing rewrite path | N/A | Yes | N/A |
+| `jupr_app/domain/replay_history.py` | `replay_history` | `league_ratings` (`delete` + `replace_league_ratings` RPC) | N/A | N/A | Yes | N/A |
+| `jupr_app/domain/player_merge.py` | `merge_player_into` | `matches` (`update` player slots) | Not match creation; maintenance path | N/A | Yes | N/A |
+| `jupr_app/domain/player_merge.py` | `merge_player_into` | `league_ratings` (`update`) | N/A | N/A | Yes | N/A |
+| `jupr_app/ui/pages/tournaments.py` | tournament generation handlers | `tournament_games` (`upsert`) | N/A | N/A | Yes | Yes (`on_conflict` present) |
+| `jupr_app/ui/pages/tournaments.py` | tournament reset/cleanup handlers | `tournament_games` (`delete`) | N/A | N/A | Yes | N/A |
+| `jupr_app/ui/pages/tournaments.py` | bracket result handlers | `tournament_games` (`update`) | N/A | N/A | Yes | N/A |
+| `jupr_app/ui/pages/record_match.py` | tournament result sync handlers | `tournament_games` (`update`) | N/A | N/A | Yes | N/A |
+
+## Violations
+
+### Raw `.insert()` to `matches`
+- **None found** in repository write paths. `matches` creation flows through `jupr_app.domain.match_pipeline.record_match()`.
+
+### Writes bypassing `record_match()` (for match creation)
+- **None found** for direct `matches` creation paths.
+- Non-creation maintenance writes (`update`/`delete`/snapshot rewrites/merge operations) are present and expected.
+
+## Notes
+- `tournament_games` generation paths already use `upsert(..., on_conflict=...)` in tournament generation handlers.
+- `league_ratings` replay paths rely on deterministic rebuild logic via `replace_league_ratings` RPC.

--- a/jupr_app/cli/replay_ratings.py
+++ b/jupr_app/cli/replay_ratings.py
@@ -16,6 +16,60 @@ from jupr_app.domain.replay_lock import (
 )
 
 
+def _count_rows(supabase, table: str, club_id: str) -> int:
+    result = (
+        supabase.table(table)
+        .select("id", count="exact")
+        .eq("club_id", str(club_id))
+        .limit(1)
+        .execute()
+    )
+    return int(getattr(result, "count", 0) or 0)
+
+
+def _load_previous_success_summary(supabase, club_id: str) -> dict:
+    try:
+        rows = (
+            supabase.table("replay_runs")
+            .select("summary")
+            .eq("club_id", str(club_id))
+            .eq("status", "success")
+            .order("id", desc=True)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+    except Exception:
+        return {}
+    if not rows:
+        return {}
+    summary = rows[0].get("summary")
+    return summary if isinstance(summary, dict) else {}
+
+
+def _verify_deterministic_counts_or_raise(supabase, club_id: str, summary: dict) -> None:
+    previous = _load_previous_success_summary(supabase, club_id)
+    current_counts = {
+        "matches": _count_rows(supabase, "matches", club_id),
+        "league_ratings": _count_rows(supabase, "league_ratings", club_id),
+    }
+    summary["post_replay_counts"] = current_counts
+
+    previous_counts = previous.get("post_replay_counts") if isinstance(previous, dict) else None
+    if not isinstance(previous_counts, dict):
+        return
+
+    if (
+        int(previous_counts.get("matches", -1)) != int(current_counts["matches"])
+        or int(previous_counts.get("league_ratings", -1)) != int(current_counts["league_ratings"])
+    ):
+        raise RuntimeError(
+            "Deterministic replay verification failed: current counts differ from previous successful run. "
+            f"previous={previous_counts} current={current_counts}"
+        )
+
+
 def _load_df_meta(supabase, club_id: str) -> pd.DataFrame:
     try:
         response = (
@@ -80,6 +134,7 @@ def main() -> int:
                 progress_cb=None,
                 acquire_lock=False,
             )
+            _verify_deterministic_counts_or_raise(supabase, str(args.club_id), summary)
             _record_run(supabase, str(args.club_id), "success", summary)
         finally:
             release_replay_lock(supabase, str(args.club_id))

--- a/jupr_app/data/client.py
+++ b/jupr_app/data/client.py
@@ -1,4 +1,8 @@
-from supabase import create_client, Client
+import os
+
+from supabase import Client, create_client
+
+from jupr_app.utils.write_guard import install_match_insert_guard
 
 
 def make_supabase(url: str, key: str) -> Client:
@@ -8,4 +12,8 @@ def make_supabase(url: str, key: str) -> Client:
     Do NOT pass ClientOptions here.
     Streamlit server-side apps manage session in st.session_state.
     """
-    return create_client(url, key)
+    client = create_client(url, key)
+    env = str(os.getenv("JUPR_ENV") or os.getenv("ENV") or "").lower()
+    if env in {"dev", "development", "local"}:
+        install_match_insert_guard(client)
+    return client

--- a/jupr_app/domain/match_pipeline.py
+++ b/jupr_app/domain/match_pipeline.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 # Match writes must go through match_pipeline.
 
+import os
+
 from typing import Any, Mapping
 
 import pandas as pd
@@ -321,6 +323,8 @@ def record_match(*, supabase: Any, club_id: str, match_payload: Mapping[str, Any
     _enforce_write_preflight(supabase)
     scoped_club_id = _require_club_id(club_id)
     _require_match_datetime(match_payload)
+    if match_payload.get("idempotency_key") is None:
+        raise RuntimeError("All match writes require idempotency_key.")
     scoped_idempotency_key = _require_idempotency_key(match_payload)
 
     existing_match = _find_existing_match_by_idempotency_key(
@@ -351,6 +355,9 @@ def record_match(*, supabase: Any, club_id: str, match_payload: Mapping[str, Any
         )
 
     payload = _coerce_match_payload(scoped_club_id, match_payload)
+    env = str(os.getenv("JUPR_ENV") or os.getenv("ENV") or "").lower()
+    if env in {"dev", "development", "local"}:
+        assert payload.get("club_id") is not None
     inserted_rows: list[dict[str, Any]] = []
     inserted_match_id: int | None = None
     warnings: list[str] = []

--- a/jupr_app/domain/replay_history.py
+++ b/jupr_app/domain/replay_history.py
@@ -6,6 +6,7 @@ from jupr_app.data.sb_write import sb_rpc, sb_update
 
 import json
 import time
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional
 
 import pandas as pd
@@ -46,7 +47,13 @@ def _set_replay_lock_running(*, supabase: Any, club_id: str) -> dict[str, Any]:
     if existing:
         supabase.table("replay_lock").update({"status": "running"}).eq("club_id", str(club_id)).execute()
     else:
-        supabase.table("replay_lock").insert({"club_id": str(club_id), "status": "running"}).execute()
+        supabase.table("replay_lock").insert(
+            {
+                "club_id": str(club_id),
+                "started_at": datetime.now(timezone.utc).isoformat(),
+                "status": "running",
+            }
+        ).execute()
 
     return {
         "club_id": str(club_id),
@@ -62,6 +69,17 @@ def _set_replay_lock_status(*, supabase: Any, club_id: str, status: str) -> None
 
 def _json_size_bytes(payload: Any) -> int:
     return len(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+
+
+def _count_rows(*, supabase: Any, table: str, club_id: str) -> int:
+    rows = (
+        supabase.table(table)
+        .select("id", count="exact")
+        .eq("club_id", str(club_id))
+        .limit(1)
+        .execute()
+    )
+    return int(getattr(rows, "count", 0) or 0)
 
 
 def _chunk_rows_by_payload_limit(rows: list[Dict[str, Any]], *, max_payload_bytes: int) -> list[list[Dict[str, Any]]]:
@@ -344,6 +362,11 @@ def replay_history(
                 except Exception:
                     pass
 
+        expected_match_count = int(len(all_matches))
+        actual_match_count = _count_rows(supabase=supabase, table="matches", club_id=club_id)
+        if expected_match_count != actual_match_count:
+            raise RuntimeError("Replay mismatch detected.")
+
         summary = {
             "target_reset": target_reset,
             "players_updated": players_updated,
@@ -351,6 +374,10 @@ def replay_history(
             "matches_rewritten": int(len(matches_to_update)),
             "league_ratings_rows": int(len(new_rows)),
             "matches_scanned_total": int(len(all_matches)),
+            "post_replay_counts": {
+                "matches": int(actual_match_count),
+                "league_ratings": _count_rows(supabase=supabase, table="league_ratings", club_id=club_id),
+            },
             "log_summary": {
                 "club_id": str(club_id),
                 "lock": {**lock_info, "final_status": "success"},

--- a/jupr_app/domain/replay_lock.py
+++ b/jupr_app/domain/replay_lock.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from time import sleep
 from typing import Any
 
@@ -28,7 +29,11 @@ def _get_api_error_code(exc: APIError) -> str | None:
 
 
 def acquire_replay_lock(supabase: Any, club_id: str) -> None:
-    payload = {"club_id": str(club_id), "status": "running"}
+    payload = {
+        "club_id": str(club_id),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "status": "running",
+    }
     try:
         supabase.table("replay_lock").insert(payload).execute()
     except APIError as exc:

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -151,6 +151,19 @@ def render(ctx):
     if len(ids) != len(set(ids)):
         raise RuntimeError("Duplicate tournament_game rows detected.")
 
+    seen: set[tuple[object, object, object, object, object]] = set()
+    for g in games:
+        key = (
+            g.get("stage"),
+            g.get("rr_round_number"),
+            g.get("rr_slot_number"),
+            g.get("playoff_game_code"),
+            g.get("series_game_number"),
+        )
+        if key in seen:
+            raise RuntimeError("Duplicate tournament_game invariant violated.")
+        seen.add(key)
+
     rr_games = [g for g in games if g.get("stage") == "ROUND_ROBIN"]
     playoff_games = [g for g in games if g.get("stage") == "PLAYOFF"]
 

--- a/jupr_app/utils/write_guard.py
+++ b/jupr_app/utils/write_guard.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def forbid_raw_match_insert(stack: Any) -> None:
+    raise RuntimeError(
+        "Direct matches insert detected. Use record_match() instead."
+    )
+
+
+def install_match_insert_guard(supabase: Any) -> Any:
+    """Monkey-patch table('matches').insert in development mode."""
+    original_table = supabase.table
+
+    def guarded_table(table_name: str, *args: Any, **kwargs: Any) -> Any:
+        query = original_table(table_name, *args, **kwargs)
+        if str(table_name) == "matches" and hasattr(query, "insert"):
+            query.insert = forbid_raw_match_insert
+        return query
+
+    supabase.table = guarded_table
+    return supabase

--- a/supabase/migrations/20260221_global_write_invariants.sql
+++ b/supabase/migrations/20260221_global_write_invariants.sql
@@ -1,0 +1,51 @@
+-- =========================================
+-- MATCH IDEMPOTENCY (GLOBAL)
+-- =========================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+matches_idempotency_unique
+ON matches (
+    club_id,
+    idempotency_key
+)
+WHERE idempotency_key IS NOT NULL;
+
+-- =========================================
+-- TOURNAMENT ROUND ROBIN
+-- =========================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+tournament_rr_unique_slot
+ON tournament_games (
+    tournament_id,
+    stage,
+    rr_round_number,
+    rr_slot_number
+)
+WHERE stage = 'ROUND_ROBIN';
+
+-- =========================================
+-- TOURNAMENT PLAYOFF
+-- =========================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+tournament_playoff_unique_slot
+ON tournament_games (
+    tournament_id,
+    stage,
+    playoff_game_code,
+    COALESCE(series_game_number, 1)
+)
+WHERE stage = 'PLAYOFF';
+
+-- =========================================
+-- TOURNAMENT GAME → MATCH LINK
+-- =========================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+matches_unique_tournament_game
+ON matches (
+    club_id,
+    tournament_game_id
+)
+WHERE tournament_game_id IS NOT NULL;

--- a/supabase/migrations/20260221_replay_lock.sql
+++ b/supabase/migrations/20260221_replay_lock.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS replay_lock (
+    club_id text PRIMARY KEY,
+    started_at timestamptz,
+    status text
+);

--- a/supabase/migrations/20260222_matches_unique_club_idempotency.sql
+++ b/supabase/migrations/20260222_matches_unique_club_idempotency.sql
@@ -1,0 +1,23 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND indexname = 'matches_unique_club_idempotency'
+    ) THEN
+        IF EXISTS (
+            SELECT 1
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = 'matches_idempotency_unique'
+        ) THEN
+            ALTER INDEX matches_idempotency_unique RENAME TO matches_unique_club_idempotency;
+        ELSE
+            CREATE UNIQUE INDEX matches_unique_club_idempotency
+            ON matches (club_id, idempotency_key)
+            WHERE idempotency_key IS NOT NULL;
+        END IF;
+    END IF;
+END;
+$$;

--- a/tests/test_no_raw_match_insert.py
+++ b/tests/test_no_raw_match_insert.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = REPO_ROOT / "jupr_app"
+
+
+def test_no_raw_match_table_insert_calls() -> None:
+    violations: list[str] = []
+    for py_file in SOURCE_ROOT.rglob("*.py"):
+        text = py_file.read_text(encoding="utf-8")
+        if 'table("matches").insert(' in text or "table('matches').insert(" in text:
+            violations.append(str(py_file.relative_to(REPO_ROOT)))
+
+    assert not violations, f"Direct matches insert detected in: {', '.join(violations)}"

--- a/tests/test_tournament_games_writes_idempotent.py
+++ b/tests/test_tournament_games_writes_idempotent.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOURNAMENTS_PAGE = REPO_ROOT / "jupr_app" / "ui" / "pages" / "tournaments.py"
+
+
+def test_no_raw_tournament_games_insert() -> None:
+    text = TOURNAMENTS_PAGE.read_text(encoding="utf-8")
+    assert 'table("tournament_games").insert(' not in text
+    assert "table('tournament_games').insert(" not in text
+
+
+def test_tournament_games_upsert_uses_on_conflict() -> None:
+    text = TOURNAMENTS_PAGE.read_text(encoding="utf-8")
+    segments = text.split('table("tournament_games").upsert(')
+    for segment in segments[1:]:
+        window = segment[:240]
+        assert "on_conflict=" in window


### PR DESCRIPTION
### Motivation
- Ensure match-level idempotency is enforced at the database layer so retries/bulk re-runs cannot create duplicate `matches` rows.  
- Make deterministic replay self-verifying so a replay that produces a different row-count fails loudly.  
- Prevent future regressions by blocking raw `matches` inserts in development and making the canonical pipeline require `idempotency_key`, and make the UI fail loudly on duplicate tournament games.

### Description
- Add migration `supabase/migrations/20260222_matches_unique_club_idempotency.sql` that creates `matches_unique_club_idempotency` or safely renames the legacy `matches_idempotency_unique` index, enforcing `UNIQUE (club_id, idempotency_key) WHERE idempotency_key IS NOT NULL`.  
- Harden replay logic in `jupr_app/domain/replay_history.py` by adding `_count_rows`, stamping `started_at` on lock creation, and validating `expected_match_count = len(all_matches)` against the actual `matches` table count and raising `RuntimeError("Replay mismatch detected.")` on mismatch.  
- Add CLI-level verification in `jupr_app/cli/replay_ratings.py` via `_verify_deterministic_counts_or_raise` which compares current `post_replay_counts` against the last successful run and fails on differences.  
- Harden canonical pipeline in `jupr_app/domain/match_pipeline.py` by explicitly raising if `match_payload.get("idempotency_key") is None` and adding a development-mode `assert payload.get("club_id")` check.  
- Install a development write-guard by adding `jupr_app/utils/write_guard.py` and wiring `install_match_insert_guard` into `jupr_app/data/client.py` so `table('matches').insert` is monkey-patched to fail in dev/local environments.  
- Add defensive duplicate detection in the tournaments UI (`jupr_app/ui/pages/tournaments.py`) using the tuple key `(stage, rr_round_number, rr_slot_number, playoff_game_code, series_game_number)` and raise `RuntimeError` on duplicates.  
- Add audit documentation `docs/write_path_audit_report.md` and tests `tests/test_no_raw_match_insert.py` and `tests/test_tournament_games_writes_idempotent.py` that assert no raw `matches` inserts and that `tournament_games` upserts include `on_conflict`.

### Testing
- Ran `pytest -q tests/test_no_raw_match_insert.py tests/test_tournament_games_writes_idempotent.py`, which passed (`3 passed`).  
- Ran `python -m py_compile` on modified modules (`jupr_app/domain/match_pipeline.py`, `jupr_app/domain/replay_history.py`, `jupr_app/ui/pages/tournaments.py`, `jupr_app/cli/replay_ratings.py`) and the files compiled successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a7c6ef878832684c4b95c36ef7e1f)