### PR TITLE
Use upsert-first player creation with safe ON CONFLICT fallback

### DIFF
--- a/jupr_app/domain/player_ops.py
+++ b/jupr_app/domain/player_ops.py
@@ -19,25 +19,16 @@ def get_or_create_player(
     normalized_name: str,
     payload: dict,
 ) -> tuple[bool, dict | None, str | None]:
-    """Insert a player, falling back to existing active row for duplicate-name conflicts."""
-    try:
-        created = (
-            supabase.table("players")
-            .insert(payload, returning="representation")
-            .execute()
-            .data
-            or []
-        )
-        if created:
-            return True, created[0], None
-        return False, None, "Player create succeeded but no player row was returned."
-    except APIError as exc:
-        code = str(getattr(exc, "code", "") or "")
-        message = str(getattr(exc, "message", "") or str(exc))
-        if code != "23505":
-            return False, None, message or "Failed to add player."
+    """Create/load player idempotently.
 
-        existing_rows = (
+    Prefer a single upsert on (club_id, normalized_name). If the schema does not expose
+    a matching unique/exclusion constraint (e.g. partial unique index), fall back to
+    insert + 23505 recovery.
+    """
+    upsert_conflict = "club_id,normalized_name"
+
+    def _lookup_existing_active() -> list[dict]:
+        return (
             supabase.table("players")
             .select("id,club_id,name,normalized_name,active,rating")
             .eq("club_id", str(club_id))
@@ -48,9 +39,61 @@ def get_or_create_player(
             .data
             or []
         )
+
+    try:
+        upserted = (
+            supabase.table("players")
+            .upsert(
+                payload,
+                on_conflict=upsert_conflict,
+                returning="representation",
+            )
+            .execute()
+            .data
+            or []
+        )
+        if upserted:
+            return True, upserted[0], None
+
+        existing_rows = _lookup_existing_active()
         if existing_rows:
             return True, existing_rows[0], "already_exists"
-        return False, None, "Player already exists but could not be loaded."
+        return False, None, "Player create succeeded but no player row was returned."
+    except APIError as exc:
+        code = str(getattr(exc, "code", "") or "")
+        message = str(getattr(exc, "message", "") or str(exc))
+        upsert_conflict_missing = (
+            code == "42P10"
+            or "NO UNIQUE OR EXCLUSION CONSTRAINT MATCHING THE ON CONFLICT SPECIFICATION"
+            in message.upper()
+        )
+        if not upsert_conflict_missing:
+            return False, None, message or "Failed to add player."
+
+        try:
+            created = (
+                supabase.table("players")
+                .insert(payload, returning="representation")
+                .execute()
+                .data
+                or []
+            )
+            if created:
+                return True, created[0], None
+            existing_rows = _lookup_existing_active()
+            if existing_rows:
+                return True, existing_rows[0], "already_exists"
+            return False, None, "Player create succeeded but no player row was returned."
+        except APIError as fallback_exc:
+            fallback_code = str(getattr(fallback_exc, "code", "") or "")
+            fallback_message = str(getattr(fallback_exc, "message", "") or str(fallback_exc))
+            if fallback_code != "23505":
+                return False, None, fallback_message or "Failed to add player."
+
+            existing_rows = _lookup_existing_active()
+            if existing_rows:
+                return True, existing_rows[0], "already_exists"
+            return False, None, "Player already exists but could not be loaded."
     except Exception as exc:
         logger.exception("get_or_create_player failed unexpectedly")
         return False, None, str(exc) or "Failed to add player."

--- a/tests/test_player_ops.py
+++ b/tests/test_player_ops.py
@@ -37,10 +37,8 @@ class _Query:
         return self
 
     def execute(self):
-        if self.supabase.raise_api_error is not None and self.supabase.last_operation in {"insert", "upsert"}:
-            err = self.supabase.raise_api_error
-            self.supabase.raise_api_error = None
-            raise err
+        if self.supabase.raise_api_errors and self.supabase.last_operation in {"insert", "upsert"}:
+            raise self.supabase.raise_api_errors.pop(0)
         if self.supabase.upsert_data is not None:
             data = self.supabase.upsert_data
             self.supabase.upsert_data = None
@@ -56,7 +54,7 @@ class _Supabase:
     def __init__(self):
         self.rows = {"players": []}
         self.upsert_data = None
-        self.raise_api_error = None
+        self.raise_api_errors = []
         self.last_payload = None
         self.last_on_conflict = None
         self.last_returning = None
@@ -102,14 +100,16 @@ def test_safe_add_player_falls_back_to_lookup_when_upsert_returns_empty_data():
 
 def test_safe_add_player_surfaces_schema_mismatch_for_on_conflict():
     supabase = _Supabase()
-    supabase.raise_api_error = APIError(
-        {
-            "code": "42P10",
-            "message": "there is no unique or exclusion constraint matching the ON CONFLICT specification",
-            "hint": None,
-            "details": None,
-        }
-    )
+    supabase.raise_api_errors = [
+        APIError(
+            {
+                "code": "42P10",
+                "message": "there is no unique or exclusion constraint matching the ON CONFLICT specification",
+                "hint": None,
+                "details": None,
+            }
+        )
+    ]
 
     ok, err = safe_add_player(
         supabase=supabase,
@@ -154,20 +154,30 @@ def test_get_or_create_player_inserts_and_returns_row():
     assert ok is True
     assert row == {"id": 7, "name": "Alice Smith"}
     assert err is None
-    assert supabase.last_operation == "insert"
+    assert supabase.last_operation == "upsert"
     assert supabase.last_returning == "representation"
 
 
-def test_get_or_create_player_duplicate_returns_existing_active_row():
+def test_get_or_create_player_falls_back_when_upsert_conflict_target_unavailable():
     supabase = _Supabase()
-    supabase.raise_api_error = APIError(
-        {
-            "code": "23505",
-            "message": "duplicate key value violates unique constraint",
-            "hint": None,
-            "details": None,
-        }
-    )
+    supabase.raise_api_errors = [
+        APIError(
+            {
+                "code": "42P10",
+                "message": "there is no unique or exclusion constraint matching the ON CONFLICT specification",
+                "hint": None,
+                "details": None,
+            }
+        ),
+        APIError(
+            {
+                "code": "23505",
+                "message": "duplicate key value violates unique constraint",
+                "hint": None,
+                "details": None,
+            }
+        ),
+    ]
     supabase.rows["players"].append(
         {
             "id": 99,
@@ -192,14 +202,16 @@ def test_get_or_create_player_duplicate_returns_existing_active_row():
 
 def test_get_or_create_player_non_duplicate_api_error_returns_failure():
     supabase = _Supabase()
-    supabase.raise_api_error = APIError(
-        {
-            "code": "42501",
-            "message": "permission denied",
-            "hint": None,
-            "details": None,
-        }
-    )
+    supabase.raise_api_errors = [
+        APIError(
+            {
+                "code": "42501",
+                "message": "permission denied",
+                "hint": None,
+                "details": None,
+            }
+        )
+    ]
 
     ok, row, err = get_or_create_player(
         supabase=supabase,


### PR DESCRIPTION
### Motivation
- Make player creation idempotent with a single call when schema supports it by using `upsert(..., on_conflict="club_id,normalized_name")` where possible.
- Provide a robust fallback for schemas that use a partial unique index or otherwise do not expose the ON CONFLICT target so UI flows never crash on duplicate-name races.

### Description
- Changed `get_or_create_player` to prefer an `upsert` on `players` with `on_conflict="club_id,normalized_name"` and `returning="representation"` for idempotent creation (file: `jupr_app/domain/player_ops.py`).
- Detects ON CONFLICT target mismatch via SQL error `42P10` or the message containing "no unique or exclusion constraint matching the ON CONFLICT specification" and automatically falls back to the safe `insert` then recover-on-`23505` flow.
- Preserves prior behavior of loading an existing active row when duplicates are detected so the function always returns `(ok, row, err)` and does not raise, keeping the UI idempotent and stable.
- Updated `tests/test_player_ops.py` to validate the upsert-first path and the fallback sequence using simulated sequential API errors.

### Testing
- Ran `pytest -q tests/test_player_ops.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aabf6ab088326b296609e070a3a40)