### PR TITLE
Fix _count_rows compatibility fallback and add regression tests

### DIFF
--- a/jupr_app/domain/replay_history.py
+++ b/jupr_app/domain/replay_history.py
@@ -76,17 +76,25 @@ def _count_rows(*, supabase: Any, table: str, club_id: str) -> int:
     try:
         query = query.select("id", count="exact")
     except TypeError:
-        query = query.select("id")
+        query = None
 
-    query = query.eq("club_id", str(club_id))
-    if hasattr(query, "limit"):
-        query = query.limit(1)
+    if query is not None:
+        query = query.eq("club_id", str(club_id))
+        if hasattr(query, "limit"):
+            try:
+                query = query.limit(1)
+            except TypeError:
+                pass
 
-    rows = query.execute()
-    count = getattr(rows, "count", None)
-    if count is not None:
-        return int(count)
-    return int(len(getattr(rows, "data", []) or []))
+        rows = query.execute()
+        count = rows.get("count") if isinstance(rows, dict) else getattr(rows, "count", None)
+        if count is not None:
+            return int(count)
+
+    rows = supabase.table(table).select("id").eq("club_id", str(club_id)).execute()
+    data = rows.get("data") if isinstance(rows, dict) else getattr(rows, "data", None)
+    data = data or []
+    return int(len(data))
 
 
 def _chunk_rows_by_payload_limit(rows: list[Dict[str, Any]], *, max_payload_bytes: int) -> list[list[Dict[str, Any]]]:

--- a/tests/test_replay_history_rpc.py
+++ b/tests/test_replay_history_rpc.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pandas as pd
 
 from jupr_app.domain import replay_history
+from jupr_app.domain.replay_history import _count_rows
 
 
 class _Query:
@@ -132,3 +133,65 @@ def test_replay_history_uses_replace_league_ratings_rpc(monkeypatch):
     assert payload["p_club_id"] == "club-1"
     assert payload["p_reset"] is True
     assert [row["player_id"] for row in payload["p_rows"]] == [1, 2, 3, 4]
+
+
+def test_count_rows_falls_back_when_select_count_kwarg_not_supported():
+    class FakeQueryNoCount:
+        def __init__(self, rows):
+            self._rows = list(rows)
+
+        def select(self, _cols):
+            return self
+
+        def eq(self, _col, _value):
+            return self
+
+        def limit(self, n):
+            self._rows = self._rows[:n]
+            return self
+
+        def execute(self):
+            return SimpleNamespace(data=list(self._rows), count=None)
+
+    class FakeSupabase:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def table(self, _name):
+            return FakeQueryNoCount(self._rows)
+
+    supabase = FakeSupabase([{"id": 1}, {"id": 2}, {"id": 3}])
+
+    assert _count_rows(supabase=supabase, table="matches", club_id="club-1") == 3
+
+
+def test_count_rows_uses_fresh_unlimited_query_when_count_metadata_missing_dict_response():
+    class FakeQueryWithCountKwarg:
+        def __init__(self, rows):
+            self._rows = list(rows)
+            self._count_requested = False
+
+        def select(self, _cols, **kwargs):
+            self._count_requested = kwargs.get("count") == "exact"
+            return self
+
+        def eq(self, _col, _value):
+            return self
+
+        def limit(self, n):
+            self._rows = self._rows[:n]
+            return self
+
+        def execute(self):
+            return {"data": list(self._rows), "count": None if self._count_requested else None}
+
+    class FakeSupabase:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def table(self, _name):
+            return FakeQueryWithCountKwarg(self._rows)
+
+    supabase = FakeSupabase([{"id": 1}, {"id": 2}, {"id": 3}])
+
+    assert _count_rows(supabase=supabase, table="matches", club_id="club-1") == 3


### PR DESCRIPTION
### Motivation

- The previous `_count_rows` could return an incorrect count because a single query builder was mutated with `.limit(1)` and then its `data` length was used as a fallback, which truncated results. 
- The previous code also assumed `select(..., count=...)` is always supported and that the response is object-like with `.count`/`.data`, which breaks against mocks or alternate clients.

### Description

- Replaced `_count_rows` with a two-phase strategy where Phase A attempts server-side `count="exact"` metadata and Phase B runs a fresh unlimited query for `len(data)` if metadata is missing or unsupported. 
- Phase A builds a fresh query, catches `TypeError` from `select(..., count=...)`, and tolerates `TypeError` from `limit()` so mocks with differing signatures don't crash. 
- Extraction now supports both object-style responses (`.count`/`.data`) and dict responses (`"count"`/`"data"`). 
- Added regression tests in `tests/test_replay_history_rpc.py` that cover (A) `select` that does not accept `count=` and (B) `select` that accepts `count=` but returns `count=None` (dict response), ensuring the fallback uses a fresh unlimited query.

### Testing

- Ran `pytest -q tests/test_replay_history_rpc.py`, which passed (`4 passed`).
- Ran `pytest -q tests -k "replay_history and count_rows"`, which passed (`2 passed, 213 deselected`).
- The new tests exercise both TypeError-on-`select` and missing-count dict responses and confirm `_count_rows` returns the true row count in both cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b644cb9a083268fd34d0507774694)