### PR TITLE
Replace league manager guest player creation with get_or_create_player

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -972,33 +972,30 @@ def render(ctx):
                                 if use_guest_sub:
                                     if not sub_player.get("name"):
                                         raise RosterChangeError("Guest name is required.")
-                                    ok, err = safe_add_player(
+                                    normalized_name = " ".join(str(sub_player["name"]).strip().lower().split())
+                                    payload = {
+                                        "club_id": str(ctx.club_id),
+                                        "name": str(sub_player["name"]).strip(),
+                                        "normalized_name": normalized_name,
+                                        "rating": float(sub_player.get("rating", 3.5)),
+                                    }
+                                    ok, player_row, err = get_or_create_player(
                                         supabase=ctx.supabase,
                                         club_id=str(ctx.club_id),
-                                        name=sub_player["name"],
-                                        rating_jupr=float(sub_player.get("rating", 3.5)),
+                                        normalized_name=normalized_name,
+                                        payload=payload,
                                     )
                                     if not ok:
                                         raise RosterChangeError(f"Could not add guest: {err}")
-
-                                    fetch = (
-                                        ctx.supabase.table("players")
-                                        .select("id,name,rating")
-                                        .eq("club_id", str(ctx.club_id))
-                                        .eq("name", sub_player["name"])
-                                        .execute()
-                                    )
-                                    rows = fetch.data or []
-                                    if not rows:
+                                    if not isinstance(player_row, dict):
                                         raise RosterChangeError("Guest player was created but could not be loaded.")
-                                    row = rows[0]
                                     sub_player = {
-                                        "id": int(row["id"]),
-                                        "name": str(row["name"]),
-                                        "rating": float(row.get("rating", 1200.0) or 1200.0),
+                                        "id": int(player_row["id"]),
+                                        "name": str(player_row["name"]),
+                                        "rating": float(player_row.get("rating", 1200.0) or 1200.0),
                                     }
-                                    id_to_name[int(row["id"])] = str(row["name"])
-                                    name_to_id[str(row["name"])] = int(row["id"])
+                                    id_to_name[int(player_row["id"])] = str(player_row["name"])
+                                    name_to_id[str(player_row["name"])] = int(player_row["id"])
 
                                 result = apply_roster_change(
                                     roster_df=base_next_roster,
@@ -1050,33 +1047,30 @@ def render(ctx):
                                 if use_guest_add:
                                     if not add_player.get("name"):
                                         raise RosterChangeError("Guest name is required.")
-                                    ok, err = safe_add_player(
+                                    normalized_name = " ".join(str(add_player["name"]).strip().lower().split())
+                                    payload = {
+                                        "club_id": str(ctx.club_id),
+                                        "name": str(add_player["name"]).strip(),
+                                        "normalized_name": normalized_name,
+                                        "rating": float(add_player.get("rating", 3.5)),
+                                    }
+                                    ok, player_row, err = get_or_create_player(
                                         supabase=ctx.supabase,
                                         club_id=str(ctx.club_id),
-                                        name=add_player["name"],
-                                        rating_jupr=float(add_player.get("rating", 3.5)),
+                                        normalized_name=normalized_name,
+                                        payload=payload,
                                     )
                                     if not ok:
                                         raise RosterChangeError(f"Could not add guest: {err}")
-
-                                    fetch = (
-                                        ctx.supabase.table("players")
-                                        .select("id,name,rating")
-                                        .eq("club_id", str(ctx.club_id))
-                                        .eq("name", add_player["name"])
-                                        .execute()
-                                    )
-                                    rows = fetch.data or []
-                                    if not rows:
+                                    if not isinstance(player_row, dict):
                                         raise RosterChangeError("Guest player was created but could not be loaded.")
-                                    row = rows[0]
                                     add_player = {
-                                        "id": int(row["id"]),
-                                        "name": str(row["name"]),
-                                        "rating": float(row.get("rating", 1200.0) or 1200.0),
+                                        "id": int(player_row["id"]),
+                                        "name": str(player_row["name"]),
+                                        "rating": float(player_row.get("rating", 1200.0) or 1200.0),
                                     }
-                                    id_to_name[int(row["id"])] = str(row["name"])
-                                    name_to_id[str(row["name"])] = int(row["id"])
+                                    id_to_name[int(player_row["id"])] = str(player_row["name"])
+                                    name_to_id[str(player_row["name"])] = int(player_row["id"])
 
                                 result = apply_roster_change(
                                     roster_df=base_next_roster,


### PR DESCRIPTION
### Motivation
- Fix a latent `NameError` and align with the project standard by replacing unimported `safe_add_player` calls with the idempotent `get_or_create_player` API. 
- Ensure guest substitute/add flows create or load players reliably without changing downstream roster behavior. 

### Description
- Replaced both guest creation code paths in `jupr_app/ui/pages/league_manager.py` (Substitute and Add Player) to call `get_or_create_player(...)` with the required signature (`supabase`, `club_id`, `normalized_name`, `payload`).
- Constructed `payload` including `club_id`, `name`, `normalized_name`, and `rating` before calling `get_or_create_player` and computed `normalized_name` the same way existing code expects. 
- Continued to populate roster objects by reusing `player_row["id"]`, `player_row["name"]`, and `player_row["rating"]` exactly as before, and preserved existing error paths when no row is returned. 
- Removed all references to `safe_add_player` from the file and did not add any new imports. 

### Testing
- Verified there are no remaining matches for `safe_add_player` in the file with `rg -n "safe_add_player\(|safe_add_player" jupr_app/ui/pages/league_manager.py` and found none. 
- Checked Python syntax by running `python -m py_compile jupr_app/ui/pages/league_manager.py`, which succeeded with no errors. 
- Confirmed the module compiles cleanly after the edits (no runtime tests were modified).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0a69bd3883269a6aba13de8839ae)