### PR TITLE
Allow Admin-only preview access to Session Ladder when feature flag disabled

### DIFF
--- a/jupr_app/ui/pages/session_console.py
+++ b/jupr_app/ui/pages/session_console.py
@@ -559,7 +559,7 @@ def render(ctx):
     mode_label = "Public" if bool(getattr(ctx, "public_mode", False)) else "Admin"
     page_shell("🗂️ Session Console", "Session Ladder shell: routing, stepper, data load, resume pointer", mode_label=mode_label)
 
-    if not bool(FEATURE_SESSION_LADDER):
+    if not bool(FEATURE_SESSION_LADDER) and not bool(getattr(ctx, "admin_logged_in", False)):
         st.info("Session Ladder is disabled by feature flag.")
         return
 

--- a/services/session_ladder_api.py
+++ b/services/session_ladder_api.py
@@ -21,7 +21,7 @@ from jupr_app.domain.session_ladder_service import (
 
 
 def post_create_session(*, supabase: Any, auth: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
-    _require_feature()
+    _require_feature(auth)
     _require_mutation_access(auth)
     league_key = _resolve_session_league_key(supabase=supabase, club_id=str(auth.get("club_id") or ""), payload=payload)
     session = createSession(
@@ -62,7 +62,7 @@ def _resolve_session_league_key(*, supabase: Any, club_id: str, payload: dict[st
 
 
 def get_session_details(*, supabase: Any, auth: dict[str, Any], session_id: str) -> dict[str, Any]:
-    _require_feature()
+    _require_feature(auth)
     _require_read_access(auth)
 
     session = _single(supabase.table("session_ladder_sessions").select("*").eq("id", str(session_id)).execute().data)
@@ -124,7 +124,7 @@ def get_session_details(*, supabase: Any, auth: dict[str, Any], session_id: str)
 
 
 def post_add_roster_entries(*, supabase: Any, auth: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
-    _require_feature()
+    _require_feature(auth)
     _require_mutation_access(auth)
     session_id = str(payload.get("session_id") or "")
     mode = str(payload.get("mode") or "manual_existing").strip().lower()
@@ -176,26 +176,26 @@ def post_add_roster_entries(*, supabase: Any, auth: dict[str, Any], payload: dic
 
 
 def post_seed_courts_by_rating(*, supabase: Any, auth: dict[str, Any], session_id: str) -> dict[str, Any]:
-    _require_feature()
+    _require_feature(auth)
     _require_mutation_access(auth)
     pods = seedCourtsByRating(supabase, sessionId=str(session_id), seeded_by=str(auth.get("user_id") or "api"))
     return {"session_id": str(session_id), "pods": pods}
 
 
 def post_lock_seeding(*, supabase: Any, auth: dict[str, Any], session_id: str) -> dict[str, Any]:
-    _require_feature()
+    _require_feature(auth)
     _require_mutation_access(auth)
     return {"session": lockSeeding(supabase, sessionId=str(session_id), updated_by=str(auth.get("user_id") or "api"))}
 
 
 def post_start_round(*, supabase: Any, auth: dict[str, Any], session_id: str, round_number: int) -> dict[str, Any]:
-    _require_feature()
+    _require_feature(auth)
     _require_mutation_access(auth)
     return {"session": startRound(supabase, sessionId=str(session_id), roundNumber=int(round_number), updated_by=str(auth.get("user_id") or "api"))}
 
 
 def post_submit_game_result(*, supabase: Any, auth: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
-    _require_feature()
+    _require_feature(auth)
     _require_mutation_access(auth)
     game = submitGameResult(
         supabase,
@@ -221,7 +221,7 @@ def post_close_round(
     allow_override: bool = False,
     override_reason: str | None = None,
 ) -> dict[str, Any]:
-    _require_feature()
+    _require_feature(auth)
     _require_mutation_access(auth)
     result = closeRound(
         supabase,
@@ -238,13 +238,13 @@ def post_close_round(
 
 
 def post_complete_session(*, supabase: Any, auth: dict[str, Any], session_id: str) -> dict[str, Any]:
-    _require_feature()
+    _require_feature(auth)
     _require_mutation_access(auth)
     return {"session": completeSession(supabase, sessionId=str(session_id), updated_by=str(auth.get("user_id") or "api"))}
 
 
 def post_publish_session(*, supabase: Any, auth: dict[str, Any], session_id: str) -> dict[str, Any]:
-    _require_feature()
+    _require_feature(auth)
     _require_mutation_access(auth)
     return {"session": publishSession(supabase, sessionId=str(session_id), updated_by=str(auth.get("user_id") or "api"))}
 
@@ -313,9 +313,16 @@ def _single(rows: list[dict[str, Any]] | None) -> dict[str, Any] | None:
     return dict(rows[0])
 
 
-def _require_feature() -> None:
-    if not bool(FEATURE_SESSION_LADDER):
-        raise RuntimeError("feature.sessionLadder disabled")
+def _require_feature(auth: dict[str, Any] | None = None) -> None:
+    # Normal feature flag enabled
+    if bool(FEATURE_SESSION_LADDER):
+        return
+
+    # Allow preview access for elevated admin sessions only
+    if auth and bool(auth.get("admin_logged_in")):
+        return
+
+    raise RuntimeError("feature.sessionLadder disabled")
 
 
 def _assert_club_scope(auth: dict[str, Any], row_club_id: str) -> None:

--- a/tests/test_session_ladder_api.py
+++ b/tests/test_session_ladder_api.py
@@ -166,7 +166,7 @@ def _seed_and_start_round_1(sb: _Supabase, monkeypatch) -> str:
     return sid
 
 
-def test_feature_flag_blocks_all_endpoints(monkeypatch):
+def test_feature_flag_blocks_non_admin_endpoints(monkeypatch):
     sb = _Supabase()
     monkeypatch.setattr(api, "FEATURE_SESSION_LADDER", False)
     with pytest.raises(RuntimeError, match="feature.sessionLadder disabled"):
@@ -181,6 +181,23 @@ def test_feature_flag_blocks_all_endpoints(monkeypatch):
                 "players_per_court": 4,
             },
         )
+
+
+def test_feature_flag_allows_elevated_admin_preview_access(monkeypatch):
+    sb = _Supabase()
+    monkeypatch.setattr(api, "FEATURE_SESSION_LADDER", False)
+    created = api.post_create_session(
+        supabase=sb,
+        auth={**_auth("manager"), "admin_logged_in": True},
+        payload={
+            "league_key": "League One",
+            "season_id": None,
+            "session_starts_at": "2026-09-03T18:00:00Z",
+            "courts_available": 1,
+            "players_per_court": 4,
+        },
+    )
+    assert created["session"]["id"]
 
 
 def test_auth_blocks_mutation_for_non_manager_non_admin(monkeypatch):


### PR DESCRIPTION
### Motivation
- Provide a minimal, safe preview unlock so elevated admin sessions (`admin_logged_in == True`) can access the Session Ladder when `FEATURE_SESSION_LADDER` is disabled while keeping the feature off for all non-admin users.
- Avoid any schema, migration, or environment changes and keep role and club scoping checks unchanged.

### Description
- Change `services/session_ladder_api._require_feature` to accept an optional `auth` parameter and allow access when `FEATURE_SESSION_LADDER` is enabled or when `auth.get("admin_logged_in")` is true, otherwise raise `RuntimeError("feature.sessionLadder disabled")`.
- Update all session ladder handlers to call `_require_feature(auth)` instead of `_require_feature()` for the endpoints `post_create_session`, `get_session_details`, `post_add_roster_entries`, `post_seed_courts_by_rating`, `post_lock_seeding`, `post_start_round`, `post_submit_game_result`, `post_close_round`, `post_complete_session`, and `post_publish_session`.
- Modify the UI gate in `jupr_app/ui/pages/session_console.py` to allow elevated admin sessions through the feature-flag check by replacing the hard block with `if not bool(FEATURE_SESSION_LADDER) and not bool(getattr(ctx, "admin_logged_in", False)):`.
- Add/adjust tests in `tests/test_session_ladder_api.py` to assert that non-admin users remain blocked when the flag is disabled and that elevated admin sessions are allowed preview access while the flag is disabled.

### Testing
- Ran `pytest -q tests/test_session_ladder_api.py tests/test_session_ladder_e2e_flow.py` and all tests passed (`8 passed`).
- Compiled the modified modules with `python -m compileall services/session_ladder_api.py jupr_app/ui/pages/session_console.py` with no syntax errors. 
- Confirmed via tests that non-admin users are still blocked and that an elevated admin session is granted access when the feature flag is disabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d2a5a230c8326895668652059c1c9)