### PR TITLE
Restore recap subsystem to main baseline

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -7,17 +7,6 @@ from zoneinfo import ZoneInfo
 import pandas as pd
 
 
-DEFAULT_MAX_FEATURED = 3
-RECAP_CATEGORY_CONFIG = {
-    "TOP_PERFORMER": {
-        "label": "Top Performer",
-    },
-    "BIGGEST_JUMP": {
-        "label": "Biggest Jump",
-    },
-}
-
-
 @dataclass
 class SpotlightCandidate:
     candidate_id: str
@@ -712,59 +701,42 @@ def _event_highlights(
     if not stats:
         return []
 
-    def top_performer_players() -> list[dict]:
-        ranked = sorted(
-            stats.items(),
-            key=lambda item: (item[1].get("wins", 0), item[1].get("games", 0)),
-            reverse=True,
-        )
-        players = []
-        for pid, entry in ranked:
-            name = id_to_name.get(pid, f"#{pid}")
-            wins = int(entry.get("wins", 0))
-            losses = int(entry.get("losses", 0))
-            display = f"{name} — {wins}-{losses}" if not short_labels else f"{name} {wins}-{losses}"
-            players.append({"id": pid, "name": name, "display": display})
-        return players
+    def top_performer():
+        best = max(stats.items(), key=lambda item: (item[1].get("wins", 0), item[1].get("games", 0)))
+        pid, entry = best
+        name = id_to_name.get(pid, f"#{pid}")
+        wins = int(entry.get("wins", 0))
+        losses = int(entry.get("losses", 0))
+        label = "Top" if short_labels else "Top Performer"
+        display = f"{name} — {wins}-{losses}" if not short_labels else f"{name} {wins}-{losses}"
+        return {"key": "TOP_PERFORMER", "label": label, "display": display, "player_ids": [pid]}
 
-    def biggest_jump_players() -> list[dict]:
-        ranked = sorted(stats.items(), key=lambda item: item[1].get("delta_jupr", 0), reverse=True)
-        players = []
-        for pid, entry in ranked:
-            delta = float(entry.get("delta_jupr", 0))
-            if delta <= 0:
-                continue
-            name = id_to_name.get(pid, f"#{pid}")
-            display = f"{name} — +{delta:.2f}" if short_labels else f"{name} — +{delta:.2f} JUPR"
-            players.append({"id": pid, "name": name, "display": display})
-        return players
+    def biggest_jump():
+        best = max(stats.items(), key=lambda item: item[1].get("delta_jupr", 0))
+        pid, entry = best
+        delta = float(entry.get("delta_jupr", 0))
+        if delta <= 0:
+            return None
+        name = id_to_name.get(pid, f"#{pid}")
+        label = "Jump" if short_labels else "Biggest Jump"
+        display = f"{name} — +{delta:.2f}" if short_labels else f"{name} — +{delta:.2f} JUPR"
+        return {"key": "BIGGEST_JUMP", "label": label, "display": display, "player_ids": [pid]}
 
-    category_players = {
-        "TOP_PERFORMER": top_performer_players(),
-        "BIGGEST_JUMP": biggest_jump_players(),
-    }
-
-    category_order = ["BIGGEST_JUMP", "TOP_PERFORMER"] if prefer_jump else ["TOP_PERFORMER", "BIGGEST_JUMP"]
-    highlights: list[dict] = []
-    for key in category_order:
-        if len(highlights) >= count:
-            break
-        config = RECAP_CATEGORY_CONFIG.get(key, {})
-        label_default = "Top Performer" if key == "TOP_PERFORMER" else "Biggest Jump"
-        short_label_default = "Top" if key == "TOP_PERFORMER" else "Jump"
-        max_featured = int(config.get("max_featured", DEFAULT_MAX_FEATURED))
-        players = category_players.get(key, [])[:max(0, max_featured)]
-        if not players:
-            continue
-        highlights.append(
-            {
-                "key": key,
-                "label": short_label_default if short_labels else config.get("label", label_default),
-                "players": players,
-            }
-        )
-
-    return highlights
+    highlights = []
+    jump = biggest_jump()
+    top = top_performer()
+    if prefer_jump and jump is not None and (jump["display"]):
+        highlights.append(jump)
+    else:
+        highlights.append(top)
+    if count > 1:
+        if prefer_jump:
+            if top["key"] != highlights[0]["key"]:
+                highlights.append(top)
+        else:
+            if jump is not None:
+                highlights.append(jump)
+    return highlights[:count]
 
 
 def _fetch_rr_event_names(supabase, rr_events: list[str]) -> dict[str, str]:

--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -193,24 +193,5 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
 
 def _render_event_block(name: str, highlights: list[dict]) -> str:
     safe = [h for h in (highlights or []) if isinstance(h, dict)]
-    items = ""
-    for highlight in safe:
-        category_players = [p for p in (highlight.get("players", []) or []) if isinstance(p, dict)]
-        label = str(highlight.get("label", "")).strip()
-        if category_players:
-            player_items = "".join(
-                f"<li>{player.get('display','')}</li>"
-                for player in category_players
-                if str(player.get("display", "")).strip() != ""
-            )
-            if player_items:
-                heading = f"<strong>{label}</strong>: " if label else ""
-                items += f"<li>{heading}<ul class='compact'>{player_items}</ul></li>"
-            continue
-
-        # Backward compatibility for older recap payloads.
-        display = str(highlight.get("display", "")).strip()
-        if display:
-            items += f"<li>{display}</li>"
-
+    items = "".join(f"<li>{h.get('display','')}</li>" for h in safe if str(h.get("display","")).strip() != "")
     return f"<div class='event-block'><div class='event-name'>{name}</div><ul class='compact'>{items}</ul></div>"


### PR DESCRIPTION
### Motivation
- Transplant the weekly recap subsystem to match the baseline implementation from main so the recap remains modular under `jupr_app/domain/recaps/` and does not hybridize with newer, unrelated systems.
- Ensure the UI layout and domain recap logic reflect the main baseline behavior rather than selectively copying individual functions or features.

### Description
- Replaced the domain recap implementation by restoring the baseline `jupr_app/domain/recaps/weekly_recap.py` behavior (spotlight candidate model, recap payload construction, simplified `_event_highlights` behavior, and related helpers). 
- Restored the baseline UI layout component in `jupr_app/ui/components/weekly_recap_layout.py` that renders the numbers strip, spotlight reel, around-club blocks, and looking-ahead section and simplified event highlight rendering to rely on the baseline payload shape.
- Kept the recap subsystem modular under `jupr_app/domain/recaps/` and intentionally avoided pulling in unrelated systems (match pipeline, session ladder engine, gamification v3, tournaments rewrite, or leaderboards rewrite).
- Did not include `jupr_app/domain/replay_history.py` or `jupr_app/domain/replay_engine.py` because the restored recap code does not import them.

### Testing
- Ran `pytest -q tests/test_weekly_recap_categories.py` and it failed with 3 failing tests in that file. 
- Failures are due to the baseline transplant removing the configurable recap-category API (`RECAP_CATEGORY_CONFIG`) and the per-category `players` structure that the tests expect, causing the tests to assert missing keys and attributes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699efbee20e083269cd08e46415b443a)