### PR TITLE
Fix account creation flow behind “Save New Players & Continue”

### DIFF
--- a/jupr_app/domain/player_ops.py
+++ b/jupr_app/domain/player_ops.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Tuple
 
+from postgrest.exceptions import APIError
+
 
 def _normalized_player_name(name: str) -> str:
     return " ".join(str(name or "").strip().lower().split())
@@ -15,4 +17,52 @@ def safe_add_player(
     name: str,
     rating_jupr: float,
 ) -> Tuple[bool, str]:
-    raise Exception("SAFE_ADD_PLAYER WAS CALLED")
+    try:
+        normalized_name = _normalized_player_name(name)
+        if not club_id:
+            return False, "club_id is required"
+        if not normalized_name:
+            return False, "Player name is required"
+
+        payload = {
+            "club_id": str(club_id),
+            "name": str(name or "").strip(),
+            "normalized_name": normalized_name,
+            "rating": float(rating_jupr),
+        }
+
+        upsert_resp = (
+            supabase.table("players")
+            .upsert(payload, on_conflict="club_id,normalized_name")
+            .select("id")
+            .execute()
+        )
+        upsert_rows = upsert_resp.data or []
+        if upsert_rows:
+            return True, int(upsert_rows[0].get("id"))
+
+        lookup_resp = (
+            supabase.table("players")
+            .select("id")
+            .eq("club_id", str(club_id))
+            .eq("normalized_name", normalized_name)
+            .limit(1)
+            .execute()
+        )
+        lookup_rows = lookup_resp.data or []
+        if lookup_rows:
+            return True, int(lookup_rows[0].get("id"))
+
+        return False, "Player create succeeded but no player row was returned."
+
+    except APIError as exc:
+        code = str(getattr(exc, "code", "") or "")
+        message = str(getattr(exc, "message", "") or str(exc))
+        if code == "42P10" or "ON CONFLICT" in message.upper():
+            return False, (
+                "Schema mismatch: missing unique constraint for "
+                "players(club_id, normalized_name)."
+            )
+        return False, message or "Failed to add player."
+    except Exception as exc:
+        return False, str(exc) or "Failed to add player."

--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -384,7 +384,13 @@ def render(ctx):
                     errs = 0
                     for _, r in edited_new.iterrows():
                         nm = str(r["Name"]).strip()
-                        jupr = float(r["Starting JUPR"])
+                        try:
+                            jupr = float(r["Starting JUPR"])
+                        except (TypeError, ValueError):
+                            errs += 1
+                            st.error(f"Could not add {nm}: invalid Starting JUPR value.")
+                            continue
+
                         ok, err = safe_add_player(
                             supabase=ctx.supabase,
                             club_id=str(ctx.club_id),


### PR DESCRIPTION
### Motivation

- Ensure the UI action “Save New Players & Continue” actually creates player accounts and that the `safe_add_player` contract (`(ok, err)`) never raises so a bad row does not abort the whole batch. 
- Make the domain operation robust and idempotent when called from multiple UI flows and pipelines.

### Description

- Implemented `safe_add_player` in `jupr_app/domain/player_ops.py` to normalize names, validate inputs, perform a Supabase `upsert` on `players` with `on_conflict="club_id,normalized_name"`, `select("id")`, and return `(True, player_id)` on success, or `(False, error)` on failure. 
- Added a fallback lookup by `club_id` + `normalized_name` when the `upsert` returns empty data and converted returned ids to `int` for callers. 
- Converted PostgREST schema-conflict (`42P10` / ON CONFLICT mismatch) and other exceptions into friendly error strings instead of raising, preserving the UI contract. 
- Hardened the League Manager batch flow in `jupr_app/ui/pages/league_manager.py` so invalid per-row `Starting JUPR` values are reported per row and do not abort the entire batch.

### Testing

- Ran `pytest -q tests/test_player_ops.py` which passed (3 tests). 
- Ran `pytest -q tests/test_player_ops.py tests/test_match_processing_canonical_pipeline.py` which produced one failing test due to an unrelated test stub limitation where the test `_Query` does not implement `upsert`/`delete` (resulting in `AttributeError`), not due to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a8d79dbb08326b8f2951e9fc48e4f)