### PR TITLE
Prevent duplicate bench players from crashing Court Board

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -230,13 +230,23 @@ def _render_court_board_grid(roster_df: pd.DataFrame, max_per_row: int = 4) -> N
     print("DEBUG: ladder_live_roster columns:", list(roster_now.columns))
 
     courts_payload = roster_df_to_courts(roster_now, ladder_court_sizes=st.session_state.get("ladder_court_sizes"))
+
+    active_player_ids = {
+        str(int(pid))
+        for pid in pd.to_numeric(roster_now.get("player_id"), errors="coerce").dropna().astype(int).tolist()
+    }
+    bench_ids_seen: set[str] = set()
     for bench_row in list(st.session_state.get("ladder_bench_players", [])):
         pid = bench_row.get("player_id")
         if pid is None:
             continue
+        pid_str = str(int(pid))
+        if pid_str in active_player_ids or pid_str in bench_ids_seen:
+            continue
+        bench_ids_seen.add(pid_str)
         courts_payload[-1]["players"].append(
             {
-                "player_id": str(int(pid)),
+                "player_id": pid_str,
                 "name": str(bench_row.get("name") or f"#{pid}"),
                 "rating": float(bench_row.get("rating", 1200.0)) / 400.0,
             }


### PR DESCRIPTION
### Motivation
- The Streamlit Court Board component can fail to render when `ladder_bench_players` contains duplicate or already-active `player_id` entries, which breaks the drag-and-drop UI during Step 4 of the League Manager flow.
- Deduplicating bench entries before constructing the component payload prevents invalid/mismatched `player_id` values from being passed to the frontend and stabilizes loading.

### Description
- Add logic in `jupr_app/ui/pages/league_manager.py` to build `active_player_ids` from the current roster and to track `bench_ids_seen` while iterating `ladder_bench_players`.
- Skip bench entries that are `None`, that already appear in the active roster, or that have been seen earlier in the bench list, preserving bench ordering for unique IDs.
- Normalize bench `player_id` to a string (`pid_str`) before appending to the `courts_payload` so the payload uses stable string IDs expected by the React component.
- This change prevents duplicate `player_id` values from being included in the `courts` payload passed to `court_board`.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/league_manager.py` which succeeded.
- Ran the full test suite with `pytest -q tests`; the suite failed with pre-existing, unrelated failures in match pipeline, schema preflight, and UI color-token tests (9 failing, 261 passing), indicating regressions outside this change.
- Ran the targeted selection `pytest -q tests -k "league_manager or court_board"` which did not execute any league_manager-specific unit tests in this repo snapshot (tests were deselected). 
- Attempted a Playwright screenshot of a running Streamlit instance to validate UI, but the server was not reachable (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca86676e0832693e313c0210b0d97)