### PR TITLE
Do not treat Streamlit Rerun/Stop control-flow as app crashes

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -12,6 +12,22 @@ from supabase import create_client
 import streamlit as st
 import pandas as pd  # noqa: F401  # kept because pages may rely on it
 
+try:
+    from streamlit.runtime.scriptrunner.exceptions import RerunException, StopException
+except ImportError:
+    try:
+        from streamlit.runtime.scriptrunner_utils.exceptions import (
+            RerunException,
+            StopException,
+        )
+    except ImportError:
+        from streamlit.runtime.scriptrunner.script_runner import (
+            RerunException,
+            StopException,
+        )
+
+STREAMLIT_CONTROL_FLOW_EXCEPTIONS = (RerunException, StopException)
+
 LOCAL_PUBLIC_BASE_URL_DEFAULT = "http://localhost:8501"
 
 
@@ -701,6 +717,8 @@ def main():
 
         render_fn(ctx)
 
+    except STREAMLIT_CONTROL_FLOW_EXCEPTIONS:
+        raise
     except Exception:
         st.error("streamlit_app.main() crashed")
         st.code(traceback.format_exc())


### PR DESCRIPTION
### Motivation
- The app marked intentional Streamlit control-flow (e.g. `st.rerun()`) as crashes because a broad `except Exception` in `main()` caught `RerunException`/`StopException` and logged "streamlit_app.main() crashed".
- The fix must allow Streamlit to perform reruns/stops (the exceptions must propagate) while preserving logging for real errors.

### Description
- Updated `streamlit_app.py` to import Streamlit control exceptions from multiple module locations (handles different Streamlit layouts) and centralize them in `STREAMLIT_CONTROL_FLOW_EXCEPTIONS`.
- Changed the `main()` top-level exception handler to re-raise any exception in `STREAMLIT_CONTROL_FLOW_EXCEPTIONS` before the generic `except Exception` crash handler so reruns/stops are not logged as crashes.
- The change is minimal and localized to error-handling in `streamlit_app.py` and does not alter existing crash logging for non-control exceptions.

### Testing
- Ran `python -m compileall .` which completed successfully.
- Ran `pytest -q tests -k "navigation or rerun or league or replay_history"` which completed with `24 passed, 191 deselected`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b66d616cc8326ab1cc68f54f0d7fb)