### PR TITLE
Fix weekly recap card text contrast in dark mode

### DIFF
--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -62,7 +62,11 @@ def _inject_baja_styles(print_view: bool) -> None:
     padding: 20px;
     margin-bottom: 20px;
     box-shadow: 0 8px 22px rgba(0,0,0,0.08);
-    color: var(--text-color);
+    color: #000;
+  }
+
+  .baja-card * {
+    color: #000;
   }
 
   .baja-top {
@@ -117,7 +121,11 @@ def _inject_baja_styles(print_view: bool) -> None:
     padding: 28px;
     margin-bottom: 24px;
     box-shadow: 0 10px 26px rgba(0,0,0,0.1);
-    color: var(--text-color);
+    color: #000;
+  }
+
+  .baja-podium * {
+    color: #000;
   }
 
   .podium-grid {


### PR DESCRIPTION
### Motivation
- Colorful cards in the weekly recap were inheriting theme text colors and became unreadable in dark mode, so card text must remain black in both light and dark themes.
- Podium card content must also keep black text for consistent readability across recap components.

### Description
- Force fixed black text by setting `color: #000` on `.baja-card` and `.baja-card *` in `_inject_baja_styles` inside `jupr_app/ui/components/weekly_recap_layout.py`.
- Apply the same `color: #000` and nested selector `.baja-podium *` to the podium card styles for consistent behavior.
- Change is limited to CSS injected by `_inject_baja_styles` and does not modify markup or behavior outside styling.

### Testing
- Ran `pytest -q tests/test_weekly_recap_spotlight.py` which passed (`1 passed`).
- Attempted an automated Playwright page capture against `http://localhost:8501`, but it failed with `ERR_EMPTY_RESPONSE` because no local app server was running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d056cb48832690f094e7c9cef1ea)