### PR TITLE
Fix league manager court board NameError and safe index fallback

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -5,6 +5,7 @@ from jupr_app.data.sb_write import sb_insert, sb_update, sb_upsert
 
 import json
 import logging
+import re
 import time
 from datetime import date, datetime, timedelta, timezone
 from jupr_app.domain.player_ops import get_or_create_player
@@ -207,12 +208,13 @@ def _render_court_board_grid(courts_payload: list[dict], max_per_row: int = 4) -
             return None
         return int(m.group(1))
 
+    def _sort_key(court: dict) -> tuple[bool, int]:
+        court_num = _court_number(str(court.get("court_id") or ""))
+        return (court_num is None, court_num or 10_000)
+
     playable = [court for court in courts_payload if str(court.get("court_id", "")).strip().lower() != "bench"]
     bench = [court for court in courts_payload if str(court.get("court_id", "")).strip().lower() == "bench"]
-    playable = sorted(
-        playable,
-        key=lambda c: (_court_number(str(c.get("court_id") or "")) is None, _court_number(str(c.get("court_id") or "")) or 10_000),
-    )
+    playable = sorted(playable, key=_sort_key)
     courts = playable + bench
 
     if not courts:
@@ -231,10 +233,17 @@ def _render_court_board_grid(courts_payload: list[dict], max_per_row: int = 4) -
             intended_local_idx = int(intended_global_idx - start)
 
             if not (0 <= intended_local_idx < cols_count):
-                raise AssertionError(
-                    f"Court column index out of range: court_id={court_id}, court_num={court_num}, "
-                    f"intended_local_idx={intended_local_idx}, cols_count={cols_count}, row_start={start}."
+                logger.warning(
+                    "Court column index out of range; falling back to default column index: "
+                    "court_id=%s, court_num=%s, intended_local_idx=%s, default_local_idx=%s, cols_count=%s, row_start=%s",
+                    court_id,
+                    court_num,
+                    intended_local_idx,
+                    default_local_idx,
+                    cols_count,
+                    start,
                 )
+                intended_local_idx = default_local_idx
 
             col = cols[intended_local_idx]
             with col:


### PR DESCRIPTION
### Motivation
- The court board renderer raised `NameError` because `re` was not imported, causing Streamlit to crash when previewing courts. 
- Sorting computed `_court_number` twice per element which is wasteful and error-prone when court identifiers are irregular. 
- An `AssertionError` was raised when computed column indices fell outside the current row, which should not hard-crash the app for non-numeric or sparse court IDs.

### Description
- Add `import re` to `jupr_app/ui/pages/league_manager.py` so regex parsing in `_court_number` works. 
- Introduce a `_sort_key(court)` helper that computes `_court_number` once and use it for sorting playable courts. 
- Replace the `AssertionError` raised for out-of-range `intended_local_idx` with a `logger.warning` and fall back to `default_local_idx` so Streamlit does not hard-fail.

### Testing
- Compiled the module with `python -m compileall jupr_app/ui/pages/league_manager.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b09c637248326b6d5cf7d4e7ea0f6)