### PR TITLE
Fix undefined supabase usage in league manager settings actions

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -1187,7 +1187,7 @@ def render(ctx):
                 }
 
                 try:
-                    resp = ctx.sb_insert(supabase, "leagues_metadata", payload)
+                    resp = sb_insert(ctx.supabase, "leagues_metadata", payload)
                 except Exception as exc:
                     st.error(f"Could not create league: {exc}")
                     st.stop()
@@ -1352,7 +1352,7 @@ def render(ctx):
                 "rules_config": rules_cfg,
                 "awards_config": awards_cfg,
             }
-            ctx.sb_insert(supabase, "leagues_metadata", payload)
+            sb_insert(ctx.supabase, "leagues_metadata", payload)
             return
             st.success("Draft duplicated.")
             return


### PR DESCRIPTION
### Motivation
- Prevent a `NameError` caused by using an undefined local `supabase` in the Settings tab and ensure the Supabase client is referenced via the existing `ctx.supabase` value when calling the imported writers.

### Description
- Replace incorrect calls such as `ctx.sb_insert(supabase, "leagues_metadata", payload)` with `sb_insert(ctx.supabase, "leagues_metadata", payload)` in `jupr_app/ui/pages/league_manager.py` and do the same for the duplicate-draft path, without changing any business logic or introducing a new `supabase` variable.

### Testing
- Searched the file to confirm no remaining `ctx.sb_insert(supabase, ...)` or bare `supabase` usages and the search returned no matches for the faulty pattern.
- Ran `python -m py_compile jupr_app/ui/pages/league_manager.py` and the file compiled without errors.
- Verified the modified file contains only the intended replacements and no other logic changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0afda7308326a11f1787138dc8bd)