### PR TITLE
Ensure Streamlit UI transitions apply on single click by invoking immediate reruns

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -43,6 +43,13 @@ from jupr_app.ui.layout import page_shell
 logger = logging.getLogger(__name__)
 
 
+def _rerun() -> None:
+    if hasattr(st, "rerun"):
+        st.rerun()
+    else:
+        st.experimental_rerun()
+
+
 def _utc_iso_now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -405,6 +412,7 @@ def render(ctx):
                 st.session_state.ladder_temp_new = new_ps
                 st.session_state.ladder_state = "REVIEW_ROSTER"
                 st.session_state.ladder_round_num = 1
+                _rerun()
                 return
 
         # -------------------------
@@ -414,6 +422,7 @@ def render(ctx):
             c_back, _ = st.columns([1, 5])
             if c_back.button("⬅️ Back (edit league/week/rounds/roster)"):
                 st.session_state.ladder_state = "SETUP"
+                _rerun()
                 return
 
             st.markdown("#### Step 2: Confirm Roster")
@@ -604,6 +613,7 @@ def render(ctx):
                 st.session_state.ladder_state = "CONFIG_COURTS"
                 st.session_state.pop("current_schedule", None)
                 st.session_state.pop("current_schedule_round", None)
+                _rerun()
                 return
 
 
@@ -614,6 +624,7 @@ def render(ctx):
             c_back, _ = st.columns([1, 5])
             if c_back.button("⬅️ Back (edit roster)"):
                 st.session_state.ladder_state = "REVIEW_ROSTER"
+                _rerun()
                 return
 
             st.markdown("#### Step 3: Configure Courts")
@@ -673,6 +684,7 @@ def render(ctx):
                     st.session_state.ladder_print_sheet = print_df
 
                     st.session_state.ladder_state = "CONFIRM_START"
+                    _rerun()
                     return
 
         # -------------------------
@@ -723,6 +735,7 @@ def render(ctx):
                 st.session_state.ladder_state = "PLAY_ROUND"
                 st.session_state.pop("current_schedule", None)
                 st.session_state.pop("current_schedule_round", None)
+                _rerun()
                 return
 
         # -------------------------
@@ -748,6 +761,7 @@ def render(ctx):
                 if cC.button("Swap", key=f"swap_btn_r{current_r}"):
                     st.session_state.ladder_live_roster = compress_courts(swap_players(roster_df, a, b))
                     st.session_state.pop("current_schedule", None)
+                    _rerun()
                     return
 
                 st.divider()
@@ -760,6 +774,7 @@ def render(ctx):
                 if st.button("Apply reorder", key=f"re_btn_r{current_r}"):
                     st.session_state.ladder_live_roster = compress_courts(move_within_court(roster_df, p, int(new_pos)))
                     st.session_state.pop("current_schedule", None)
+                    _rerun()
                     return
 
                 st.divider()
@@ -773,6 +788,7 @@ def render(ctx):
                 if m4.button("Move", key=f"mv_btn_r{current_r}"):
                     st.session_state.ladder_live_roster = move_player_to_court(roster_df, mv_player, int(target_court), int(target_pos))
                     st.session_state.pop("current_schedule", None)
+                    _rerun()
                     return
 
             # Build schedule once per round unless roster changed
@@ -833,6 +849,7 @@ def render(ctx):
             if movement_df is None or movement_df.empty:
                 st.error("No movement preview found.")
                 st.session_state.ladder_state = "PLAY_ROUND"
+                _rerun()
                 return
 
             # Display per court
@@ -1127,6 +1144,7 @@ def render(ctx):
                     ]:
                         st.session_state.pop(k, None)
                     st.session_state.ladder_state = "SETUP"
+                    _rerun()
                     return
 
                 override = st.session_state.get("ladder_next_roster_override")
@@ -1154,6 +1172,7 @@ def render(ctx):
                 st.session_state.ladder_round_num = current_r + 1
                 st.session_state.ladder_state = "CONFIRM_START"
                 st.session_state.pop("current_schedule", None)
+                _rerun()
                 return
 
     # ============================================================
@@ -1662,6 +1681,7 @@ def render(ctx):
                     st.session_state["end_league_frozen_at"] = ended_at
                     st.session_state["end_league_step"] = 2
                     st.session_state["end_league_wizard_open"] = True
+                    _rerun()
                     return
 
             elif step == 2:
@@ -1687,6 +1707,7 @@ def render(ctx):
                     if st.button("Continue to Overrides"):
                         st.session_state["end_league_step"] = 3
                         st.session_state["end_league_wizard_open"] = True
+                        _rerun()
                         return
                 else:
                     st.warning("No winners found. Check eligibility rules or standings.")
@@ -1724,6 +1745,7 @@ def render(ctx):
                 if st.button("Continue to Confirm"):
                     st.session_state["end_league_step"] = 4
                     st.session_state["end_league_wizard_open"] = True
+                    _rerun()
                     return
 
             elif step == 4:
@@ -1761,6 +1783,7 @@ def render(ctx):
                     st.success(f"Minted {len(created)} top performer badges.")
                     st.session_state["end_league_step"] = 5
                     st.session_state["end_league_wizard_open"] = True
+                    _rerun()
                     return
 
             elif step == 5:

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -34,6 +34,13 @@ TOURNAMENT_CHARTS = [
 ]
 
 
+def _rerun() -> None:
+    if hasattr(st, "rerun"):
+        st.rerun()
+    else:
+        st.experimental_rerun()
+
+
 def _require_club_id_payload(payload):
     # NOTE: non-functional touch to retrigger CI checks.
     rows = payload if isinstance(payload, list) else [payload]
@@ -184,7 +191,10 @@ def render(ctx):
         _render_podium_read_only(podium_rows, teams_by_id, id_to_name)
     else:
         if st.button("🏁 Complete Tournament"):
-            st.session_state[f"podium_review_open_{tournament_id}"] = True
+            podium_key = f"podium_review_open_{tournament_id}"
+            if not st.session_state.get(podium_key):
+                st.session_state[podium_key] = True
+                _rerun()
         if st.session_state.get(f"podium_review_open_{tournament_id}"):
             _render_podium_review(
                 ctx,
@@ -785,6 +795,7 @@ def _render_podium_review(
         st.success("Tournament completed and podium locked.")
         st.session_state.pop(f"podium_review_open_{tournament_id}", None)
         st.session_state["force_data_refresh"] = True
+        _rerun()
 
 
 def _render_podium_read_only(podium_rows: list[dict], teams_by_id: dict[str, dict], id_to_name: dict) -> None:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -178,6 +178,13 @@ def _process_pending_nav():
         st.session_state["_nav_pending"] = None
 
 
+def _rerun() -> None:
+    if hasattr(st, "rerun"):
+        st.rerun()
+    else:
+        st.experimental_rerun()
+
+
 def resolve_tenant(session):
     if session:
         token = session.access_token
@@ -264,11 +271,16 @@ def main():
             col1, col2 = st.columns(2)
             with col1:
                 if st.button("🔐 Login", use_container_width=True):
-                    st.session_state["entry_mode"] = "login"
+                    if st.session_state.get("entry_mode") != "login":
+                        st.session_state["entry_mode"] = "login"
+                        _rerun()
             with col2:
                 if st.button("🌎 Public Pages", use_container_width=True):
+                    changed = st.session_state.get("entry_mode") != "public" or st.session_state["auth"].get("mode") != "public"
                     st.session_state["entry_mode"] = "public"
                     st.session_state["auth"]["mode"] = "public"
+                    if changed:
+                        _rerun()
             return
 
         if entry_mode == "login" and not session:
@@ -296,6 +308,7 @@ def main():
                     st.session_state["auth"]["mode"] = "user"
                     st.session_state["auth"]["supabase_session"] = session_obj
                     st.session_state["entry_mode"] = "auth"
+                    _rerun()
                 except Exception as e:
                     st.error(f"Login exception: {e}")
 
@@ -333,7 +346,8 @@ def main():
                     try:
                         supabase_auth.auth.update_user({"password": new_password})
                         st.success("Password updated successfully.")
-                        st.session_state.pop("recovery_mode", None)
+                        if st.session_state.pop("recovery_mode", None) is not None:
+                            _rerun()
                     except Exception:
                         st.error("Password update failed.")
             return
@@ -643,7 +657,9 @@ def main():
         _process_pending_nav()
 
         if st.session_state.get("_nav_target") == "login":
-            st.session_state["entry_mode"] = "login"
+            if st.session_state.get("entry_mode") != "login":
+                st.session_state["entry_mode"] = "login"
+                _rerun()
             return
 
         current_page = st.session_state["_nav_target"]
@@ -652,13 +668,16 @@ def main():
             st.session_state["_nav_target"] = current_page
 
         if current_page in ADMIN_ONLY_LABELS and not admin_logged_in:
-            st.session_state["_nav_pending"] = "login"
+            if st.session_state.get("_nav_pending") != "login":
+                st.session_state["_nav_pending"] = "login"
+                _rerun()
             return
 
         if PUBLIC_MODE:
             selected = render_public_top_nav(labels_in_order=public_labels_in_order, current_label=current_page)
-            if selected != current_page:
+            if selected != current_page and st.session_state.get("_nav_pending") != selected:
                 st.session_state["_nav_pending"] = selected
+                _rerun()
         else:
             render_admin_sidebar_nav(current_label=current_page, admin_logged_in=admin_logged_in)
 


### PR DESCRIPTION
### Motivation
- Fix systemic read-before-write behavior where button clicks mutated `st.session_state` but the UI branch remained the same for the remainder of the run, forcing a second click to see the new branch. 
- Ensure pending navigation (`_nav_pending`) and other branch-driving flags are applied immediately so navigation and state-machine transitions happen on the same click. 

### Description
- Added a small compatibility helper `_rerun()` (prefers `st.rerun`, falls back to `st.experimental_rerun`) and used it where needed to trigger an immediate rerun in `streamlit_app.py`, `jupr_app/ui/pages/league_manager.py`, and `jupr_app/ui/pages/tournaments.py`. 
- Updated gateway/login/recovery flows in `streamlit_app.py` to call `_rerun()` after changing `entry_mode`/auth state and added guards so reruns only occur when state actually changes. 
- Changed public navigation handling in `streamlit_app.py` so selecting a new public page writes `_nav_pending` and immediately reruns (with a guard against redundant writes). 
- Patched League Manager (`jupr_app/ui/pages/league_manager.py`) to call `_rerun()` after branch-changing button handlers (examples: `Analyze & Seed` -> `REVIEW_ROSTER`, `Proceed to Court Setup` -> `CONFIG_COURTS`, `Start Event` -> `PLAY_ROUND`, movement/finish flows, and end-league wizard step transitions) so the UI advances on the first click. 
- Patched Tournaments (`jupr_app/ui/pages/tournaments.py`) to set `podium_review_open_{id}` with a guard and call `_rerun()` when opening the podium review and to call `_rerun()` after finalizing tournament completion so the completed UI renders immediately. 

### Testing
- Ran `python -m py_compile streamlit_app.py jupr_app/ui/pages/league_manager.py jupr_app/ui/pages/tournaments.py` to verify the patched modules are syntactically valid, and compilation succeeded. 
- Attempted an automated UI validation via a Playwright script against `http://localhost:8501`, but the Streamlit app was not running in the test environment resulting in `net::ERR_EMPTY_RESPONSE`; this did not exercise the UI but indicates the server must be running for end-to-end validation. 
- No other automated tests were present or modified; changes are limited to adding guarded `_rerun()` calls to ensure single-click transitions without changing business logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b5d6c094c832691eb036b70b65a85)