### PR TITLE
recaps: persist featured past event + tournaments snapshot

### DIFF
--- a/jupr_app/domain/recaps/__init__.py
+++ b/jupr_app/domain/recaps/__init__.py
@@ -1,3 +1,12 @@
 from .weekly_recap import compute_weekly_recap, get_spotlight_candidates, get_week_bounds
+from .engine import compute_recap, load_events_in_period, load_events_upcoming, validate_featured_past_event
 
-__all__ = ["compute_weekly_recap", "get_spotlight_candidates", "get_week_bounds"]
+__all__ = [
+    "compute_weekly_recap",
+    "get_spotlight_candidates",
+    "get_week_bounds",
+    "compute_recap",
+    "load_events_in_period",
+    "load_events_upcoming",
+    "validate_featured_past_event",
+]

--- a/jupr_app/domain/recaps/engine.py
+++ b/jupr_app/domain/recaps/engine.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+MEXICO_CITY_TZ = ZoneInfo("America/Mexico_City")
+_TOURNAMENT_KEYWORDS = (
+    "tournament",
+    "championship",
+    "classic",
+    "open",
+    "cup",
+    "invitational",
+)
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    ok: bool
+    error: str | None = None
+
+
+def _coerce_dt(value: str | datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        try:
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=MEXICO_CITY_TZ)
+    return dt.astimezone(MEXICO_CITY_TZ)
+
+
+def _normalize_item(row: dict[str, Any], *, source: str) -> dict[str, Any]:
+    title = str(row.get("title") or row.get("name") or "").strip()
+    starts_at = _coerce_dt(row.get("starts_at") or row.get("datetime") or row.get("created_at"))
+    item = {
+        "event_id": row.get("id"),
+        "title": title,
+        "datetime": starts_at.isoformat() if starts_at else None,
+        "location": row.get("location") or row.get("venue") or "",
+        "reg_url": row.get("reg_url") or row.get("registration_url") or "",
+        "results_link": row.get("results_link") or "",
+        "winners": row.get("winners"),
+        "event_type": row.get("event_type") or row.get("type"),
+        "category": row.get("category"),
+        "source": source,
+        "raw": row,
+    }
+    item["is_tournament"] = is_tournament_item(item)
+    return item
+
+
+def is_tournament_item(item: dict[str, Any]) -> bool:
+    source = str(item.get("source") or "").lower()
+    if source == "tournaments":
+        return True
+
+    event_type = item.get("event_type")
+    category = item.get("category")
+    if event_type is not None or category is not None:
+        type_blob = f"{event_type or ''} {category or ''}".strip().lower()
+        return "tournament" in type_blob
+
+    title = str(item.get("title") or "").lower()
+    return any(keyword in title for keyword in _TOURNAMENT_KEYWORDS)
+
+
+def _load_events_rows(club_id: str, *, supabase, events_rows: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    if events_rows is not None:
+        return [row for row in events_rows if str(row.get("club_id")) == str(club_id)]
+    if supabase is None:
+        return []
+    response = (
+        supabase.table("events")
+        .select("id,club_id,name,event_type,starts_at,created_at,notes")
+        .eq("club_id", club_id)
+        .execute()
+    )
+    return response.data or []
+
+
+def _load_tournaments_rows(club_id: str, *, supabase, tournaments_rows: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    if tournaments_rows is not None:
+        return [row for row in tournaments_rows if str(row.get("club_id")) == str(club_id)]
+    if supabase is None:
+        return []
+    response = (
+        supabase.table("tournaments")
+        .select("id,club_id,name,status,created_at")
+        .eq("club_id", club_id)
+        .execute()
+    )
+    return response.data or []
+
+
+def load_events_in_period(
+    club_id: str,
+    report_start: datetime,
+    report_end: datetime,
+    *,
+    supabase=None,
+    events_rows: list[dict[str, Any]] | None = None,
+    tournaments_rows: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    start_local = _coerce_dt(report_start)
+    end_local = _coerce_dt(report_end)
+    if start_local is None or end_local is None:
+        return []
+
+    items: list[dict[str, Any]] = []
+    for row in _load_events_rows(club_id, supabase=supabase, events_rows=events_rows):
+        item = _normalize_item(row, source="events")
+        dt = _coerce_dt(item.get("datetime"))
+        if dt is not None and start_local <= dt < end_local:
+            items.append(item)
+    for row in _load_tournaments_rows(club_id, supabase=supabase, tournaments_rows=tournaments_rows):
+        item = _normalize_item(row, source="tournaments")
+        dt = _coerce_dt(item.get("datetime"))
+        if dt is not None and start_local <= dt < end_local:
+            items.append(item)
+    return sorted(items, key=lambda x: x.get("datetime") or "")
+
+
+def load_events_upcoming(
+    club_id: str,
+    now: datetime,
+    lookahead_days: int,
+    *,
+    supabase=None,
+    events_rows: list[dict[str, Any]] | None = None,
+    tournaments_rows: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    now_local = _coerce_dt(now)
+    if now_local is None:
+        return []
+    return load_events_in_period(
+        club_id,
+        now_local,
+        now_local + timedelta(days=max(int(lookahead_days), 0)),
+        supabase=supabase,
+        events_rows=events_rows,
+        tournaments_rows=tournaments_rows,
+    )
+
+
+def validate_featured_past_event(
+    featured_past_event: dict[str, Any] | None,
+    report_start: datetime,
+    report_end: datetime,
+) -> ValidationResult:
+    if not featured_past_event:
+        return ValidationResult(ok=True)
+    featured_dt = _coerce_dt(featured_past_event.get("datetime"))
+    if featured_dt is None:
+        return ValidationResult(ok=True)
+    start_local = _coerce_dt(report_start)
+    end_local = _coerce_dt(report_end)
+    if start_local is None or end_local is None:
+        return ValidationResult(ok=False, error="Invalid report window")
+    if start_local <= featured_dt < end_local:
+        return ValidationResult(ok=True)
+    return ValidationResult(ok=False, error="featured_past_event must be inside [report_start, report_end)")
+
+
+def compute_recap(
+    club_id: str,
+    report_start: datetime,
+    report_end: datetime,
+    *,
+    lookahead_days: int,
+    now: datetime | None = None,
+    featured_upcoming_event: dict[str, Any] | None = None,
+    featured_past_event: dict[str, Any] | None = None,
+    supabase=None,
+    events_rows: list[dict[str, Any]] | None = None,
+    tournaments_rows: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    now_value = now or datetime.now(tz=MEXICO_CITY_TZ)
+    in_period = load_events_in_period(
+        club_id,
+        report_start,
+        report_end,
+        supabase=supabase,
+        events_rows=events_rows,
+        tournaments_rows=tournaments_rows,
+    )
+    upcoming = load_events_upcoming(
+        club_id,
+        now_value,
+        lookahead_days,
+        supabase=supabase,
+        events_rows=events_rows,
+        tournaments_rows=tournaments_rows,
+    )
+
+    events_in_period = [item for item in in_period if not item.get("is_tournament")]
+    tournaments_in_period = [item for item in in_period if item.get("is_tournament")]
+    upcoming_events = [item for item in upcoming if not item.get("is_tournament")]
+    upcoming_tournaments = [item for item in upcoming if item.get("is_tournament")]
+
+    featured_past = dict(featured_past_event or {})
+    featured_past_event_id = featured_past.get("event_id")
+    if featured_past_event_id:
+        matched = next((item for item in in_period if str(item.get("event_id")) == str(featured_past_event_id)), None)
+        if matched:
+            featured_past = {
+                **matched,
+                **featured_past,
+            }
+
+    return {
+        "club_id": str(club_id),
+        "report_start": _coerce_dt(report_start).isoformat() if _coerce_dt(report_start) else None,
+        "report_end": _coerce_dt(report_end).isoformat() if _coerce_dt(report_end) else None,
+        "events_in_period": events_in_period,
+        "tournaments_in_period": tournaments_in_period,
+        "upcoming_events": upcoming_events,
+        "upcoming_tournaments": upcoming_tournaments,
+        "featured_upcoming_event": featured_upcoming_event,
+        "featured_past_event": featured_past or None,
+        "featured_past_event_validation": validate_featured_past_event(featured_past or None, report_start, report_end).__dict__,
+    }

--- a/jupr_app/domain/recaps/store.py
+++ b/jupr_app/domain/recaps/store.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Protocol
+
+
+RecapVisibility = str
+
+
+@dataclass(frozen=True)
+class FeaturedUpcomingEvent:
+    title: str
+    datetime: str
+    location: str
+    reg_url: str
+    pitch: str
+    event_id: str | None = None
+
+
+@dataclass(frozen=True)
+class FeaturedPastEvent:
+    title: str
+    datetime: str
+    location: str
+    summary_bullets: list[str]
+    link_url: str
+    link_label: str
+    event_id: str | None = None
+
+
+@dataclass
+class RecapRecord:
+    recap_id: str
+    club_id: str
+    level: str
+    status: str
+    report_start: str
+    report_end: str
+    timezone: str = "America/Mexico_City"
+    visibility: RecapVisibility = "public"
+    featured_upcoming_event: FeaturedUpcomingEvent | None = None
+    featured_past_event: FeaturedPastEvent | None = None
+    content_snapshot: dict[str, Any] = field(default_factory=dict)
+    published_at: str | None = None
+
+
+class RecapStore(Protocol):
+    def save(self, recap: RecapRecord) -> RecapRecord: ...
+
+    def get(self, recap_id: str) -> RecapRecord | None: ...
+
+    def publish(self, recap_id: str, *, visibility: RecapVisibility | None = None) -> RecapRecord: ...
+
+
+class InMemoryRecapStore:
+    def __init__(self) -> None:
+        self._records: dict[str, RecapRecord] = {}
+
+    def save(self, recap: RecapRecord) -> RecapRecord:
+        saved = deepcopy(recap)
+        self._records[recap.recap_id] = saved
+        return deepcopy(saved)
+
+    def get(self, recap_id: str) -> RecapRecord | None:
+        recap = self._records.get(recap_id)
+        return deepcopy(recap) if recap else None
+
+    def publish(self, recap_id: str, *, visibility: RecapVisibility | None = None) -> RecapRecord:
+        recap = self._records.get(recap_id)
+        if recap is None:
+            raise KeyError(f"Recap not found: {recap_id}")
+        if recap.featured_upcoming_event is None:
+            raise ValueError("featured_upcoming_event is required at publish time")
+
+        recap.status = "published"
+        recap.visibility = visibility or "public"
+        recap.published_at = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+        self._records[recap_id] = deepcopy(recap)
+        return deepcopy(recap)

--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -12,15 +12,16 @@ from jupr_app.domain.recaps.weekly_recap import (
     build_around_descriptions,
 )
 
-def build_weekly_recap_html(
+def build_recap_html(
     recap: dict,
     *,
+    level: str = "weekly",
     print_view: bool,
     title_override: str | None = None,
 ) -> str:
     week_start = recap.get("week_start")
     week_end = recap.get("week_end")
-    title = title_override or "Tres Palapas Weekly Recap"
+    title = title_override or ("Tres Palapas Weekly Recap" if level == "weekly" else f"Tres Palapas {level.title()} Recap")
     theme = (recap.get("meta") or {}).get("print_theme", "classic")
 
     date_label = ""
@@ -38,6 +39,11 @@ def build_weekly_recap_html(
     around_descriptions = recap.get("around_descriptions") or build_around_descriptions(around)
     challenge_ladder = recap.get("challenge_ladder") or {}
     looking_ahead = recap.get("looking_ahead", []) or []
+
+    featured_past_event = recap.get("featured_past_event") or None
+    member_of_month = recap.get("member_of_month") or None
+    tournaments_in_period = recap.get("tournaments_in_period") or ((recap.get("content_snapshot") or {}).get("tournaments_in_period") or [])
+    upcoming_tournaments = recap.get("upcoming_tournaments") or ((recap.get("content_snapshot") or {}).get("upcoming_tournaments") or [])
 
     league_items = around.get("leagues", []) or []
     rr_items = around.get("round_robins", []) or []
@@ -116,6 +122,13 @@ def build_weekly_recap_html(
             accent_class=looking_ahead_accent,
         )
     looking_section_html = f"<div class='section'>{looking_card_html}</div>" if looking_card_html else ""
+
+    featured_past_section_html = _render_featured_past_event_section(featured_past_event)
+    member_of_month_section_html = _render_member_of_month_section(member_of_month) if level == "monthly" else ""
+    tournaments_section_html = _render_tournaments_section(
+        tournaments_in_period=tournaments_in_period,
+        upcoming_tournaments=upcoming_tournaments,
+    )
 
     print_mode_notice = "<!-- PRINT MODE -->" if print_view else ""
     print_view_css = ".no-print { display: none !important; }" if print_view else ""
@@ -352,6 +365,30 @@ def build_weekly_recap_html(
           .event-card.accent-ink {{
             border-left-color: var(--ink, #111827);
           }}
+          .tournament-subheading {{
+            margin: 10px 0 6px;
+            font-size: 13px;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--muted);
+          }}
+          .tournament-entry {{
+            border: 1px solid var(--border, #e5e7eb);
+            border-left: 4px solid var(--accent, #111827);
+            border-radius: 10px;
+            padding: 10px;
+            margin-bottom: 8px;
+            background: var(--card, #ffffff);
+          }}
+          .tournament-entry__title {{
+            font-weight: 700;
+            font-size: 14px;
+          }}
+          .tournament-entry__meta {{
+            margin-top: 4px;
+            color: var(--muted, #475569);
+            font-size: 12.5px;
+          }}
           @media (min-width: 820px) {{
             .award-grid {{
               grid-template-columns: 1fr 1fr;
@@ -407,6 +444,10 @@ def build_weekly_recap_html(
             .award-card,
             .event-card,
             .section-card,
+            .tournament-entry,
+            #featured-past-event,
+            #member-of-month,
+            #tournaments,
             .number-card {{
               break-inside: avoid;
               page-break-inside: avoid;
@@ -495,6 +536,9 @@ def build_weekly_recap_html(
               {around_cards_html}
             </div>
           </div>
+          {featured_past_section_html}
+          {member_of_month_section_html}
+          {tournaments_section_html}
           {challenge_ladder_section_html}
           {looking_section_html}
         </div>
@@ -504,10 +548,94 @@ def build_weekly_recap_html(
     return html
 
 
+def build_weekly_recap_html(
+    recap: dict,
+    *,
+    print_view: bool,
+    title_override: str | None = None,
+) -> str:
+    return build_recap_html(recap, level="weekly", print_view=print_view, title_override=title_override)
+
+
 def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | None = None) -> None:
     html = build_weekly_recap_html(recap, print_view=print_view, title_override=title_override)
     height = 2600 if not print_view else 3000
     components.html(html, height=height, scrolling=True)
+
+
+def _render_featured_past_event_section(featured_past_event: dict | None) -> str:
+    if not isinstance(featured_past_event, dict) or not featured_past_event:
+        return ""
+    title = str(featured_past_event.get("title") or "Featured Past Event").strip()
+    when = str(featured_past_event.get("datetime") or "").strip()
+    where = str(featured_past_event.get("location") or "").strip()
+    bullets = featured_past_event.get("summary_bullets") or []
+    link_url = str(featured_past_event.get("link_url") or "").strip()
+    link_label = str(featured_past_event.get("link_label") or "Learn more").strip()
+
+    details = []
+    if when:
+        details.append(f"<li><strong>Date:</strong> {escape(when)}</li>")
+    if where:
+        details.append(f"<li><strong>Location:</strong> {escape(where)}</li>")
+    for bullet in bullets:
+        text = str(bullet).strip()
+        if text:
+            details.append(f"<li>{escape(text)}</li>")
+    if link_url:
+        details.append(f"<li><a href=\"{escape(link_url)}\">{escape(link_label or 'Learn more')}</a></li>")
+
+    body = f"<ul class='compact'>{''.join(details)}</ul>" if details else ""
+    fallback_body = "<div class='muted-label'>No details provided.</div>"
+    card_html = _render_simple_card(title=title, body_html=body or fallback_body, accent_class="accent-ocean")
+    return f"<div class='section' id='featured-past-event'>{card_html}</div>"
+
+
+def _render_member_of_month_section(member_of_month: dict | None) -> str:
+    if not isinstance(member_of_month, dict) or not member_of_month:
+        return ""
+    name = escape(str(member_of_month.get("name") or member_of_month.get("member_name") or "Member of the Month"))
+    summary = escape(str(member_of_month.get("summary") or ""))
+    body = f"<div class='event-card__desc'>{summary}</div>" if summary else ""
+    fallback_body = "<div class='muted-label'>Member spotlight</div>"
+    card_html = _render_simple_card(title=name, body_html=body or fallback_body, accent_class="accent-sand")
+    return f"<div class='section' id='member-of-month'>{card_html}</div>"
+
+
+def _render_tournament_entry(item: dict, *, include_register: bool) -> str:
+    title = escape(str(item.get("title") or "Tournament").strip())
+    dt = escape(str(item.get("datetime") or "").strip())
+    location = escape(str(item.get("location") or "").strip())
+    reg_url = str(item.get("reg_url") or "").strip()
+    results_link = str(item.get("results_link") or "").strip()
+    meta_parts = [part for part in [dt, location] if part]
+    links = []
+    if include_register and reg_url:
+        links.append(f"<a href=\"{escape(reg_url)}\">Register</a>")
+    if results_link:
+        links.append(f"<a href=\"{escape(results_link)}\">Results</a>")
+    links_html = (" • ".join(links)) if links else ""
+    meta_html = f"<div class='tournament-entry__meta'>{escape(' • '.join(meta_parts))}</div>" if meta_parts else ""
+    if links_html:
+        meta_html += f"<div class='tournament-entry__meta'>{links_html}</div>"
+    return f"<div class='tournament-entry'><div class='tournament-entry__title'>{title}</div>{meta_html}</div>"
+
+
+def _render_tournaments_section(*, tournaments_in_period: list[dict], upcoming_tournaments: list[dict]) -> str:
+    in_period = [item for item in tournaments_in_period if isinstance(item, dict)]
+    upcoming = [item for item in upcoming_tournaments if isinstance(item, dict)]
+    if not in_period and not upcoming:
+        return ""
+
+    in_period_html = "".join(_render_tournament_entry(item, include_register=False) for item in in_period)
+    upcoming_html = "".join(_render_tournament_entry(item, include_register=True) for item in upcoming)
+    body_parts = [
+        "<div class='tournament-subheading'>Tournaments This Period</div>",
+        in_period_html or "<div class='muted-label'>No tournaments in this reporting window.</div>",
+        "<div class='tournament-subheading'>Upcoming Tournaments</div>",
+        upcoming_html or "<div class='muted-label'>No upcoming tournaments in lookahead window.</div>",
+    ]
+    return f"<div class='section' id='tournaments'>{_render_simple_card(title='Tournaments', body_html=''.join(body_parts), accent_class='accent-sunset')}</div>"
 
 
 def _render_award_card(item: dict, *, theme: str) -> str:

--- a/supabase/migrations/20260223_recap_artifacts_snapshot.sql
+++ b/supabase/migrations/20260223_recap_artifacts_snapshot.sql
@@ -1,0 +1,12 @@
+alter table public.weekly_recaps
+    add column if not exists visibility text not null default 'public',
+    add column if not exists featured_upcoming_event jsonb not null default '{}'::jsonb,
+    add column if not exists featured_past_event jsonb null,
+    add column if not exists content_snapshot jsonb not null default '{}'::jsonb;
+
+alter table public.weekly_recaps
+    drop constraint if exists weekly_recaps_visibility_check;
+
+alter table public.weekly_recaps
+    add constraint weekly_recaps_visibility_check
+    check (visibility in ('public', 'unlisted', 'private'));

--- a/tests/test_recap_engine.py
+++ b/tests/test_recap_engine.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+
+from jupr_app.domain.recaps.engine import (
+    compute_recap,
+    is_tournament_item,
+    validate_featured_past_event,
+)
+
+
+def test_tournament_classifier_prefers_type_over_keyword_fallback() -> None:
+    typed_non_tournament = {
+        "title": "Summer Tournament Preview",
+        "event_type": "social",
+        "category": None,
+        "source": "events",
+    }
+    typed_tournament = {
+        "title": "Weekly Mixer",
+        "event_type": "tournament",
+        "category": None,
+        "source": "events",
+    }
+    keyword_fallback = {
+        "title": "Baja Open",
+        "event_type": None,
+        "category": None,
+        "source": "events",
+    }
+
+    assert is_tournament_item(typed_non_tournament) is False
+    assert is_tournament_item(typed_tournament) is True
+    assert is_tournament_item(keyword_fallback) is True
+
+
+def test_validate_featured_past_event_in_window() -> None:
+    report_start = datetime.fromisoformat("2026-02-10T00:00:00-06:00")
+    report_end = datetime.fromisoformat("2026-02-17T00:00:00-06:00")
+
+    ok_result = validate_featured_past_event(
+        {"datetime": "2026-02-12T20:00:00-06:00"},
+        report_start,
+        report_end,
+    )
+    bad_result = validate_featured_past_event(
+        {"datetime": "2026-02-17T00:00:00-06:00"},
+        report_start,
+        report_end,
+    )
+
+    assert ok_result.ok is True
+    assert bad_result.ok is False
+
+
+def test_compute_recap_buckets_events_and_tournaments() -> None:
+    report_start = datetime.fromisoformat("2026-02-10T00:00:00-06:00")
+    report_end = datetime.fromisoformat("2026-02-17T00:00:00-06:00")
+    now = datetime.fromisoformat("2026-02-17T00:00:00-06:00")
+
+    events_rows = [
+        {
+            "id": "event-1",
+            "club_id": "club-1",
+            "name": "Members Night",
+            "event_type": "social",
+            "starts_at": "2026-02-12T18:00:00-06:00",
+        },
+        {
+            "id": "event-2",
+            "club_id": "club-1",
+            "name": "Club Open",
+            "starts_at": "2026-02-14T09:00:00-06:00",
+        },
+        {
+            "id": "event-3",
+            "club_id": "club-1",
+            "name": "Sunset Social",
+            "event_type": "social",
+            "starts_at": "2026-02-20T18:00:00-06:00",
+        },
+    ]
+    tournaments_rows = [
+        {
+            "id": "tour-1",
+            "club_id": "club-1",
+            "name": "Winter Cup",
+            "created_at": "2026-02-11T10:00:00-06:00",
+        },
+        {
+            "id": "tour-2",
+            "club_id": "club-1",
+            "name": "Spring Classic",
+            "created_at": "2026-02-19T11:00:00-06:00",
+        },
+    ]
+
+    recap = compute_recap(
+        "club-1",
+        report_start,
+        report_end,
+        lookahead_days=7,
+        now=now,
+        featured_past_event={"event_id": "event-2", "link_label": "Recap"},
+        events_rows=events_rows,
+        tournaments_rows=tournaments_rows,
+    )
+
+    assert [item["event_id"] for item in recap["events_in_period"]] == ["event-1"]
+    assert [item["event_id"] for item in recap["tournaments_in_period"]] == ["tour-1", "event-2"]
+    assert [item["event_id"] for item in recap["upcoming_events"]] == ["event-3"]
+    assert [item["event_id"] for item in recap["upcoming_tournaments"]] == ["tour-2"]
+    assert recap["featured_past_event"]["title"] == "Club Open"
+    assert recap["featured_past_event"]["link_label"] == "Recap"

--- a/tests/test_recap_html_layout.py
+++ b/tests/test_recap_html_layout.py
@@ -1,0 +1,62 @@
+from jupr_app.ui.components.weekly_recap_layout import build_recap_html, build_weekly_recap_html
+
+
+def _base_recap() -> dict:
+    return {
+        "week_start": "2026-02-10",
+        "week_end": "2026-02-16",
+        "numbers": {},
+        "spotlight": [],
+        "around_club": {"leagues": [], "round_robins": []},
+        "around_descriptions": {},
+        "challenge_ladder": {},
+        "looking_ahead": [],
+        "meta": {},
+    }
+
+
+def test_featured_past_event_section_rendered_when_present() -> None:
+    recap = _base_recap()
+    recap["featured_past_event"] = {
+        "title": "Winter Open Finals",
+        "datetime": "2026-02-12T19:00:00-06:00",
+        "location": "Center Court",
+        "summary_bullets": ["Packed crowd"],
+    }
+
+    html = build_weekly_recap_html(recap, print_view=False)
+
+    assert "id='featured-past-event'" in html
+    assert "Winter Open Finals" in html
+
+
+def test_tournaments_section_rendered_with_subheadings() -> None:
+    recap = _base_recap()
+    recap["tournaments_in_period"] = [
+        {"title": "Baja Classic", "datetime": "2026-02-14T09:00:00-06:00", "location": "Court A"}
+    ]
+    recap["upcoming_tournaments"] = [
+        {
+            "title": "Spring Open",
+            "datetime": "2026-02-21T09:00:00-06:00",
+            "location": "Court B",
+            "reg_url": "https://example.com/register",
+        }
+    ]
+
+    html = build_weekly_recap_html(recap, print_view=False)
+
+    assert "id='tournaments'" in html
+    assert "Tournaments This Period" in html
+    assert "Upcoming Tournaments" in html
+    assert "Register" in html
+
+
+def test_monthly_member_of_month_anchor_rendered_when_provided() -> None:
+    recap = _base_recap()
+    recap["member_of_month"] = {"name": "Ana", "summary": "Great leadership."}
+
+    html = build_recap_html(recap, level="monthly", print_view=False)
+
+    assert "id='member-of-month'" in html
+    assert "Ana" in html

--- a/tests/test_recaps_store.py
+++ b/tests/test_recaps_store.py
@@ -1,0 +1,89 @@
+from jupr_app.domain.recaps.store import (
+    FeaturedPastEvent,
+    FeaturedUpcomingEvent,
+    InMemoryRecapStore,
+    RecapRecord,
+)
+
+
+def _base_recap() -> RecapRecord:
+    return RecapRecord(
+        recap_id="recap-1",
+        club_id="club-1",
+        level="weekly",
+        status="draft",
+        report_start="2026-02-09T00:00:00-06:00",
+        report_end="2026-02-16T00:00:00-06:00",
+        featured_upcoming_event=FeaturedUpcomingEvent(
+            event_id="event-upcoming-1",
+            title="Club Mixer",
+            datetime="2026-02-20T18:00:00-06:00",
+            location="Center Court",
+            reg_url="https://example.com/register",
+            pitch="Sign up now!",
+        ),
+    )
+
+
+def test_featured_past_event_can_be_stored() -> None:
+    store = InMemoryRecapStore()
+    recap = _base_recap()
+    recap.featured_past_event = FeaturedPastEvent(
+        event_id="event-past-1",
+        title="Winter Doubles",
+        datetime="2026-02-10T19:00:00-06:00",
+        location="Court 2",
+        summary_bullets=["Great turnout", "Tight finals"],
+        link_url="https://example.com/results",
+        link_label="Full Results",
+    )
+
+    store.save(recap)
+    saved = store.get(recap.recap_id)
+
+    assert saved is not None
+    assert saved.featured_past_event is not None
+    assert saved.featured_past_event.event_id == "event-past-1"
+
+
+def test_content_snapshot_can_store_tournaments_lists() -> None:
+    store = InMemoryRecapStore()
+    recap = _base_recap()
+    recap.content_snapshot = {
+        "tournaments_in_period": [
+            {
+                "title": "Winter Open",
+                "datetime": "2026-02-12T10:00:00-06:00",
+                "location": "Main Courts",
+                "results_link": "https://example.com/winter-open",
+                "winners": ["A Team", "B Team"],
+            }
+        ],
+        "upcoming_tournaments": [
+            {
+                "title": "Spring Classic",
+                "datetime": "2026-02-28T09:00:00-06:00",
+                "location": "North Courts",
+                "reg_url": "https://example.com/spring-classic",
+            }
+        ],
+    }
+
+    store.save(recap)
+    saved = store.get(recap.recap_id)
+
+    assert saved is not None
+    assert saved.content_snapshot["tournaments_in_period"][0]["title"] == "Winter Open"
+    assert saved.content_snapshot["upcoming_tournaments"][0]["title"] == "Spring Classic"
+
+
+def test_publish_defaults_visibility_to_public() -> None:
+    store = InMemoryRecapStore()
+    recap = _base_recap()
+    recap.visibility = "private"
+    store.save(recap)
+
+    published = store.publish(recap.recap_id)
+
+    assert published.status == "published"
+    assert published.visibility == "public"


### PR DESCRIPTION
### Motivation
- Persist recap artifacts required by the Recap Composer MVP: featured upcoming event (required at publish), optional featured past event (within report window), and tournaments snapshot data. 
- Record recap visibility with the canonical `public`/`unlisted`/`private` semantics and default `public` at publish time. 
- Provide a simple store interface and in-memory implementation to exercise read/write/publish behavior and enforce publish-time validation.

### Description
- Added a DB migration `supabase/migrations/20260223_recap_artifacts_snapshot.sql` that alters `public.weekly_recaps` to add `visibility` (default `'public'` with a CHECK constraint), `featured_upcoming_event` (JSONB), `featured_past_event` (JSONB, nullable), and `content_snapshot` (JSONB) fields. 
- Introduced a typed recap store module `jupr_app/domain/recaps/store.py` containing `FeaturedUpcomingEvent`, `FeaturedPastEvent`, `RecapRecord`, a `RecapStore` protocol, and an `InMemoryRecapStore` implementing `save`, `get`, and `publish`; `publish` enforces that `featured_upcoming_event` is present and defaults visibility to `public`. 
- Added tests `tests/test_recaps_store.py` that verify storing a `featured_past_event`, storing tournaments lists inside `content_snapshot`, and that `publish` still defaults visibility to `public`.

### Testing
- Ran the new in-memory tests with `pytest -q tests/test_recaps_store.py`, which executed 3 tests and they all passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8430b1f88326971ad8b056a8c494)