### PR TITLE
Harden jupr_court_board frontend asset packaging for production deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ __pycache__/
 
 # Local scratch
 archive/
+
+# Custom Streamlit component artifacts
+jupr_court_board/frontend/node_modules/
+!jupr_court_board/frontend/build/
+!jupr_court_board/frontend/build/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt \
 # App code
 COPY . /app
 
+# Fail build early if Streamlit component frontend assets are missing.
+RUN test -f /app/jupr_court_board/frontend/build/index.html
+
 # Make start script executable
 RUN chmod +x /app/start.sh
 


### PR DESCRIPTION
### Motivation
- The Streamlit custom component `jupr_court_board` is declared in release mode using a filesystem `path` that points at `jupr_court_board/frontend/build`, so production depends on committed static assets. 
- Fly/Docker did not previously build or validate the frontend, so missing `frontend/build` causes the component to fail to load at runtime. 
- The change aims to make the packaging contract explicit and to fail fast at image-build time when assets are absent.

### Description
- Updated `.gitignore` to ignore `jupr_court_board/frontend/node_modules/` while explicitly allowing `jupr_court_board/frontend/build/**` to be tracked and deployed. 
- Added a Dockerfile build-time assertion `RUN test -f /app/jupr_court_board/frontend/build/index.html` immediately after `COPY . /app` to cause image builds to fail early if the component build artifacts are missing. 
- No Streamlit logic, schema, or refactors were introduced; the component continues to use `path=os.path.join(parent_dir, "frontend", "build")` in release mode.

### Testing
- Verified the component declaration and release/dev gating by inspecting `jupr_court_board/__init__.py` and confirmed it uses `path=<...>/frontend/build` in release mode (command checks succeeded). 
- Confirmed build artifacts exist and are tracked by running `git ls-files jupr_court_board/frontend/build` and inspecting `jupr_court_board/frontend/build/index.html`, which succeeded. 
- Confirmed repository diffs and commit of changes with `git diff`/`git commit`, and validated the Dockerfile change will fail image builds when `jupr_court_board/frontend/build/index.html` is missing; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b1599dfc88326880041e4117eae74)