### PR TITLE
Make player creation idempotent by handling Postgres 23505 duplicates

### DIFF
--- a/jupr_app/domain/player_ops.py
+++ b/jupr_app/domain/player_ops.py
@@ -12,6 +12,50 @@ def _normalized_player_name(name: str) -> str:
     return " ".join(str(name or "").strip().lower().split())
 
 
+def get_or_create_player(
+    *,
+    supabase,
+    club_id: str,
+    normalized_name: str,
+    payload: dict,
+) -> tuple[bool, dict | None, str | None]:
+    """Insert a player, falling back to existing active row for duplicate-name conflicts."""
+    try:
+        created = (
+            supabase.table("players")
+            .insert(payload, returning="representation")
+            .execute()
+            .data
+            or []
+        )
+        if created:
+            return True, created[0], None
+        return False, None, "Player create succeeded but no player row was returned."
+    except APIError as exc:
+        code = str(getattr(exc, "code", "") or "")
+        message = str(getattr(exc, "message", "") or str(exc))
+        if code != "23505":
+            return False, None, message or "Failed to add player."
+
+        existing_rows = (
+            supabase.table("players")
+            .select("id,club_id,name,normalized_name,active,rating")
+            .eq("club_id", str(club_id))
+            .eq("normalized_name", str(normalized_name))
+            .eq("active", True)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        if existing_rows:
+            return True, existing_rows[0], "already_exists"
+        return False, None, "Player already exists but could not be loaded."
+    except Exception as exc:
+        logger.exception("get_or_create_player failed unexpectedly")
+        return False, None, str(exc) or "Failed to add player."
+
+
 def safe_add_player(
     *,
     supabase,

--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -4,6 +4,7 @@ import re
 
 from jupr_app.ui.layout import page_shell
 from jupr_app.domain.player_merge import merge_player_into
+from jupr_app.domain.player_ops import get_or_create_player
 from streamlit_app import get_data
 
 def render(ctx):
@@ -47,21 +48,6 @@ def render(ctx):
                 if not normalized_name:
                     st.error("Name must include at least one letter or number.")
                     st.stop()
-                existing = (
-                    supabase.table("players")
-                    .select("id,name")
-                    .eq("club_id", club_id)
-                    .eq("name", name_clean)
-                    .limit(1)
-                    .execute()
-                    .data
-                    or []
-                )
-                if existing:
-                    st.info("Player already exists — opening existing record.")
-                    get_data.clear()
-                    st.session_state["_player_editor_pending_pick"] = name_clean
-                    st.stop()
                 payload = {
                     "club_id": club_id,
                     "name": name_clean,
@@ -69,10 +55,22 @@ def render(ctx):
                     "active": True,
                     "rating": int(round(float(rating) * 400.0)),
                 }
-                supabase.table("players").insert(payload).execute()
-                st.success(f"Player created: {name_clean} (Starting JUPR {float(rating):.1f})")
+                ok, player_row, err = get_or_create_player(
+                    supabase=supabase,
+                    club_id=club_id,
+                    normalized_name=normalized_name,
+                    payload=payload,
+                )
+                if not ok:
+                    st.error(err or "Failed to create player.")
+                    st.stop()
+                resolved_name = str((player_row or {}).get("name") or name_clean)
+                if err == "already_exists":
+                    st.info(f"Player already existed: {resolved_name} — opening existing record.")
+                else:
+                    st.success(f"Player created: {resolved_name} (Starting JUPR {float(rating):.1f})")
                 get_data.clear()
-                st.session_state["_player_editor_pending_pick"] = name_clean
+                st.session_state["_player_editor_pending_pick"] = resolved_name
                 st.session_state["_reset_add_player_form"] = True
                 st.session_state["force_data_refresh"] = True
 

--- a/tests/test_player_ops.py
+++ b/tests/test_player_ops.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 from postgrest.exceptions import APIError
 
-from jupr_app.domain.player_ops import safe_add_player
+from jupr_app.domain.player_ops import get_or_create_player, safe_add_player
 
 
 class _Query:
@@ -17,6 +17,13 @@ class _Query:
         self.supabase.last_payload = dict(payload)
         self.supabase.last_on_conflict = on_conflict
         self.supabase.last_returning = returning
+        self.supabase.last_operation = "upsert"
+        return self
+
+    def insert(self, payload, returning=None):
+        self.supabase.last_payload = dict(payload)
+        self.supabase.last_returning = returning
+        self.supabase.last_operation = "insert"
         return self
 
     def select(self, _fields: str):
@@ -30,8 +37,10 @@ class _Query:
         return self
 
     def execute(self):
-        if self.supabase.raise_api_error is not None:
-            raise self.supabase.raise_api_error
+        if self.supabase.raise_api_error is not None and self.supabase.last_operation in {"insert", "upsert"}:
+            err = self.supabase.raise_api_error
+            self.supabase.raise_api_error = None
+            raise err
         if self.supabase.upsert_data is not None:
             data = self.supabase.upsert_data
             self.supabase.upsert_data = None
@@ -51,6 +60,7 @@ class _Supabase:
         self.last_payload = None
         self.last_on_conflict = None
         self.last_returning = None
+        self.last_operation = None
 
     def table(self, name: str):
         return _Query(self, name)
@@ -128,3 +138,76 @@ def test_safe_add_player_converts_unexpected_exception_to_error(caplog):
     assert ok is False
     assert err == "db unavailable"
     assert "safe_add_player failed unexpectedly" in caplog.text
+
+
+def test_get_or_create_player_inserts_and_returns_row():
+    supabase = _Supabase()
+    supabase.upsert_data = [{"id": 7, "name": "Alice Smith"}]
+
+    ok, row, err = get_or_create_player(
+        supabase=supabase,
+        club_id="club-1",
+        normalized_name="alice_smith",
+        payload={"club_id": "club-1", "name": "Alice Smith", "normalized_name": "alice_smith", "active": True, "rating": 1400},
+    )
+
+    assert ok is True
+    assert row == {"id": 7, "name": "Alice Smith"}
+    assert err is None
+    assert supabase.last_operation == "insert"
+    assert supabase.last_returning == "representation"
+
+
+def test_get_or_create_player_duplicate_returns_existing_active_row():
+    supabase = _Supabase()
+    supabase.raise_api_error = APIError(
+        {
+            "code": "23505",
+            "message": "duplicate key value violates unique constraint",
+            "hint": None,
+            "details": None,
+        }
+    )
+    supabase.rows["players"].append(
+        {
+            "id": 99,
+            "club_id": "club-1",
+            "name": "Alice Smith",
+            "normalized_name": "alice_smith",
+            "active": True,
+        }
+    )
+
+    ok, row, err = get_or_create_player(
+        supabase=supabase,
+        club_id="club-1",
+        normalized_name="alice_smith",
+        payload={"club_id": "club-1", "name": "Alice Smith", "normalized_name": "alice_smith", "active": True, "rating": 1400},
+    )
+
+    assert ok is True
+    assert row["id"] == 99
+    assert err == "already_exists"
+
+
+def test_get_or_create_player_non_duplicate_api_error_returns_failure():
+    supabase = _Supabase()
+    supabase.raise_api_error = APIError(
+        {
+            "code": "42501",
+            "message": "permission denied",
+            "hint": None,
+            "details": None,
+        }
+    )
+
+    ok, row, err = get_or_create_player(
+        supabase=supabase,
+        club_id="club-1",
+        normalized_name="alice_smith",
+        payload={"club_id": "club-1", "name": "Alice Smith", "normalized_name": "alice_smith", "active": True, "rating": 1400},
+    )
+
+    assert ok is False
+    assert row is None
+    assert err == "permission denied"


### PR DESCRIPTION
### Motivation
- Prevent the UI from crashing on Postgres unique-constraint violations (error code `23505`) when creating players, making roster confirmation idempotent.
- Treat already-existing players as a successful outcome so a duplicate does not abort batch creates or surface a traceback to the user.

### Description
- Added `get_or_create_player(...)` in `jupr_app/domain/player_ops.py` which attempts `insert(..., returning="representation")`, and on `APIError` with code `23505` selects the existing active player via `.select(...).eq(...).eq(...).limit(1).execute()` and returns `(ok, player_row, err)` without raising for expected duplicates.
- Updated `jupr_app/ui/pages/player_editor.py` to call `get_or_create_player()` instead of calling `.insert()` directly, showing an info message when the player already existed and proceeding to open that record.
- Updated the Supabase test double and extended `tests/test_player_ops.py` with tests for the insert success path, duplicate fallback lookup path, and non-duplicate API error handling.

### Testing
- Ran `pytest -q tests/test_player_ops.py` and all tests passed (`7 passed`).
- New unit tests cover the happy insert path, duplicate fallback to existing active player, and non-duplicate API error handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aab54a12c8326b0a847692465354e)