### PR TITLE
Include tournament_game_id in weekly recap tournament query

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -241,7 +241,7 @@ def _load_completed_tournaments(supabase, club_id: str, start_dt: datetime, end_
 
     response = (
         supabase.table("matches")
-        .select("tournament_id,context_type,match_type,week_tag,league,score_t1,score_t2")
+        .select("tournament_id,tournament_game_id,context_type,match_type,week_tag,league,score_t1,score_t2")
         .eq("club_id", club_id)
         .gte("date", start_dt.isoformat())
         .lte("date", end_dt.isoformat())


### PR DESCRIPTION
### Motivation
- Fix tournament detection in the weekly recap by ensuring the Supabase query returns `tournament_game_id` so completed tournament matches are correctly recognized.

### Description
- Update `_load_completed_tournaments` in `jupr_app/domain/recaps/weekly_recap.py` to add `tournament_game_id` to the `matches` `.select(...)` list and make no other logic changes.

### Testing
- Successfully ran `python -m py_compile jupr_app/domain/recaps/weekly_recap.py` to validate the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c449d7708326ad03d10e797de978)