### PR TITLE
Fix live ladder submit flow to advance to Confirm Movement

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -14,7 +14,7 @@ import streamlit as st
 from jupr_court_board import court_board
 
 from jupr_app.domain.constants import DEFAULT_K_FACTOR
-from jupr_app.domain.live_ladder import validate_courts
+from jupr_app.domain.live_ladder import build_movement_preview, compute_round_stats, validate_courts
 from jupr_app.domain.league_night_roster import (
     RosterChangeError,
     apply_roster_change,
@@ -835,9 +835,19 @@ def render(ctx):
                 submitted = st.form_submit_button("Submit Round & Calculate Movement")
 
             if submitted:
-                st.session_state["_nav_pending"] = "🧾 Record Match"
-                st.query_params["page"] = "record_match"
-                st.rerun()
+                roster_pids = roster_now["player_id"].astype(int).tolist()
+                round_stats = compute_round_stats(all_results, roster_pids)
+                max_court = int(roster_now["court"].astype(int).max()) if not roster_now.empty else 1
+                movement_df = build_movement_preview(roster_now.copy(), round_stats, max_court=max_court)
+
+                if movement_df is None or movement_df.empty:
+                    st.error("Unable to compute movement preview. Check round scores and try again.")
+                    st.stop()
+
+                st.session_state.ladder_movement_preview = movement_df
+                st.session_state.ladder_state = "CONFIRM_MOVEMENT"
+                _rerun()
+                st.stop()
 
         # -------------------------
         # 5) CONFIRM MOVEMENT


### PR DESCRIPTION
### Motivation
- The live ladder scoring submit action was incorrectly forcing global navigation to the Record Match page, bypassing the ladder state machine and breaking the intended round -> movement workflow.
- The change restores deterministic in-page progression so scoring advances to movement preview and next-round confirmation instead of leaving the ladder flow.

### Description
- Replaced the submit handler's explicit navigation override with a proper in-flow transition in `jupr_app/ui/pages/league_manager.py` by importing `compute_round_stats` and `build_movement_preview` from `jupr_app.domain.live_ladder`.
- On `Submit Round & Calculate Movement`, the code now computes `round_stats` from entered scores, builds `movement_df` from the current roster, stores `st.session_state.ladder_movement_preview`, sets `st.session_state.ladder_state = "CONFIRM_MOVEMENT"`, and performs a rerun via `_rerun()` followed by `st.stop()` to prevent fallthrough.
- Added a guard that shows an error and halts if the movement preview cannot be computed (empty/invalid), preserving the current state for correction.

### Testing
- Ran the existing unit tests: `pytest -q tests/test_league_night_roster.py` and all tests passed (`6 passed`).
- Manual inspection of state transitions and navigation logic in `streamlit_app.py` and `league_manager.py` was performed to ensure the app-level navigation (`_nav_pending` / `query_params`) is no longer written by the submit path and that the ladder state machine is the single source of truth for progression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b95b0665c8326a6a49a8708dbc9d5)