### PR TITLE
Fix weekly recap PDF rendering with spotlight-based payloads

### DIFF
--- a/jupr_app/ui/pages/weekly_recap.py
+++ b/jupr_app/ui/pages/weekly_recap.py
@@ -19,7 +19,14 @@ def _build_recap_pdf(recap: dict, week_start: str, week_end: str) -> bytes:
         "",
         "Highlights",
     ]
-    for item in recap.get("highlights", [])[:5]:
+    highlights = [str(item).strip() for item in (recap.get("highlights", []) or []) if str(item).strip()]
+    if not highlights:
+        for item in (recap.get("spotlight", []) or []):
+            players = [str(player).strip() for player in (item.get("players", []) or []) if str(player).strip()]
+            if players:
+                highlights.append(f"{item.get('label', 'Award')}: {', '.join(players)}")
+
+    for item in highlights[:5]:
         text = str(item).strip()
         if text:
             lines.append(f"- {text}")

--- a/tests/test_weekly_recap_pdf.py
+++ b/tests/test_weekly_recap_pdf.py
@@ -1,0 +1,17 @@
+from jupr_app.ui.pages.weekly_recap import _build_recap_pdf
+
+
+def test_build_recap_pdf_uses_spotlight_when_highlights_missing():
+    recap = {
+        "spotlight": [
+            {"label": "Top Performer", "players": ["Alice 3-0", "Bob 2-1"]},
+            {"label": "Biggest Jump", "players": ["Cara +0.12"]},
+        ],
+        "looking_ahead": ["Finals this Friday"],
+    }
+
+    pdf_bytes = _build_recap_pdf(recap, "2026-02-01", "2026-02-07")
+    text = pdf_bytes.decode("latin-1")
+
+    assert "Top Performer: Alice 3-0, Bob 2-1" in text
+    assert "Biggest Jump: Cara +0.12" in text


### PR DESCRIPTION
### Motivation
- The PDF generator was producing headers but no recap lines because it only read the legacy `highlights` key while the computed recap payloads populate spotlight content under `spotlight`.
- The change is a minimal, targeted fix to ensure generated PDFs include recap content without changing recap computation, UI layout, or styling.

### Description
- Added fallback logic in `jupr_app/ui/pages/weekly_recap.py::_build_recap_pdf` to synthesize highlight lines from `recap["spotlight"]` when `recap["highlights"]` is absent, preserving the existing `highlights` behavior if present.
- The fallback composes lines as `"<label>: <player1>, <player2>, ..."` using the `players` list on each spotlight item and limits output to the first five highlights.
- No changes were made to recap computation, layout rendering, or styling; the patch touches only PDF extraction logic and a new test file.
- Added `tests/test_weekly_recap_pdf.py` to cover the regression and assert spotlight entries appear in the generated PDF text stream.

### Testing
- Ran `pytest -q tests/test_weekly_recap_pdf.py tests/test_weekly_recap_range_driven.py` and the tests passed (`3 passed`).
- Verified the new test confirms `Top Performer` and `Biggest Jump` spotlight lines are present in the PDF byte stream.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d068f15083269b518fc9865ddfaa)