### PR TITLE
Support configurable featured-player caps in weekly recap categories

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -7,6 +7,17 @@ from zoneinfo import ZoneInfo
 import pandas as pd
 
 
+DEFAULT_MAX_FEATURED = 3
+RECAP_CATEGORY_CONFIG = {
+    "TOP_PERFORMER": {
+        "label": "Top Performer",
+    },
+    "BIGGEST_JUMP": {
+        "label": "Biggest Jump",
+    },
+}
+
+
 @dataclass
 class SpotlightCandidate:
     candidate_id: str
@@ -701,42 +712,59 @@ def _event_highlights(
     if not stats:
         return []
 
-    def top_performer():
-        best = max(stats.items(), key=lambda item: (item[1].get("wins", 0), item[1].get("games", 0)))
-        pid, entry = best
-        name = id_to_name.get(pid, f"#{pid}")
-        wins = int(entry.get("wins", 0))
-        losses = int(entry.get("losses", 0))
-        label = "Top" if short_labels else "Top Performer"
-        display = f"{name} — {wins}-{losses}" if not short_labels else f"{name} {wins}-{losses}"
-        return {"key": "TOP_PERFORMER", "label": label, "display": display, "player_ids": [pid]}
+    def top_performer_players() -> list[dict]:
+        ranked = sorted(
+            stats.items(),
+            key=lambda item: (item[1].get("wins", 0), item[1].get("games", 0)),
+            reverse=True,
+        )
+        players = []
+        for pid, entry in ranked:
+            name = id_to_name.get(pid, f"#{pid}")
+            wins = int(entry.get("wins", 0))
+            losses = int(entry.get("losses", 0))
+            display = f"{name} — {wins}-{losses}" if not short_labels else f"{name} {wins}-{losses}"
+            players.append({"id": pid, "name": name, "display": display})
+        return players
 
-    def biggest_jump():
-        best = max(stats.items(), key=lambda item: item[1].get("delta_jupr", 0))
-        pid, entry = best
-        delta = float(entry.get("delta_jupr", 0))
-        if delta <= 0:
-            return None
-        name = id_to_name.get(pid, f"#{pid}")
-        label = "Jump" if short_labels else "Biggest Jump"
-        display = f"{name} — +{delta:.2f}" if short_labels else f"{name} — +{delta:.2f} JUPR"
-        return {"key": "BIGGEST_JUMP", "label": label, "display": display, "player_ids": [pid]}
+    def biggest_jump_players() -> list[dict]:
+        ranked = sorted(stats.items(), key=lambda item: item[1].get("delta_jupr", 0), reverse=True)
+        players = []
+        for pid, entry in ranked:
+            delta = float(entry.get("delta_jupr", 0))
+            if delta <= 0:
+                continue
+            name = id_to_name.get(pid, f"#{pid}")
+            display = f"{name} — +{delta:.2f}" if short_labels else f"{name} — +{delta:.2f} JUPR"
+            players.append({"id": pid, "name": name, "display": display})
+        return players
 
-    highlights = []
-    jump = biggest_jump()
-    top = top_performer()
-    if prefer_jump and jump is not None and (jump["display"]):
-        highlights.append(jump)
-    else:
-        highlights.append(top)
-    if count > 1:
-        if prefer_jump:
-            if top["key"] != highlights[0]["key"]:
-                highlights.append(top)
-        else:
-            if jump is not None:
-                highlights.append(jump)
-    return highlights[:count]
+    category_players = {
+        "TOP_PERFORMER": top_performer_players(),
+        "BIGGEST_JUMP": biggest_jump_players(),
+    }
+
+    category_order = ["BIGGEST_JUMP", "TOP_PERFORMER"] if prefer_jump else ["TOP_PERFORMER", "BIGGEST_JUMP"]
+    highlights: list[dict] = []
+    for key in category_order:
+        if len(highlights) >= count:
+            break
+        config = RECAP_CATEGORY_CONFIG.get(key, {})
+        label_default = "Top Performer" if key == "TOP_PERFORMER" else "Biggest Jump"
+        short_label_default = "Top" if key == "TOP_PERFORMER" else "Jump"
+        max_featured = int(config.get("max_featured", DEFAULT_MAX_FEATURED))
+        players = category_players.get(key, [])[:max(0, max_featured)]
+        if not players:
+            continue
+        highlights.append(
+            {
+                "key": key,
+                "label": short_label_default if short_labels else config.get("label", label_default),
+                "players": players,
+            }
+        )
+
+    return highlights
 
 
 def _fetch_rr_event_names(supabase, rr_events: list[str]) -> dict[str, str]:

--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -193,5 +193,24 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
 
 def _render_event_block(name: str, highlights: list[dict]) -> str:
     safe = [h for h in (highlights or []) if isinstance(h, dict)]
-    items = "".join(f"<li>{h.get('display','')}</li>" for h in safe if str(h.get("display","")).strip() != "")
+    items = ""
+    for highlight in safe:
+        category_players = [p for p in (highlight.get("players", []) or []) if isinstance(p, dict)]
+        label = str(highlight.get("label", "")).strip()
+        if category_players:
+            player_items = "".join(
+                f"<li>{player.get('display','')}</li>"
+                for player in category_players
+                if str(player.get("display", "")).strip() != ""
+            )
+            if player_items:
+                heading = f"<strong>{label}</strong>: " if label else ""
+                items += f"<li>{heading}<ul class='compact'>{player_items}</ul></li>"
+            continue
+
+        # Backward compatibility for older recap payloads.
+        display = str(highlight.get("display", "")).strip()
+        if display:
+            items += f"<li>{display}</li>"
+
     return f"<div class='event-block'><div class='event-name'>{name}</div><ul class='compact'>{items}</ul></div>"

--- a/tests/test_weekly_recap_categories.py
+++ b/tests/test_weekly_recap_categories.py
@@ -1,0 +1,65 @@
+from jupr_app.domain.recaps import weekly_recap
+
+
+def _stats_row(wins: int, games: int, delta: float, losses: int = 0) -> dict:
+    return {
+        "wins": wins,
+        "losses": losses,
+        "games": games,
+        "delta_jupr": delta,
+    }
+
+
+def test_event_highlights_default_featured_limit_is_three():
+    stats = {
+        1: _stats_row(6, 8, 0.20, losses=2),
+        2: _stats_row(5, 9, 0.15, losses=4),
+        3: _stats_row(4, 7, 0.10, losses=3),
+        4: _stats_row(3, 6, 0.05, losses=3),
+    }
+
+    highlights = weekly_recap._event_highlights(stats, {1: "A", 2: "B", 3: "C", 4: "D"}, count=1, short_labels=False, prefer_jump=False)
+
+    assert len(highlights) == 1
+    assert highlights[0]["key"] == "TOP_PERFORMER"
+    assert [player["id"] for player in highlights[0]["players"]] == [1, 2, 3]
+
+
+def test_event_highlights_respects_per_category_max_featured(monkeypatch):
+    original = weekly_recap.RECAP_CATEGORY_CONFIG
+    monkeypatch.setattr(
+        weekly_recap,
+        "RECAP_CATEGORY_CONFIG",
+        {
+            **original,
+            "TOP_PERFORMER": {
+                "label": "Top Performer",
+                "max_featured": 2,
+            },
+            "BIGGEST_JUMP": {
+                "label": "Biggest Jump",
+                "max_featured": 1,
+            },
+        },
+    )
+    stats = {
+        1: _stats_row(6, 8, 0.20, losses=2),
+        2: _stats_row(5, 9, 0.15, losses=4),
+        3: _stats_row(4, 7, 0.10, losses=3),
+    }
+
+    highlights = weekly_recap._event_highlights(stats, {1: "A", 2: "B", 3: "C"}, count=2, short_labels=False, prefer_jump=True)
+
+    assert highlights[0]["key"] == "BIGGEST_JUMP"
+    assert len(highlights[0]["players"]) == 1
+    assert len(highlights[1]["players"]) == 2
+
+
+def test_event_highlights_handles_empty_categories_without_errors():
+    stats = {1: _stats_row(3, 5, 0, losses=2)}
+
+    highlights = weekly_recap._event_highlights(stats, {1: "A"}, count=2, short_labels=False, prefer_jump=True)
+
+    assert len(highlights) == 1
+    assert highlights[0]["key"] == "TOP_PERFORMER"
+    assert highlights[0]["players"]


### PR DESCRIPTION
### Motivation
- Allow each recap category to feature 1–N players (default 3) instead of a single player to make the Spotlight / Around-the-Club UI more flexible.
- Centralize per-category caps so different categories can define different limits while preserving existing ranking/sorting logic.
- Maintain backward compatibility and ensure empty or undersized categories are handled gracefully.

### Description
- Introduced `DEFAULT_MAX_FEATURED = 3` and `RECAP_CATEGORY_CONFIG` in `jupr_app/domain/recaps/weekly_recap.py` to declare per-category `max_featured` values with a 3-player default.
- Refactored `_event_highlights` to build ranked player lists, slice each category to `max_featured` (without changing sort/metrics), and return highlights using a consistent `players` list payload instead of a single `display` entry.
- Updated the recap renderer `jupr_app/ui/components/weekly_recap_layout.py` to iterate over `highlight["players"]` and render flexible-length lists while keeping a fallback for legacy `display` entries.
- Added unit tests `tests/test_weekly_recap_categories.py` that validate the default limit, per-category overrides, and graceful handling of empty/fewer-than-limit categories.

### Testing
- Ran `pytest -q tests/test_weekly_recap_categories.py tests/test_weekly_recap_spotlight.py tests/test_weekly_recap_delta.py` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e21c5f5c08326b45e4ee1a39fe445)