### PR TITLE
Fix League Manager player creation rating scale mismatch

### DIFF
--- a/jupr_app/domain/player_ops.py
+++ b/jupr_app/domain/player_ops.py
@@ -8,6 +8,32 @@ from postgrest.exceptions import APIError
 logger = logging.getLogger(__name__)
 
 
+def _coerce_rating_to_elo(value: float | int | str | None) -> float:
+    """Normalize incoming rating writes to canonical ELO storage.
+
+    We store ratings as ELO points in DB (e.g., 1400), while some UI paths
+    collect JUPR inputs (e.g., 3.5). Defensive rule for new writes:
+    if rating < 20, treat it as JUPR and convert to ELO.
+    """
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return 1200.0
+
+    if parsed < 20.0:
+        return parsed * 400.0
+    return parsed
+
+
+def _normalize_player_payload_for_write(payload: dict) -> dict:
+    normalized = dict(payload or {})
+    if "rating" in normalized:
+        normalized["rating"] = _coerce_rating_to_elo(normalized.get("rating"))
+    if "starting_rating" in normalized:
+        normalized["starting_rating"] = _coerce_rating_to_elo(normalized.get("starting_rating"))
+    return normalized
+
+
 def _normalized_player_name(name: str) -> str:
     return " ".join(str(name or "").strip().lower().split())
 
@@ -26,6 +52,7 @@ def get_or_create_player(
     insert + 23505 recovery.
     """
     upsert_conflict = "club_id,normalized_name"
+    write_payload = _normalize_player_payload_for_write(payload)
 
     def _lookup_existing_active() -> list[dict]:
         return (
@@ -44,7 +71,7 @@ def get_or_create_player(
         upserted = (
             supabase.table("players")
             .upsert(
-                payload,
+                write_payload,
                 on_conflict=upsert_conflict,
                 returning="representation",
             )
@@ -73,7 +100,7 @@ def get_or_create_player(
         try:
             created = (
                 supabase.table("players")
-                .insert(payload, returning="representation")
+                .insert(write_payload, returning="representation")
                 .execute()
                 .data
                 or []
@@ -117,7 +144,7 @@ def safe_add_player(
             "club_id": str(club_id),
             "name": str(name or "").strip(),
             "normalized_name": normalized_name,
-            "rating": float(rating_jupr),
+            "rating": _coerce_rating_to_elo(rating_jupr),
         }
 
         upsert_resp = (

--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -8,6 +8,7 @@ import logging
 import re
 from datetime import date, datetime, timedelta, timezone
 from jupr_app.domain.player_ops import get_or_create_player
+from jupr_app.domain.ratings import jupr_to_elo
 
 import pandas as pd
 import streamlit as st
@@ -574,7 +575,7 @@ def render(ctx):
                             "club_id": str(ctx.club_id),
                             "name": nm,
                             "normalized_name": normalized_name,
-                            "rating": float(jupr),
+                            "rating": float(jupr_to_elo(jupr)),
                         }
                         try:
                             ok, player_row, err = get_or_create_player(
@@ -1070,7 +1071,7 @@ def render(ctx):
                                         "club_id": str(ctx.club_id),
                                         "name": str(sub_player["name"]).strip(),
                                         "normalized_name": normalized_name,
-                                        "rating": float(sub_player.get("rating", 3.5)),
+                                        "rating": float(jupr_to_elo(sub_player.get("rating", 3.5))),
                                     }
                                     ok, player_row, err = get_or_create_player(
                                         supabase=ctx.supabase,
@@ -1145,7 +1146,7 @@ def render(ctx):
                                         "club_id": str(ctx.club_id),
                                         "name": str(add_player["name"]).strip(),
                                         "normalized_name": normalized_name,
-                                        "rating": float(add_player.get("rating", 3.5)),
+                                        "rating": float(jupr_to_elo(add_player.get("rating", 3.5))),
                                     }
                                     ok, player_row, err = get_or_create_player(
                                         supabase=ctx.supabase,

--- a/tests/test_player_ops_rating_scale.py
+++ b/tests/test_player_ops_rating_scale.py
@@ -1,0 +1,54 @@
+from jupr_app.domain.player_ops import _coerce_rating_to_elo, get_or_create_player
+
+
+class _Query:
+    def __init__(self, sink):
+        self.sink = sink
+
+    def upsert(self, payload, on_conflict=None, returning=None):
+        self.sink["payload"] = payload
+        self.sink["on_conflict"] = on_conflict
+        return self
+
+    def execute(self):
+        return type("Resp", (), {"data": [{"id": 1, **self.sink["payload"]}]})
+
+
+class _FakeSupabase:
+    def __init__(self):
+        self.sink = {}
+
+    def table(self, name):
+        assert name == "players"
+        return _Query(self.sink)
+
+
+def test_coerce_rating_to_elo_converts_jupr_scale_values():
+    assert _coerce_rating_to_elo(3.5) == 1400.0
+    assert _coerce_rating_to_elo("3.0") == 1200.0
+
+
+def test_coerce_rating_to_elo_preserves_elo_scale_values():
+    assert _coerce_rating_to_elo(1400) == 1400.0
+
+
+def test_get_or_create_player_normalizes_rating_payload_before_write():
+    supabase = _FakeSupabase()
+    ok, row, err = get_or_create_player(
+        supabase=supabase,
+        club_id="club-1",
+        normalized_name="new_player",
+        payload={
+            "club_id": "club-1",
+            "name": "New Player",
+            "normalized_name": "new_player",
+            "rating": 3.5,
+            "starting_rating": 3.5,
+        },
+    )
+
+    assert ok is True
+    assert err is None
+    assert row is not None
+    assert supabase.sink["payload"]["rating"] == 1400.0
+    assert supabase.sink["payload"]["starting_rating"] == 1400.0


### PR DESCRIPTION
### Motivation
- League Manager Step 2 and guest add/sub flows were writing UI JUPR values directly into `players.rating`, while the system stores canonical ratings as raw Elo (e.g. 1400).
- Display code converts stored Elo to JUPR via `/ 400.0`, producing tiny values (e.g. 0.009) when JUPR was stored directly.

### Description
- Added a normalization helper `_coerce_rating_to_elo` that treats values `< 20` as JUPR and converts them to Elo (`* 400`), and returns numeric Elo otherwise.
- Added `_normalize_player_payload_for_write` and applied it so `get_or_create_player` upserts/inserts use the normalized `write_payload` and `safe_add_player` uses `_coerce_rating_to_elo` for `rating` writes.
- Updated League Manager creation and guest add/substitute paths to convert UI JUPR to Elo at point-of-write using `jupr_to_elo` before calling `get_or_create_player`.
- Added unit tests `tests/test_player_ops_rating_scale.py` covering the conversion helper and `get_or_create_player` payload normalization, and kept all changes limited to new writes (no bulk DB migration).

### Testing
- Ran focused unit tests with `pytest -q tests/test_player_ops_rating_scale.py`, which passed: `3 passed`.
- Verified display and rating math remain unchanged because stored format is canonical Elo and UI continues to convert with `/ 400.0` for presentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0fe576bc83269b5f0671b73ef3d1)