### PR TITLE
Add consolidated migration to align Supabase upsert conflict targets

### DIFF
--- a/supabase/migrations/20260222_full_upsert_alignment.sql
+++ b/supabase/migrations/20260222_full_upsert_alignment.sql
@@ -1,0 +1,80 @@
+-- =========================================
+-- MATCHES TABLE
+-- =========================================
+
+-- Required for replay_history upsert
+CREATE UNIQUE INDEX IF NOT EXISTS
+matches_unique_club_id_id
+ON matches (club_id, id);
+
+-- Required for tournament sync upsert
+CREATE UNIQUE INDEX IF NOT EXISTS
+matches_unique_tournament_game
+ON matches (club_id, tournament_game_id)
+WHERE tournament_game_id IS NOT NULL;
+
+-- Required for idempotency enforcement
+CREATE UNIQUE INDEX IF NOT EXISTS
+matches_unique_idempotency
+ON matches (club_id, idempotency_key)
+WHERE idempotency_key IS NOT NULL;
+
+
+-- =========================================
+-- TOURNAMENT TABLES
+-- =========================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+tournament_teams_unique
+ON tournament_teams (tournament_id, team_number);
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+tournament_podium_unique
+ON tournament_podium (tournament_id, placement);
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+tournament_rr_unique
+ON tournament_games (
+    tournament_id,
+    stage,
+    rr_round_number,
+    rr_slot_number
+)
+WHERE stage = 'ROUND_ROBIN';
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+tournament_playoff_unique
+ON tournament_games (
+    tournament_id,
+    stage,
+    playoff_game_code,
+    COALESCE(series_game_number, 1)
+)
+WHERE stage = 'PLAYOFF';
+
+
+-- =========================================
+-- BADGES
+-- =========================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+badges_unique_badge_id
+ON badges (badge_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+player_badges_unique_context
+ON player_badges (club_id, player_id, badge_id, context_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+badge_queue_unique_match
+ON badge_eval_queue (event_type, match_id)
+WHERE match_id IS NOT NULL;
+
+
+-- =========================================
+-- WEEKLY RECAPS
+-- =========================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+weekly_recaps_unique
+ON weekly_recaps (club_id, week_start);


### PR DESCRIPTION
### Motivation
- Postgres `ON CONFLICT` upserts require a matching unique index, and several `upsert(... on_conflict=...)` targets in the app lacked the required indexes causing upsert failures (notably playoff/tournament sync on `matches (club_id, tournament_game_id)`).
- Provide a single idempotent migration that ensures all currently-used conflict targets are backed by unique indexes to prevent runtime crashes and make deployments deterministic.

### Description
- Added a new migration file `supabase/migrations/20260222_full_upsert_alignment.sql` that creates unique indexes with `CREATE UNIQUE INDEX IF NOT EXISTS` for all known upsert conflict targets. 
- For the `matches` table the migration adds `matches_unique_club_id_id (club_id, id)`, a partial `matches_unique_tournament_game (club_id, tournament_game_id) WHERE tournament_game_id IS NOT NULL`, and a partial `matches_unique_idempotency (club_id, idempotency_key) WHERE idempotency_key IS NOT NULL`.
- Added tournament-related indexes including `tournament_teams_unique (tournament_id, team_number)`, `tournament_podium_unique (tournament_id, placement)`, `tournament_rr_unique` for ROUND_ROBIN game slots, and `tournament_playoff_unique` for PLAYOFF games using `COALESCE(series_game_number, 1)`.
- Added badge and recap uniqueness indexes including `badges_unique_badge_id`, `player_badges_unique_context (club_id, player_id, badge_id, context_id)`, `badge_queue_unique_match (event_type, match_id) WHERE match_id IS NOT NULL`, and `weekly_recaps_unique (club_id, week_start)`.

### Testing
- Verified the migration file exists and its line count with `wc -l supabase/migrations/20260222_full_upsert_alignment.sql` which succeeded. 
- Inspected the file contents with `nl -ba supabase/migrations/20260222_full_upsert_alignment.sql` to confirm all expected index statements are present. 
- Listed recent migrations with `ls -1 supabase/migrations | tail -n 20` to confirm the migration is in the migrations directory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a824b83e883268c99d7d692f2390a)