### PR TITLE
Avoid calling .select() on Supabase write builders; use `returning="representation"` for upsert

### DIFF
--- a/jupr_app/domain/player_ops.py
+++ b/jupr_app/domain/player_ops.py
@@ -35,8 +35,11 @@ def safe_add_player(
 
         upsert_resp = (
             supabase.table("players")
-            .upsert(payload, on_conflict="club_id,normalized_name")
-            .select("id")
+            .upsert(
+                payload,
+                on_conflict="club_id,normalized_name",
+                returning="representation",
+            )
             .execute()
         )
         upsert_rows = upsert_resp.data or []

--- a/tests/test_player_ops.py
+++ b/tests/test_player_ops.py
@@ -13,9 +13,10 @@ class _Query:
         self.table_name = table_name
         self._filters: list[tuple[str, object]] = []
 
-    def upsert(self, payload, on_conflict=None):
+    def upsert(self, payload, on_conflict=None, returning=None):
         self.supabase.last_payload = dict(payload)
         self.supabase.last_on_conflict = on_conflict
+        self.supabase.last_returning = returning
         return self
 
     def select(self, _fields: str):
@@ -49,6 +50,7 @@ class _Supabase:
         self.raise_api_error = None
         self.last_payload = None
         self.last_on_conflict = None
+        self.last_returning = None
 
     def table(self, name: str):
         return _Query(self, name)
@@ -68,6 +70,7 @@ def test_safe_add_player_sets_normalized_name_and_conflict_target():
     assert ok is True
     assert err is None
     assert supabase.last_on_conflict == "club_id,normalized_name"
+    assert supabase.last_returning == "representation"
     assert supabase.last_payload["normalized_name"] == "alice smith"
 
 


### PR DESCRIPTION
### Motivation
- An attempted write path chained `.select("id")` after an `upsert(...)` which triggered an AttributeError from the Supabase client (`'SyncQueryRequestBuilder' object has no attribute 'select'`), so writes that should return row data failed.
- The change ensures write calls use the supabase-py pattern that returns rows (`returning="representation"`) or falls back to a separate `select` query so inserted IDs remain obtainable.

### Description
- Replaced the chained `.upsert(...).select("id")` usage in `safe_add_player` with `.upsert(..., returning="representation").execute()` and read returned rows from `upsert_resp.data` in `jupr_app/domain/player_ops.py`.
- Preserved the existing fallback lookup `select(...)` query when the write response contains no rows to keep id retrieval resilient.
- Updated the unit-test Supabase stub in `tests/test_player_ops.py` to accept and assert the new `returning` argument and to reflect the new behavior.

### Testing
- Ran `pytest -q tests/test_player_ops.py` and all tests passed (`4 passed`).
- Performed a repo-wide scan for patterns chaining `.insert(...).select(...)` or `.upsert(...).select(...)` and verified no remaining offending chains in Python sources.
- Verified that `safe_add_player` now requests `returning="representation"` and still falls back to a follow-up `select` when write responses are empty.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aaab603b883269577389ef97aa321)