### PR TITLE
Source weekly recap tournaments from canonical `matches` and remove date filters on `tournament_games`

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -254,28 +254,6 @@ def _load_matches(
     )
     frames.append(pd.DataFrame(response.data or []))
 
-    if include_tournaments:
-        for table_name in ("tournament_games", "playoff_matches"):
-            try:
-                table_response = (
-                    supabase.table(table_name)
-                    .select(
-                        "id,date,t1_p1,t1_p2,t2_p1,t2_p2,score_t1,score_t2,t1_p1_r,t1_p2_r,t2_p1_r,t2_p2_r,t1_p1_r_end,t1_p2_r_end,t2_p1_r_end,t2_p2_r_end"
-                    )
-                    .eq("club_id", club_id)
-                    .gte("date", start_dt.isoformat())
-                    .lte("date", end_dt.isoformat())
-                    .execute()
-                )
-            except Exception:
-                continue
-            table_df = pd.DataFrame(table_response.data or [])
-            if table_df.empty:
-                continue
-            table_df["match_type"] = "Tournament"
-            table_df["context_type"] = "TOURNAMENT"
-            frames.append(table_df)
-
     return pd.concat([df for df in frames if not df.empty], ignore_index=True) if frames else pd.DataFrame()
 
 
@@ -283,17 +261,24 @@ def _load_completed_tournaments(supabase, club_id, start_dt_utc, end_dt_utc):
     if supabase is None:
         return []
 
-    # Step 1: Find tournament_ids that had games within the recap date range
-    game_response = (
-        supabase.table("tournament_games")
-        .select("tournament_id,date")
+    # Step 1: Find tournament_ids from canonical match history in the recap date range
+    response = (
+        supabase.table("matches")
+        .select("*")
         .eq("club_id", club_id)
+        .eq("context_type", "TOURNAMENT")
         .gte("date", start_dt_utc.isoformat())
         .lte("date", end_dt_utc.isoformat())
         .execute()
     )
 
-    games = game_response.data or []
+    df_tournaments = pd.DataFrame(response.data or [])
+    if not df_tournaments.empty:
+        df_tournaments = df_tournaments[
+            (df_tournaments.get("score_t1", 0) + df_tournaments.get("score_t2", 0)) > 0
+        ]
+
+    games = df_tournaments.to_dict("records")
     if not games:
         return []
 

--- a/tests/test_weekly_recap_tournament_source.py
+++ b/tests/test_weekly_recap_tournament_source.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from jupr_app.domain.recaps.weekly_recap import _load_completed_tournaments
+
+
+class FakeTable:
+    def __init__(self, storage: dict[str, list[dict]], name: str):
+        self.storage = storage
+        self.name = name
+        self.filters: list[tuple[str, str, object]] = []
+
+    def select(self, _columns: str):
+        return self
+
+    def eq(self, column: str, value: object):
+        self.filters.append(("eq", column, value))
+        return self
+
+    def in_(self, column: str, values: list[object]):
+        self.filters.append(("in", column, values))
+        return self
+
+    def gte(self, column: str, value: object):
+        self.filters.append(("gte", column, value))
+        return self
+
+    def lte(self, column: str, value: object):
+        self.filters.append(("lte", column, value))
+        return self
+
+    def execute(self):
+        rows = list(self.storage.get(self.name, []))
+        for op, column, value in self.filters:
+            if op == "eq":
+                rows = [row for row in rows if str(row.get(column)) == str(value)]
+            elif op == "in":
+                rows = [row for row in rows if row.get(column) in value]
+            elif op in {"gte", "lte"}:
+                rows = [
+                    row
+                    for row in rows
+                    if row.get(column) is not None
+                    and (
+                        str(row.get(column)) >= str(value)
+                        if op == "gte"
+                        else str(row.get(column)) <= str(value)
+                    )
+                ]
+        return SimpleNamespace(data=rows)
+
+
+class FakeSupabase:
+    def __init__(self, storage: dict[str, list[dict]]):
+        self.storage = storage
+
+    def table(self, name: str):
+        return FakeTable(self.storage, name)
+
+
+def test_load_completed_tournaments_uses_matches_and_range_with_scores():
+    storage = {
+        "matches": [
+            {
+                "id": "m1",
+                "club_id": "club-1",
+                "context_type": "TOURNAMENT",
+                "tournament_id": "t-1",
+                "date": "2025-02-08T12:00:00+00:00",
+                "score_t1": 11,
+                "score_t2": 7,
+            },
+            {
+                "id": "m2",
+                "club_id": "club-1",
+                "context_type": "TOURNAMENT",
+                "tournament_id": "t-2",
+                "date": "2025-02-08T13:00:00+00:00",
+                "score_t1": 0,
+                "score_t2": 0,
+            },
+        ],
+        "tournaments": [
+            {"id": "t-1", "club_id": "club-1", "name": "Cup", "status": "COMPLETE"},
+            {"id": "t-2", "club_id": "club-1", "name": "Open", "status": "COMPLETE"},
+        ],
+    }
+
+    supabase = FakeSupabase(storage)
+    tournaments = _load_completed_tournaments(
+        supabase,
+        "club-1",
+        datetime(2025, 2, 8, 0, 0, tzinfo=timezone.utc),
+        datetime(2025, 2, 8, 23, 59, tzinfo=timezone.utc),
+    )
+
+    assert [row["id"] for row in tournaments] == ["t-1"]
+
+
+def test_load_completed_tournaments_returns_empty_when_no_range_matches():
+    storage = {
+        "matches": [
+            {
+                "id": "m1",
+                "club_id": "club-1",
+                "context_type": "TOURNAMENT",
+                "tournament_id": "t-1",
+                "date": "2025-02-01T12:00:00+00:00",
+                "score_t1": 11,
+                "score_t2": 7,
+            }
+        ],
+        "tournaments": [
+            {"id": "t-1", "club_id": "club-1", "name": "Cup", "status": "COMPLETE"},
+        ],
+    }
+
+    supabase = FakeSupabase(storage)
+    tournaments = _load_completed_tournaments(
+        supabase,
+        "club-1",
+        datetime(2025, 2, 8, 0, 0, tzinfo=timezone.utc),
+        datetime(2025, 2, 8, 23, 59, tzinfo=timezone.utc),
+    )
+
+    assert tournaments == []


### PR DESCRIPTION
### Motivation
- Weekly recap logic was querying `tournament_games` / `playoff_matches` with `.gte("date")` / `.lte("date")`, which caused invalid date-filter usage and crashes when sourcing tournament recaps. 
- The recap should consume canonical match history, so tournament data must be sourced from the `matches` table (where `context_type = "TOURNAMENT"`) instead of ad-hoc date-filtered tournament-specific tables.

### Description
- Removed the runtime queries against `tournament_games` / `playoff_matches` in `_load_matches` so recap rows now come only from `matches` with the selected columns via `supabase.table("matches")` and date bounds. 
- Replaced `_load_completed_tournaments` to query `matches` (with `.eq("context_type","TOURNAMENT")` and date bounds) and derive `tournament_id`s from those canonical records. 
- Added a guard to drop zero-score tournament match rows by filtering `(score_t1 + score_t2) > 0` before extracting tournament ids. 
- Added regression tests in `tests/test_weekly_recap_tournament_source.py` that mock `matches` and `tournaments` to verify in-range tournament detection and out-of-range behavior.

### Testing
- Ran the focused recap tests with `pytest -q tests/test_weekly_recap_tournament_source.py tests/test_weekly_recap_range_driven.py` and both test files passed. 
- Ran the full test suite with `pytest -q` which reported one unrelated failing test (`tests/test_ui_color_tokens.py`) due to pre-existing hard-coded UI color literals not introduced by this change. 
- Verified there are no remaining `.gte("date")` / `.lte("date")` usages against `tournament_games` via repository search (`rg`), which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0ba8b85688326b97a87dd2231a82f)