### PR TITLE
fix: apply ladder movement once in CONFIRM_MOVEMENT instead of PLAY_ROUND

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -1016,15 +1016,6 @@ def render(ctx):
                     st.error("Unable to compute movement preview. Check round scores and try again.")
                     st.stop()
 
-                current_order = [int(pid) for pid in st.session_state.live_ladder.get("ordered_player_ids", [])]
-                next_ordered_ids = compute_next_order_from_movement(
-                    current_order=current_order,
-                    movement_df=movement_df,
-                    players_per_court=st.session_state.live_ladder["players_per_court"],
-                )
-
-                st.session_state.live_ladder["ordered_player_ids"] = next_ordered_ids
-
                 st.session_state.ladder_movement_preview = movement_df
                 st.session_state.ladder_state = "CONFIRM_MOVEMENT"
                 _rerun()
@@ -1037,6 +1028,21 @@ def render(ctx):
             st.markdown("#### Round Results & Movement")
 
             movement_df = st.session_state.get("ladder_movement_preview", pd.DataFrame())
+            if not st.session_state.get("movement_applied", False):
+                current_order = [
+                    int(pid)
+                    for pid in st.session_state.live_ladder.get("ordered_player_ids", [])
+                ]
+
+                next_ordered_ids = compute_next_order_from_movement(
+                    current_order=current_order,
+                    movement_df=movement_df,
+                    players_per_court=st.session_state.live_ladder.get("players_per_court", 4),
+                )
+
+                st.session_state.live_ladder["ordered_player_ids"] = next_ordered_ids
+                st.session_state.movement_applied = True
+
             if movement_df is None or movement_df.empty:
                 st.error("No movement preview found.")
                 st.session_state.ladder_state = "PLAY_ROUND"
@@ -1224,6 +1230,7 @@ def render(ctx):
                     return
 
                 st.session_state.ladder_round_num = current_r + 1
+                st.session_state.pop("movement_applied", None)
                 st.session_state.ladder_state = "CONFIRM_START"
                 st.session_state.pop("current_schedule", None)
                 _rerun()


### PR DESCRIPTION
### Motivation
- Fix a bug where ladder movement was applied during the `PLAY_ROUND` submit path and then effectively overwritten during `CONFIRM_MOVEMENT`, causing double-application or order reversion; movement must be applied exactly once at confirmation.

### Description
- Removed the early mutation of `st.session_state.live_ladder["ordered_player_ids"]` from the `PLAY_ROUND` submit handler so that `PLAY_ROUND` only stores `ladder_movement_preview`, sets `ladder_state` to `CONFIRM_MOVEMENT`, and reruns.
- Added a one-time application block at the top of the `CONFIRM_MOVEMENT` branch guarded by `movement_applied` that reads the current order, calls `compute_next_order_from_movement(...)`, writes the resulting `ordered_player_ids`, and sets `movement_applied = True`.
- Reset the `movement_applied` flag before advancing the round by popping `movement_applied` in the "Start Next Round" button flow so the next round can apply movement again.
- Kept `compute_next_order_from_movement()` and `build_movement_preview()` unchanged, per constraints.

### Testing
- Ran `pytest -q tests/test_league_night_roster.py` and it passed (7 tests).
- Ran full test suite with `pytest -q` and observed unrelated pre-existing failures in other modules (9 failed, 267 passed), none introduced by this change based on focused tests and diffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d35f615448326a273c3530f6c9643)