### PR TITLE
Separate tournaments from recap events and add podium podium UI

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -145,38 +145,12 @@ def _compute_weekly_recap_payload(
         supabase,
     )
 
-    completed = _load_completed_tournaments(
+    tournaments_section = _build_tournament_section(
         supabase,
         club_id,
         start_dt_utc,
         end_dt_utc,
     )
-    tournament_cards = []
-    for t in completed:
-        podium_rows = _load_tournament_podium(supabase, t["id"])
-        if not podium_rows:
-            continue
-
-        ordered = sorted(
-            podium_rows,
-            key=lambda r: int(r.get("placement", 999))
-        )
-
-        display_rows = [
-            row.get("display_name", "")
-            for row in ordered
-            if row.get("display_name")
-        ]
-
-        if not display_rows:
-            continue
-
-        tournament_cards.append(
-            {
-                "title": t.get("name", "Tournament"),
-                "podium": display_rows,
-            }
-        )
 
     recap = {
         "club_id": club_id,
@@ -188,7 +162,7 @@ def _compute_weekly_recap_payload(
         "category_sections": _build_category_sections(stats, id_to_name),
         "spotlight": spotlight,
         "around_club": around_club,
-        "tournaments": tournament_cards,
+        "tournaments": tournaments_section,
         "looking_ahead": ["", "", ""],
         "meta": {
             "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -257,41 +231,29 @@ def _load_matches(
     return pd.concat([df for df in frames if not df.empty], ignore_index=True) if frames else pd.DataFrame()
 
 
-def _load_completed_tournaments(supabase, club_id, start_dt_utc, end_dt_utc):
+def _build_tournament_section(supabase, club_id, start_dt, end_dt) -> list[dict]:
     if supabase is None:
         return []
 
-    # Step 1: Find tournament_ids from canonical match history in the recap date range
     response = (
         supabase.table("matches")
-        .select("*")
+        .select("tournament_id")
         .eq("club_id", club_id)
         .eq("context_type", "TOURNAMENT")
-        .gte("date", start_dt_utc.isoformat())
-        .lte("date", end_dt_utc.isoformat())
+        .gte("date", start_dt.isoformat())
+        .lte("date", end_dt.isoformat())
         .execute()
     )
 
-    df_tournaments = pd.DataFrame(response.data or [])
-    if not df_tournaments.empty:
-        df_tournaments = df_tournaments[
-            (df_tournaments.get("score_t1", 0) + df_tournaments.get("score_t2", 0)) > 0
-        ]
-
-    games = df_tournaments.to_dict("records")
-    if not games:
-        return []
-
     tournament_ids = list({
         row.get("tournament_id")
-        for row in games
+        for row in (response.data or [])
         if row.get("tournament_id")
     })
 
     if not tournament_ids:
         return []
 
-    # Step 2: Load only completed tournaments from those IDs
     response = (
         supabase.table("tournaments")
         .select("id,name,status")
@@ -301,7 +263,44 @@ def _load_completed_tournaments(supabase, club_id, start_dt_utc, end_dt_utc):
         .execute()
     )
 
-    return response.data or []
+    tournaments = response.data or []
+    if not tournaments:
+        return []
+
+    tournament_section: list[dict] = []
+    for tournament in tournaments:
+        tournament_id = tournament.get("id")
+        if not tournament_id:
+            continue
+
+        podium_rows = _load_tournament_podium(supabase, tournament_id)
+        if not podium_rows:
+            continue
+
+        podium = [
+            {
+                "placement": int(row.get("placement", 0) or 0),
+                "display_name": str(row.get("display_name", "") or "").strip(),
+            }
+            for row in sorted(
+                podium_rows,
+                key=lambda row: int(row.get("placement", 999) or 999),
+            )
+            if str(row.get("display_name", "") or "").strip()
+        ]
+
+        if not podium:
+            continue
+
+        tournament_section.append(
+            {
+                "tournament_id": tournament_id,
+                "tournament_name": str(tournament.get("name") or "Tournament"),
+                "podium": podium,
+            }
+        )
+
+    return tournament_section
 
 
 def _load_tournament_podium(supabase, tournament_id: str) -> list[dict]:
@@ -403,6 +402,8 @@ def _safe_float(value, default: float | None = None) -> float | None:
 
 
 def _resolve_event_key(match: dict) -> tuple[str, str] | None:
+    if str(match.get("context_type", "") or "").strip().upper() == "TOURNAMENT":
+        return None
     league = str(match.get("league", "") or "").strip()
     match_type = str(match.get("match_type", "") or "").strip()
     week_tag = str(match.get("week_tag", "") or "").strip()

--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -102,39 +102,42 @@ def _inject_baja_styles(print_view: bool) -> None:
   }
 
   .baja-podium {
-    background: linear-gradient(135deg, #FFF6E6, #FFE5CC);
-    border-left: 6px solid #E67700;
-    border-radius: 20px;
-    padding: 24px;
+    background: linear-gradient(135deg, #FFE7A3, #FFD166);
+    border: 2px solid #E0A100;
+    border-radius: 14px;
+    padding: 28px;
     margin-bottom: 24px;
     box-shadow: 0 10px 26px rgba(0,0,0,0.1);
   }
 
   .podium-grid {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
+    align-items: flex-end;
+    gap: 20px;
     margin-top: 15px;
   }
 
   .podium-col {
-    flex: 1;
     text-align: center;
   }
 
   .podium-1 {
-    font-size: 1.1rem;
+    font-size: 1.25rem;
     font-weight: 700;
-    color: #E67700;
+    color: #7A5600;
   }
 
   .podium-2 {
+    font-size: 1rem;
     font-weight: 600;
-    color: #666;
+    color: #5D5D5D;
   }
 
   .podium-3 {
+    font-size: 1rem;
     font-weight: 600;
-    color: #8C6239;
+    color: #78512A;
   }
 
   .podium-label {
@@ -196,29 +199,42 @@ def render_section_card(title: str, rows: list[str], css_class: str) -> None:
     )
 
 
-def render_tournament_podium(title: str, podium_rows: list[str]) -> None:
-    first = podium_rows[0] if len(podium_rows) > 0 else ""
-    second = podium_rows[1] if len(podium_rows) > 1 else ""
-    third = podium_rows[2] if len(podium_rows) > 2 else ""
+def render_podium_layout(podium_rows: list[dict]) -> str:
+    podium_by_place = {
+        int(item.get("placement", 0) or 0): str(item.get("display_name", "") or "")
+        for item in podium_rows
+    }
+    first = podium_by_place.get(1, "")
+    second = podium_by_place.get(2, "")
+    third = podium_by_place.get(3, "")
+
+    return f"""
+<div class="podium-grid">
+  <div class="podium-col">
+    <div class="podium-label">2nd</div>
+    <div class="podium-2">🥈 {second}</div>
+  </div>
+  <div class="podium-col">
+    <div class="podium-label">1st</div>
+    <div class="podium-1">🥇 {first}</div>
+  </div>
+  <div class="podium-col">
+    <div class="podium-label">3rd</div>
+    <div class="podium-3">🥉 {third}</div>
+  </div>
+</div>
+"""
+
+
+def render_tournament_podium(tournament: dict) -> None:
+    title = str(tournament.get("tournament_name") or "Tournament")
+    podium_rows = tournament.get("podium", []) or []
 
     st.markdown(
         f"""
 <div class="baja-podium">
   <div class="section-title">🏆 {title}</div>
-  <div class="podium-grid">
-    <div class="podium-col">
-      <div class="podium-label">1st</div>
-      <div class="podium-1">🥇 {first}</div>
-    </div>
-    <div class="podium-col">
-      <div class="podium-label">2nd</div>
-      <div class="podium-2">🥈 {second}</div>
-    </div>
-    <div class="podium-col">
-      <div class="podium-label">3rd</div>
-      <div class="podium-3">🥉 {third}</div>
-    </div>
-  </div>
+  {render_podium_layout(podium_rows)}
 </div>
 """,
         unsafe_allow_html=True,
@@ -310,24 +326,17 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
         else:
             around_sections.append((title_text, rows, "baja-roundrobin"))
 
-    if tournaments:
-        st.markdown("### Tournaments")
-        col1, col2 = st.columns(2)
-
-        for idx, item in enumerate(tournaments):
-            target_col = col1 if idx % 2 == 0 else col2
-            with target_col:
-                render_tournament_podium(
-                    item.get("title", "Tournament"),
-                    item.get("podium", []),
-                )
-
     st.markdown("### Around the Club")
     around_col1, around_col2 = st.columns(2)
     for idx, (title_text, rows, css_class) in enumerate(around_sections):
         target_col = around_col1 if idx % 2 == 0 else around_col2
         with target_col:
             render_section_card(title_text, rows, css_class)
+
+    if tournaments:
+        st.markdown("### Tournaments")
+        for tournament in tournaments:
+            render_tournament_podium(tournament)
 
     if looking_ahead:
         st.markdown("### Looking Ahead")

--- a/jupr_app/ui/pages/weekly_recap_admin.py
+++ b/jupr_app/ui/pages/weekly_recap_admin.py
@@ -13,10 +13,23 @@ from jupr_app.domain.recaps.weekly_recap import (
     compute_weekly_recap,
     get_spotlight_candidates,
 )
-from jupr_app.ui.components.weekly_recap_layout import render_weekly_recap
+from jupr_app.ui.components.weekly_recap_layout import render_podium_layout, render_weekly_recap
 from jupr_app.ui.layout import page_shell
 from jupr_app.ui.url import qp_get
 
+
+
+
+def render_tournament_podium(tournament: dict) -> None:
+    st.subheader(str(tournament.get("tournament_name") or "Tournament"))
+    st.markdown(render_podium_layout(tournament.get("podium", []) or []), unsafe_allow_html=True)
+
+
+def _render_tournament_section(recap: dict) -> None:
+    if recap.get("tournaments"):
+        st.header("🏆 Tournaments")
+        for tournament in recap["tournaments"]:
+            render_tournament_podium(tournament)
 
 def _get_default_date_range(tz_name: str) -> tuple[date, date]:
     today = datetime.now(ZoneInfo(tz_name)).date()


### PR DESCRIPTION
### Motivation
- Keep tournament data and UI distinct from generic event highlights so tournament podiums are rendered as a structured, first-class section. 
- Provide a visually prominent, centered gold-first podium layout for weekly recap pages and admin UI.

### Description
- Added `_build_tournament_section(supabase, club_id, start_dt, end_dt)` which queries `matches` for `context_type == "TOURNAMENT"`, collects distinct `tournament_id`s, fetches completed tournaments and their podiums, and returns structured objects with `tournament_id`, `tournament_name`, and `podium` rows. 
- Replaced the inline tournament extraction in `compute_weekly_recap` with the new `_build_tournament_section` and now attach the result to `recap["tournaments"]`.
- Prevented tournament matches from being treated as league/round-robin events by short-circuiting `_resolve_event_key` when `context_type` is `TOURNAMENT` so tournaments no longer mix into `around_club` highlights. 
- Implemented `render_podium_layout(...)` and updated `render_tournament_podium(...)` in `jupr_app/ui/components/weekly_recap_layout.py` to render a centered podium (1st place larger in the middle, 2nd/3rd slightly smaller) and updated CSS (`.baja-podium`, `.podium-grid`, `.podium-1/2/3`) for a stronger gold container, rounded corners, and elevated padding. 
- Added small admin helpers `render_tournament_podium` and `_render_tournament_section` in `jupr_app/ui/pages/weekly_recap_admin.py` to render the new tournament section after the "Around the Club" section using the shared layout helper.

### Testing
- Ran `python -m compileall jupr_app/domain/recaps/weekly_recap.py jupr_app/ui/components/weekly_recap_layout.py jupr_app/ui/pages/weekly_recap_admin.py` which succeeded. 
- Attempted a Playwright screenshot of a running Streamlit app at `http://localhost:8501`, but no server was available in this environment resulting in `ERR_EMPTY_RESPONSE`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0bbfafe7c832684766cf62e0cdec2)