### PR TITLE
Fix league manager between-round roster updates and sequential substitutions

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -212,6 +212,17 @@ def _summarize_roster(roster_df: pd.DataFrame) -> pd.DataFrame:
     return df.sort_values(["court", "slot"]).reset_index(drop=True)
 
 
+def _effective_next_roster(base_roster_df: pd.DataFrame, override_roster_df: object | None) -> pd.DataFrame:
+    if override_roster_df is None:
+        return base_roster_df
+    if hasattr(override_roster_df, "empty"):
+        return override_roster_df if not override_roster_df.empty else base_roster_df
+    try:
+        return override_roster_df if len(override_roster_df) > 0 else base_roster_df
+    except Exception:
+        return override_roster_df
+
+
 def _render_court_board_grid(roster_df: pd.DataFrame, max_per_row: int = 4) -> None:
     _ = max_per_row
     roster_now = compress_courts(normalize_slots(roster_df.copy()))
@@ -1042,6 +1053,10 @@ def render(ctx):
             base_next_roster = base_next_roster.sort_values(["court", "rating"], ascending=[True, False]).copy()
             base_next_roster["slot"] = base_next_roster.groupby("court").cumcount() + 1
             base_next_roster = base_next_roster[["player_id", "name", "rating", "court", "slot"]].copy()
+            working_next_roster = _effective_next_roster(
+                base_roster_df=base_next_roster,
+                override_roster_df=st.session_state.get("ladder_next_roster_override"),
+            )
 
             if st.session_state.get("ladder_next_roster_override") is not None:
                 st.info("Roster changes queued for the next round.")
@@ -1120,14 +1135,14 @@ def render(ctx):
 
                     with tabs_rc[0]:
                         st.markdown("Replace player (active roster):")
-                        active_names = movement_df["name"].astype(str).tolist()
+                        active_names = working_next_roster["name"].astype(str).tolist()
                         active_map = {
                             str(r["name"]): {
                                 "id": int(r["player_id"]),
                                 "name": str(r["name"]),
                                 "rating": float(r.get("rating", 1200.0)),
                             }
-                            for _, r in movement_df.iterrows()
+                            for _, r in working_next_roster.iterrows()
                         }
                         replaced_name = st.selectbox("Replace player", active_names, key="ladder_sub_out")
                         replace_info = active_map.get(replaced_name, {})
@@ -1184,7 +1199,7 @@ def render(ctx):
                                     name_to_id[str(player_row["name"])] = int(player_row["id"])
 
                                 result = apply_roster_change(
-                                    roster_df=base_next_roster,
+                                    roster_df=working_next_roster,
                                     change_type="substitute",
                                     replaced_player_id=int(replace_info.get("id")),
                                     new_player=sub_player,
@@ -1259,7 +1274,7 @@ def render(ctx):
                                     name_to_id[str(player_row["name"])] = int(player_row["id"])
 
                                 result = apply_roster_change(
-                                    roster_df=base_next_roster,
+                                    roster_df=working_next_roster,
                                     change_type="add",
                                     new_player=add_player,
                                     court_sizes=st.session_state.get("ladder_court_sizes"),
@@ -1297,17 +1312,10 @@ def render(ctx):
                     _rerun()
                     return
 
-                override = st.session_state.get("ladder_next_roster_override")
-                if override is None:
-                    new_roster = base_next_roster
-                else:
-                    if hasattr(override, "empty"):
-                        new_roster = override if not override.empty else base_next_roster
-                    else:
-                        try:
-                            new_roster = override if len(override) > 0 else base_next_roster
-                        except Exception:
-                            new_roster = override
+                new_roster = _effective_next_roster(
+                    base_roster_df=base_next_roster,
+                    override_roster_df=st.session_state.get("ladder_next_roster_override"),
+                )
                 new_court_sizes = st.session_state.get("ladder_next_court_sizes") or [
                     int(x) for x in new_roster["court"].value_counts().sort_index().tolist()
                 ]

--- a/tests/test_league_night_roster.py
+++ b/tests/test_league_night_roster.py
@@ -115,3 +115,29 @@ def test_add_player_benches_lowest_rating_first():
     assert 99 in result.roster_df["player_id"].astype(int).tolist()
     assert len(result.bench_ids) == 2
     assert 99 not in result.bench_ids
+
+
+def test_multiple_substitutions_can_be_applied_sequentially():
+    roster = _make_roster([1, 2, 3, 4, 5, 6, 7, 8])
+
+    first = apply_roster_change(
+        roster_df=roster,
+        change_type="substitute",
+        replaced_player_id=2,
+        new_player={"id": 90, "name": "Sub A", "rating": 1250.0},
+        court_sizes=[4, 4],
+    )
+
+    second = apply_roster_change(
+        roster_df=first.roster_df,
+        change_type="substitute",
+        replaced_player_id=5,
+        new_player={"id": 91, "name": "Sub B", "rating": 1260.0},
+        court_sizes=first.court_sizes,
+    )
+
+    updated_ids = second.roster_df["player_id"].astype(int).tolist()
+    assert 2 not in updated_ids
+    assert 5 not in updated_ids
+    assert 90 in updated_ids
+    assert 91 in updated_ids


### PR DESCRIPTION
### Motivation
- Between-round flows could lose queued roster changes and the court board would revert to a stale movement preview, and attempting a second substitute between rounds could fail because the UI applied changes against the wrong roster.

### Description
- Add `_effective_next_roster(base_roster_df, override_roster_df)` to pick the correct effective next-round roster (either the queued override or the base editor roster).
- Use the helper when building the next-round roster preview so the court board and UI controls always reflect queued roster overrides.
- Change the roster-change dialog to build replacement options from and apply `apply_roster_change` against the effective next roster (`working_next_roster`) instead of the stale base preview.
- Add a regression test `test_multiple_substitutions_can_be_applied_sequentially` to verify sequential substitutions can be applied and preserved.

### Testing
- Ran `pytest -q tests/test_league_night_roster.py` and all tests passed (`7 passed`).
- Ran `pytest -q tests/test_session_console_ui.py tests/test_league_night_roster.py` and all tests passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cd10d67108326b90ce691eeb2d1e8)