### PR TITLE
Fix Supabase init crash and harden weekly_recap guards

### DIFF
--- a/jupr_app/ui/pages/weekly_recap.py
+++ b/jupr_app/ui/pages/weekly_recap.py
@@ -89,6 +89,9 @@ def _handle_missing_table(exc: APIError) -> bool:
 
 
 def render(ctx):
+    supabase = ctx.supabase
+    club_id = ctx.club_id
+
     mode_label = "Public" if bool(ctx.public_mode) else "Admin"
     page_shell("🗞️ Tres Palapas Weekly Recap", "Club-wide weekly recap.", mode_label=mode_label)
 
@@ -96,9 +99,6 @@ def render(ctx):
 
     if print_mode:
         st.markdown("<style>header{visibility:hidden;} footer{visibility:hidden;} </style>", unsafe_allow_html=True)
-
-    supabase = ctx.supabase
-    club_id = str(ctx.club_id)
 
     try:
         response = (
@@ -141,11 +141,16 @@ def render(ctx):
         st.download_button(
             "Download Weekly Recap PDF",
             data=pdf_bytes,
-            file_name=f"weekly_recap_{selected_row.get('week_start')}.pdf",
+            file_name=f"weekly_recap_{selected_row.get('week_start') or 'recap'}.pdf",
             mime="application/pdf",
         )
 
-    if (not print_mode) and (not bool(ctx.public_mode)):
+    if (
+        (not print_mode)
+        and (not bool(ctx.public_mode))
+        and supabase
+        and club_id
+    ):
         try:
             draft_check = (
                 supabase.table("weekly_recaps")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -127,31 +127,17 @@ def get_supabase():
     admin_password = "..."  # your chosen admin login password
     admin_session_secret = "..."  # used to sign short-lived admin sessions
     """
-    url = get_secret(["supabase", "url"], "")
-    key = get_secret(["supabase", "anon_key"], "") or get_secret(["supabase", "key"], "")
+    url = st.secrets.get("SUPABASE_URL")
+    key = (
+        st.secrets.get("SUPABASE_ANON_KEY")
+        or st.secrets.get("SUPABASE_SERVICE_ROLE_KEY")
+    )
 
     if not url or not key:
-        st.error("Supabase secrets are missing or misnamed.")
-        st.code(
-            "[supabase]\n"
-            'url = "https://YOUR_PROJECT_REF.supabase.co"\n'
-            'anon_key = "YOUR_SUPABASE_ANON_KEY"  # or use key = "…"\n'
-            'admin_password = "YOUR_ADMIN_PASSWORD"\n'
-            'admin_session_secret = "YOUR_ADMIN_SESSION_SECRET"\n'
-        )
-
-        # Debug keys only (no values) - Mapping-safe (no .get usage)
-        try:
-            st.write("Secrets keys:", list(st.secrets.keys()))
-            sb = get_secret(["supabase"], default={})
-            if isinstance(sb, Mapping):
-                st.write("Supabase keys:", list(sb.keys()))
-        except Exception:
-            pass
-
+        st.error("Supabase credentials missing.")
         st.stop()
 
-    return make_supabase(str(url), str(key))
+    return make_supabase(url, key)
 
 
 @st.cache_data(ttl=30)


### PR DESCRIPTION
### Motivation
- Prevent app crash on Streamlit Cloud when Supabase secrets are absent or named via top-level env-style keys, and avoid initializing Supabase at import time.
- Eliminate undefined-variable risks in the weekly recap page introduced by recent changes.
- Avoid running admin-only draft checks in public/partial contexts and ensure PDF filenames never contain None.

### Description
- Updated `get_supabase()` in `streamlit_app.py` to read `SUPABASE_URL` and `SUPABASE_ANON_KEY` (fallback `SUPABASE_SERVICE_ROLE_KEY`) from `st.secrets`, emit `st.error(...)` and `st.stop()` when missing, and call `make_supabase(url, key)` at runtime.
- In `jupr_app/ui/pages/weekly_recap.py`, bound `supabase = ctx.supabase` and `club_id = ctx.club_id` at the start of `render(ctx)` and used those variables throughout.
- Added defensive guards to the admin-only draft lookup so it only runs when not print mode, not public mode, and both `supabase` and `club_id` are present.
- Hardened PDF download filename to fallback to `'recap'` when `week_start` is absent.

### Testing
- Compiled the modified files with `python -m py_compile streamlit_app.py jupr_app/ui/pages/weekly_recap.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0ccecd9b88326be97481a36bbfcda)