### PR TITLE
Backport tournament engine schema into rollback-feb8

### DIFF
--- a/supabase/migrations/2026XX_backport_tournament_engine.sql
+++ b/supabase/migrations/2026XX_backport_tournament_engine.sql
@@ -1,0 +1,89 @@
+-- Backport tournament engine schema updates.
+-- Scoped to tournament tables only.
+
+CREATE TABLE IF NOT EXISTS public.tournaments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  club_id text NOT NULL,
+  name text NOT NULL,
+  status text NOT NULL DEFAULT 'DRAFT',
+  team_count integer NOT NULL,
+  playoff_advance_count integer NULL,
+  created_by_admin_id text NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tournaments_club_id
+  ON public.tournaments (club_id);
+
+CREATE TABLE IF NOT EXISTS public.tournament_games (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tournament_id uuid NOT NULL REFERENCES public.tournaments(id) ON DELETE CASCADE,
+  stage text NOT NULL,
+  rr_round_number integer NULL,
+  rr_slot_number integer NULL,
+  playoff_game_code text NULL,
+  playoff_round text NULL,
+  team_a_id uuid NULL REFERENCES public.tournament_teams(id),
+  team_b_id uuid NULL REFERENCES public.tournament_teams(id),
+  team_a_source jsonb NULL,
+  team_b_source jsonb NULL,
+  score_a integer NULL,
+  score_b integer NULL,
+  winner_team_id uuid NULL REFERENCES public.tournament_teams(id),
+  loser_team_id uuid NULL REFERENCES public.tournament_teams(id),
+  finalized_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tournament_games_tournament_id
+  ON public.tournament_games (tournament_id);
+
+CREATE INDEX IF NOT EXISTS idx_tournament_games_stage
+  ON public.tournament_games (stage);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'tournament_games_rr_unique'
+      AND conrelid = 'public.tournament_games'::regclass
+  ) THEN
+    ALTER TABLE public.tournament_games
+      ADD CONSTRAINT tournament_games_rr_unique
+      UNIQUE (tournament_id, rr_round_number, rr_slot_number);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'tournament_games_playoff_unique'
+      AND conrelid = 'public.tournament_games'::regclass
+  ) THEN
+    ALTER TABLE public.tournament_games
+      ADD CONSTRAINT tournament_games_playoff_unique
+      UNIQUE (tournament_id, playoff_game_code);
+  END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS public.tournament_podium (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tournament_id uuid NOT NULL REFERENCES public.tournaments(id) ON DELETE CASCADE,
+  placement integer NOT NULL,
+  team_id uuid NOT NULL REFERENCES public.tournament_teams(id) ON DELETE RESTRICT,
+  source text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT tournament_podium_unique_placement UNIQUE (tournament_id, placement),
+  CONSTRAINT tournament_podium_unique_team UNIQUE (tournament_id, team_id),
+  CONSTRAINT tournament_podium_valid_placement CHECK (placement BETWEEN 1 AND 3)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tournament_podium_tournament_id
+  ON public.tournament_podium (tournament_id);


### PR DESCRIPTION
### Motivation
- Backport the tournament schema changes from the main branch into the `rollback-feb8` branch so rollback deployments have the tournament engine DDL available. 
- Keep the backport strictly scoped to tournament-related tables and constraints and avoid touching unrelated schemas (match pipeline, replay, badge, ladder, RLS/global idempotency rewrites).

### Description
- Added a single migration file `supabase/migrations/2026XX_backport_tournament_engine.sql` that consolidates tournament DDL in dependency order (`tournaments` → `tournament_games` → `tournament_podium`).
- Created `public.tournaments` with `idx_tournaments_club_id` and `public.tournament_games` with `idx_tournament_games_tournament_id` and `idx_tournament_games_stage` using `CREATE ... IF NOT EXISTS` for idempotency.
- Added guarded unique constraints on `public.tournament_games` for round-robin and playoff uniqueness via `DO $$ ... IF NOT EXISTS (SELECT 1 FROM pg_constraint ...)` blocks to avoid duplicate constraint-name errors across environments.
- Created `public.tournament_podium` with uniqueness constraints and a placement check, plus `idx_tournament_podium_tournament_id`, and avoided any DDL touching non-tournament tables.

### Testing
- Located the source DDL with `rg -n "tournament|playoff|division|rr_unique|game_conflict_key|tournament_games_unique|canonicalize_tournament" migrations/*.sql` and confirmed relevant migration files were found (successful).
- Inspected source migrations with `sed -n '1,220p' migrations/20250425_tournaments.sql` and `sed -n '1,220p' migrations/20250505_tournament_podium.sql` to extract the required statements (successful).
- Verified the new migration content with `nl -ba supabase/migrations/2026XX_backport_tournament_engine.sql` to confirm order and presence of guarded constraints (successful).
- Checked for excluded domains using `rg -n "match_pipeline|replay|badge|ladder|RLS|idempotency" supabase/migrations/2026XX_backport_tournament_engine.sql` and confirmed there were no matches (successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b2a07bb483269a62a1469ae82a05)