### PR TITLE
Enable click-and-drag ordering in ladder sortable list

### DIFF
--- a/streamlit_sortable.py
+++ b/streamlit_sortable.py
@@ -3,12 +3,44 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 
+from jupr_court_board import court_board
+
 
 def sort_items(items: list[str], key: str = "sortable") -> list[str]:
-    """Streamlit-native sortable list fallback.
+    """Sortable list with drag-and-drop and an editor fallback."""
+    cards = [
+        {
+            "player_id": str(idx),
+            "name": str(item),
+        }
+        for idx, item in enumerate(items)
+    ]
+    payload = [{"court_id": "Court 1", "players": cards}]
+    try:
+        dragged = court_board(payload, key=f"{key}_dnd")
+    except Exception:
+        dragged = None
 
-    Users can change the Rank column to reorder items deterministically.
-    """
+    if isinstance(dragged, dict):
+        dragged_courts = dragged.get("courts")
+        if isinstance(dragged_courts, list):
+            by_id = {str(idx): item for idx, item in enumerate(items)}
+            new_order: list[str] = []
+            seen: set[str] = set()
+            for court in dragged_courts:
+                if not isinstance(court, dict):
+                    continue
+                for player in court.get("players", []):
+                    if not isinstance(player, dict):
+                        continue
+                    pid = str(player.get("player_id", ""))
+                    if pid in by_id and pid not in seen:
+                        new_order.append(by_id[pid])
+                        seen.add(pid)
+            if len(new_order) == len(items):
+                return new_order
+
+    st.caption("Drag-and-drop unavailable here; use Rank to reorder.")
     rows = [{"Rank": idx + 1, "Player": item} for idx, item in enumerate(items)]
     df = pd.DataFrame(rows)
     edited = st.data_editor(

--- a/tests/test_streamlit_sortable.py
+++ b/tests/test_streamlit_sortable.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pandas as pd
+
+import streamlit_sortable
+
+
+def test_sort_items_uses_drag_order(monkeypatch):
+    items = ["A", "B", "C"]
+
+    def fake_court_board(_payload, key=None):
+        return {
+            "courts": [
+                {
+                    "court_id": "Court 1",
+                    "players": [
+                        {"player_id": "2", "name": "C"},
+                        {"player_id": "0", "name": "A"},
+                        {"player_id": "1", "name": "B"},
+                    ],
+                }
+            ]
+        }
+
+    monkeypatch.setattr(streamlit_sortable, "court_board", fake_court_board)
+
+    result = streamlit_sortable.sort_items(items, key="test")
+
+    assert result == ["C", "A", "B"]
+
+
+def test_sort_items_falls_back_to_rank_editor(monkeypatch):
+    items = ["A", "B", "C"]
+
+    def raising_court_board(_payload, key=None):
+        raise RuntimeError("component unavailable")
+
+    def fake_data_editor(df, **_kwargs):
+        assert list(df["Player"]) == items
+        return pd.DataFrame(
+            [
+                {"Rank": 2, "Player": "A"},
+                {"Rank": 1, "Player": "B"},
+                {"Rank": 3, "Player": "C"},
+            ]
+        )
+
+    monkeypatch.setattr(streamlit_sortable, "court_board", raising_court_board)
+    monkeypatch.setattr(streamlit_sortable.st, "caption", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(streamlit_sortable.st, "data_editor", fake_data_editor)
+    monkeypatch.setattr(streamlit_sortable.st, "column_config", streamlit_sortable.st.column_config)
+
+    result = streamlit_sortable.sort_items(items, key="test")
+
+    assert result == ["B", "A", "C"]


### PR DESCRIPTION
### Motivation
- The ladder sortable UX was previously limited to a rank-based editor and needs true click-and-drag ordering. 
- The repo already contains a Streamlit component (`jupr_court_board`) that implements drag-and-drop for courts/players. 
- Use the existing component to provide a better, native drag-and-drop experience while preserving a deterministic fallback.

### Description
- Wire `sort_items` to the `jupr_court_board.court_board` component by mapping each item to a `player_id`/`name` card and passing a single `Court 1` payload. 
- Parse the component's returned `courts` payload to reconstruct and return the reordered item list when a full ordering is produced. 
- Preserve the previous `st.data_editor` rank-based editor as a fallback and display a caption when the drag component is unavailable. 
- Add `tests/test_streamlit_sortable.py` covering both the drag-and-drop ordering path and the fallback editor path.

### Testing
- Ran `pytest -q tests/test_streamlit_sortable.py` and the two tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cffc4e7bc8326bc276fe473f09152)