### PR TITLE
Ignore Streamlit rerun/stop exceptions in login flow

### DIFF
--- a/jupr_app/ui/streamlit_exceptions.py
+++ b/jupr_app/ui/streamlit_exceptions.py
@@ -1,0 +1,22 @@
+"""Helpers for preserving Streamlit control-flow exceptions."""
+
+from __future__ import annotations
+
+
+def is_streamlit_control_exception(exc: BaseException) -> bool:
+    name = exc.__class__.__name__
+    if name in {"RerunException", "StopException"}:
+        return True
+
+    module = getattr(exc.__class__, "__module__", "") or ""
+    if "streamlit.runtime.scriptrunner" in module and (
+        "Rerun" in name or "Stop" in name
+    ):
+        return True
+
+    return False
+
+
+def rethrow_if_streamlit_control(exc: BaseException) -> None:
+    if is_streamlit_control_exception(exc):
+        raise exc

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -12,21 +12,7 @@ from supabase import create_client
 import streamlit as st
 import pandas as pd  # noqa: F401  # kept because pages may rely on it
 
-try:
-    from streamlit.runtime.scriptrunner.exceptions import RerunException, StopException
-except ImportError:
-    try:
-        from streamlit.runtime.scriptrunner_utils.exceptions import (
-            RerunException,
-            StopException,
-        )
-    except ImportError:
-        from streamlit.runtime.scriptrunner.script_runner import (
-            RerunException,
-            StopException,
-        )
-
-STREAMLIT_CONTROL_FLOW_EXCEPTIONS = (RerunException, StopException)
+from jupr_app.ui.streamlit_exceptions import rethrow_if_streamlit_control
 
 LOCAL_PUBLIC_BASE_URL_DEFAULT = "http://localhost:8501"
 
@@ -325,8 +311,9 @@ def main():
                     st.session_state["auth"]["supabase_session"] = session_obj
                     st.session_state["entry_mode"] = "auth"
                     _rerun()
-                except Exception as e:
-                    st.error(f"Login exception: {e}")
+                except BaseException as exc:
+                    rethrow_if_streamlit_control(exc)
+                    st.error(f"Login exception: {exc}")
 
             if st.button("Send Magic Link", use_container_width=True):
                 if not email:
@@ -717,9 +704,8 @@ def main():
 
         render_fn(ctx)
 
-    except STREAMLIT_CONTROL_FLOW_EXCEPTIONS:
-        raise
-    except Exception:
+    except BaseException as exc:
+        rethrow_if_streamlit_control(exc)
         st.error("streamlit_app.main() crashed")
         st.code(traceback.format_exc())
         st.stop()

--- a/tests/test_streamlit_control_exceptions.py
+++ b/tests/test_streamlit_control_exceptions.py
@@ -1,0 +1,48 @@
+from jupr_app.ui.streamlit_exceptions import (
+    is_streamlit_control_exception,
+    rethrow_if_streamlit_control,
+)
+
+
+class RerunException(Exception):
+    pass
+
+
+class StopException(Exception):
+    pass
+
+
+def test_rerun_exception_detected():
+    assert is_streamlit_control_exception(RerunException())
+
+
+def test_stop_exception_detected():
+    assert is_streamlit_control_exception(StopException())
+
+
+def test_normal_exception_not_detected():
+    assert not is_streamlit_control_exception(Exception("x"))
+
+
+def test_rethrow_reraises_rerun_exception():
+    exc = RerunException()
+    try:
+        rethrow_if_streamlit_control(exc)
+    except RerunException as raised:
+        assert raised is exc
+    else:
+        raise AssertionError("expected RerunException to be re-raised")
+
+
+def test_rethrow_reraises_stop_exception():
+    exc = StopException()
+    try:
+        rethrow_if_streamlit_control(exc)
+    except StopException as raised:
+        assert raised is exc
+    else:
+        raise AssertionError("expected StopException to be re-raised")
+
+
+def test_rethrow_ignores_normal_exception():
+    rethrow_if_streamlit_control(Exception("x"))


### PR DESCRIPTION
### Motivation
- The login UI was treating Streamlit control-flow reruns as regular errors and displaying messages like `Login exception: RerunData(...)`, which is incorrect during normal `st.rerun()` flows.
- The change should preserve Streamlit control-flow behavior while still surfacing genuine login/auth/runtime errors to the user.

### Description
- Add a small helper module `jupr_app.ui.streamlit_exceptions` that provides `is_streamlit_control_exception(exc: BaseException) -> bool` and `rethrow_if_streamlit_control(exc: BaseException) -> None` which detect `RerunException`/`StopException` by class-name and module-prefix without importing Streamlit internals. 
- Update `streamlit_app.py` login submission handler to catch `BaseException`, call `rethrow_if_streamlit_control(exc)` to re-raise Streamlit rerun/stop control exceptions immediately, and only call `st.error(...)` for real failures. 
- Update the top-level `streamlit_app.main()` error boundary so rerun/stop exceptions are re-thrown instead of being trapped by the crash UI. 
- Add regression tests `tests/test_streamlit_control_exceptions.py` that use dummy `RerunException` and `StopException` classes to validate detection and rethrow behavior without requiring Streamlit to be installed.

### Testing
- Ran `python -m compileall .` which completed successfully. 
- Ran `pytest -q tests/test_streamlit_control_exceptions.py` and the new test suite passed (`6 passed`).
- Ran targeted integration tests `pytest -q tests -k "navigation or league or replay_history"` which completed successfully (`24 passed, 197 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b6a3662248326b555322ab8b4d698)