### PR TITLE
Fix UUID key mismatch in tournament podium team lookup

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -323,7 +323,7 @@ def _load_tournament_podium(supabase, tournament_id: str, *, id_to_name: dict[in
         {
             "placement": _normalize_podium_placement(row.get("placement")),
             "team_id": row.get("team_id"),
-            "display_name": _format_team_display_name(teams_by_id.get(row.get("team_id")), id_to_name=id_to_name),
+            "display_name": _format_team_display_name(teams_by_id.get(str(row.get("team_id"))), id_to_name=id_to_name),
         }
         for row in sorted(podium_rows, key=lambda item: _normalize_podium_placement(item.get("placement")) or 999)
     ]
@@ -355,7 +355,7 @@ def _load_tournament_teams(supabase, team_ids: list[object]) -> dict[object, dic
 
     id_to_name = _load_player_names(supabase, player_ids)
     return {
-        team.get("id"): {
+        str(team.get("id")): {
             **team,
             "player1_name": id_to_name.get(_safe_int(team.get("player1_id")), "Unknown"),
             "player2_name": id_to_name.get(_safe_int(team.get("player2_id")), "Unknown"),


### PR DESCRIPTION
### Motivation
- Podium display names could be missing because team IDs from the database were UUIDs of one type while dictionary keys used a different Python type, causing lookups to fail in the recap rendering.

### Description
- Normalize team ID keys and lookups to strings by storing `str(team.get("id"))` in `_load_tournament_teams` and using `teams_by_id.get(str(row.get("team_id")))` in `_load_tournament_podium` to ensure consistent key types.

### Testing
- Compiled the updated module with `python -m compileall jupr_app/domain/recaps/weekly_recap.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c6a132908326a28510e493da8744)