### PR TITLE
Persist live ladder sessions and round submissions

### DIFF
--- a/jupr_app/domain/live_ladder_store.py
+++ b/jupr_app/domain/live_ladder_store.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+
+def _to_builtin(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(k): _to_builtin(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_to_builtin(v) for v in value]
+    if isinstance(value, tuple):
+        return [_to_builtin(v) for v in value]
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except Exception:
+            return value
+    return value
+
+
+def _df_to_records(df: pd.DataFrame | None) -> list[dict[str, Any]]:
+    if df is None or df.empty:
+        return []
+    safe = df.where(pd.notnull(df), None)
+    rows = safe.to_dict("records")
+    return [_to_builtin(row) for row in rows]
+
+
+def get_active_session(ctx, club_id: str, league_name: str, week: str) -> dict[str, Any] | None:
+    rows = (
+        ctx.supabase.table("live_ladder_sessions")
+        .select("*")
+        .eq("club_id", str(club_id))
+        .eq("league_name", str(league_name))
+        .eq("week", str(week))
+        .eq("active", True)
+        .order("created_at", desc=True)
+        .limit(1)
+        .execute()
+        .data
+        or []
+    )
+    return rows[0] if rows else None
+
+
+def get_or_create_session(
+    ctx,
+    club_id: str,
+    league_name: str,
+    week: str,
+    total_rounds: int,
+    ladder_round_num: int,
+    state: str,
+    players_per_court: int,
+    court_sizes: list[int],
+    ordered_player_ids: list[int],
+) -> dict[str, Any]:
+    existing = get_active_session(ctx, club_id=club_id, league_name=league_name, week=week)
+    if existing:
+        update_session_snapshot(
+            ctx,
+            str(existing.get("id")),
+            total_rounds=int(total_rounds),
+            ladder_round_num=int(ladder_round_num),
+            state=str(state),
+            players_per_court=int(players_per_court),
+            court_sizes=[int(x) for x in (court_sizes or [])],
+            ordered_player_ids=[int(x) for x in (ordered_player_ids or [])],
+            active=True,
+        )
+        refreshed = (
+            ctx.supabase.table("live_ladder_sessions")
+            .select("*")
+            .eq("id", str(existing.get("id")))
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return refreshed[0] if refreshed else existing
+
+    payload = {
+        "club_id": str(club_id),
+        "league_name": str(league_name),
+        "week": str(week),
+        "total_rounds": int(total_rounds),
+        "ladder_round_num": int(ladder_round_num),
+        "state": str(state),
+        "players_per_court": int(players_per_court),
+        "court_sizes": [int(x) for x in (court_sizes or [])],
+        "ordered_player_ids": [int(x) for x in (ordered_player_ids or [])],
+        "active": True,
+    }
+    rows = ctx.supabase.table("live_ladder_sessions").insert(payload).execute().data or []
+    if not rows:
+        raise RuntimeError("Unable to create live ladder session")
+    return rows[0]
+
+
+def update_session_snapshot(ctx, session_id: str, **fields) -> None:
+    payload = _to_builtin(fields)
+    if "court_sizes" in payload:
+        payload["court_sizes"] = [int(x) for x in (payload.get("court_sizes") or [])]
+    if "ordered_player_ids" in payload:
+        payload["ordered_player_ids"] = [int(x) for x in (payload.get("ordered_player_ids") or [])]
+    if "ladder_round_num" in payload and payload["ladder_round_num"] is not None:
+        payload["ladder_round_num"] = int(payload["ladder_round_num"])
+    if "players_per_court" in payload and payload["players_per_court"] is not None:
+        payload["players_per_court"] = int(payload["players_per_court"])
+    ctx.supabase.table("live_ladder_sessions").update(payload).eq("id", str(session_id)).execute()
+
+
+def upsert_round_submission(
+    ctx,
+    session_id: str,
+    round_num: int,
+    status: str,
+    schedule_sig: str | None,
+    schedule_json: list[dict[str, Any]] | pd.DataFrame | None,
+    results_json: list[dict[str, Any]] | pd.DataFrame | None,
+    round_stats_json: list[dict[str, Any]] | pd.DataFrame | None,
+    movement_preview_json: list[dict[str, Any]] | pd.DataFrame | None,
+    ordered_ids_before: list[int],
+    court_sizes: list[int],
+    roster_ids: list[int],
+    ordered_ids_after: list[int] | None = None,
+) -> None:
+    schedule_payload = _df_to_records(schedule_json) if isinstance(schedule_json, pd.DataFrame) else _to_builtin(schedule_json or [])
+    results_payload = _df_to_records(results_json) if isinstance(results_json, pd.DataFrame) else _to_builtin(results_json or [])
+    stats_payload = _df_to_records(round_stats_json) if isinstance(round_stats_json, pd.DataFrame) else _to_builtin(round_stats_json or [])
+    movement_payload = _df_to_records(movement_preview_json) if isinstance(movement_preview_json, pd.DataFrame) else _to_builtin(movement_preview_json or [])
+
+    payload = {
+        "session_id": str(session_id),
+        "round_num": int(round_num),
+        "status": str(status),
+        "schedule_sig": str(schedule_sig) if schedule_sig else None,
+        "schedule_json": schedule_payload,
+        "results_json": results_payload,
+        "round_stats_json": stats_payload,
+        "movement_preview_json": movement_payload,
+        "ordered_ids_before": [int(x) for x in (ordered_ids_before or [])],
+        "ordered_ids_after": [int(x) for x in (ordered_ids_after or [])] if ordered_ids_after else None,
+        "court_sizes": [int(x) for x in (court_sizes or [])],
+        "roster_ids": [int(x) for x in (roster_ids or [])],
+    }
+
+    ctx.supabase.table("live_ladder_rounds").upsert(payload, on_conflict="session_id,round_num").execute()
+
+
+def confirm_round(ctx, session_id: str, round_num: int, ordered_ids_after: list[int]) -> None:
+    ctx.supabase.table("live_ladder_rounds").upsert(
+        {
+            "session_id": str(session_id),
+            "round_num": int(round_num),
+            "status": "CONFIRMED",
+            "ordered_ids_after": [int(x) for x in (ordered_ids_after or [])],
+        },
+        on_conflict="session_id,round_num",
+    ).execute()
+
+
+def load_resume_payload(ctx, session_id: str) -> dict[str, Any]:
+    rows = (
+        ctx.supabase.table("live_ladder_sessions")
+        .select("*")
+        .eq("id", str(session_id))
+        .limit(1)
+        .execute()
+        .data
+        or []
+    )
+    if not rows:
+        raise ValueError(f"Live ladder session not found: {session_id}")
+    session = rows[0]
+    round_rows = (
+        ctx.supabase.table("live_ladder_rounds")
+        .select("*")
+        .eq("session_id", str(session_id))
+        .order("round_num", desc=True)
+        .limit(1)
+        .execute()
+        .data
+        or []
+    )
+    latest = round_rows[0] if round_rows else None
+
+    default_order = [int(x) for x in (session.get("ordered_player_ids") or [])]
+    latest_order = [int(x) for x in (latest.get("ordered_ids_after") or [])] if latest else []
+    restored_order = latest_order or default_order
+
+    payload: dict[str, Any] = {
+        "session_id": str(session.get("id")),
+        "ladder_state": str(session.get("state") or "SETUP"),
+        "ladder_round_num": int(session.get("ladder_round_num") or 1),
+        "ladder_total_rounds": int(session.get("total_rounds") or 1),
+        "live_ladder": {
+            "ordered_player_ids": restored_order,
+            "court_sizes": [int(x) for x in (session.get("court_sizes") or [])],
+            "players_per_court": int(session.get("players_per_court") or 4),
+        },
+    }
+
+    if latest and latest.get("movement_preview_json"):
+        payload["ladder_movement_preview"] = _to_builtin(latest.get("movement_preview_json") or [])
+    if latest and latest_order:
+        payload["movement_applied_round"] = int(latest.get("round_num") or 0)
+    return payload

--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -21,6 +21,12 @@ from jupr_app.domain.live_ladder import (
     compute_round_stats,
     validate_courts,
 )
+from jupr_app.domain.live_ladder_store import (
+    get_or_create_session,
+    load_resume_payload,
+    update_session_snapshot,
+    upsert_round_submission,
+)
 from jupr_app.domain.session_ladder_engine import computeCourtStandings, resolveTies
 from jupr_app.domain.league_night_roster import RosterChangeError, roster_change_availability, suggest_court_sizes
 from jupr_app.domain.leagues import (
@@ -453,6 +459,7 @@ def render(ctx):
     st.session_state.setdefault("ladder_state", "SETUP")
     st.session_state.setdefault("ladder_round_num", 1)
     st.session_state.setdefault("ladder_total_rounds", 5)
+    st.session_state.setdefault("lm_session_id", None)
     st.session_state.setdefault("ladder_roster", [])
     st.session_state.setdefault("ladder_court_sizes", [])
     if "live_ladder" not in st.session_state:
@@ -640,6 +647,47 @@ def render(ctx):
                 step=1,
                 key="ladder_total_rounds_input",
             )
+
+            with st.expander("Resume active session", expanded=False):
+                active_sessions = (
+                    ctx.supabase.table("live_ladder_sessions")
+                    .select("id,league_name,week,created_at,state,ladder_round_num,total_rounds")
+                    .eq("club_id", str(ctx.club_id))
+                    .eq("active", True)
+                    .order("created_at", desc=True)
+                    .limit(5)
+                    .execute()
+                    .data
+                    or []
+                )
+                if not active_sessions:
+                    st.caption("No active sessions to resume.")
+                else:
+                    options = {
+                        f"{row.get('league_name','?')} / {row.get('week','?')} · R{int(row.get('ladder_round_num') or 1)}/{int(row.get('total_rounds') or 1)} · {str(row.get('state') or 'SETUP')} · {str(row.get('created_at') or '')}": row
+                        for row in active_sessions
+                    }
+                    selected_label = st.selectbox("Active session", list(options.keys()), key="ladder_resume_session")
+                    if st.button("Resume Selected Session", key="ladder_resume_btn"):
+                        selected = options[selected_label]
+                        payload = load_resume_payload(ctx, str(selected.get("id")))
+                        st.session_state["lm_session_id"] = payload.get("session_id")
+                        st.session_state["ladder_round_num"] = int(payload.get("ladder_round_num") or 1)
+                        st.session_state["ladder_total_rounds"] = int(payload.get("ladder_total_rounds") or 1)
+                        st.session_state["saved_ladder_lg"] = str(selected.get("league_name") or "")
+                        st.session_state["saved_ladder_wk"] = str(selected.get("week") or "")
+                        st.session_state.live_ladder = payload.get("live_ladder") or {
+                            "ordered_player_ids": [],
+                            "players_per_court": 4,
+                            "court_sizes": [],
+                        }
+                        if payload.get("ladder_movement_preview"):
+                            st.session_state["ladder_movement_preview"] = pd.DataFrame(payload.get("ladder_movement_preview") or [])
+                        if payload.get("movement_applied_round") is not None:
+                            st.session_state["movement_applied_round"] = int(payload.get("movement_applied_round") or 0)
+                        _lm_transition(str(payload.get("ladder_state") or "SETUP"), clear_schedule=True, clear_round=False)
+                        return
+
             raw = st.text_area("Paste Player List (one per line)", height=150, key="ladder_raw_input")
 
             if st.button("Analyze & Seed"):
@@ -930,6 +978,20 @@ def render(ctx):
                     st.session_state.live_ladder["ordered_player_ids"] = final_roster["player_id"].astype(int).tolist()
                     st.session_state.live_ladder["players_per_court"] = int(court_sizes[0]) if court_sizes else 4
 
+                    session_row = get_or_create_session(
+                        ctx,
+                        club_id=str(ctx.club_id),
+                        league_name=str(st.session_state.get("saved_ladder_lg") or st.session_state.get("ladder_lg") or "Default"),
+                        week=str(st.session_state.get("saved_ladder_wk") or st.session_state.get("ladder_wk") or "Week 1"),
+                        total_rounds=int(st.session_state.get("ladder_total_rounds", 1)),
+                        ladder_round_num=int(st.session_state.get("ladder_round_num", 1)),
+                        state="CONFIRM_START",
+                        players_per_court=int(st.session_state.live_ladder.get("players_per_court", 4) or 4),
+                        court_sizes=list(map(int, court_sizes)),
+                        ordered_player_ids=final_roster["player_id"].astype(int).tolist(),
+                    )
+                    st.session_state["lm_session_id"] = str(session_row.get("id"))
+
                     # Printable sheet
                     print_df = final_roster.copy()
                     print_df["JUPR"] = (print_df["rating"].astype(float) / 400.0).round(3)
@@ -1067,6 +1129,57 @@ def render(ctx):
                     st.stop()
 
                 st.session_state.ladder_movement_preview = movement_df
+                current_order = [int(pid) for pid in st.session_state.live_ladder.get("ordered_player_ids", [])]
+                next_ordered_ids = compute_next_order_from_movement(
+                    current_order=current_order,
+                    movement_df=movement_df,
+                    players_per_court=st.session_state.live_ladder.get("court_sizes") or st.session_state.live_ladder.get("players_per_court", 4),
+                )
+                st.session_state.live_ladder["ordered_player_ids"] = next_ordered_ids
+                st.session_state["movement_applied_round"] = current_r
+
+                lm_session_id = st.session_state.get("lm_session_id")
+                if not lm_session_id:
+                    session_row = get_or_create_session(
+                        ctx,
+                        club_id=str(ctx.club_id),
+                        league_name=str(st.session_state.get("saved_ladder_lg") or st.session_state.get("ladder_lg") or "Default"),
+                        week=str(st.session_state.get("saved_ladder_wk") or st.session_state.get("ladder_wk") or "Week 1"),
+                        total_rounds=int(st.session_state.get("ladder_total_rounds", 1)),
+                        ladder_round_num=int(st.session_state.get("ladder_round_num", 1)),
+                        state="CONFIRM_MOVEMENT",
+                        players_per_court=int(st.session_state.live_ladder.get("players_per_court", 4) or 4),
+                        court_sizes=[int(size) for size in st.session_state.live_ladder.get("court_sizes", [])],
+                        ordered_player_ids=current_order,
+                    )
+                    lm_session_id = str(session_row.get("id"))
+                    st.session_state["lm_session_id"] = lm_session_id
+
+                upsert_round_submission(
+                    ctx,
+                    session_id=str(lm_session_id),
+                    round_num=int(current_r),
+                    status="SUBMITTED",
+                    schedule_sig=st.session_state.get("current_schedule_sig"),
+                    schedule_json=st.session_state.get("current_schedule", []),
+                    results_json=all_results,
+                    round_stats_json=round_stats,
+                    movement_preview_json=movement_df,
+                    ordered_ids_before=current_order,
+                    ordered_ids_after=next_ordered_ids,
+                    court_sizes=[int(size) for size in st.session_state.live_ladder.get("court_sizes", [])],
+                    roster_ids=roster_pids,
+                )
+                update_session_snapshot(
+                    ctx,
+                    str(lm_session_id),
+                    state="CONFIRM_MOVEMENT",
+                    ladder_round_num=int(current_r),
+                    total_rounds=int(total_r),
+                    ordered_player_ids=next_ordered_ids,
+                    court_sizes=[int(size) for size in st.session_state.live_ladder.get("court_sizes", [])],
+                    players_per_court=int(st.session_state.live_ladder.get("players_per_court", 4) or 4),
+                )
                 _lm_transition("CONFIRM_MOVEMENT")
                 st.stop()
 
@@ -1265,6 +1378,16 @@ def render(ctx):
 
             if st.button(btn_label):
                 if current_r >= total_r:
+                    if st.session_state.get("lm_session_id"):
+                        update_session_snapshot(
+                            ctx,
+                            str(st.session_state.get("lm_session_id")),
+                            state="COMPLETED",
+                            active=False,
+                            ladder_round_num=int(current_r),
+                            ordered_player_ids=[int(pid) for pid in st.session_state.live_ladder.get("ordered_player_ids", [])],
+                            court_sizes=[int(size) for size in st.session_state.live_ladder.get("court_sizes", [])],
+                        )
                     st.success("League Night Complete! All matches saved.")
                     for k in [
                         "ladder_round_num",
@@ -1280,9 +1403,22 @@ def render(ctx):
                         "movement_applied_round",
                     ]:
                         st.session_state.pop(k, None)
+                    st.session_state.pop("lm_session_id", None)
                     st.session_state.live_ladder = {"ordered_player_ids": [], "players_per_court": 4, "court_sizes": []}
                     _lm_transition("SETUP", clear_schedule=True, clear_round=True)
                     return
+
+                if st.session_state.get("lm_session_id"):
+                    update_session_snapshot(
+                        ctx,
+                        str(st.session_state.get("lm_session_id")),
+                        ladder_round_num=int(current_r + 1),
+                        state="CONFIRM_START",
+                        ordered_player_ids=[int(pid) for pid in st.session_state.live_ladder.get("ordered_player_ids", [])],
+                        court_sizes=[int(size) for size in st.session_state.live_ladder.get("court_sizes", [])],
+                        players_per_court=int(st.session_state.live_ladder.get("players_per_court", 4) or 4),
+                        active=True,
+                    )
 
                 _lm_transition("CONFIRM_START", clear_schedule=True, clear_round=True, ladder_round_num=current_r + 1)
                 return

--- a/supabase/migrations/20260818_live_ladder_persistence.sql
+++ b/supabase/migrations/20260818_live_ladder_persistence.sql
@@ -1,0 +1,55 @@
+begin;
+
+create table if not exists public.live_ladder_sessions (
+  id uuid primary key default gen_random_uuid(),
+  club_id text not null,
+  league_name text not null,
+  week text not null,
+  total_rounds integer not null,
+  ladder_round_num integer not null default 1,
+  state text not null default 'SETUP',
+  players_per_court integer not null default 4,
+  court_sizes jsonb not null default '[]'::jsonb,
+  ordered_player_ids jsonb not null default '[]'::jsonb,
+  active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists live_ladder_sessions_active_uniq
+on public.live_ladder_sessions (club_id, league_name, week)
+where active = true;
+
+create table if not exists public.live_ladder_rounds (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid not null references public.live_ladder_sessions(id) on delete cascade,
+  round_num integer not null,
+  status text not null default 'SUBMITTED',
+  schedule_sig text,
+  schedule_json jsonb,
+  results_json jsonb,
+  round_stats_json jsonb,
+  movement_preview_json jsonb,
+  ordered_ids_before jsonb,
+  ordered_ids_after jsonb,
+  court_sizes jsonb,
+  roster_ids jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (session_id, round_num)
+);
+
+create index if not exists idx_live_ladder_rounds_session_round
+  on public.live_ladder_rounds (session_id, round_num desc);
+
+drop trigger if exists live_ladder_sessions_set_updated_at on public.live_ladder_sessions;
+create trigger live_ladder_sessions_set_updated_at
+before update on public.live_ladder_sessions
+for each row execute function public.set_updated_at_timestamp();
+
+drop trigger if exists live_ladder_rounds_set_updated_at on public.live_ladder_rounds;
+create trigger live_ladder_rounds_set_updated_at
+before update on public.live_ladder_rounds
+for each row execute function public.set_updated_at_timestamp();
+
+commit;


### PR DESCRIPTION
### Motivation
- Prevent loss of live ladder round scores, schedules and movement previews when a browser refresh or Streamlit worker restart occurs by persisting session and per-round snapshots to the DB. 
- Provide an operational "Resume active session" flow so admins can recover an in-progress event and continue without re-entering scores. 
- Keep the change pragmatic and idempotent by storing payloads as JSONB and using per-round upserts to avoid duplicate rounds.

### Description
- Add a DB migration `supabase/migrations/20260818_live_ladder_persistence.sql` that creates `live_ladder_sessions` and `live_ladder_rounds`, adds the partial unique index to ensure a single active session per `(club_id, league_name, week)`, and enforces uniqueness per `(session_id, round_num)` with `updated_at` triggers. 
- Add `jupr_app/domain/live_ladder_store.py` which implements helpers: `get_active_session`, `get_or_create_session`, `update_session_snapshot`, `upsert_round_submission`, `confirm_round`, and `load_resume_payload`; it also contains utilities to convert pandas DataFrame / numpy types into JSON-serializable builtins. 
- Wire persistence into the League Manager UI (`jupr_app/ui/pages/league_manager.py`) by adding `lm_session_id` state and a `Resume active session` expander in SETUP, creating/updating a session on court confirmation, upserting a `live_ladder_rounds` row on round submit (schedule/results/stats/movement/ordering), and updating session snapshot on "Start Next Round" and on completion. 
- Make writes idempotent by using `upsert(..., on_conflict='session_id,round_num')` for per-round writes and persist `ordered_ids_after` so resume can restore applied movement immediately.

### Testing
- Run compilation check with `python -m compileall jupr_app`, which completed successfully. 
- Run unit tests `pytest -q tests/test_live_ladder_ordering.py`, which passed (`1 passed`).

Deployment note: apply migration `supabase/migrations/20260818_live_ladder_persistence.sql` to the production database before enabling resume/persistence features in production.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dd93650b88326b85ae8da2b5a2981)