### PR TITLE
Use movement preview ordering for next court computation

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -251,41 +251,22 @@ def compute_next_order_from_movement(
     current_order: list[int], movement_df: pd.DataFrame, players_per_court: int
 ) -> list[int]:
     """
-    current_order: list[int]
-    movement_df: DataFrame from build_movement_preview
-    players_per_court: int
-    returns next_ordered_ids: list[int]
+    Uses the existing sorted order in movement_df (already sorted by
+    court + performance metrics).
     """
-    # Build stats lookup
-    stats_lookup = {
-        int(row["player_id"]): (
-            int(row["Round Wins"]),
-            int(row["Round Diff"]),
-            int(row["Round Pts"]),
-        )
-        for _, row in movement_df.iterrows()
-    }
+    _ = (current_order, players_per_court)
 
-    # Split current order into court blocks
-    courts = [
-        current_order[i : i + players_per_court]
-        for i in range(0, len(current_order), players_per_court)
-    ]
+    # Group players by current court using movement_df order
+    courts = []
+    for c_num in sorted(movement_df["court"].astype(int).unique()):
+        court_players = movement_df[movement_df["court"].astype(int) == int(c_num)][
+            "player_id"
+        ].astype(int).tolist()
+        courts.append(court_players)
 
-    # Sort each court internally by performance
-    sorted_courts = []
-    for court in courts:
-        sorted_court = sorted(
-            court,
-            key=lambda pid: stats_lookup.get(int(pid), (0, 0, 0)),
-            reverse=True,
-        )
-        sorted_courts.append(sorted_court)
+    next_courts = [[] for _ in courts]
 
-    # Apply movement
-    next_courts = [[] for _ in sorted_courts]
-
-    for i, court in enumerate(sorted_courts):
+    for i, court in enumerate(courts):
         if not court:
             continue
 
@@ -299,16 +280,15 @@ def compute_next_order_from_movement(
         else:
             next_courts[i].append(top)
 
-        # Keep middle
+        # Keep middle in same order
         next_courts[i].extend(middle)
 
         # Demote bottom
-        if i < len(sorted_courts) - 1:
+        if i < len(courts) - 1:
             next_courts[i + 1].insert(0, bottom)
         else:
             next_courts[i].append(bottom)
 
-    # Flatten
     return [pid for court in next_courts for pid in court]
 
 


### PR DESCRIPTION
### Motivation
- Ensure the next ladder order is derived from the already-sorted movement preview instead of recomputing per-court sorts, so the movement preview is the canonical source of ordering.
- Preserve existing promote/top and demote/bottom movement behavior while keeping middle-player order stable.
- Keep the public API unchanged so callers of `compute_next_order_from_movement` remain compatible.

### Description
- Replaced the internal logic of `compute_next_order_from_movement` to ignore the previous in-function stats sort and instead group players by `movement_df` court order. 
- The function now iterates courts from `movement_df`, promotes each court's top player to the previous court and demotes each bottom player to the next court, while preserving middle-player order, and returns a flattened list of player ids. 
- Kept the original function signature and return shape and explicitly ignored the now-unused `current_order` and `players_per_court` parameters for compatibility.

### Testing
- Ran the full test suite with `pytest -q`, which reported unrelated failures (9 failures) in the current repository state that are not caused by this change. 
- Ran the focused ladder engine tests with `pytest -q tests/test_session_ladder_engine.py`, which passed (`7 passed`). 
- No new runtime dependencies or additional test frameworks were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d32dfcdc8832682f3ff2e7291ef1c)