### PR TITLE
Support custom date-range recap generation in Weekly Recap Admin

### DIFF
--- a/jupr_app/domain/recaps/__init__.py
+++ b/jupr_app/domain/recaps/__init__.py
@@ -1,3 +1,15 @@
-from .weekly_recap import compute_weekly_recap, get_spotlight_candidates, get_week_bounds
+from .weekly_recap import (
+    compute_weekly_recap,
+    get_date_range_bounds,
+    get_spotlight_candidates,
+    get_week_bounds,
+    normalize_date_range,
+)
 
-__all__ = ["compute_weekly_recap", "get_spotlight_candidates", "get_week_bounds"]
+__all__ = [
+    "compute_weekly_recap",
+    "get_spotlight_candidates",
+    "get_week_bounds",
+    "get_date_range_bounds",
+    "normalize_date_range",
+]

--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -19,34 +19,75 @@ class SpotlightCandidate:
     band: str | None = None
 
 
-def get_week_bounds(week_start: date, tz_name: str) -> tuple[datetime, datetime]:
+def normalize_date_range(start_date: date, end_date: date) -> tuple[date, date]:
+    if end_date < start_date:
+        raise ValueError("end_date must be on or after start_date")
+    return start_date, end_date
+
+
+def get_date_range_bounds(start_date: date, end_date: date, tz_name: str) -> tuple[datetime, datetime]:
+    start_date, end_date = normalize_date_range(start_date, end_date)
     tz = ZoneInfo(tz_name)
-    start_local = datetime.combine(week_start, time.min).replace(tzinfo=tz)
-    end_local = start_local + timedelta(days=7) - timedelta(microseconds=1)
+    start_local = datetime.combine(start_date, time.min).replace(tzinfo=tz)
+    end_local = datetime.combine(end_date, time.max).replace(tzinfo=tz)
     return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
 
 
-def compute_weekly_recap(ctx, week_start: date, *, tz_name: str = "America/Mazatlan") -> dict:
-    recap, _ = _compute_weekly_recap_payload(ctx, week_start, tz_name=tz_name)
+def get_week_bounds(week_start: date, tz_name: str) -> tuple[datetime, datetime]:
+    week_end = week_start + timedelta(days=6)
+    return get_date_range_bounds(week_start, week_end, tz_name)
+
+
+def compute_weekly_recap(
+    ctx,
+    week_start: date | None = None,
+    *,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    tz_name: str = "America/Mazatlan",
+) -> dict:
+    start_date, end_date = _resolve_range_inputs(week_start, start_date, end_date)
+    recap, _ = _compute_weekly_recap_payload(ctx, start_date, end_date, tz_name=tz_name)
     return recap
 
 
-def get_spotlight_candidates(ctx, week_start: date, *, tz_name: str = "America/Mazatlan") -> dict[str, list[dict]]:
-    _, candidates = _compute_weekly_recap_payload(ctx, week_start, tz_name=tz_name)
+def get_spotlight_candidates(
+    ctx,
+    week_start: date | None = None,
+    *,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    tz_name: str = "America/Mazatlan",
+) -> dict[str, list[dict]]:
+    start_date, end_date = _resolve_range_inputs(week_start, start_date, end_date)
+    _, candidates = _compute_weekly_recap_payload(ctx, start_date, end_date, tz_name=tz_name)
     return {
         key: [candidate.__dict__ for candidate in items]
         for key, items in candidates.items()
     }
 
 
-def _compute_weekly_recap_payload(ctx, week_start: date, *, tz_name: str) -> tuple[dict, dict[str, list[SpotlightCandidate]]]:
+def _resolve_range_inputs(
+    week_start: date | None,
+    start_date: date | None,
+    end_date: date | None,
+) -> tuple[date, date]:
+    if start_date is not None and end_date is not None:
+        return normalize_date_range(start_date, end_date)
+    if week_start is None:
+        raise ValueError("Either week_start or both start_date and end_date are required")
+    return normalize_date_range(week_start, week_start + timedelta(days=6))
+
+
+def _compute_weekly_recap_payload(ctx, start_date: date, end_date: date, *, tz_name: str) -> tuple[dict, dict[str, list[SpotlightCandidate]]]:
     club_id = str(ctx.club_id)
     supabase = getattr(ctx, "supabase", None)
     df_matches = getattr(ctx, "df_matches", pd.DataFrame())
     id_to_name = getattr(ctx, "id_to_name", {}) or {}
     df_players_all = getattr(ctx, "df_players_all", pd.DataFrame())
 
-    start_dt_utc, end_dt_utc = get_week_bounds(week_start, tz_name)
+    start_date, end_date = normalize_date_range(start_date, end_date)
+    start_dt_utc, end_dt_utc = get_date_range_bounds(start_date, end_date, tz_name)
     df_week = _load_week_matches(df_matches, supabase, club_id, start_dt_utc, end_dt_utc)
     df_week = _filter_week_matches(df_week)
 
@@ -70,11 +111,10 @@ def _compute_weekly_recap_payload(ctx, week_start: date, *, tz_name: str) -> tup
         supabase,
     )
 
-    week_end = week_start + timedelta(days=6)
     recap = {
         "club_id": club_id,
-        "week_start": week_start.isoformat(),
-        "week_end": week_end.isoformat(),
+        "week_start": start_date.isoformat(),
+        "week_end": end_date.isoformat(),
         "numbers": numbers,
         "spotlight": [item.__dict__ for item in spotlight],
         "around_club": around_club,

--- a/jupr_app/ui/pages/weekly_recap_admin.py
+++ b/jupr_app/ui/pages/weekly_recap_admin.py
@@ -13,9 +13,12 @@ from jupr_app.ui.layout import page_shell
 from jupr_app.ui.url import qp_get
 
 
-def _get_default_week_start(tz_name: str) -> date:
+def _get_default_date_range(tz_name: str) -> tuple[date, date]:
     today = datetime.now(ZoneInfo(tz_name)).date()
-    return today - timedelta(days=today.weekday())
+    current_week_start = today - timedelta(days=today.weekday())
+    start_date = current_week_start - timedelta(days=7)
+    end_date = current_week_start - timedelta(days=1)
+    return start_date, end_date
 
 
 def _get_api_error_code(exc: APIError) -> str | None:
@@ -35,12 +38,13 @@ def _handle_missing_table(exc: APIError) -> bool:
     return False
 
 
-def _load_weekly_row(supabase, club_id: str, week_start: date) -> dict | None:
+def _load_weekly_row(supabase, club_id: str, start_date: date, end_date: date) -> dict | None:
     response = (
         supabase.table("weekly_recaps")
         .select("*")
         .eq("club_id", club_id)
-        .eq("week_start", week_start.isoformat())
+        .eq("week_start", start_date.isoformat())
+        .eq("week_end", end_date.isoformat())
         .execute()
     )
     if response.data:
@@ -91,10 +95,16 @@ def render(ctx):
     club_id = str(ctx.club_id)
     tz_name = "America/Mazatlan"
 
-    week_start = st.date_input("Week start (Monday)", value=_get_default_week_start(tz_name))
+    default_start, default_end = _get_default_date_range(tz_name)
+    start_date = st.date_input("Start date", value=default_start)
+    end_date = st.date_input("End date", value=default_end)
+
+    date_range_valid = bool(start_date and end_date and end_date >= start_date)
+    if end_date < start_date:
+        st.error("End date must be on or after start date.")
 
     try:
-        row = _load_weekly_row(supabase, club_id, week_start)
+        row = _load_weekly_row(supabase, club_id, start_date, end_date)
     except APIError as exc:
         if _handle_missing_table(exc):
             return
@@ -103,12 +113,12 @@ def render(ctx):
 
     st.write(f"Status: **{status}**")
 
-    if st.button("Generate Draft"):
+    if st.button("Generate Draft", disabled=not date_range_valid):
         with st.spinner("Generating weekly recap..."):
-            recap = compute_weekly_recap(ctx, week_start, tz_name=tz_name)
+            recap = compute_weekly_recap(ctx, start_date=start_date, end_date=end_date, tz_name=tz_name)
             payload = {
                 "club_id": club_id,
-                "week_start": week_start.isoformat(),
+                "week_start": start_date.isoformat(),
                 "week_end": recap.get("week_end"),
                 "status": "draft",
                 "generated_json": recap,
@@ -130,7 +140,7 @@ def render(ctx):
 
     generated_json = row.get("generated_json") or {}
     edits_json = row.get("edits_json") or {}
-    candidates = get_spotlight_candidates(ctx, week_start, tz_name=tz_name)
+    candidates = get_spotlight_candidates(ctx, start_date=start_date, end_date=end_date, tz_name=tz_name)
 
     st.subheader("Edit Draft")
 
@@ -180,7 +190,7 @@ def render(ctx):
         final_json = _apply_edits(generated_json, edits_json, candidates)
         payload = {
             "club_id": club_id,
-            "week_start": week_start.isoformat(),
+            "week_start": start_date.isoformat(),
             "week_end": generated_json.get("week_end"),
             "status": "draft",
             "generated_json": generated_json,
@@ -208,7 +218,7 @@ def render(ctx):
         final_json = _apply_edits(generated_json, edits_json, candidates)
         payload = {
             "club_id": club_id,
-            "week_start": week_start.isoformat(),
+            "week_start": start_date.isoformat(),
             "week_end": generated_json.get("week_end"),
             "status": "published",
             "generated_json": generated_json,
@@ -229,7 +239,7 @@ def render(ctx):
     if st.button("Unpublish"):
         payload = {
             "club_id": club_id,
-            "week_start": week_start.isoformat(),
+            "week_start": start_date.isoformat(),
             "week_end": generated_json.get("week_end"),
             "status": "draft",
             "generated_json": generated_json,

--- a/tests/test_weekly_recap_bounds.py
+++ b/tests/test_weekly_recap_bounds.py
@@ -1,9 +1,23 @@
 from datetime import date, timedelta
 
-from jupr_app.domain.recaps.weekly_recap import get_week_bounds
+import pytest
+
+from jupr_app.domain.recaps.weekly_recap import get_date_range_bounds, get_week_bounds, normalize_date_range
 
 
 def test_week_bounds_seven_days():
     start = date(2025, 1, 6)
     start_dt, end_dt = get_week_bounds(start, "America/Mazatlan")
     assert end_dt - start_dt == timedelta(days=7) - timedelta(microseconds=1)
+
+
+def test_date_range_bounds_inclusive_custom_span():
+    start = date(2025, 2, 1)
+    end = date(2025, 2, 3)
+    start_dt, end_dt = get_date_range_bounds(start, end, "America/Mazatlan")
+    assert end_dt - start_dt == timedelta(days=3) - timedelta(microseconds=1)
+
+
+def test_normalize_date_range_rejects_inverted_dates():
+    with pytest.raises(ValueError):
+        normalize_date_range(date(2025, 2, 2), date(2025, 2, 1))


### PR DESCRIPTION
### Motivation
- Replace the fixed "previous week" timeframe with an editable inclusive `start_date`/`end_date` so admins can generate recaps for arbitrary date ranges while preserving existing recap metrics and logic.
- Keep backward compatibility for existing callers that pass a `week_start` and avoid duplicating recap computations; only the timeframe derivation should change.

### Description
- Introduced `normalize_date_range(start_date, end_date)` and `get_date_range_bounds(start_date, end_date, tz_name)` to validate ranges and produce timezone-aware UTC boundaries (`00:00:00` start, `23:59:59.999999` end) for queries.
- Kept `get_week_bounds(week_start, tz_name)` as a compatibility shim that derives a 7-day range and delegates to `get_date_range_bounds`.
- Updated `compute_weekly_recap` and `get_spotlight_candidates` to accept either the legacy `week_start` or explicit `start_date`/`end_date`, with `_resolve_range_inputs` deciding the final inclusive range.
- Refactored `_compute_weekly_recap_payload` to accept `start_date`/`end_date` and use `get_date_range_bounds` so all match/session/rating/new-player queries use the normalized inclusive date range (`>= start` and `<= end`).
- Updated admin UI (`weekly_recap_admin`) to replace the single `Week start` input with required `Start date` and `End date` inputs (defaulting to the previous full week), validate `end_date >= start_date`, disable generation when invalid, and pass the selected range into recap generation and spotlight candidate fetch.
- Exported new date-range helpers from the recaps package and updated the recap payload to continue writing `week_start`/`week_end` (now reflecting the selected `start_date`/`end_date`).

### Testing
- Ran unit tests: `pytest -q tests/test_weekly_recap_bounds.py tests/test_weekly_recap_delta.py tests/test_weekly_recap_spotlight.py` and all tests passed (`5 passed`).
- Performed a manual UI smoke check by running `streamlit run streamlit_app.py` and capturing a Playwright screenshot of the updated Weekly Recap Admin page, confirming the new date inputs and validation behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1ed03d548326ad0b13002011b2e3)