### PR TITLE
Fix playoff best-of series propagation and dependency resolution

### DIFF
--- a/jupr_app/domain/tournaments/__init__.py
+++ b/jupr_app/domain/tournaments/__init__.py
@@ -567,173 +567,155 @@ def resolve_series_results(games: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """
 
     updates = []
-    grouped: dict[str, list[dict[str, Any]]] = {}
+    series_groups: dict[str, list[dict[str, Any]]] = {}
 
-    # Group games by playoff_game_code
-    for g in games:
-        if g.get("stage") != "PLAYOFF":
+    for game in games:
+        if game.get("stage") != "PLAYOFF":
             continue
-        code = g.get("playoff_game_code")
+        code = game.get("playoff_game_code")
         if not code:
             continue
-        grouped.setdefault(code, []).append(g)
+        series_groups.setdefault(code, []).append(game)
 
-    for _, series_games in grouped.items():
+    for series_games in series_groups.values():
+        ordered_games = sorted(series_games, key=_series_game_sort_key)
+        required_wins = 2 if len(ordered_games) >= 3 else 1
         wins: dict[str, int] = {}
 
-        for g in series_games:
-            winner = g.get("winner_team_id")
-            if winner:
-                wins[winner] = wins.get(winner, 0) + 1
+        for game in ordered_games:
+            winner = game.get("winner_team_id")
+            if not winner:
+                continue
+            wins[winner] = wins.get(winner, 0) + 1
 
-        if not wins:
+        winning_team_id = next((team_id for team_id, win_count in wins.items() if win_count >= required_wins), None)
+        if not winning_team_id:
             continue
 
-        # Determine required wins
-        required = 2 if len(series_games) >= 3 else 1
+        deciding_game = None
+        win_counter = 0
+        for game in ordered_games:
+            if game.get("winner_team_id") != winning_team_id:
+                continue
+            win_counter += 1
+            if win_counter == required_wins:
+                deciding_game = game
+                break
 
-        for team_id, win_count in wins.items():
-            if win_count >= required:
-                # Determine loser
-                opponents = [tid for tid in wins.keys() if tid != team_id]
-                loser_id = opponents[0] if opponents else None
+        if not deciding_game:
+            continue
 
-                # Sort series games by series_game_number ascending
-                ordered_games = sorted(
-                    series_games,
-                    key=lambda x: x.get("series_game_number") or 1,
-                )
+        opponent_ids = {
+            game.get("team_a_id") for game in ordered_games if game.get("team_a_id")
+        } | {
+            game.get("team_b_id") for game in ordered_games if game.get("team_b_id")
+        }
+        opponent_ids.discard(winning_team_id)
+        loser_id = next(iter(opponent_ids), None)
 
-                win_counter = 0
-                deciding_game = None
-
-                for g in ordered_games:
-                    if g.get("winner_team_id") == team_id:
-                        win_counter += 1
-                        if win_counter == required:
-                            deciding_game = g
-                            break
-
-                if not deciding_game:
-                    continue
-
-                updates.append(
-                    {
-                        "id": deciding_game["id"],
-                        "winner_team_id": team_id,
-                        "loser_team_id": loser_id,
-                        "finalized_at": datetime.now(timezone.utc).isoformat(),
-                    }
-                )
+        updates.append(
+            {
+                "id": deciding_game["id"],
+                "winner_team_id": winning_team_id,
+                "loser_team_id": loser_id,
+                "finalized_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
 
     return updates
 
 
 def resolve_playoff_dependencies(games: list[dict[str, Any]]) -> list[dict[str, Any]]:
     updates: dict[str, dict[str, Any]] = {}
+    local_games = [dict(game) for game in games if game.get("stage") == "PLAYOFF" and game.get("playoff_game_code")]
 
-    # --- Collapse series rows into one logical row per playoff_game_code ---
-    series_map: dict[str, list[dict[str, Any]]] = {}
-    for g in games:
-        code = g.get("playoff_game_code")
-        if not code:
-            continue
-        series_map.setdefault(code, []).append(g)
-
-    by_code: dict[str, dict[str, Any]] = {}
-
-    for code, series_games in series_map.items():
-        # Prefer finalized game in series
-        finalized_game = next((g for g in series_games if g.get("finalized_at")), None)
-
-        if finalized_game:
-            by_code[code] = finalized_game
-        else:
-            # No finalized game -> treat series as unresolved
-            # Use a representative row but clear winner/loser logically
-            representative = series_games[0]
-            rep_copy = dict(representative)
-            rep_copy["winner_team_id"] = None
-            rep_copy["loser_team_id"] = None
-            rep_copy["finalized_at"] = None
-            by_code[code] = rep_copy
-
-    # Collapse to one logical game per playoff_game_code
-    logical_games = list(by_code.values())
-    local_games = [dict(g) for g in logical_games]
-
-    def resolve_source(source: Any) -> tuple[bool, str | None]:
-        if not source:
-            return False, None
-        if isinstance(source, str):
-            return False, None
-        if "winnerOf" in source:
-            return True, by_code.get(source["winnerOf"], {}).get("winner_team_id")
-        if "loserOf" in source:
-            return True, by_code.get(source["loserOf"], {}).get("loser_team_id")
-        return False, None
-
-    def set_update(game: dict[str, Any], field: str, value: Any) -> None:
-        gid = game["id"]
-        updates.setdefault(gid, {"id": gid})[field] = value
+    def set_update(game_id: str, field: str, value: Any) -> None:
+        updates.setdefault(game_id, {"id": game_id})[field] = value
 
     changed = True
     while changed:
         changed = False
-        series_map = {}
-
-        for g in local_games:
-            code = g.get("playoff_game_code")
-            if not code:
-                continue
-            series_map.setdefault(code, []).append(g)
-
-        by_code = {}
-        for code, series_games in series_map.items():
-            finalized_game = next((g for g in series_games if g.get("finalized_at")), None)
-
-            if finalized_game:
-                by_code[code] = finalized_game
-            else:
-                representative = series_games[0]
-                rep_copy = dict(representative)
-                rep_copy["winner_team_id"] = None
-                rep_copy["loser_team_id"] = None
-                rep_copy["finalized_at"] = None
-                by_code[code] = rep_copy
+        series_groups: dict[str, list[dict[str, Any]]] = {}
         for game in local_games:
-            if game.get("stage") != "PLAYOFF":
-                continue
-            dep_a, desired_a = resolve_source(_parse_source(game.get("team_a_source")))
-            dep_b, desired_b = resolve_source(_parse_source(game.get("team_b_source")))
+            series_groups.setdefault(game["playoff_game_code"], []).append(game)
 
-            for key, is_dep, desired in (
-                ("team_a_id", dep_a, desired_a),
-                ("team_b_id", dep_b, desired_b),
-            ):
-                if not is_dep:
-                    continue
-                if desired is None:
-                    if game.get(key) is not None:
-                        set_update(game, key, None)
-                        _clear_game_results(game, updates)
-                        game[key] = None
-                        changed = True
-                    continue
-                if game.get(key) != desired:
-                    set_update(game, key, desired)
-                    _clear_game_results(game, updates)
-                    game[key] = desired
+        series_outcomes = _compute_series_outcomes(series_groups)
+
+        def resolve_source(source: Any) -> tuple[bool, str | None]:
+            parsed = _parse_source(source)
+            if not parsed:
+                return False, None
+            if "winnerOf" in parsed:
+                return True, series_outcomes.get(parsed["winnerOf"], {}).get("winner_team_id")
+            if "loserOf" in parsed:
+                return True, series_outcomes.get(parsed["loserOf"], {}).get("loser_team_id")
+            return False, None
+
+        for code, series_games in series_groups.items():
+            anchor = _pick_series_anchor(series_games)
+            dep_a, desired_team_a = resolve_source(anchor.get("team_a_source"))
+            dep_b, desired_team_b = resolve_source(anchor.get("team_b_source"))
+
+            for series_game in series_games:
+                participants_changed = False
+
+                for key, is_dependency, desired_value in (
+                    ("team_a_id", dep_a, desired_team_a),
+                    ("team_b_id", dep_b, desired_team_b),
+                ):
+                    if not is_dependency:
+                        continue
+                    if series_game.get(key) == desired_value:
+                        continue
+                    set_update(series_game["id"], key, desired_value)
+                    series_game[key] = desired_value
+                    participants_changed = True
+
+                if participants_changed:
+                    _clear_game_results(series_game, updates)
                     changed = True
 
-            for field in ["winner_team_id", "loser_team_id", "finalized_at"]:
-                if field in updates.get(game["id"], {}):
-                    game[field] = updates[game["id"]].get(field)
-            for field in ["score_a", "score_b"]:
-                if field in updates.get(game["id"], {}):
-                    game[field] = updates[game["id"]].get(field)
-
     return list(updates.values())
+
+
+def _series_game_sort_key(game: dict[str, Any]) -> tuple[int, str]:
+    return int(game.get("series_game_number") or 1), str(game.get("id") or "")
+
+
+def _pick_series_anchor(series_games: list[dict[str, Any]]) -> dict[str, Any]:
+    ordered_games = sorted(series_games, key=_series_game_sort_key)
+    return next((game for game in ordered_games if int(game.get("series_game_number") or 1) == 1), ordered_games[0])
+
+
+def _compute_series_outcomes(series_groups: dict[str, list[dict[str, Any]]]) -> dict[str, dict[str, Any]]:
+    outcomes: dict[str, dict[str, Any]] = {}
+    for code, series_games in series_groups.items():
+        ordered_games = sorted(series_games, key=_series_game_sort_key)
+        required_wins = 2 if len(ordered_games) >= 3 else 1
+        wins: dict[str, int] = {}
+
+        for game in ordered_games:
+            winner = game.get("winner_team_id")
+            if winner:
+                wins[winner] = wins.get(winner, 0) + 1
+
+        winner_team_id = next((team_id for team_id, win_count in wins.items() if win_count >= required_wins), None)
+        loser_team_id = None
+        if winner_team_id:
+            participants = {
+                game.get("team_a_id") for game in ordered_games if game.get("team_a_id")
+            } | {
+                game.get("team_b_id") for game in ordered_games if game.get("team_b_id")
+            }
+            participants.discard(winner_team_id)
+            loser_team_id = next(iter(participants), None)
+
+        outcomes[code] = {
+            "winner_team_id": winner_team_id,
+            "loser_team_id": loser_team_id,
+        }
+
+    return outcomes
 
 
 def _parse_source(source: Any) -> dict[str, Any] | None:

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -470,6 +470,38 @@ def render(ctx):
             st.session_state["force_data_refresh"] = True
 
         if playoff_games:
+            if st.button("🔄 Recompute Bracket Dependencies", disabled=is_complete):
+                playoff_games_resp = (
+                    supabase.table("tournament_games")
+                    .select("*")
+                    .eq("club_id", str(club_id))
+                    .eq("tournament_id", tournament_id)
+                    .eq("stage", "PLAYOFF")
+                    .execute()
+                )
+                playoff_games = playoff_games_resp.data or []
+
+                series_updates = resolve_series_results(playoff_games)
+                for upd in series_updates:
+                    supabase.table("tournament_games").update(upd).eq("club_id", str(club_id)).eq("id", upd["id"]).execute()
+
+                playoff_games_resp = (
+                    supabase.table("tournament_games")
+                    .select("*")
+                    .eq("club_id", str(club_id))
+                    .eq("tournament_id", tournament_id)
+                    .eq("stage", "PLAYOFF")
+                    .execute()
+                )
+                playoff_games = playoff_games_resp.data or []
+
+                dependency_updates = resolve_playoff_dependencies(playoff_games)
+                for upd in dependency_updates:
+                    supabase.table("tournament_games").update(upd).eq("club_id", str(club_id)).eq("id", upd["id"]).execute()
+
+                st.success("Bracket dependencies recomputed.")
+                st.session_state["force_data_refresh"] = True
+
             _render_playoff_bracket(
                 games=playoff_games,
                 teams_by_id=teams_by_id,
@@ -549,14 +581,16 @@ def _render_playoff_bracket(*, games, teams_by_id, id_to_name, on_save, disabled
 
         with st.form(key=f"playoff_{round_name}"):
             for series_code, series_games in series_groups.items():
+                series_len = max((g.get("series_game_number") or 1) for g in series_games)
                 st.markdown(f"### {series_code}")
                 for game in sorted(series_games, key=lambda x: x.get("series_game_number") or 1):
                     team_a = teams_by_id.get(game.get("team_a_id"), {})
                     team_b = teams_by_id.get(game.get("team_b_id"), {})
                     label_a = _team_label(team_a, id_to_name)
                     label_b = _team_label(team_b, id_to_name)
+                    game_number = game.get("series_game_number") or 1
                     col1, col2, col3, col4 = st.columns([4, 1, 1, 2])
-                    col1.write(f"{game.get('playoff_game_code')}: {label_a} vs {label_b}")
+                    col1.write(f"{game.get('playoff_game_code')} (Game {game_number}/{series_len}): {label_a} vs {label_b}")
                     col2.number_input(
                         "Score A",
                         min_value=0,


### PR DESCRIPTION
### Motivation
- Fix UX and correctness for playoff best-of series so repeated P1/P2/P3 rows are labeled as distinct games (e.g., Game 1/3) and downstream matchups use series winners, not per-row winners.
- Ensure that when a playoff series determines a participant (e.g., SF -> Final), the resolved team ids propagate to every game row in the dependent series and that stale scores/finalization are cleared if participants change.

### Description
- UI: updated `_render_playoff_bracket()` to compute `series_len = max((g.get("series_game_number") or 1) for g in series_games)` and show `(<playoff_game_code> (Game {n}/{series_len}): ...)` while keeping form keys based on `game['id']`.
- Admin action: added a Playoffs button `🔄 Recompute Bracket Dependencies` that refetches playoff games, runs `resolve_series_results()`, refetches, runs `resolve_playoff_dependencies()`, and sets `st.session_state["force_data_refresh"] = True`.
- Domain logic: refactored `resolve_series_results()` to order games by `series_game_number`, compute the series winner for best-of formats, and finalize the deciding game with `winner_team_id`, `loser_team_id`, and `finalized_at`.
- Domain logic: rewrote `resolve_playoff_dependencies()` to operate at series level by grouping on `playoff_game_code`, deriving series outcomes via a new `_compute_series_outcomes()` helper, choosing a series anchor via `_pick_series_anchor()`, propagating resolved `team_a_id`/`team_b_id` to all games in the destination series, and calling `_clear_game_results()` to reset `score_a`, `score_b`, `winner_team_id`, `loser_team_id`, and `finalized_at` whenever participants change; added `_series_game_sort_key`, `_pick_series_anchor`, and `_compute_series_outcomes` helpers.

### Testing
- Ran `python -m py_compile jupr_app/domain/tournaments/__init__.py jupr_app/ui/pages/tournaments.py` which succeeded without syntax errors.
- Executed an automated sanity script invoking `resolve_playoff_dependencies(...)` for an SF->Final best-of scenario and confirmed updates for all Final rows (`f1/f2/f3`) showed propagated teams as expected.
- Launched the app and captured an automated screenshot of the Playoffs UI to verify the new labels and button; the recompute flow was exercised in an automated script and produced expected dependency updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a8c1946c88326ade792c1d558d76b)