### PR TITLE
Backport tournament engine 6-team round robin support and add regression test

### DIFF
--- a/tests/test_tournament_bracket_builder.py
+++ b/tests/test_tournament_bracket_builder.py
@@ -1,0 +1,21 @@
+from jupr_app.domain.tournaments.bracket_builder import SUPPORTED_TEAM_COUNTS, build_round_robin_games
+
+
+def test_supported_team_counts_include_six() -> None:
+    assert SUPPORTED_TEAM_COUNTS == [4, 5, 6, 7, 8]
+
+
+def test_round_robin_6_team_template_loads_from_csv() -> None:
+    team_ids_by_number = {team_number: f"team-{team_number}" for team_number in range(1, 7)}
+
+    games = build_round_robin_games(tournament_id="tour-1", team_ids_by_number=team_ids_by_number)
+
+    assert len(games) == 15
+    assert {game["rr_round_number"] for game in games} == {1, 2, 3, 4, 5}
+    assert {game["rr_slot_number"] for game in games} == {1, 2, 3}
+
+    pairings = {
+        tuple(sorted((game["team_a_id"], game["team_b_id"])))
+        for game in games
+    }
+    assert len(pairings) == 15


### PR DESCRIPTION
### Motivation
- Backport the tournament domain engine into the rollback branch to add explicit 6-team round robin support and ensure the backport is rollback-compatible. 
- Ensure the 6-team template is loaded from an asset CSV and that team-count configuration matches rollback patterns.

### Description
- Verified presence of the backported surfaces in `jupr_app/domain/tournaments/__init__.py`, `jupr_app/domain/tournaments/bracket_builder.py`, `jupr_app/domain/tournaments/sync.py`, `jupr_app/domain/tournament_podium.py`, and asset `jupr_app/ui/assets/tournaments/rr-6.csv`, including `SUPPORTED_TEAM_COUNTS = [4, 5, 6, 7, 8]`.
- Confirmed `_load_rr6_template()` reads `rr-6.csv` and `_round_robin_template()` returns the CSV-backed template for `team_count == 6` so `build_round_robin_games()` materializes the 6-team schedule.
- Added a focused regression test `tests/test_tournament_bracket_builder.py` that asserts `SUPPORTED_TEAM_COUNTS` includes `6` and that the 6-team round robin produces 15 unique pairings across 5 rounds and 3 slots.
- No compatibility shims were added and no global systems were modified, as there were no references to `match_pipeline`, `replay_engine`, `idempotency`, or global write guard markers in the backported files.

### Testing
- Ran `pytest -q tests/test_tournament_bracket_builder.py` and it passed (`2 passed`).
- Executed a runtime sanity-check by importing and calling `build_round_robin_games()` with 6 teams and verified it returns 15 games and expected sample pairings, which succeeded.
- Searched the backported files with `rg` for `match_pipeline`, `replay_engine`, `idempotency`, and global write guard terms and found no matches, so no compatibility shims were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b5233cc483269d7080c1c17ca3d0)