### PR TITLE
Fix 42P10 tournament game upserts via generated conflict key

### DIFF
--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -296,12 +296,12 @@ def render(ctx):
             _require_club_id_payload(games_payload)
             if getattr(ctx, "DEBUG_MODE", False):
                 print(
-                    "RR upsert conflict target:",
-                    "club_id,tournament_id,stage,rr_round_number,rr_slot_number",
+                    "tournament_games upsert conflict:",
+                    "club_id,tournament_id,stage,game_conflict_key",
                 )
             supabase.table("tournament_games").upsert(
                 games_payload,
-                on_conflict="club_id,tournament_id,stage,rr_round_number,rr_slot_number"
+                on_conflict="club_id,tournament_id,stage,game_conflict_key"
             ).execute()
             sb_update(supabase, "tournaments", {"status": "ROUND_ROBIN"}, filters={"club_id": str(club_id), "id": tournament_id})
             st.success("Round robin schedule generated.")
@@ -433,9 +433,11 @@ def render(ctx):
                             game["club_id"] = str(club_id)
                         _require_club_id_payload(games_payload)
 
+                        if getattr(ctx, "DEBUG_MODE", False):
+                            print("tournament_games upsert conflict:", "club_id,tournament_id,stage,game_conflict_key")
                         supabase.table("tournament_games").upsert(
                             games_payload,
-                            on_conflict="club_id,tournament_id,stage,playoff_game_code,series_game_number"
+                            on_conflict="club_id,tournament_id,stage,game_conflict_key"
                         ).execute()
 
                         st.success("Playoff bracket regenerated.")
@@ -461,9 +463,11 @@ def render(ctx):
                 # Explicit club_id for tenant isolation (RLS + multi-club safety)
                 game["club_id"] = str(club_id)
             _require_club_id_payload(games_payload)
+            if getattr(ctx, "DEBUG_MODE", False):
+                print("tournament_games upsert conflict:", "club_id,tournament_id,stage,game_conflict_key")
             supabase.table("tournament_games").upsert(
                 games_payload,
-                on_conflict="club_id,tournament_id,stage,playoff_game_code,series_game_number"
+                on_conflict="club_id,tournament_id,stage,game_conflict_key"
             ).execute()
             sb_update(
                 supabase,

--- a/supabase/migrations/20260222_tournament_games_conflict_key.sql
+++ b/supabase/migrations/20260222_tournament_games_conflict_key.sql
@@ -1,0 +1,46 @@
+-- PostgREST-compatible ON CONFLICT target for tournament_games.
+-- Replaces partial-unique-index inference (which requires ON CONFLICT ... WHERE, not supported by PostgREST).
+
+ALTER TABLE public.tournament_games
+ADD COLUMN IF NOT EXISTS game_conflict_key text;
+
+-- Backfill for existing rows (safe, deterministic)
+UPDATE public.tournament_games
+SET game_conflict_key =
+  CASE
+    WHEN stage = 'ROUND_ROBIN'
+      THEN 'RR:' || COALESCE(rr_round_number::text,'') || ':' || COALESCE(rr_slot_number::text,'')
+    WHEN stage = 'PLAYOFF'
+      THEN 'PO:' || COALESCE(playoff_game_code,'') || ':' || COALESCE(series_game_number::text,'')
+    ELSE
+      'OTHER:' || COALESCE(id::text,'')
+  END
+WHERE game_conflict_key IS NULL;
+
+-- Make it generated (stored) going forward.
+-- NOTE: Postgres requires DROP/ADD to convert to GENERATED; do it safely.
+ALTER TABLE public.tournament_games
+DROP COLUMN IF EXISTS game_conflict_key;
+
+ALTER TABLE public.tournament_games
+ADD COLUMN game_conflict_key text GENERATED ALWAYS AS (
+  CASE
+    WHEN stage = 'ROUND_ROBIN'
+      THEN 'RR:' || COALESCE(rr_round_number::text,'') || ':' || COALESCE(rr_slot_number::text,'')
+    WHEN stage = 'PLAYOFF'
+      THEN 'PO:' || COALESCE(playoff_game_code,'') || ':' || COALESCE(series_game_number::text,'')
+    ELSE
+      'OTHER:' || COALESCE(id::text,'')
+  END
+) STORED;
+
+-- Drop prior uniqueness variants that may conflict or cause drift (safe)
+DROP INDEX IF EXISTS tournament_games_rr_unique;
+DROP INDEX IF EXISTS tournament_games_playoff_unique;
+DROP INDEX IF EXISTS tournament_rr_unique_slot;
+DROP INDEX IF EXISTS tournament_playoff_unique;
+DROP INDEX IF EXISTS tournament_playoff_unique_slot;
+
+-- Install canonical PostgREST-compatible uniqueness constraint
+CREATE UNIQUE INDEX IF NOT EXISTS tournament_games_conflict_unique
+ON public.tournament_games (club_id, tournament_id, stage, game_conflict_key);


### PR DESCRIPTION
### Motivation
- PostgREST cannot express `ON CONFLICT ... WHERE` used to infer partial unique indexes, causing persistent Postgres `42P10` errors during tournament game upserts. 
- Provide a canonical, PostgREST-compatible uniqueness target so RR and Playoff upserts are deterministic and idempotent.

### Description
- Added migration `supabase/migrations/20260222_tournament_games_conflict_key.sql` that adds a `game_conflict_key` column, backfills existing rows, converts it to a stored generated column expression keyed by `stage`, drops legacy RR/Playoff partial-unique indexes, and creates a canonical unique index `tournament_games_conflict_unique` on `(club_id, tournament_id, stage, game_conflict_key)`.
- Updated all tournament game upserts in `jupr_app/ui/pages/tournaments.py` to use `on_conflict="club_id,tournament_id,stage,game_conflict_key"` instead of partial-index-based targets for RR and Playoff paths.
- Inserted DEBUG-only one-line prints immediately before each `tournament_games` upsert to log the active conflict target when `ctx.DEBUG_MODE` is true.
- No other application logic changes were made; the change only alters conflict targets and adds the migration.

### Testing
- Compiled the modified Python module with `python -m py_compile jupr_app/ui/pages/tournaments.py` and it completed successfully.
- No automated database migration or runtime integration tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a9d0da8f483268b583c6f11ff17f3)