### PR TITLE
Fix Weekly Recap tenant scoping and runtime stability issues

### DIFF
--- a/docs/weekly_recap_bug_audit.md
+++ b/docs/weekly_recap_bug_audit.md
@@ -1,0 +1,93 @@
+# Weekly Recap Bug Audit
+
+## Scope
+- Feature audited: **Weekly Recap** only.
+- Branch: `rebuild`.
+- Constraint followed: bug-fix stabilization only (no feature expansion, no format redesign).
+
+## 1) Entrypoints and dependency map
+
+### UI pages
+- Public/Admin recap display page: `jupr_app/ui/pages/weekly_recap.py` (`render(ctx)`).
+- Weekly Recap Admin page: `jupr_app/ui/pages/weekly_recap_admin.py` (`render(ctx)`).
+- Route wiring: `streamlit_app.py` maps `weekly_recap` and `weekly_recap_admin` page keys.
+
+### Service layer and recap assembly
+- Core recap payload generation:
+  - `compute_weekly_recap(...)` in `jupr_app/domain/recaps/weekly_recap.py`.
+  - `_compute_weekly_recap_payload(...)` in same file.
+- Spotlight candidates for admin overrides:
+  - `get_spotlight_candidates(...)` in same file.
+
+### Data fetchers / query paths
+- Match loading:
+  - `_load_week_matches(...)` reads from in-memory `ctx.df_matches` first, then Supabase `matches` table fallback.
+- Derived stats and sections:
+  - `_compute_stats(...)`, `_build_numbers(...)`, `_compute_new_faces(...)`, `_build_around_club(...)`.
+- Challenge ladder summary:
+  - `_fetch_challenge_ladder_week_summary(...)`.
+
+### Rendering / templates
+- HTML generation and section rendering:
+  - `build_weekly_recap_html(...)` in `jupr_app/ui/components/weekly_recap_layout.py`.
+- Streamlit embedding:
+  - `render_weekly_recap(...)` in same file.
+- PDF generation path (admin):
+  - `_pdf_for_recap(...)` + download button flow in `jupr_app/ui/pages/weekly_recap_admin.py`.
+
+### Background job / CLI / scheduled task
+- No standalone Weekly Recap CLI command or scheduler entrypoint was found in this repository during this audit.
+
+## 2) Failure reproduction and findings
+
+## Commands run for reproduction and verification
+- `pytest -q tests -k weekly_recap`
+- `pytest -q tests/test_weekly_recap_regression.py tests/test_weekly_recap_bounds.py tests/test_weekly_recap_delta.py tests/test_weekly_recap_spotlight.py tests/test_weekly_recap_challenge_ladder.py tests/test_weekly_recap_layout_challenge_ladder.py`
+- Static trace/search:
+  - `rg -n "weekly_recap|compute_weekly_recap|weekly_recap_admin|weekly_recaps" jupr_app streamlit_app.py tests -S`
+
+### Bug A — Missing tenant scoping in local match path
+- **Symptom:** Weekly recap could include matches from other clubs when `ctx.df_matches` contains multi-club rows.
+- **Repro (pre-fix logic):** `_load_week_matches(...)` filtered local matches by date only, not by `club_id`.
+- **Impact:** Inaccurate recap statistics and spotlight data for the selected club.
+- **Category:** Incorrect data pull / missing club scoping.
+
+### Bug B — PDF export hard failure risk (WeasyPrint import/runtime)
+- **Symptom:** Admin page could crash in environments lacking WeasyPrint runtime dependencies.
+- **Repro path:** `_pdf_for_recap(...)` imported WeasyPrint directly and admin render flow called it unguarded.
+- **Impact:** Runtime exception blocks recap admin page actions and prevents PDF download flow from degrading gracefully.
+- **Category:** Runtime reliability failure.
+
+### Empty dataset handling status
+- Validated that recap computation and HTML rendering complete without crash when no weekly matches are present.
+- Ensured output remains structurally valid/non-empty HTML with zeroed number tiles.
+
+## 3) Fixes applied
+
+1. Added `club_id` filtering to `_load_week_matches(...)` for local DataFrame path before date filtering.
+2. Hardened `_pdf_for_recap(...)` to raise controlled runtime error when WeasyPrint import is unavailable.
+3. Wrapped admin PDF generation in a guarded `try/except` and show warning fallback instead of crashing the page.
+
+## 4) Files modified
+- `jupr_app/domain/recaps/weekly_recap.py`
+- `jupr_app/ui/pages/weekly_recap_admin.py`
+- `tests/test_weekly_recap_regression.py`
+- `docs/weekly_recap_bug_audit.md`
+
+## 5) What was NOT changed (explicit)
+- No new recap sections were added.
+- No output format restructuring was introduced.
+- No newsletter content/tone logic was changed.
+- No performance optimization/refactor unrelated to correctness/reliability was introduced.
+- No new configuration knobs were added.
+
+## 6) Minimal regression tests added
+- Added tests covering:
+  - Local DataFrame tenant scoping in `_load_week_matches(...)`.
+  - End-to-end recap payload + HTML non-empty output with valid input data.
+  - End-to-end recap payload + HTML safe handling with empty dataset.
+
+## 7) Remaining technical debt (not fixed in this pass)
+- Admin preview uses session-state render mode flags that are currently set/reset in page code; behavior works but remains loosely coupled and lightly exercised by tests.
+- PDF generation still depends on deployment runtime packages for full capability; this pass adds graceful degradation but does not bundle system libs.
+- Supabase query resilience in some helper paths relies on broad exception handling patterns that could benefit from tighter typed error branches in future hardening work.

--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -159,6 +159,8 @@ def _load_week_matches(
 ) -> pd.DataFrame:
     if df_matches is not None and not df_matches.empty:
         df_local = df_matches.copy()
+        if "club_id" in df_local.columns:
+            df_local = df_local[df_local["club_id"].astype(str) == str(club_id)].copy()
         df_local["date_dt"] = pd.to_datetime(df_local.get("date", None), utc=True, errors="coerce")
         in_range = df_local[(df_local["date_dt"] >= start_dt) & (df_local["date_dt"] <= end_dt)].copy()
         if not in_range.empty:

--- a/jupr_app/ui/pages/weekly_recap_admin.py
+++ b/jupr_app/ui/pages/weekly_recap_admin.py
@@ -143,7 +143,10 @@ def _apply_edits(generated_json: dict, edits_json: dict, candidates: dict[str, l
 
 @st.cache_data(show_spinner=False)
 def _pdf_for_recap(html: str) -> bytes:
-    from weasyprint import HTML
+    try:
+        from weasyprint import HTML
+    except Exception as exc:  # pragma: no cover - depends on deployment image
+        raise RuntimeError("PDF export unavailable: WeasyPrint is not installed.") from exc
 
     return HTML(string=html).write_pdf()
 
@@ -396,13 +399,17 @@ def render(ctx):
             st.session_state.pop("weekly_recap_render_mode", None)
     st.subheader("Download PDF")
     html = build_weekly_recap_html(final_json, print_view=True)
-    pdf_bytes = _pdf_for_recap(html)
-    st.download_button(
-        "Download PDF",
-        data=pdf_bytes,
-        file_name=_pdf_filename(final_json),
-        mime="application/pdf",
-    )
+    try:
+        pdf_bytes = _pdf_for_recap(html)
+    except Exception:
+        st.warning("PDF export is unavailable in this environment. Use browser print view as a fallback.")
+    else:
+        st.download_button(
+            "Download PDF",
+            data=pdf_bytes,
+            file_name=_pdf_filename(final_json),
+            mime="application/pdf",
+        )
     st.markdown("</div>", unsafe_allow_html=True)
 
     if st.button("Publish"):

--- a/tests/test_weekly_recap_regression.py
+++ b/tests/test_weekly_recap_regression.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pandas as pd
+
+from jupr_app.domain.recaps.weekly_recap import _load_week_matches, compute_weekly_recap, get_week_bounds
+from jupr_app.ui.components.weekly_recap_layout import build_weekly_recap_html
+
+
+class _Ctx:
+    def __init__(self, *, club_id: str, df_matches: pd.DataFrame, id_to_name: dict[int, str] | None = None):
+        self.club_id = club_id
+        self.df_matches = df_matches
+        self.id_to_name = id_to_name or {}
+        self.df_players_all = pd.DataFrame()
+        self.supabase = None
+
+
+def test_load_week_matches_filters_local_df_by_club_id():
+    week_start = date(2025, 1, 6)
+    start_dt, end_dt = get_week_bounds(week_start, "UTC")
+    df = pd.DataFrame(
+        [
+            {"id": 1, "club_id": "club-a", "date": "2025-01-06T10:00:00Z", "score_t1": 11, "score_t2": 9},
+            {"id": 2, "club_id": "club-b", "date": "2025-01-06T11:00:00Z", "score_t1": 11, "score_t2": 9},
+        ]
+    )
+
+    loaded = _load_week_matches(df, None, "club-a", start_dt, end_dt)
+
+    assert set(loaded["id"].tolist()) == {1}
+
+
+def test_compute_weekly_recap_and_layout_non_empty_with_valid_data():
+    df = pd.DataFrame(
+        [
+            {
+                "id": 1,
+                "club_id": "club-a",
+                "date": "2025-01-06T10:00:00Z",
+                "league": "Alpha",
+                "match_type": "League",
+                "week_tag": "Week 1",
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+                "score_t1": 11,
+                "score_t2": 7,
+                "t1_p1_r": 1200,
+                "t1_p2_r": 1200,
+                "t2_p1_r": 1200,
+                "t2_p2_r": 1200,
+                "t1_p1_r_end": 1215,
+                "t1_p2_r_end": 1210,
+                "t2_p1_r_end": 1190,
+                "t2_p2_r_end": 1185,
+                "context_type": "LEAGUE",
+                "context_id": "alpha",
+                "tournament_id": None,
+            }
+        ]
+    )
+    ctx = _Ctx(club_id="club-a", df_matches=df, id_to_name={1: "A", 2: "B", 3: "C", 4: "D"})
+
+    recap = compute_weekly_recap(ctx, date(2025, 1, 6), tz_name="UTC")
+    html = build_weekly_recap_html(recap, print_view=False)
+
+    assert recap["numbers"]["matches"] == 1
+    assert "Spotlight Reel" in html
+    assert "Around the Club" in html
+
+
+def test_compute_weekly_recap_and_layout_handle_empty_dataset():
+    ctx = _Ctx(club_id="club-a", df_matches=pd.DataFrame())
+
+    recap = compute_weekly_recap(ctx, date(2025, 1, 6), tz_name="UTC")
+    html = build_weekly_recap_html(recap, print_view=False)
+
+    assert recap["numbers"]["matches"] == 0
+    assert "Tres Palapas Weekly Recap" in html
+    assert len(html.strip()) > 0


### PR DESCRIPTION
### Motivation
- Prevent cross-club data leakage when in-memory match data (`ctx.df_matches`) contains rows for multiple clubs by ensuring local-data path is tenant-scoped. 
- Avoid hard crashes in the Weekly Recap Admin when PDF runtime dependencies (WeasyPrint) are missing so the admin workflow degrades gracefully. 
- Ensure recap generation and rendering remain safe on empty datasets and preserve existing recap structure and output format.

### Description
- Add `club_id` filtering to the local DataFrame path in `_load_week_matches(...)` so only matches for the current club are considered (fixes incorrect data pulls). (file: `jupr_app/domain/recaps/weekly_recap.py`)
- Harden `_pdf_for_recap(...)` to catch WeasyPrint import failures and raise a controlled runtime error, and wrap the admin PDF generation in a `try/except` that shows a warning fallback instead of crashing. (file: `jupr_app/ui/pages/weekly_recap_admin.py`)
- Add focused regression tests that assert tenant scoping, non-empty output with valid data, and safe behavior with empty datasets. (file: `tests/test_weekly_recap_regression.py`)
- Add the audit report documenting entrypoints, failures found, fixes applied, and remaining technical debt. (file: `docs/weekly_recap_bug_audit.md`)

### Testing
- Ran targeted recap tests including the new regression tests with: `pytest -q tests/test_weekly_recap_regression.py tests/test_weekly_recap_bounds.py tests/test_weekly_recap_delta.py tests/test_weekly_recap_spotlight.py tests/test_weekly_recap_challenge_ladder.py tests/test_weekly_recap_layout_challenge_ladder.py`, all tests passed (`11 passed`).
- Ran the broader weekly-recap selection with `pytest -q tests -k weekly_recap`, which passed (`11 passed, 207 deselected`).
- Manual verification ensured HTML generation completes for valid and empty inputs and admin PDF flow now degrades with a user-facing warning when PDF export is unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b6b258eb8832686939dac8a684519)