### PR TITLE
Add unique matches index for tournament_game upserts

### DIFF
--- a/supabase/migrations/20260221_matches_tournament_game_unique.sql
+++ b/supabase/migrations/20260221_matches_tournament_game_unique.sql
@@ -1,0 +1,7 @@
+CREATE UNIQUE INDEX IF NOT EXISTS
+matches_unique_tournament_game
+ON matches (
+    club_id,
+    tournament_game_id
+)
+WHERE tournament_game_id IS NOT NULL;


### PR DESCRIPTION
### Motivation
- Ensure the database enforces the invariant that a `tournament_game` maps to at most one `matches` row so upserts are safe and idempotent.
- Provide an index that exactly matches the `ON CONFLICT` target used by the sync path to avoid runtime conflicts when converting inserts to upserts.

### Description
- Added migration `supabase/migrations/20260221_matches_tournament_game_unique.sql` which creates a partial unique index on `matches (club_id, tournament_game_id)` with `WHERE tournament_game_id IS NOT NULL`.
- Verified `sync_tournament_game_to_match()` in `jupr_app/domain/tournaments/sync.py` uses the exact conflict key `conflict="club_id,tournament_game_id"`.
- No application code changes were required beyond adding the migration file.

### Testing
- Ran `pytest -q tests/test_tournament_games_writes_idempotent.py`, which passed (`2 passed`).
- Attempted to deploy with `supabase db push` but the Supabase CLI is not available in this environment (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a806289bc83268122b9fd27dddb70)