### PR TITLE
Fix tournament_games upsert conflict constraint (tenant-safe partial unique indexes)

### DIFF
--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -296,7 +296,7 @@ def render(ctx):
             _require_club_id_payload(games_payload)
             supabase.table("tournament_games").upsert(
                 games_payload,
-                on_conflict="tournament_id,stage,rr_round_number,rr_slot_number"
+                on_conflict="club_id,tournament_id,stage,rr_round_number,rr_slot_number"
             ).execute()
             sb_update(supabase, "tournaments", {"status": "ROUND_ROBIN"}, filters={"club_id": str(club_id), "id": tournament_id})
             st.success("Round robin schedule generated.")
@@ -430,7 +430,7 @@ def render(ctx):
 
                         supabase.table("tournament_games").upsert(
                             games_payload,
-                            on_conflict="tournament_id,stage,playoff_game_code,series_game_number"
+                            on_conflict="club_id,tournament_id,stage,playoff_game_code,series_game_number"
                         ).execute()
 
                         st.success("Playoff bracket regenerated.")
@@ -458,7 +458,7 @@ def render(ctx):
             _require_club_id_payload(games_payload)
             supabase.table("tournament_games").upsert(
                 games_payload,
-                on_conflict="tournament_id,stage,playoff_game_code,series_game_number"
+                on_conflict="club_id,tournament_id,stage,playoff_game_code,series_game_number"
             ).execute()
             sb_update(
                 supabase,

--- a/supabase/migrations/20260221_tournament_games_unique_constraints.sql
+++ b/supabase/migrations/20260221_tournament_games_unique_constraints.sql
@@ -1,0 +1,24 @@
+-- Tournament Games Uniqueness Enforcement (Tenant Safe)
+-- Forward-only, non-destructive migration.
+
+-- Round Robin uniqueness
+CREATE UNIQUE INDEX IF NOT EXISTS tournament_games_rr_unique
+ON public.tournament_games (
+    club_id,
+    tournament_id,
+    stage,
+    rr_round_number,
+    rr_slot_number
+)
+WHERE stage = 'ROUND_ROBIN';
+
+-- Playoff uniqueness
+CREATE UNIQUE INDEX IF NOT EXISTS tournament_games_playoff_unique
+ON public.tournament_games (
+    club_id,
+    tournament_id,
+    stage,
+    playoff_game_code,
+    series_game_number
+)
+WHERE stage = 'PLAYOFF';


### PR DESCRIPTION
### Motivation
- Prevent Postgres `42P10` errors by ensuring `ON CONFLICT` targets have matching unique indexes and make tournament game writes tenant-safe and idempotent. 
- Preserve all production data by applying a forward-only, additive migration rather than dropping or altering existing constraints. 

### Description
- Add an additive migration `supabase/migrations/20260221_tournament_games_unique_constraints.sql` that creates two partial unique indexes including `club_id`: `tournament_games_rr_unique` (WHERE `stage = 'ROUND_ROBIN'`) and `tournament_games_playoff_unique` (WHERE `stage = 'PLAYOFF'`).
- Update `jupr_app/ui/pages/tournaments.py` to include `club_id` in the `on_conflict` clauses for the Round Robin upsert and both Playoff upserts so the conflict targets match the new indexes. 
- Ensure defensive tenant-safety checks with `_require_club_id_payload(games_payload)` exist immediately before each upsert path. 
- No destructive changes are made: existing constraints, RLS, and table structure are preserved. 

### Testing
- Ran `python -m compileall jupr_app/ui/pages/tournaments.py` and compilation succeeded. 
- Ran a code search to confirm the old `on_conflict` patterns are no longer present and the new `club_id`-prefixed conflict targets appear, which succeeded. 
- Created the migration file at `supabase/migrations/20260221_tournament_games_unique_constraints.sql` and validated its contents match the intended stage-scoped partial unique indexes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a944b43c483268c641c707b1c9bbf)