### PR TITLE
Fix League Manager submit to navigate to Record Match wizard

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -819,9 +819,9 @@ def render(ctx):
                 submitted = st.form_submit_button("Submit Round & Calculate Movement")
 
             if submitted:
-                st.warning("Round result submission moved to the unified Record Match Result wizard.")
-                st.link_button("Open Record Match Result", "/?page=record_match", use_container_width=True)
-                st.stop()
+                st.session_state["_nav_pending"] = "🧾 Record Match"
+                st.query_params["page"] = "record_match"
+                st.rerun()
 
         # -------------------------
         # 5) CONFIRM MOVEMENT


### PR DESCRIPTION
### Motivation
- The "Submit Round & Calculate Movement" button in the League Manager entered a handler that only showed a warning and link then called `st.stop()`, resulting in a silent non-action instead of routing users into the unified Record Match flow.

### Description
- Replace the passive handler with deterministic navigation by setting `st.session_state["_nav_pending"] = "🧾 Record Match"`, setting `st.query_params["page"] = "record_match"`, and calling `st.rerun()` in `jupr_app/ui/pages/league_manager.py` so the app immediately opens the Record Match wizard on submit.

### Testing
- Compiled the modified file with `python -m compileall jupr_app/ui/pages/league_manager.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b59ca11f0832692501ca0f166f350)