### PR TITLE
Add in-memory PDF builder and wire download button for weekly recap

### DIFF
--- a/jupr_app/ui/pages/weekly_recap.py
+++ b/jupr_app/ui/pages/weekly_recap.py
@@ -8,6 +8,69 @@ from jupr_app.ui.layout import page_shell
 from jupr_app.ui.url import qp_get
 
 
+def _pdf_escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+
+def _build_recap_pdf(recap: dict, week_start: str, week_end: str) -> bytes:
+    lines = [
+        "JUPR Weekly Recap",
+        f"Week: {week_start} to {week_end}",
+        "",
+        "Highlights",
+    ]
+    for item in recap.get("highlights", [])[:5]:
+        text = str(item).strip()
+        if text:
+            lines.append(f"- {text}")
+
+    lines.append("")
+    lines.append("Looking Ahead")
+    for item in recap.get("looking_ahead", [])[:5]:
+        text = str(item).strip()
+        if text:
+            lines.append(f"- {text}")
+
+    text_commands = ["BT", "/F1 12 Tf", "72 770 Td", "14 TL"]
+    for idx, line in enumerate(lines):
+        safe_line = _pdf_escape(line).encode("latin-1", "replace").decode("latin-1")
+        text_commands.append(f"({safe_line}) Tj")
+        if idx < len(lines) - 1:
+            text_commands.append("T*")
+    text_commands.append("ET")
+    content = "\n".join(text_commands).encode("latin-1")
+
+    objects = [
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n",
+        b"4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+        f"5 0 obj\n<< /Length {len(content)} >>\nstream\n".encode("latin-1") + content + b"\nendstream\nendobj\n",
+    ]
+
+    pdf = bytearray(b"%PDF-1.4\n")
+    offsets = [0]
+    for obj in objects:
+        offsets.append(len(pdf))
+        pdf.extend(obj)
+
+    xref_offset = len(pdf)
+    pdf.extend(f"xref\n0 {len(offsets)}\n".encode("latin-1"))
+    pdf.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        pdf.extend(f"{offset:010d} 00000 n \n".encode("latin-1"))
+    pdf.extend(
+        (
+            "trailer\n"
+            f"<< /Size {len(offsets)} /Root 1 0 R >>\n"
+            "startxref\n"
+            f"{xref_offset}\n"
+            "%%EOF\n"
+        ).encode("latin-1")
+    )
+    return bytes(pdf)
+
+
 def _get_api_error_code(exc: APIError) -> str | None:
     code = getattr(exc, "code", None)
     if code:
@@ -70,6 +133,17 @@ def render(ctx):
         if base_url:
             print_url = f"{base_url}/?page=weekly_recap&public=1&print=1"
             st.link_button("Open Print-Friendly View", print_url)
+        pdf_bytes = _build_recap_pdf(
+            recap,
+            str(selected_row.get("week_start") or ""),
+            str(selected_row.get("week_end") or ""),
+        )
+        st.download_button(
+            "Download Weekly Recap PDF",
+            data=pdf_bytes,
+            file_name=f"weekly_recap_{selected_row.get('week_start')}.pdf",
+            mime="application/pdf",
+        )
 
     if (not print_mode) and (not bool(ctx.public_mode)):
         try:


### PR DESCRIPTION
### Motivation
- Provide a real downloadable PDF for the Weekly Recap page instead of only an "Open Print-Friendly View" link which did not supply PDF bytes.
- Avoid introducing filesystem writes or redesigning the recap flow by generating PDF bytes in-memory and serving them in the same render pass.

### Description
- Added `_build_recap_pdf(recap, week_start, week_end)` to create a minimal in-memory PDF payload and `_pdf_escape()` to sanitize text for PDF content.
- Wired `st.download_button(..., data=pdf_bytes, mime="application/pdf")` so the download button is passed raw PDF bytes during the same render where the recap is shown.
- The PDF generator returns `bytes` and does not write any files to disk, preserving current layout and design.
- The change targets `jupr_app/ui/pages/weekly_recap.py` and keeps the fix minimal and localized to the public weekly recap page.

### Testing
- Ran repository searches with `rg` to confirm absence/presence of prior PDF builders and to locate recap code (completed successfully).
- Compiled the modified module with `python -m compileall jupr_app/ui/pages/weekly_recap.py` which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0cad941a483269649c4466c741698)