### PR TITLE
Persist live ladder drag order and preserve uploaded seed order

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -296,6 +296,7 @@ def _render_live_ladder_sortable(roster_df: pd.DataFrame) -> pd.DataFrame:
         candidate = [display_to_pid[item] for item in new_display_order if item in display_to_pid]
         if len(candidate) == len(ordered_ids):
             pending_id_order = candidate
+            st.session_state.live_ladder["ordered_player_ids"] = pending_id_order
 
     with c_apply:
         if st.button("Save ladder order", key="live_ladder_save_order"):
@@ -807,7 +808,6 @@ def render(ctx):
                         current_idx += int(size)
 
                     final_roster = pd.DataFrame(final_assignments)
-                    final_roster = final_roster.sort_values(["court", "rating"], ascending=[True, False]).copy()
                     final_roster["slot"] = final_roster.groupby("court").cumcount() + 1
 
                     st.session_state.ladder_live_roster = final_roster[["player_id", "name", "rating", "court", "slot"]].copy()


### PR DESCRIPTION
### Motivation
- Fix two UX issues in the live ladder flow: the drag-and-drop order was not persisted and the manual/uploaded seed order was being overwritten by an unnecessary per-court sort.

### Description
- Immediately persist the drag-and-drop result into `st.session_state.live_ladder["ordered_player_ids"]` when `sort_items` returns a new ordering so the list no longer snaps back after reruns.
- Remove the extra `sort_values(["court", "rating"])` step when building preview assignments so the uploaded/manual seed order is preserved.

### Testing
- Ran `pytest -q tests/test_session_ladder_api.py tests/test_session_ladder_engine.py` and all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d0966103c8326a97a3edc283e040c)