### PR TITLE
Fix missing sb_insert import in tournaments page

### DIFF
--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from jupr_app.data.sb_write import sb_update, sb_upsert
+from jupr_app.data.sb_write import sb_insert, sb_update, sb_upsert
 
 from datetime import datetime, timezone
 from pathlib import Path


### PR DESCRIPTION
### Motivation
- Prevent a runtime `NameError` during tournament creation by ensuring the `sb_insert` helper used in the file is imported alongside other `sb_*` write helpers.

### Description
- Added `sb_insert` to the `from jupr_app.data.sb_write import ...` line in `jupr_app/ui/pages/tournaments.py` so all `sb_*` helpers used in the module are imported.

### Testing
- Verified helper usage with `rg` to locate `sb_insert`, `sb_update`, and `sb_upsert` occurrences and confirmed imports; command succeeded.
- Successfully compiled the modified file with `python -m py_compile jupr_app/ui/pages/tournaments.py` indicating no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a90e353cc83269e1cf17858eec93f)