### PR TITLE
Render recap tournaments from official podium data

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -145,6 +145,22 @@ def _compute_weekly_recap_payload(
         supabase,
     )
 
+    completed = _load_completed_tournaments(supabase, club_id, start_dt_utc, end_dt_utc)
+    tournament_cards = []
+    for tournament in completed:
+        podium_rows = _load_tournament_podium(supabase, tournament["id"])
+        if not podium_rows:
+            continue
+
+        ordered = sorted(podium_rows, key=lambda row: int(row.get("placement", 999)))
+        display_rows = [row.get("display_name", "") for row in ordered]
+        tournament_cards.append(
+            {
+                "title": tournament.get("name", "Tournament"),
+                "podium": display_rows,
+            }
+        )
+
     recap = {
         "club_id": club_id,
         "start_date": start_date.isoformat(),
@@ -155,6 +171,7 @@ def _compute_weekly_recap_payload(
         "category_sections": _build_category_sections(stats, id_to_name),
         "spotlight": spotlight,
         "around_club": around_club,
+        "tournaments": tournament_cards,
         "looking_ahead": ["", "", ""],
         "meta": {
             "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -243,6 +260,36 @@ def _load_matches(
             frames.append(table_df)
 
     return pd.concat([df for df in frames if not df.empty], ignore_index=True) if frames else pd.DataFrame()
+
+
+def _load_completed_tournaments(supabase, club_id: str, start_dt: datetime, end_dt: datetime) -> list[dict]:
+    if supabase is None:
+        return []
+
+    response = (
+        supabase.table("tournaments")
+        .select("id,name,start_date,status")
+        .eq("club_id", club_id)
+        .eq("status", "COMPLETE")
+        .gte("start_date", start_dt.date().isoformat())
+        .lte("start_date", end_dt.date().isoformat())
+        .execute()
+    )
+    return response.data or []
+
+
+def _load_tournament_podium(supabase, tournament_id: str) -> list[dict]:
+    if supabase is None:
+        return []
+
+    response = (
+        supabase.table("tournament_podium")
+        .select("placement,display_name")
+        .eq("tournament_id", tournament_id)
+        .order("placement")
+        .execute()
+    )
+    return response.data or []
 
 
 def _filter_matches(df_matches: pd.DataFrame, *, include_tournaments: bool) -> pd.DataFrame:

--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -225,14 +225,6 @@ def render_tournament_podium(title: str, podium_rows: list[str]) -> None:
     )
 
 
-def is_tournament(title: str) -> bool:
-    normalized_title = title.lower()
-    return any(
-        keyword in normalized_title
-        for keyword in ["tournament", "sweethearts", "open", "championship", "classic", "cup"]
-    )
-
-
 def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | None = None) -> None:
     week_start = recap.get("week_start") or recap.get("start_date")
     week_end = recap.get("week_end") or recap.get("end_date")
@@ -250,6 +242,7 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
     numbers = recap.get("numbers", {})
     spotlight = recap.get("spotlight", []) or []
     around = recap.get("around_club", {})
+    tournaments = recap.get("tournaments", []) or []
     looking_ahead = [str(item).strip() for item in (recap.get("looking_ahead", []) or []) if str(item).strip()]
 
     _inject_baja_styles(print_view)
@@ -287,7 +280,6 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
                 ACCENT_CLASS_BY_KEY.get(item.get("key"), "baja-top"),
             )
 
-    tournament_sections: list[tuple[str, list[str]]] = []
     around_sections: list[tuple[str, list[str], str]] = []
 
     for item in around.get("leagues", []) or []:
@@ -299,9 +291,7 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
         ]
         if not rows:
             continue
-        if is_tournament(title_text):
-            tournament_sections.append((title_text, rows))
-        elif "pop" in title_text.lower():
+        if "pop" in title_text.lower():
             around_sections.append((title_text, rows, "baja-pop"))
         else:
             around_sections.append((title_text, rows, "baja-league"))
@@ -315,19 +305,21 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
         ]
         if not rows:
             continue
-        if is_tournament(title_text):
-            tournament_sections.append((title_text, rows))
-        elif "pop" in title_text.lower():
+        if "pop" in title_text.lower():
             around_sections.append((title_text, rows, "baja-pop"))
         else:
             around_sections.append((title_text, rows, "baja-roundrobin"))
 
-    st.markdown("### Tournaments")
-    tournament_col1, tournament_col2 = st.columns(2)
-    for idx, (title_text, rows) in enumerate(tournament_sections):
-        target_col = tournament_col1 if idx % 2 == 0 else tournament_col2
-        with target_col:
-            render_tournament_podium(title_text, rows)
+    if tournaments:
+        st.markdown("### Tournaments")
+        tournament_col1, tournament_col2 = st.columns(2)
+        for idx, item in enumerate(tournaments):
+            target_col = tournament_col1 if idx % 2 == 0 else tournament_col2
+            with target_col:
+                render_tournament_podium(
+                    item.get("title", "Tournament"),
+                    item.get("podium", []),
+                )
 
     st.markdown("### Around the Club")
     around_col1, around_col2 = st.columns(2)


### PR DESCRIPTION
### Motivation
- Stop inferring tournaments from free-form highlights and drive tournament rendering from the authoritative podium tables so recap tournaments reflect completed, official results.

### Description
- Added `_load_completed_tournaments` and `_load_tournament_podium` to `jupr_app/domain/recaps/weekly_recap.py` and populate `recap["tournaments"]` with cards containing `title` and ordered `podium` rows. 
- Updated `_compute_weekly_recap_payload` to load completed tournaments in-range and build `tournament_cards` from `tournaments` + `tournament_podium` data. 
- Removed `is_tournament()` usage and the title-heuristic path in `jupr_app/ui/components/weekly_recap_layout.py` and render the Tournaments section exclusively from `recap.get("tournaments", [])`. 
- Around the Club now renders only leagues, round-robins and pop-ups that are not tournaments, and no other systems (tournament engine, replay, match pipeline, migrations) were modified. 

### Testing
- Ran `python -m compileall jupr_app/domain/recaps/weekly_recap.py jupr_app/ui/components/weekly_recap_layout.py` which completed successfully. 
- Attempted a Playwright screenshot of the running Streamlit UI but the local endpoint returned `ERR_EMPTY_RESPONSE`, so no visual artifact was produced. 
- Verified the updated modules import/compile without syntax errors and that `recap["tournaments"]` is now the authoritative source for tournament rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b6dca1848326bf3c885b25ec7ea2)