### PR TITLE
Canonicalize tournament_games uniqueness (tenant-scoped only)

### DIFF
--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -294,6 +294,11 @@ def render(ctx):
                 # Explicit club_id for tenant isolation (RLS + multi-club safety)
                 game["club_id"] = str(club_id)
             _require_club_id_payload(games_payload)
+            if getattr(ctx, "DEBUG_MODE", False):
+                print(
+                    "RR upsert conflict target:",
+                    "club_id,tournament_id,stage,rr_round_number,rr_slot_number",
+                )
             supabase.table("tournament_games").upsert(
                 games_payload,
                 on_conflict="club_id,tournament_id,stage,rr_round_number,rr_slot_number"

--- a/supabase/migrations/20260222_canonicalize_tournament_games_uniqueness.sql
+++ b/supabase/migrations/20260222_canonicalize_tournament_games_uniqueness.sql
@@ -1,0 +1,35 @@
+-- Canonicalize tournament_games uniqueness
+-- This removes legacy/global uniqueness definitions and installs tenant-scoped invariants.
+-- Safe because duplicate check has already been confirmed clean.
+
+-- Drop legacy/global RR uniqueness variants
+DROP INDEX IF EXISTS tournament_rr_unique_slot;
+DROP INDEX IF EXISTS tournament_games_rr_unique;
+DROP INDEX IF EXISTS tournament_games_rr_unique_slot;
+
+-- Drop legacy/global Playoff uniqueness variants
+DROP INDEX IF EXISTS tournament_playoff_unique;
+DROP INDEX IF EXISTS tournament_playoff_unique_slot;
+DROP INDEX IF EXISTS tournament_games_playoff_unique;
+
+-- Install canonical tenant-scoped RR uniqueness
+CREATE UNIQUE INDEX tournament_games_rr_unique
+ON public.tournament_games (
+    club_id,
+    tournament_id,
+    stage,
+    rr_round_number,
+    rr_slot_number
+)
+WHERE stage = 'ROUND_ROBIN';
+
+-- Install canonical tenant-scoped Playoff uniqueness
+CREATE UNIQUE INDEX tournament_games_playoff_unique
+ON public.tournament_games (
+    club_id,
+    tournament_id,
+    stage,
+    playoff_game_code,
+    series_game_number
+)
+WHERE stage = 'PLAYOFF';


### PR DESCRIPTION
### Motivation

- Remove legacy/global unique index variants that cause schema drift and Postgres `42P10` errors by consolidating to tenant-scoped uniqueness.
- Ensure runtime upserts target the same conflict keys used by the canonical indexes to avoid invariant mismatch across environments.
- Keep historical migrations intact while adding a final canonical migration that will be applied going forward.

### Description

- Added a new migration `supabase/migrations/20260222_canonicalize_tournament_games_uniqueness.sql` that drops legacy/global RR and Playoff index variants and creates tenant-scoped partial unique indexes `tournament_games_rr_unique` and `tournament_games_playoff_unique`.
- `tournament_games_rr_unique` enforces uniqueness on `(club_id, tournament_id, stage, rr_round_number, rr_slot_number)` for `stage = 'ROUND_ROBIN'`.
- `tournament_games_playoff_unique` enforces uniqueness on `(club_id, tournament_id, stage, playoff_game_code, series_game_number)` for `stage = 'PLAYOFF'`.
- Added an optional debug guard in `jupr_app/ui/pages/tournaments.py` that prints the RR upsert conflict target when `ctx.DEBUG_MODE` is enabled, placed immediately before the RR upsert call.
- Left older migrations unchanged (no history rewrite) so this migration acts as the final canonical definition.

### Testing

- Ran a repository search with `rg -n "tournament_rr_unique|tournament_playoff_unique|COALESCE(series_game_number" supabase/migrations jupr_app` to verify legacy patterns, which succeeded.
- Verified Python syntax for the modified UI file with `python -m py_compile jupr_app/ui/pages/tournaments.py`, which succeeded.
- Confirmed the new migration file exists at `supabase/migrations/20260222_canonicalize_tournament_games_uniqueness.sql` and the inserted debug guard appears in `jupr_app/ui/pages/tournaments.py` using automated file listings, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a9ae1acc08326a9eb81aa0e8b32bf)