### PR TITLE
Fix 1-based court-to-column mapping for Court Board rendering

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -201,8 +201,18 @@ def _summarize_roster(roster_df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _render_court_board_grid(courts_payload: list[dict], max_per_row: int = 4) -> None:
+    def _court_number(court_id: str) -> int | None:
+        m = re.search(r"(\d+)", str(court_id or ""))
+        if not m:
+            return None
+        return int(m.group(1))
+
     playable = [court for court in courts_payload if str(court.get("court_id", "")).strip().lower() != "bench"]
     bench = [court for court in courts_payload if str(court.get("court_id", "")).strip().lower() == "bench"]
+    playable = sorted(
+        playable,
+        key=lambda c: (_court_number(str(c.get("court_id") or "")) is None, _court_number(str(c.get("court_id") or "")) or 10_000),
+    )
     courts = playable + bench
 
     if not courts:
@@ -213,9 +223,29 @@ def _render_court_board_grid(courts_payload: list[dict], max_per_row: int = 4) -
     for start in range(0, len(courts), per_row):
         row = courts[start : start + per_row]
         cols = st.columns(len(row))
-        for col, court in zip(cols, row):
+        cols_count = len(cols)
+        for default_local_idx, court in enumerate(row):
+            court_id = str(court.get("court_id") or "Court")
+            court_num = _court_number(court_id)
+            intended_global_idx = int(court_num - 1) if isinstance(court_num, int) else int(start + default_local_idx)
+            intended_local_idx = int(intended_global_idx - start)
+
+            if not (0 <= intended_local_idx < cols_count):
+                raise AssertionError(
+                    f"Court column index out of range: court_id={court_id}, court_num={court_num}, "
+                    f"intended_local_idx={intended_local_idx}, cols_count={cols_count}, row_start={start}."
+                )
+
+            col = cols[intended_local_idx]
             with col:
-                court_id = str(court.get("court_id") or "Court")
+                logger.debug(
+                    "Rendering court %s into column %s (row_start=%s, cols=%s, court_num=%s)",
+                    court_id,
+                    intended_local_idx,
+                    start,
+                    cols_count,
+                    court_num,
+                )
                 players = list(court.get("players") or [])
                 st.markdown(f"##### {court_id}")
                 st.caption(f"{len(players)} player(s)")


### PR DESCRIPTION
### Motivation

- Court labels like "Court 1" were being placed by list order instead of their numeric court number, which can mis-route courts when labels are 1-based.
- The prior rendering could silently fall back and effectively render content into the wrong column (or column 0) without failing loudly.
- Add a small debug trace so the intended index and column count are visible when rendering each court.

### Description

- Parse numeric court numbers from `court_id` with a new helper `def _court_number(court_id: str) -> int | None:` and use the `court_num - 1` mapping to compute zero-based column indexes during render in `jupr_app/ui/pages/league_manager.py`.
- Sort playable courts by their extracted numeric court number so `Court 1..N` map to distinct, stable positions before rendering.
- Replace the implicit/fallback behavior with a bounds assertion that raises an `AssertionError` if the computed local column index is out of range, preventing silent routing into column 0.
- Add a `logger.debug(...)` line that logs the `court_id`, intended local index, row start, and number of columns during rendering for easier debugging.

### Testing

- Compiled the modified module with `python -m py_compile jupr_app/ui/pages/league_manager.py` and it succeeded.
- Verified the new logic is present in `jupr_app/ui/pages/league_manager.py` and that `logger` is used for debug output during rendering.
- No runtime unit tests were available; change is limited to rendering mapping logic and includes a fail-fast assertion and logging to catch any remaining mismatches at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab23a408c8326a2d90ceb7b557eec)