### PR TITLE
Port weekly recap to date-range API with tournament-aware categories

### DIFF
--- a/jupr_app/domain/recaps/__init__.py
+++ b/jupr_app/domain/recaps/__init__.py
@@ -2,14 +2,12 @@ from .weekly_recap import (
     compute_weekly_recap,
     get_date_range_bounds,
     get_spotlight_candidates,
-    get_week_bounds,
     normalize_date_range,
 )
 
 __all__ = [
     "compute_weekly_recap",
     "get_spotlight_candidates",
-    "get_week_bounds",
     "get_date_range_bounds",
     "normalize_date_range",
 ]

--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import date, datetime, time, timezone
 from zoneinfo import ZoneInfo
 
 import pandas as pd
@@ -19,6 +19,13 @@ class SpotlightCandidate:
     band: str | None = None
 
 
+MAX_FEATURED_PER_CATEGORY = 3
+RECAP_CATEGORY_CONFIG = {
+    "TOP_PERFORMER": {"label": "Top Performer", "max_featured": MAX_FEATURED_PER_CATEGORY},
+    "BIGGEST_JUMP": {"label": "Biggest Jump", "max_featured": MAX_FEATURED_PER_CATEGORY},
+}
+
+
 def normalize_date_range(start_date: date, end_date: date) -> tuple[date, date]:
     if end_date < start_date:
         raise ValueError("end_date must be on or after start_date")
@@ -33,53 +40,57 @@ def get_date_range_bounds(start_date: date, end_date: date, tz_name: str) -> tup
     return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
 
 
-def get_week_bounds(week_start: date, tz_name: str) -> tuple[datetime, datetime]:
-    week_end = week_start + timedelta(days=6)
-    return get_date_range_bounds(week_start, week_end, tz_name)
-
-
 def compute_weekly_recap(
     ctx,
-    week_start: date | None = None,
+    start_date: date,
+    end_date: date,
     *,
-    start_date: date | None = None,
-    end_date: date | None = None,
+    include_tournaments: bool = True,
     tz_name: str = "America/Mazatlan",
 ) -> dict:
-    start_date, end_date = _resolve_range_inputs(week_start, start_date, end_date)
-    recap, _ = _compute_weekly_recap_payload(ctx, start_date, end_date, tz_name=tz_name)
+    recap, _ = _compute_weekly_recap_payload(
+        ctx,
+        start_date,
+        end_date,
+        include_tournaments=include_tournaments,
+        tz_name=tz_name,
+    )
     return recap
 
 
 def get_spotlight_candidates(
     ctx,
-    week_start: date | None = None,
+    start_date: date,
+    end_date: date,
     *,
-    start_date: date | None = None,
-    end_date: date | None = None,
+    include_tournaments: bool = True,
     tz_name: str = "America/Mazatlan",
 ) -> dict[str, list[dict]]:
-    start_date, end_date = _resolve_range_inputs(week_start, start_date, end_date)
-    _, candidates = _compute_weekly_recap_payload(ctx, start_date, end_date, tz_name=tz_name)
+    _, candidates = _compute_weekly_recap_payload(
+        ctx,
+        start_date,
+        end_date,
+        include_tournaments=include_tournaments,
+        tz_name=tz_name,
+    )
     return {
         key: [candidate.__dict__ for candidate in items]
         for key, items in candidates.items()
     }
 
 
-def _resolve_range_inputs(
-    week_start: date | None,
-    start_date: date | None,
-    end_date: date | None,
-) -> tuple[date, date]:
-    if start_date is not None and end_date is not None:
-        return normalize_date_range(start_date, end_date)
-    if week_start is None:
-        raise ValueError("Either week_start or both start_date and end_date are required")
-    return normalize_date_range(week_start, week_start + timedelta(days=6))
+def _within_bounds(match_date: date, start_date: date, end_date: date) -> bool:
+    return start_date <= match_date <= end_date
 
 
-def _compute_weekly_recap_payload(ctx, start_date: date, end_date: date, *, tz_name: str) -> tuple[dict, dict[str, list[SpotlightCandidate]]]:
+def _compute_weekly_recap_payload(
+    ctx,
+    start_date: date,
+    end_date: date,
+    *,
+    include_tournaments: bool,
+    tz_name: str,
+) -> tuple[dict, dict[str, list[SpotlightCandidate]]]:
     club_id = str(ctx.club_id)
     supabase = getattr(ctx, "supabase", None)
     df_matches = getattr(ctx, "df_matches", pd.DataFrame())
@@ -88,8 +99,17 @@ def _compute_weekly_recap_payload(ctx, start_date: date, end_date: date, *, tz_n
 
     start_date, end_date = normalize_date_range(start_date, end_date)
     start_dt_utc, end_dt_utc = get_date_range_bounds(start_date, end_date, tz_name)
-    df_week = _load_week_matches(df_matches, supabase, club_id, start_dt_utc, end_dt_utc)
-    df_week = _filter_week_matches(df_week)
+    df_week = _load_matches(
+        df_matches,
+        supabase,
+        club_id,
+        start_date,
+        end_date,
+        start_dt_utc,
+        end_dt_utc,
+        include_tournaments=include_tournaments,
+    )
+    df_week = _filter_matches(df_week, include_tournaments=include_tournaments)
 
     rating_map = _build_rating_map(df_players_all)
 
@@ -113,9 +133,12 @@ def _compute_weekly_recap_payload(ctx, start_date: date, end_date: date, *, tz_n
 
     recap = {
         "club_id": club_id,
-        "week_start": start_date.isoformat(),
-        "week_end": end_date.isoformat(),
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        "display_range": f"{start_date.isoformat()} – {end_date.isoformat()}",
         "numbers": numbers,
+        "top_performers": _build_top_performers(stats, id_to_name),
+        "category_sections": _build_category_sections(stats, id_to_name),
         "spotlight": [item.__dict__ for item in spotlight],
         "around_club": around_club,
         "looking_ahead": ["", "", ""],
@@ -127,22 +150,27 @@ def _compute_weekly_recap_payload(ctx, start_date: date, end_date: date, *, tz_n
     return recap, spotlight_candidates
 
 
-def _load_week_matches(
+def _load_matches(
     df_matches: pd.DataFrame | None,
     supabase,
     club_id: str,
+    start_date: date,
+    end_date: date,
     start_dt: datetime,
     end_dt: datetime,
+    *,
+    include_tournaments: bool,
 ) -> pd.DataFrame:
+    frames: list[pd.DataFrame] = []
     if df_matches is not None and not df_matches.empty:
         df_local = df_matches.copy()
         df_local["date_dt"] = pd.to_datetime(df_local.get("date", None), utc=True, errors="coerce")
-        in_range = df_local[(df_local["date_dt"] >= start_dt) & (df_local["date_dt"] <= end_dt)].copy()
+        in_range = _filter_by_date_bounds(df_local, start_date, end_date)
         if not in_range.empty:
-            return in_range
+            frames.append(in_range)
 
     if supabase is None:
-        return pd.DataFrame()
+        return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
 
     select_cols = [
         "id",
@@ -176,27 +204,63 @@ def _load_week_matches(
         .lte("date", end_dt.isoformat())
         .execute()
     )
-    return pd.DataFrame(response.data or [])
+    frames.append(pd.DataFrame(response.data or []))
+
+    if include_tournaments:
+        for table_name in ("tournament_games", "playoff_matches"):
+            try:
+                table_response = (
+                    supabase.table(table_name)
+                    .select(
+                        "id,date,t1_p1,t1_p2,t2_p1,t2_p2,score_t1,score_t2,t1_p1_r,t1_p2_r,t2_p1_r,t2_p2_r,t1_p1_r_end,t1_p2_r_end,t2_p1_r_end,t2_p2_r_end"
+                    )
+                    .eq("club_id", club_id)
+                    .gte("date", start_dt.isoformat())
+                    .lte("date", end_dt.isoformat())
+                    .execute()
+                )
+            except Exception:
+                continue
+            table_df = pd.DataFrame(table_response.data or [])
+            if table_df.empty:
+                continue
+            table_df["match_type"] = "Tournament"
+            table_df["context_type"] = "TOURNAMENT"
+            frames.append(table_df)
+
+    return pd.concat([df for df in frames if not df.empty], ignore_index=True) if frames else pd.DataFrame()
 
 
-def _filter_week_matches(df_matches: pd.DataFrame) -> pd.DataFrame:
+def _filter_matches(df_matches: pd.DataFrame, *, include_tournaments: bool) -> pd.DataFrame:
     if df_matches is None or df_matches.empty:
         return pd.DataFrame()
     df = df_matches.copy()
     df["score_t1"] = pd.to_numeric(df.get("score_t1", 0), errors="coerce").fillna(0).astype(int)
     df["score_t2"] = pd.to_numeric(df.get("score_t2", 0), errors="coerce").fillna(0).astype(int)
     df = df[(df["score_t1"] + df["score_t2"]) > 0].copy()
-    if "context_type" in df.columns:
+    if not include_tournaments and "context_type" in df.columns:
         df = df[df["context_type"].fillna("").astype(str).str.upper() != "TOURNAMENT"].copy()
-    if "tournament_id" in df.columns:
+    if not include_tournaments and "tournament_id" in df.columns:
         df = df[df["tournament_id"].isna()].copy()
-    if "match_type" in df.columns:
+    if not include_tournaments and "match_type" in df.columns:
         df = df[df["match_type"].fillna("").astype(str) != "Tournament"].copy()
     df["league"] = df.get("league", "").fillna("").astype(str).str.strip()
     df["match_type"] = df.get("match_type", "").fillna("").astype(str).str.strip()
-    df["week_tag"] = df.get("week_tag", "").fillna("").astype(str).str.strip()
+    if "week_tag" in df.columns:
+        df["week_tag"] = df["week_tag"].fillna("").astype(str).str.strip()
+    else:
+        df["week_tag"] = ""
     df["date_dt"] = pd.to_datetime(df.get("date", None), utc=True, errors="coerce")
     return df
+
+
+def _filter_by_date_bounds(df: pd.DataFrame, start_date: date, end_date: date) -> pd.DataFrame:
+    if df.empty:
+        return df
+    date_values = pd.to_datetime(df.get("date", None), utc=True, errors="coerce")
+    dates = date_values.dt.date
+    mask = dates.apply(lambda d: isinstance(d, date) and _within_bounds(d, start_date, end_date))
+    return df.loc[mask.fillna(False)].copy()
 
 
 def _build_rating_map(df_players_all: pd.DataFrame | None) -> dict[int, float]:
@@ -691,6 +755,45 @@ def _build_around_club(
     return {"leagues": league_items, "round_robins": rr_items}
 
 
+def _stable_ranked_players(
+    stats: dict[int, dict],
+    *,
+    primary_metric: str,
+    tie_break_metric: str,
+    descending: bool = True,
+) -> list[tuple[int, dict]]:
+    direction = -1 if descending else 1
+    return sorted(
+        stats.items(),
+        key=lambda item: (
+            direction * float(item[1].get(primary_metric, 0) or 0),
+            direction * float(item[1].get(tie_break_metric, 0) or 0),
+            int(item[0]),
+        ),
+    )
+
+
+def _build_top_performers(stats: dict[int, dict], id_to_name: dict[int, str]) -> list[dict]:
+    ranked = _stable_ranked_players(stats, primary_metric="wins", tie_break_metric="games")
+    return [
+        {
+            "player_id": pid,
+            "player_name": id_to_name.get(pid, f"#{pid}"),
+            "wins": int(entry.get("wins", 0)),
+            "losses": int(entry.get("losses", 0)),
+            "games": int(entry.get("games", 0)),
+        }
+        for pid, entry in ranked[:MAX_FEATURED_PER_CATEGORY]
+    ]
+
+
+def _build_category_sections(stats: dict[int, dict], id_to_name: dict[int, str]) -> dict[str, list[dict]]:
+    return {
+        "top_performer": _event_highlights(stats, id_to_name, count=1, short_labels=False, prefer_jump=False),
+        "biggest_jump": _event_highlights(stats, id_to_name, count=1, short_labels=False, prefer_jump=True),
+    }
+
+
 def _event_highlights(
     stats: dict[int, dict],
     id_to_name: dict[int, str],
@@ -701,42 +804,51 @@ def _event_highlights(
     if not stats:
         return []
 
-    def top_performer():
-        best = max(stats.items(), key=lambda item: (item[1].get("wins", 0), item[1].get("games", 0)))
-        pid, entry = best
-        name = id_to_name.get(pid, f"#{pid}")
-        wins = int(entry.get("wins", 0))
-        losses = int(entry.get("losses", 0))
-        label = "Top" if short_labels else "Top Performer"
-        display = f"{name} — {wins}-{losses}" if not short_labels else f"{name} {wins}-{losses}"
-        return {"key": "TOP_PERFORMER", "label": label, "display": display, "player_ids": [pid]}
+    def _players_payload(ranked: list[tuple[int, dict]], limit: int) -> list[dict]:
+        return [
+            {
+                "id": pid,
+                "name": id_to_name.get(pid, f"#{pid}"),
+                "wins": int(entry.get("wins", 0)),
+                "losses": int(entry.get("losses", 0)),
+                "games": int(entry.get("games", 0)),
+                "delta_jupr": float(entry.get("delta_jupr", 0) or 0),
+            }
+            for pid, entry in ranked[:limit]
+        ]
 
-    def biggest_jump():
-        best = max(stats.items(), key=lambda item: item[1].get("delta_jupr", 0))
-        pid, entry = best
-        delta = float(entry.get("delta_jupr", 0))
-        if delta <= 0:
-            return None
-        name = id_to_name.get(pid, f"#{pid}")
-        label = "Jump" if short_labels else "Biggest Jump"
-        display = f"{name} — +{delta:.2f}" if short_labels else f"{name} — +{delta:.2f} JUPR"
-        return {"key": "BIGGEST_JUMP", "label": label, "display": display, "player_ids": [pid]}
+    categories: list[dict] = []
+    top_cfg = RECAP_CATEGORY_CONFIG.get("TOP_PERFORMER", {})
+    top_ranked = _stable_ranked_players(stats, primary_metric="wins", tie_break_metric="games")
+    top_players = _players_payload(top_ranked, int(top_cfg.get("max_featured", MAX_FEATURED_PER_CATEGORY)))
+    if top_players:
+        categories.append(
+            {
+                "key": "TOP_PERFORMER",
+                "label": "Top" if short_labels else top_cfg.get("label", "Top Performer"),
+                "players": top_players,
+                "player_ids": [p["id"] for p in top_players],
+                "display": ", ".join(f"{p['name']} {p['wins']}-{p['losses']}" for p in top_players),
+            }
+        )
 
-    highlights = []
-    jump = biggest_jump()
-    top = top_performer()
-    if prefer_jump and jump is not None and (jump["display"]):
-        highlights.append(jump)
-    else:
-        highlights.append(top)
-    if count > 1:
-        if prefer_jump:
-            if top["key"] != highlights[0]["key"]:
-                highlights.append(top)
-        else:
-            if jump is not None:
-                highlights.append(jump)
-    return highlights[:count]
+    jump_cfg = RECAP_CATEGORY_CONFIG.get("BIGGEST_JUMP", {})
+    jump_ranked = [row for row in _stable_ranked_players(stats, primary_metric="delta_jupr", tie_break_metric="games") if float(row[1].get("delta_jupr", 0) or 0) > 0]
+    jump_players = _players_payload(jump_ranked, int(jump_cfg.get("max_featured", MAX_FEATURED_PER_CATEGORY)))
+    if jump_players:
+        categories.append(
+            {
+                "key": "BIGGEST_JUMP",
+                "label": "Jump" if short_labels else jump_cfg.get("label", "Biggest Jump"),
+                "players": jump_players,
+                "player_ids": [p["id"] for p in jump_players],
+                "display": ", ".join(f"{p['name']} +{p['delta_jupr']:.2f}" for p in jump_players),
+            }
+        )
+
+    if prefer_jump:
+        categories.sort(key=lambda item: 0 if item["key"] == "BIGGEST_JUMP" else 1)
+    return categories[:count]
 
 
 def _fetch_rr_event_names(supabase, rr_events: list[str]) -> dict[str, str]:

--- a/jupr_app/ui/pages/weekly_recap_admin.py
+++ b/jupr_app/ui/pages/weekly_recap_admin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 from zoneinfo import ZoneInfo
 
 import streamlit as st
@@ -15,10 +15,7 @@ from jupr_app.ui.url import qp_get
 
 def _get_default_date_range(tz_name: str) -> tuple[date, date]:
     today = datetime.now(ZoneInfo(tz_name)).date()
-    current_week_start = today - timedelta(days=today.weekday())
-    start_date = current_week_start - timedelta(days=7)
-    end_date = current_week_start - timedelta(days=1)
-    return start_date, end_date
+    return today, today
 
 
 def _get_api_error_code(exc: APIError) -> str | None:
@@ -96,12 +93,20 @@ def render(ctx):
     tz_name = "America/Mazatlan"
 
     default_start, default_end = _get_default_date_range(tz_name)
-    start_date = st.date_input("Start date", value=default_start)
-    end_date = st.date_input("End date", value=default_end)
+    start_date = st.date_input("Start Date", value=default_start)
+    end_date = st.date_input("End Date", value=default_end)
 
     date_range_valid = bool(start_date and end_date and end_date >= start_date)
     if end_date < start_date:
         st.error("End date must be on or after start date.")
+        date_range_valid = False
+    day_span = (end_date - start_date).days + 1
+    if day_span <= 0:
+        st.error("Date range cannot be empty.")
+        date_range_valid = False
+    if day_span > 60:
+        st.error("Date range cannot exceed 60 days.")
+        date_range_valid = False
 
     try:
         row = _load_weekly_row(supabase, club_id, start_date, end_date)
@@ -115,11 +120,11 @@ def render(ctx):
 
     if st.button("Generate Draft", disabled=not date_range_valid):
         with st.spinner("Generating weekly recap..."):
-            recap = compute_weekly_recap(ctx, start_date=start_date, end_date=end_date, tz_name=tz_name)
+            recap = compute_weekly_recap(ctx, start_date=start_date, end_date=end_date, include_tournaments=True, tz_name=tz_name)
             payload = {
                 "club_id": club_id,
                 "week_start": start_date.isoformat(),
-                "week_end": recap.get("week_end"),
+                "week_end": recap.get("end_date"),
                 "status": "draft",
                 "generated_json": recap,
                 "edits_json": {},
@@ -140,7 +145,7 @@ def render(ctx):
 
     generated_json = row.get("generated_json") or {}
     edits_json = row.get("edits_json") or {}
-    candidates = get_spotlight_candidates(ctx, start_date=start_date, end_date=end_date, tz_name=tz_name)
+    candidates = get_spotlight_candidates(ctx, start_date=start_date, end_date=end_date, include_tournaments=True, tz_name=tz_name)
 
     st.subheader("Edit Draft")
 
@@ -191,7 +196,7 @@ def render(ctx):
         payload = {
             "club_id": club_id,
             "week_start": start_date.isoformat(),
-            "week_end": generated_json.get("week_end"),
+            "week_end": generated_json.get("end_date"),
             "status": "draft",
             "generated_json": generated_json,
             "edits_json": edits_json,
@@ -219,7 +224,7 @@ def render(ctx):
         payload = {
             "club_id": club_id,
             "week_start": start_date.isoformat(),
-            "week_end": generated_json.get("week_end"),
+            "week_end": generated_json.get("end_date"),
             "status": "published",
             "generated_json": generated_json,
             "edits_json": edits_json,
@@ -240,7 +245,7 @@ def render(ctx):
         payload = {
             "club_id": club_id,
             "week_start": start_date.isoformat(),
-            "week_end": generated_json.get("week_end"),
+            "week_end": generated_json.get("end_date"),
             "status": "draft",
             "generated_json": generated_json,
             "edits_json": edits_json,

--- a/tests/test_weekly_recap_bounds.py
+++ b/tests/test_weekly_recap_bounds.py
@@ -2,13 +2,7 @@ from datetime import date, timedelta
 
 import pytest
 
-from jupr_app.domain.recaps.weekly_recap import get_date_range_bounds, get_week_bounds, normalize_date_range
-
-
-def test_week_bounds_seven_days():
-    start = date(2025, 1, 6)
-    start_dt, end_dt = get_week_bounds(start, "America/Mazatlan")
-    assert end_dt - start_dt == timedelta(days=7) - timedelta(microseconds=1)
+from jupr_app.domain.recaps.weekly_recap import _within_bounds, get_date_range_bounds, normalize_date_range
 
 
 def test_date_range_bounds_inclusive_custom_span():
@@ -16,6 +10,13 @@ def test_date_range_bounds_inclusive_custom_span():
     end = date(2025, 2, 3)
     start_dt, end_dt = get_date_range_bounds(start, end, "America/Mazatlan")
     assert end_dt - start_dt == timedelta(days=3) - timedelta(microseconds=1)
+
+
+def test_within_bounds_is_inclusive_for_lower_and_upper_bound():
+    start = date(2025, 2, 1)
+    end = date(2025, 2, 3)
+    assert _within_bounds(start, start, end)
+    assert _within_bounds(end, start, end)
 
 
 def test_normalize_date_range_rejects_inverted_dates():

--- a/tests/test_weekly_recap_categories.py
+++ b/tests/test_weekly_recap_categories.py
@@ -63,3 +63,15 @@ def test_event_highlights_handles_empty_categories_without_errors():
     assert len(highlights) == 1
     assert highlights[0]["key"] == "TOP_PERFORMER"
     assert highlights[0]["players"]
+
+
+def test_event_highlights_tie_breaks_by_player_id_for_stability():
+    stats = {
+        10: _stats_row(4, 8, 0.12, losses=4),
+        5: _stats_row(4, 8, 0.12, losses=4),
+        12: _stats_row(4, 8, 0.12, losses=4),
+    }
+
+    highlights = weekly_recap._event_highlights(stats, {5: "E", 10: "J", 12: "L"}, count=1, short_labels=False, prefer_jump=False)
+
+    assert [player["id"] for player in highlights[0]["players"]] == [5, 10, 12]

--- a/tests/test_weekly_recap_range_driven.py
+++ b/tests/test_weekly_recap_range_driven.py
@@ -1,0 +1,99 @@
+from datetime import date
+from types import SimpleNamespace
+
+import pandas as pd
+
+from jupr_app.domain.recaps.weekly_recap import compute_weekly_recap
+
+
+def _ctx(df_matches: pd.DataFrame) -> SimpleNamespace:
+    return SimpleNamespace(
+        club_id="club-1",
+        supabase=None,
+        df_matches=df_matches,
+        id_to_name={1: "A", 2: "B", 3: "C", 4: "D"},
+        df_players_all=pd.DataFrame(
+            [
+                {"id": 1, "rating": 1200},
+                {"id": 2, "rating": 1200},
+                {"id": 3, "rating": 1200},
+                {"id": 4, "rating": 1200},
+            ]
+        ),
+    )
+
+
+def test_recap_is_date_range_driven_not_week_driven():
+    df = pd.DataFrame(
+        [
+            {
+                "id": 1,
+                "date": "2025-02-01T10:00:00Z",
+                "league": "Alpha",
+                "match_type": "League",
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+                "score_t1": 11,
+                "score_t2": 5,
+            },
+            {
+                "id": 2,
+                "date": "2025-02-08T10:00:00Z",
+                "league": "Alpha",
+                "match_type": "League",
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+                "score_t1": 11,
+                "score_t2": 7,
+            },
+        ]
+    )
+
+    recap = compute_weekly_recap(_ctx(df), start_date=date(2025, 2, 1), end_date=date(2025, 2, 1))
+
+    assert recap["numbers"]["matches"] == 1
+    assert recap["start_date"] == "2025-02-01"
+    assert recap["end_date"] == "2025-02-01"
+
+
+def test_tournament_matches_are_conditionally_included():
+    df = pd.DataFrame(
+        [
+            {
+                "id": 1,
+                "date": "2025-02-01T10:00:00Z",
+                "league": "Alpha",
+                "match_type": "League",
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+                "score_t1": 11,
+                "score_t2": 8,
+            },
+            {
+                "id": 2,
+                "date": "2025-02-01T11:00:00Z",
+                "league": "Alpha",
+                "match_type": "Tournament",
+                "context_type": "TOURNAMENT",
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+                "score_t1": 11,
+                "score_t2": 6,
+            },
+        ]
+    )
+    ctx = _ctx(df)
+
+    included = compute_weekly_recap(ctx, start_date=date(2025, 2, 1), end_date=date(2025, 2, 1), include_tournaments=True)
+    excluded = compute_weekly_recap(ctx, start_date=date(2025, 2, 1), end_date=date(2025, 2, 1), include_tournaments=False)
+
+    assert included["numbers"]["matches"] == 2
+    assert excluded["numbers"]["matches"] == 1


### PR DESCRIPTION
### Motivation
- Remove all week-number/ISO-week coupling and make recap computation explicitly driven by an admin-provided `start_date`/`end_date` range. 
- Add conditional tournament inclusion and multi-feature-per-category support to match the richer recap behavior from main. 
- Keep changes focused to the recap layer and admin UI without touching unrelated systems or DB schema.

### Description
- Replaced week-based API with explicit `compute_weekly_recap(ctx, start_date, end_date, *, include_tournaments: bool = True)` and updated `get_spotlight_candidates` to the same signature. 
- Centralized bounds logic in `_within_bounds` and switched all match/tournament filtering/loading to date-range comparisons (timezone-safe via `get_date_range_bounds`). 
- Added tournament-aware loading of `tournament_games`/`playoff_matches` (conditional on `include_tournaments`) and unified match filtering via `_load_matches`/`_filter_matches`/`_filter_by_date_bounds`. 
- Updated payload shape to remove week fields and include `start_date`, `end_date`, `display_range`, `top_performers`, and `category_sections` while preserving `spotlight` and `around_club`. 
- Introduced multi-feature-per-category support (`MAX_FEATURED_PER_CATEGORY = 3`), deterministic ranking (`_stable_ranked_players` using primary metric, tie-break, then `player_id`), and configurable per-category limits via `RECAP_CATEGORY_CONFIG`. 
- Updated admin UI `jupr_app/ui/pages/weekly_recap_admin.py` to present explicit `Start Date`/`End Date` controls, validate bounds (inclusive, non-empty, optional 60-day guardrail), and call the new date-range API without any week derivation. 
- Removed the obsolete `get_week_bounds` export and added/adjusted recap tests to use date ranges and validate bounds, category behavior, deterministic ordering, and tournament inclusion.

### Testing
- Ran the focused recap test suite with `pytest -q tests/test_weekly_recap_bounds.py tests/test_weekly_recap_categories.py tests/test_weekly_recap_range_driven.py tests/test_weekly_recap_spotlight.py tests/test_weekly_recap_delta.py` and all tests passed (`11 passed`). 
- Ran repository search for week-based artifacts with `rg -n "week_number|iso_week|calendar_week|get_week_range"` to verify no remaining week-number recap references were left. 
- Tests added/updated: `tests/test_weekly_recap_range_driven.py` (new), and adjustments to `tests/test_weekly_recap_bounds.py` and `tests/test_weekly_recap_categories.py` to use date-range-driven assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0a29f691883268c72d59254f0ce9b)