### PR TITLE
Fix court board remount between rounds

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -241,7 +241,8 @@ def _render_court_board_grid(roster_df: pd.DataFrame, max_per_row: int = 4) -> N
         )
 
     round_num = int(st.session_state.get("ladder_round_num", 1))
-    result = court_board(courts_payload, key=f"court_board_confirm_start_r{round_num}")
+    board_nonce = int(st.session_state.get("ladder_board_nonce", 0))
+    result = court_board(courts_payload, key=f"court_board_confirm_start_r{round_num}_v{board_nonce}")
     if not (result and isinstance(result, dict) and "courts" in result):
         return
 
@@ -310,6 +311,7 @@ def render(ctx):
     st.session_state.setdefault("ladder_total_rounds", 5)
     st.session_state.setdefault("ladder_roster", [])
     st.session_state.setdefault("ladder_court_sizes", [])
+    st.session_state.setdefault("ladder_board_nonce", 0)
 
     df_players_all = ctx.df_players_all
     df_leagues = ctx.df_leagues
@@ -686,6 +688,7 @@ def render(ctx):
                     )
                     st.session_state.ladder_print_sheet = print_df
 
+                    st.session_state.ladder_board_nonce = int(st.session_state.get("ladder_board_nonce", 0)) + 1
                     st.session_state.ladder_state = "CONFIRM_START"
                     _rerun()
                     return
@@ -1206,6 +1209,7 @@ def render(ctx):
                 st.session_state.pop("ladder_roster_bench_ids", None)
 
                 st.session_state.ladder_round_num = current_r + 1
+                st.session_state.ladder_board_nonce = int(st.session_state.get("ladder_board_nonce", 0)) + 1
                 st.session_state.ladder_state = "CONFIRM_START"
                 st.session_state.pop("current_schedule", None)
                 _rerun()


### PR DESCRIPTION
### Motivation
- The court board UI could fail to re-render when moving between rounds because the Streamlit component key stayed constant, preventing a remount with the updated roster.  

### Description
- Append a session nonce to the `court_board` component key so each version is unique (`court_board_confirm_start_r{round}_v{nonce}`).  
- Initialize `ladder_board_nonce` in `st.session_state` defaults.  
- Increment `ladder_board_nonce` when entering `CONFIRM_START` after the initial preview and when advancing to the next round so the component is forced to remount.  
- Modified file: `jupr_app/ui/pages/league_manager.py`.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/league_manager.py` which succeeded.  
- Ran `pytest -q` which produced 9 failing tests in unrelated areas (match pipeline, schema preflight, tournament, and UI token tests); these failures appear outside the scope of the `league_manager.py` change.  
- Also exercised the app locally via `start.sh` and captured a homepage screenshot to validate the UI loaded (manual visual smoke check).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb348449083269dd7741ec1a9b845)