### PR TITLE
Enforce canonical session league keys to preserve rating partitions

### DIFF
--- a/docs/session-ladder/schema.md
+++ b/docs/session-ladder/schema.md
@@ -20,12 +20,12 @@ Represents a single run-night/session.
 Key columns:
 - `id` (uuid pk)
 - `club_id` (FK to `clubs.id`)
-- `league_id` (text)
+- `league_id` (text, **league key** used for rating partition continuity)
 - `season_id` (nullable text)
 - `session_starts_at`, `session_ends_at`
 - `courts_available`
 - `players_per_court` (check: 4 or 5)
-- `state` (`draft/setup/active/completed/cancelled/archived`)
+- `state` (`draft/roster_open/seeded_locked/round_1_active/round_1_closed/round_2_active/round_2_closed/round_3_active/round_3_closed/completed/published`)
 - audit: `created_by`, `updated_by`, `created_at`, `updated_at`
 
 Indexes:
@@ -128,3 +128,9 @@ This follows existing tenant-club policy patterns while adding manager/admin wri
 - `session_ladder_rating_history` stores per-player session rating deltas (idempotent key: `session_id + player_id`).
 - `session_ladder_attendance` stores per-session attendance facts.
 - `session_ladder_awards_attendance` stores cumulative attendance counts by `(club_id, league_id, season_id, player_id)` for awards eligibility checks.
+
+## League key and rating continuity contract
+
+- Session Ladder stores the **rating partition key** in `session_ladder_sessions.league_id`.
+- This key must match `league_ratings.league_name` exactly for ratings to continue in the same league partition.
+- Session creation resolves/validates this value against `leagues_metadata.league_name` (case-insensitive lookup, canonical stored casing) before the session row is created.

--- a/jupr_app/domain/session_ladder_models.py
+++ b/jupr_app/domain/session_ladder_models.py
@@ -3,10 +3,25 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
+from enum import Enum
 from typing import Literal
 
 
-SessionState = Literal["draft", "setup", "active", "completed", "cancelled", "archived"]
+class SessionState(str, Enum):
+    DRAFT = "draft"
+    ROSTER_OPEN = "roster_open"
+    SEEDED_LOCKED = "seeded_locked"
+    ROUND_1_ACTIVE = "round_1_active"
+    ROUND_1_CLOSED = "round_1_closed"
+    ROUND_2_ACTIVE = "round_2_active"
+    ROUND_2_CLOSED = "round_2_closed"
+    ROUND_3_ACTIVE = "round_3_active"
+    ROUND_3_CLOSED = "round_3_closed"
+    COMPLETED = "completed"
+    PUBLISHED = "published"
+
+
+SESSION_STATE_VALUES = tuple(state.value for state in SessionState)
 RosterStatus = Literal["EXPECTED", "CHECKED_IN", "NO_SHOW", "WALK_IN"]
 CourtPodState = Literal["planned", "in_progress", "complete", "void"]
 

--- a/jupr_app/domain/session_ladder_service.py
+++ b/jupr_app/domain/session_ladder_service.py
@@ -13,33 +13,22 @@ from jupr_app.domain.session_ladder_engine import (
     getMovers,
     resolveTies,
 )
+from jupr_app.domain.session_ladder_models import SessionState
 
-SESSION_STATES = [
-    "DRAFT",
-    "ROSTER_OPEN",
-    "SEEDED_LOCKED",
-    "ROUND_1_ACTIVE",
-    "ROUND_1_CLOSED",
-    "ROUND_2_ACTIVE",
-    "ROUND_2_CLOSED",
-    "ROUND_3_ACTIVE",
-    "ROUND_3_CLOSED",
-    "COMPLETED",
-    "PUBLISHED",
-]
+SESSION_STATES = [state.value for state in SessionState]
 
 _VALID_TRANSITIONS = {
-    "DRAFT": {"ROSTER_OPEN"},
-    "ROSTER_OPEN": {"SEEDED_LOCKED"},
-    "SEEDED_LOCKED": {"ROUND_1_ACTIVE"},
-    "ROUND_1_ACTIVE": {"ROUND_1_CLOSED"},
-    "ROUND_1_CLOSED": {"ROUND_2_ACTIVE"},
-    "ROUND_2_ACTIVE": {"ROUND_2_CLOSED"},
-    "ROUND_2_CLOSED": {"ROUND_3_ACTIVE", "COMPLETED"},
-    "ROUND_3_ACTIVE": {"ROUND_3_CLOSED"},
-    "ROUND_3_CLOSED": {"COMPLETED"},
-    "COMPLETED": {"PUBLISHED"},
-    "PUBLISHED": set(),
+    SessionState.DRAFT: {SessionState.ROSTER_OPEN},
+    SessionState.ROSTER_OPEN: {SessionState.SEEDED_LOCKED},
+    SessionState.SEEDED_LOCKED: {SessionState.ROUND_1_ACTIVE},
+    SessionState.ROUND_1_ACTIVE: {SessionState.ROUND_1_CLOSED},
+    SessionState.ROUND_1_CLOSED: {SessionState.ROUND_2_ACTIVE},
+    SessionState.ROUND_2_ACTIVE: {SessionState.ROUND_2_CLOSED},
+    SessionState.ROUND_2_CLOSED: {SessionState.ROUND_3_ACTIVE, SessionState.COMPLETED},
+    SessionState.ROUND_3_ACTIVE: {SessionState.ROUND_3_CLOSED},
+    SessionState.ROUND_3_CLOSED: {SessionState.COMPLETED},
+    SessionState.COMPLETED: {SessionState.PUBLISHED},
+    SessionState.PUBLISHED: set(),
 }
 
 
@@ -51,9 +40,38 @@ class SessionCompleteness:
 
 
 def canTransition(from_state: str, to_state: str) -> bool:
-    src = str(from_state or "").strip().upper()
-    dst = str(to_state or "").strip().upper()
+    src = _parse_session_state(from_state)
+    dst = _parse_session_state(to_state)
+    if src is None or dst is None:
+        return False
     return dst in _VALID_TRANSITIONS.get(src, set())
+
+
+def _parse_session_state(state: str | SessionState | None) -> SessionState | None:
+    if isinstance(state, SessionState):
+        return state
+    normalized = str(state or "").strip().lower()
+    if not normalized:
+        return None
+    normalized = normalized.replace(" ", "_")
+    try:
+        return SessionState(normalized)
+    except ValueError:
+        legacy = {
+            "setup": SessionState.SEEDED_LOCKED,
+            "active": SessionState.ROSTER_OPEN,
+            "cancelled": SessionState.COMPLETED,
+            "archived": SessionState.PUBLISHED,
+        }
+        return legacy.get(normalized)
+
+
+def _round_state(round_number: int, phase: str) -> SessionState:
+    key = f"round_{int(round_number)}_{str(phase).strip().lower()}"
+    try:
+        return SessionState(key)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported round state: {key}") from exc
 
 
 def _fetch_rows(supabase: Any, table: str, **filters: Any) -> list[dict[str, Any]]:
@@ -117,7 +135,7 @@ def createSession(
         "courts_available": int(courts_available),
         "players_per_court": int(players_per_court),
         "rounds_planned": max(2, min(int(rounds_planned), 3)),
-        "state": "DRAFT",
+        "state": SessionState.DRAFT.value,
         "created_by": str(created_by),
         "updated_by": str(created_by),
     }
@@ -209,11 +227,11 @@ def seedCourtsByRating(supabase: Any, *, sessionId: str, seeded_by: str) -> list
 
 
 def lockSeeding(supabase: Any, *, sessionId: str, updated_by: str) -> dict[str, Any]:
-    return _transition_state(supabase, sessionId=sessionId, to_state="SEEDED_LOCKED", updated_by=updated_by)
+    return _transition_state(supabase, sessionId=sessionId, to_state=SessionState.SEEDED_LOCKED, updated_by=updated_by)
 
 
 def startRound(supabase: Any, *, sessionId: str, roundNumber: int, updated_by: str) -> dict[str, Any]:
-    state = f"ROUND_{int(roundNumber)}_ACTIVE"
+    state = _round_state(roundNumber, "active")
     out = _transition_state(supabase, sessionId=sessionId, to_state=state, updated_by=updated_by)
     sb_update(
         supabase,
@@ -237,8 +255,8 @@ def submitGameResult(
     edited_by: str,
 ) -> dict[str, Any]:
     session = _require_session(supabase, sessionId)
-    state = str(session.get("state") or "").upper()
-    if state in {"COMPLETED", "PUBLISHED"}:
+    state = _parse_session_state(session.get("state"))
+    if state in {SessionState.COMPLETED, SessionState.PUBLISHED}:
         raise RuntimeError("Session is locked; game results cannot be edited after completion/publish")
     payload = {
         "club_id": str(session["club_id"]),
@@ -285,7 +303,7 @@ def closeRound(
     if incomplete_courts and not bool(allow_override):
         raise RuntimeError(f"Cannot close round: incomplete courts {incomplete_courts}")
 
-    state = f"ROUND_{int(roundNumber)}_CLOSED"
+    state = _round_state(roundNumber, "closed")
     _transition_state(supabase, sessionId=sessionId, to_state=state, updated_by=updated_by)
 
     ranked_courts: list[list[int]] = []
@@ -413,7 +431,7 @@ def completeSession(supabase: Any, *, sessionId: str, updated_by: str) -> dict[s
     completeness = validateSessionCompleteness(supabase, sessionId)
     if not completeness.ok:
         raise RuntimeError(f"Session incomplete: {completeness.missing}")
-    result = _transition_state(supabase, sessionId=sessionId, to_state="COMPLETED", updated_by=updated_by)
+    result = _transition_state(supabase, sessionId=sessionId, to_state=SessionState.COMPLETED, updated_by=updated_by)
     rating_summary = _apply_session_rating_updates(supabase, session_id=sessionId, updated_by=updated_by)
     result["rating_update_hook_triggered"] = True
     result["rating_update"] = rating_summary
@@ -422,24 +440,57 @@ def completeSession(supabase: Any, *, sessionId: str, updated_by: str) -> dict[s
 
 def publishSession(supabase: Any, *, sessionId: str, updated_by: str) -> dict[str, Any]:
     session = _require_session(supabase, sessionId)
-    if str(session.get("state") or "").upper() != "PUBLISHED":
-        _transition_state(supabase, sessionId=sessionId, to_state="PUBLISHED", updated_by=updated_by)
+    if _is_already_published(session):
+        return _published_response_from_session(session)
+
+    current_state = _parse_session_state(session.get("state"))
+    if current_state is None or not canTransition(current_state, SessionState.PUBLISHED):
+        raise RuntimeError(f"Invalid state transition: {current_state} -> {SessionState.PUBLISHED}")
 
     attendance = _apply_attendance_for_session(supabase, session_id=sessionId, updated_by=updated_by)
     recap = _build_session_recap(supabase, session_id=sessionId)
     leaderboard = _build_ratings_leaderboard(supabase, club_id=str(session.get("club_id") or ""))
-    sb_update(
+    published_at = datetime.now(timezone.utc).isoformat()
+    snapshot = {"recap": recap, "leaderboard": leaderboard, "attendance": attendance}
+    published_rows = sb_update(
         supabase,
         "session_ladder_sessions",
         {
-            "published_at": datetime.now(timezone.utc).isoformat(),
+            "state": SessionState.PUBLISHED.value,
+            "published_at": published_at,
             "recap_json": recap,
             "leaderboard_json": leaderboard,
+            "published_snapshot_json": snapshot,
             "updated_by": str(updated_by),
         },
-        filters={"id": str(sessionId)},
+        filters={"id": str(sessionId), "published_at": None},
+    ).data or []
+
+    if not published_rows:
+        return _published_response_from_session(_require_session(supabase, sessionId))
+
+    return _published_response_from_session(dict(published_rows[0]))
+
+
+def _is_already_published(session: dict[str, Any]) -> bool:
+    return _parse_session_state(session.get("state")) == SessionState.PUBLISHED or bool(session.get("published_at"))
+
+
+def _published_response_from_session(session: dict[str, Any]) -> dict[str, Any]:
+    snapshot = session.get("published_snapshot_json") or {}
+    if not isinstance(snapshot, dict):
+        snapshot = {}
+
+    recap = snapshot.get("recap") if isinstance(snapshot.get("recap"), dict) else session.get("recap_json") or {}
+    leaderboard = (
+        snapshot.get("leaderboard")
+        if isinstance(snapshot.get("leaderboard"), list)
+        else session.get("leaderboard_json") or []
     )
-    out = _require_session(supabase, sessionId)
+    attendance = snapshot.get("attendance") if isinstance(snapshot.get("attendance"), dict) else {}
+
+    out = dict(session)
+    out["state"] = SessionState.PUBLISHED.value
     out["recap"] = recap
     out["leaderboard"] = leaderboard
     out["attendance"] = attendance
@@ -609,21 +660,29 @@ def _build_ratings_leaderboard(supabase: Any, *, club_id: str) -> list[dict[str,
     ]
 
 
-def _transition_state(supabase: Any, *, sessionId: str, to_state: str, updated_by: str) -> dict[str, Any]:
+def _transition_state(
+    supabase: Any,
+    *,
+    sessionId: str,
+    to_state: str | SessionState,
+    updated_by: str,
+) -> dict[str, Any]:
     session = _require_session(supabase, sessionId)
-    current = str(session.get("state") or "").upper()
-    target = str(to_state).upper()
+    current = _parse_session_state(session.get("state"))
+    target = _parse_session_state(to_state)
+    if target is None:
+        raise RuntimeError(f"Invalid target state: {to_state}")
     if current == target:
         return session
-    if not canTransition(current, target):
+    if current is None or not canTransition(current, target):
         raise RuntimeError(f"Invalid state transition: {current} -> {target}")
 
     sb_update(
         supabase,
         "session_ladder_sessions",
-        {"state": target, "updated_by": str(updated_by)},
+        {"state": target.value, "updated_by": str(updated_by)},
         filters={"id": str(sessionId)},
     )
-    session["state"] = target
+    session["state"] = target.value
     session["updated_by"] = str(updated_by)
     return session

--- a/services/session_ladder_api.py
+++ b/services/session_ladder_api.py
@@ -23,10 +23,11 @@ from jupr_app.domain.session_ladder_service import (
 def post_create_session(*, supabase: Any, auth: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
     _require_feature()
     _require_mutation_access(auth)
+    league_key = _resolve_session_league_key(supabase=supabase, club_id=str(auth.get("club_id") or ""), payload=payload)
     session = createSession(
         supabase,
         club_id=str(auth.get("club_id") or ""),
-        league_id=str(payload.get("league_id") or ""),
+        league_id=league_key,
         season_id=payload.get("season_id"),
         session_starts_at=str(payload.get("session_starts_at") or ""),
         courts_available=int(payload.get("courts_available") or 0),
@@ -35,6 +36,29 @@ def post_create_session(*, supabase: Any, auth: dict[str, Any], payload: dict[st
         created_by=str(auth.get("user_id") or auth.get("email") or "api"),
     )
     return {"session": session}
+
+
+def _resolve_session_league_key(*, supabase: Any, club_id: str, payload: dict[str, Any]) -> str:
+    raw_key = payload.get("league_key")
+    if raw_key is None:
+        raw_key = payload.get("league_id")
+    candidate = str(raw_key or "").strip()
+    if not candidate:
+        raise ValueError("league_key (or legacy league_id) is required")
+
+    rows = (
+        supabase.table("leagues_metadata")
+        .select("league_name")
+        .eq("club_id", str(club_id))
+        .execute()
+        .data
+        or []
+    )
+    by_key = {str(r.get("league_name") or "").strip().lower(): str(r.get("league_name") or "").strip() for r in rows}
+    canonical = by_key.get(candidate.lower())
+    if not canonical:
+        raise ValueError(f"Unknown league key for club {club_id}: {candidate}")
+    return canonical
 
 
 def get_session_details(*, supabase: Any, auth: dict[str, Any], session_id: str) -> dict[str, Any]:

--- a/supabase/migrations/20260816_session_ladder_session_state_alignment.sql
+++ b/supabase/migrations/20260816_session_ladder_session_state_alignment.sql
@@ -1,0 +1,44 @@
+begin;
+
+update public.session_ladder_sessions
+set state = case lower(state)
+  when 'draft' then 'draft'
+  when 'roster_open' then 'roster_open'
+  when 'seeded_locked' then 'seeded_locked'
+  when 'round_1_active' then 'round_1_active'
+  when 'round_1_closed' then 'round_1_closed'
+  when 'round_2_active' then 'round_2_active'
+  when 'round_2_closed' then 'round_2_closed'
+  when 'round_3_active' then 'round_3_active'
+  when 'round_3_closed' then 'round_3_closed'
+  when 'completed' then 'completed'
+  when 'published' then 'published'
+  when 'setup' then 'seeded_locked'
+  when 'active' then 'roster_open'
+  when 'cancelled' then 'completed'
+  when 'archived' then 'published'
+  else lower(state)
+end;
+
+alter table if exists public.session_ladder_sessions
+  drop constraint if exists session_ladder_sessions_state_check;
+
+alter table if exists public.session_ladder_sessions
+  add constraint session_ladder_sessions_state_check
+  check (
+    state in (
+      'draft',
+      'roster_open',
+      'seeded_locked',
+      'round_1_active',
+      'round_1_closed',
+      'round_2_active',
+      'round_2_closed',
+      'round_3_active',
+      'round_3_closed',
+      'completed',
+      'published'
+    )
+  );
+
+commit;

--- a/supabase/migrations/20260817_session_ladder_publish_snapshot_json.sql
+++ b/supabase/migrations/20260817_session_ladder_publish_snapshot_json.sql
@@ -1,0 +1,16 @@
+begin;
+
+alter table if exists public.session_ladder_sessions
+  add column if not exists published_snapshot_json jsonb null;
+
+update public.session_ladder_sessions
+set published_snapshot_json = jsonb_build_object(
+  'recap', coalesce(recap_json, '{}'::jsonb),
+  'leaderboard', coalesce(leaderboard_json, '[]'::jsonb),
+  'attendance', '{}'::jsonb
+)
+where published_snapshot_json is null
+  and (published_at is not null or state = 'published')
+  and (recap_json is not null or leaderboard_json is not null);
+
+commit;

--- a/tests/test_session_ladder_api.py
+++ b/tests/test_session_ladder_api.py
@@ -97,6 +97,10 @@ class _Query:
 class _Supabase:
     def __init__(self):
         self.storage: dict[str, list[dict]] = {
+            "leagues_metadata": [
+                {"id": 1, "club_id": "club-1", "league_name": "League One", "is_active": True},
+                {"id": 2, "club_id": "club-1", "league_name": "League Two", "is_active": True},
+            ],
             "players": [
                 {"id": 1, "club_id": "club-1", "name": "A One", "normalized_name": "a one", "rating": 1500, "active": True},
                 {"id": 2, "club_id": "club-1", "name": "B Two", "normalized_name": "b two", "rating": 1400, "active": True},
@@ -132,7 +136,7 @@ def _seed_and_start_round_1(sb: _Supabase, monkeypatch) -> str:
         supabase=sb,
         auth=_auth("manager"),
         payload={
-            "league_id": "league-1",
+            "league_key": "league one",
             "season_id": None,
             "session_starts_at": "2026-09-03T18:00:00Z",
             "courts_available": 2,
@@ -141,7 +145,7 @@ def _seed_and_start_round_1(sb: _Supabase, monkeypatch) -> str:
     )["session"]["id"]
 
     # service expects roster open first
-    sb.storage["session_ladder_sessions"][0]["state"] = "ROSTER_OPEN"
+    sb.storage["session_ladder_sessions"][0]["state"] = "roster_open"
 
     for pid, rating in zip(range(1, 9), [1500, 1400, 1300, 1200, 1100, 1000, 900, 800]):
         api.post_add_roster_entries(
@@ -170,7 +174,7 @@ def test_feature_flag_blocks_all_endpoints(monkeypatch):
             supabase=sb,
             auth=_auth("manager"),
             payload={
-                "league_id": "l",
+                "league_key": "League One",
                 "season_id": None,
                 "session_starts_at": "2026-09-03T18:00:00Z",
                 "courts_available": 1,
@@ -187,10 +191,41 @@ def test_auth_blocks_mutation_for_non_manager_non_admin(monkeypatch):
             supabase=sb,
             auth=_auth("player"),
             payload={
-                "league_id": "l",
+                "league_key": "League One",
                 "season_id": None,
                 "session_starts_at": "2026-09-03T18:00:00Z",
                 "courts_available": 1,
+                "players_per_court": 4,
+            },
+        )
+
+
+def test_create_session_validates_and_canonicalizes_league_key(monkeypatch):
+    sb = _Supabase()
+    monkeypatch.setattr(api, "FEATURE_SESSION_LADDER", True)
+
+    created = api.post_create_session(
+        supabase=sb,
+        auth=_auth("manager"),
+        payload={
+            "league_key": "league one",
+            "season_id": None,
+            "session_starts_at": "2026-09-03T18:00:00Z",
+            "courts_available": 2,
+            "players_per_court": 4,
+        },
+    )
+    assert created["session"]["league_id"] == "League One"
+
+    with pytest.raises(ValueError, match="Unknown league key"):
+        api.post_create_session(
+            supabase=sb,
+            auth=_auth("manager"),
+            payload={
+                "league_key": "Missing League",
+                "season_id": None,
+                "session_starts_at": "2026-09-03T18:00:00Z",
+                "courts_available": 2,
                 "players_per_court": 4,
             },
         )
@@ -300,14 +335,14 @@ def test_complete_and_publish_endpoints(monkeypatch):
             api.post_start_round(supabase=sb, auth=_auth("manager"), session_id=sid, round_number=2)
 
     done = api.post_complete_session(supabase=sb, auth=_auth("manager"), session_id=sid)
-    assert done["session"]["state"] == "COMPLETED"
+    assert done["session"]["state"] == "completed"
     assert done["session"]["rating_update"]["applied"] is False
 
     done_again = api.post_complete_session(supabase=sb, auth=_auth("manager"), session_id=sid)
     assert done_again["session"]["rating_update"]["applied"] is False
 
     pub = api.post_publish_session(supabase=sb, auth=_auth("manager"), session_id=sid)
-    assert pub["session"]["state"] == "PUBLISHED"
+    assert pub["session"]["state"] == "published"
     assert pub["session"].get("recap")
     assert pub["session"].get("leaderboard")
 

--- a/tests/test_session_ladder_e2e_flow.py
+++ b/tests/test_session_ladder_e2e_flow.py
@@ -81,6 +81,9 @@ class _Query:
 class _Supabase:
     def __init__(self):
         self.storage = {
+            "leagues_metadata": [
+                {"id": 1, "club_id": "club-1", "league_name": "League One", "is_active": True},
+            ],
             "players": [
                 {"id": 1, "club_id": "club-1", "name": "A", "normalized_name": "a", "rating": 1500, "active": True},
                 {"id": 2, "club_id": "club-1", "name": "B", "normalized_name": "b", "rating": 1400, "active": True},
@@ -114,7 +117,7 @@ def test_e2e_roster_seed_score_close_creates_round2(monkeypatch):
         supabase=sb,
         auth=_auth(),
         payload={
-            "league_id": "league-1",
+            "league_key": "league one",
             "season_id": None,
             "session_starts_at": "2026-09-03T18:00:00Z",
             "courts_available": 2,
@@ -122,7 +125,7 @@ def test_e2e_roster_seed_score_close_creates_round2(monkeypatch):
         },
     )["session"]["id"]
 
-    sb.storage["session_ladder_sessions"][0]["state"] = "ROSTER_OPEN"
+    sb.storage["session_ladder_sessions"][0]["state"] = "roster_open"
 
     for pid, rating in zip(range(1, 9), [1500, 1400, 1300, 1200, 1100, 1000, 900, 800]):
         api.post_add_roster_entries(

--- a/tests/test_session_ladder_service.py
+++ b/tests/test_session_ladder_service.py
@@ -112,7 +112,7 @@ def _seed_basic_session(sb: _Supabase) -> str:
         created_by="admin",
     )
     sid = created["id"]
-    svc._transition_state(sb, sessionId=sid, to_state="ROSTER_OPEN", updated_by="admin")
+    svc._transition_state(sb, sessionId=sid, to_state="roster_open", updated_by="admin")
     for idx, rating in enumerate([1600, 1500, 1400, 1300, 1200, 1100, 1000, 900], start=1):
         svc.updateRosterStatus(
             sb,
@@ -128,10 +128,27 @@ def _seed_basic_session(sb: _Supabase) -> str:
 
 
 def test_can_transition_state_machine_paths():
-    assert svc.canTransition("DRAFT", "ROSTER_OPEN")
-    assert svc.canTransition("ROUND_2_CLOSED", "COMPLETED")
-    assert not svc.canTransition("DRAFT", "ROUND_1_ACTIVE")
-    assert not svc.canTransition("PUBLISHED", "COMPLETED")
+    assert svc.canTransition("draft", "roster_open")
+    assert svc.canTransition("round_2_closed", "completed")
+    assert not svc.canTransition("draft", "round_1_active")
+    assert not svc.canTransition("published", "completed")
+
+
+def test_session_state_values_match_db_allowed_list():
+    db_allowed_states = {
+        "draft",
+        "roster_open",
+        "seeded_locked",
+        "round_1_active",
+        "round_1_closed",
+        "round_2_active",
+        "round_2_closed",
+        "round_3_active",
+        "round_3_closed",
+        "completed",
+        "published",
+    }
+    assert set(svc.SESSION_STATES) == db_allowed_states
 
 
 def test_close_round_is_idempotent_for_next_round_generation():
@@ -263,7 +280,7 @@ def test_complete_and_publish_session_flow():
     svc.closeRound(sb, sessionId=sid, roundNumber=2, updated_by="admin", allow_override=True, override_reason="test override")
 
     completed = svc.completeSession(sb, sessionId=sid, updated_by="admin")
-    assert completed["state"] == "COMPLETED"
+    assert completed["state"] == "completed"
     assert completed["rating_update_hook_triggered"] is True
     assert completed["rating_update"]["applied"] is False
 
@@ -271,13 +288,25 @@ def test_complete_and_publish_session_flow():
     assert completed_again["rating_update"]["applied"] is False
 
     published = svc.publishSession(sb, sessionId=sid, updated_by="admin")
-    assert published["state"] == "PUBLISHED"
+    assert published["state"] == "published"
     assert published.get("recap")
     assert published.get("leaderboard")
+    assert published.get("attendance")
+    assert published.get("published_at")
     assert sb.storage["session_ladder_rating_history"]
+    assert {row["league_name"] for row in sb.storage["league_ratings"]} == {"league-a"}
+
+    first_published_at = published["published_at"]
+    first_recap = published["recap"]
+    first_leaderboard = published["leaderboard"]
+    first_attendance = published["attendance"]
     first_attendance_count = len(sb.storage["session_ladder_attendance"])
 
     published_again = svc.publishSession(sb, sessionId=sid, updated_by="admin")
+    assert published_again["published_at"] == first_published_at
+    assert published_again["recap"] == first_recap
+    assert published_again["leaderboard"] == first_leaderboard
+    assert published_again["attendance"] == first_attendance
     assert len(sb.storage["session_ladder_attendance"]) == first_attendance_count
 
 
@@ -320,7 +349,7 @@ def test_submit_game_result_upsert_idempotent():
 def test_submit_game_result_blocked_when_session_locked():
     sb = _Supabase()
     sid = _seed_basic_session(sb)
-    sb.storage["session_ladder_sessions"][0]["state"] = "PUBLISHED"
+    sb.storage["session_ladder_sessions"][0]["state"] = "published"
     pod = [r for r in sb.storage["session_ladder_court_pods"] if r["round_number"] == 1][0]
     pod_players = [r for r in sb.storage["session_ladder_court_pod_players"] if r["court_pod_id"] == pod["id"]]
     p = [x["player_id"] for x in sorted(pod_players, key=lambda r: r["player_order"])]
@@ -382,4 +411,4 @@ def test_round_close_auto_completes_final_round():
     out2 = svc.closeRound(sb, sessionId=sid, roundNumber=2, updated_by="admin", allow_override=True, override_reason="ok")
     assert out2["auto_completed"] is True
     session = sb.storage["session_ladder_sessions"][0]
-    assert session["state"] == "COMPLETED"
+    assert session["state"] == "completed"


### PR DESCRIPTION
### Motivation
- Prevent ratings from splitting into separate partitions when Session Ladder sessions use non‑canonical league identifiers. 
- Ensure session creation uses a validated, canonical league key so writes to `league_ratings.league_name` remain continuous. 

### Description
- Added `._resolve_session_league_key` in `services/session_ladder_api.py` to accept `league_key` (with legacy `league_id` fallback), validate it against `leagues_metadata.league_name` for the club, and return the canonical casing to store in `session_ladder_sessions.league_id` before calling `createSession`.
- Updated tests to include `leagues_metadata` fixtures and to exercise canonicalization and unknown‑league rejection in `tests/test_session_ladder_api.py` and `tests/test_session_ladder_e2e_flow.py`, and added an assertion that rating writes target the expected `league_ratings` partition in `tests/test_session_ladder_service.py`.
- Documented the contract in `docs/session-ladder/schema.md` that `session_ladder_sessions.league_id` is the rating partition key and must match `league_ratings.league_name` (create‑time validation/canonicalization is performed).
- Introduced related state/value normalization improvements (SessionState enum and parsing) and included migrations to align session states and add `published_snapshot_json` used by the publish flow.

### Testing
- Ran the focused test suite: `pytest -q tests/test_session_ladder_service.py tests/test_session_ladder_api.py tests/test_session_ladder_e2e_flow.py` which resulted in `15 passed`.
- New/updated automated tests verify that `post_create_session` canonicalizes `league_key`, rejects unknown keys, and that rating updates target the expected league partition key.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca0f814c8832699e7ced013af30e6)