### PR TITLE
Fix replay_history row counting for Supabase client compatibility; add Leagues Manager audit

### DIFF
--- a/AUDIT_LEAGUES_MANAGER.md
+++ b/AUDIT_LEAGUES_MANAGER.md
@@ -1,0 +1,69 @@
+# AUDIT: Leagues Manager (branch `rebuild`)
+
+## Overview + scope
+This audit covered the Streamlit **League Manager** page, the league domain logic it relies on, and the replay/recompute paths that keep league state and standings coherent.
+
+Scoped code paths:
+- UI entry + routing: `streamlit_app.py`, `jupr_app/ui/pages/league_manager.py`
+- League domain/status + awards: `jupr_app/domain/leagues.py`
+- League data loading/persistence touchpoints: `jupr_app/data/load.py`
+- Replay path used by Admin/league maintenance: `jupr_app/domain/replay_history.py`, `jupr_app/ui/pages/admin_tools.py`
+- Regression test coverage: `tests/test_replay_history_rpc.py`
+
+## Architecture map (short)
+1. Request/UI navigation:
+   - Streamlit routes "🏟️ League Manager" to `league_manager.render(ctx)`.
+2. Handler/UI workflow:
+   - `league_manager.render` initializes ladder state, reads `ctx.df_leagues/df_meta`, and runs setup + roster + live event flow.
+3. Service/domain:
+   - League metadata/status/awards helpers from `jupr_app/domain/leagues.py`.
+4. Persistence/data:
+   - `jupr_app/data/load.py` loads `league_ratings`, `leagues_metadata`, and `matches` from Supabase.
+5. Maintenance/rebuild path:
+   - Admin tools trigger replay via `jupr_app/domain/replay_history.py`, which recomputes and writes league ratings through `replace_league_ratings` RPC.
+
+Flow summary: `Streamlit page -> league_manager.render -> domain helpers + Supabase reads/writes -> replay_history (when maintenance/replay is run) -> updated league_ratings/matches/players`.
+
+## Expected behavior (source of truth)
+- The League Manager page should be reachable from app navigation and render for admin users.
+- Replay history should recompute league ratings and invoke `replace_league_ratings` RPC for league resets.
+- Replay logic should be robust to Supabase query implementations used in tests/mocks.
+
+Primary source of truth used:
+- `tests/test_replay_history_rpc.py` (explicitly validates replay uses `replace_league_ratings` RPC)
+- `streamlit_app.py` + `league_manager.py` routing/render wiring
+- `admin_tools.py` replay controls and dispatch
+
+## Reproducing original failure
+### Minimal failing command (pre-fix)
+```bash
+pytest -q tests -k "league_manager or leagues or league"
+```
+
+### Observed failure
+- `tests/test_replay_history_rpc.py::test_replay_history_uses_replace_league_ratings_rpc` failed.
+- Error: `_Query.select() got an unexpected keyword argument 'count'` from `replay_history._count_rows`.
+
+This blocked league replay maintenance flow in compatibility contexts using a minimal/mock Supabase query object.
+
+## Issue list
+
+| Severity | Area | File(s) | Evidence | Root cause | Fix | Test coverage |
+|---|---|---|---|---|---|---|
+| High | League replay maintenance | `jupr_app/domain/replay_history.py`, `tests/test_replay_history_rpc.py` | Failing test shows TypeError on `select(..., count="exact")` with mock query impl | `_count_rows` assumed a specific Supabase client signature (`count` kwarg + `limit`) and no fallback path | Added compatibility fallback: try `select(..., count="exact")`, fallback to `select("id")`; apply `.limit(1)` only when available; fallback to `len(data)` when response has no `.count` | `tests/test_replay_history_rpc.py` passes; league-focused test subset passes |
+
+## What changed (high level)
+- Updated replay row counting to be client-signature tolerant and resilient when count metadata is absent.
+- Verified league replay RPC path tests and league-focused suite now pass.
+
+## Commands run + outcomes
+- `git branch --show-current && git status --short && rg -n "LeaguesManager|LeagueManager|leagues manager|/leagues|league_|league-" .` (inventory/search)
+- `pytest -q tests/test_end_league_top_performers.py tests/test_load_data_leagues_metadata.py tests/test_navigation_determinism.py` (initial targeted baseline, passed)
+- `pytest -q tests -k "league_manager or leagues or league"` (pre-fix repro, failed on replay_history count signature)
+- `pytest -q tests/test_replay_history_rpc.py tests/test_end_league_top_performers.py tests/test_load_data_leagues_metadata.py tests/test_navigation_determinism.py` (post-fix targeted validation, passed)
+- `pytest -q tests -k "league_manager or leagues or league or replay_history"` (post-fix broader league subset, passed)
+- `python -m compileall .` (CI-aligned compile check, passed)
+
+## Remaining risks / follow-ups
+- Replay behavior correctness against a real Supabase backend is not fully end-to-end covered here (only unit-level + mock-level replay test).
+- Existing uncommitted `jupr_court_board/frontend/node_modules/.package-lock.json` workspace change was pre-existing and intentionally left untouched.

--- a/jupr_app/domain/replay_history.py
+++ b/jupr_app/domain/replay_history.py
@@ -72,14 +72,21 @@ def _json_size_bytes(payload: Any) -> int:
 
 
 def _count_rows(*, supabase: Any, table: str, club_id: str) -> int:
-    rows = (
-        supabase.table(table)
-        .select("id", count="exact")
-        .eq("club_id", str(club_id))
-        .limit(1)
-        .execute()
-    )
-    return int(getattr(rows, "count", 0) or 0)
+    query = supabase.table(table)
+    try:
+        query = query.select("id", count="exact")
+    except TypeError:
+        query = query.select("id")
+
+    query = query.eq("club_id", str(club_id))
+    if hasattr(query, "limit"):
+        query = query.limit(1)
+
+    rows = query.execute()
+    count = getattr(rows, "count", None)
+    if count is not None:
+        return int(count)
+    return int(len(getattr(rows, "data", []) or []))
 
 
 def _chunk_rows_by_payload_limit(rows: list[Dict[str, Any]], *, max_payload_bytes: int) -> list[list[Dict[str, Any]]]:


### PR DESCRIPTION
### Motivation
- A failing league replay unit test showed `_count_rows` in `jupr_app/domain/replay_history.py` assumed a Supabase client signature (`select(..., count="exact")` + `.limit()`) that breaks against minimal/mock query implementations, preventing the Leagues Manager replay/replace flow from running in some contexts.

### Description
- Made `_count_rows` tolerant to multiple Supabase query styles by trying `select("id", count="exact")` and falling back to `select("id")` on `TypeError`, only calling `.limit(1)` if supported, and returning `rows.count` when present or `len(rows.data)` as a fallback. 
- Added `AUDIT_LEAGUES_MANAGER.md` with the audit report covering scope, repro steps, architecture map, root-cause, fixes, and follow-ups.
- Changes are localized to `jupr_app/domain/replay_history.py` and the new audit document; no new runtime dependencies were introduced.

### Testing
- Reproduced the original failing test with `pytest -q tests -k "league_manager or leagues or league"` and observed the `_Query.select()` `TypeError` before the fix. 
- Verified the targeted regression and related league tests with `pytest -q tests/test_replay_history_rpc.py tests/test_end_league_top_performers.py tests/test_load_data_leagues_metadata.py tests/test_navigation_determinism.py`, which passed. 
- Ran the broader league-focused subset with `pytest -q tests -k "league_manager or leagues or league or replay_history"` and `python -m compileall .`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b5f369e8c832694e8ebc52fc123aa)