### PR TITLE
Add 6-Player Pop-Up RR (9 rounds) and exclude tournament matches from Pop-Up RR grouping

### DIFF
--- a/jupr_app/domain/match_filters.py
+++ b/jupr_app/domain/match_filters.py
@@ -42,6 +42,28 @@ def resolve_match_id_column(df_matches: pd.DataFrame) -> str:
     )
 
 
+def _normalize_context_value(value) -> str:
+    return str(value or "").strip().upper()
+
+
+def is_tournament_match(row: dict | pd.Series) -> bool:
+    context_type = _normalize_context_value(row.get("context_type"))
+    match_type = _normalize_context_value(row.get("match_type"))
+    return (
+        context_type == "TOURNAMENT"
+        or row.get("tournament_id") is not None
+        or match_type == "TOURNAMENT"
+    )
+
+
+def is_popup_event_match(row: dict | pd.Series) -> bool:
+    if is_tournament_match(row):
+        return False
+    match_type = _normalize_context_value(row.get("match_type"))
+    context_type = _normalize_context_value(row.get("context_type"))
+    return match_type == "POPUP" or context_type == "EVENT"
+
+
 def _apply_match_filters(
     df_matches: pd.DataFrame, context_filters: dict | None, audit: MatchFilterAudit | None
 ) -> pd.DataFrame:
@@ -81,7 +103,7 @@ def _apply_match_filters(
 
     if "context_type" in df.columns:
         before = df
-        df = df[df["context_type"].fillna("").astype(str).str.upper() != "TOURNAMENT"].copy()
+        df = df[df["context_type"].map(_normalize_context_value) != "TOURNAMENT"].copy()
         _record_audit_step(audit, "exclude_context_type_tournament", before, df, match_id_col)
 
     if "tournament_id" in df.columns:
@@ -91,7 +113,7 @@ def _apply_match_filters(
 
     if "match_type" in df.columns:
         before = df
-        df = df[df["match_type"].fillna("").astype(str) != "Tournament"].copy()
+        df = df[df["match_type"].map(_normalize_context_value) != "TOURNAMENT"].copy()
         _record_audit_step(audit, "exclude_match_type_tournament", before, df, match_id_col)
 
     for col in [

--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -7,6 +7,7 @@ from zoneinfo import ZoneInfo
 import pandas as pd
 
 from jupr_app.data.sb_safe import safe_execute
+from jupr_app.domain.match_filters import is_popup_event_match, is_tournament_match
 
 
 @dataclass
@@ -459,16 +460,12 @@ def _normalize_podium_placement(value) -> int | None:
 
 
 def _is_tournament_match(match: dict) -> bool:
-    context_type = str(match.get("context_type") or "").strip().upper()
-    match_type = str(match.get("match_type") or "").strip().upper()
     week_tag = str(match.get("week_tag") or "").strip().upper()
     league = str(match.get("league") or "").strip().upper()
 
     return (
-        context_type == "TOURNAMENT"
-        or match.get("tournament_id") is not None
+        is_tournament_match(match)
         or match.get("tournament_game_id") is not None
-        or match_type == "TOURNAMENT"
         or week_tag == "TOURNAMENT"
         or "TOURNAMENT" in league
     )
@@ -559,9 +556,8 @@ def _resolve_event_key(match: dict) -> tuple[str, str] | None:
     if _is_tournament_match(match):
         return None
     league = str(match.get("league", "") or "").strip()
-    match_type = str(match.get("match_type", "") or "").strip()
     week_tag = str(match.get("week_tag", "") or "").strip()
-    if match_type == "PopUp":
+    if is_popup_event_match(match):
         context_id = match.get("context_id")
         if context_id is None or str(context_id).strip() == "":
             fallback = ":".join([x for x in [league, week_tag] if x]) or "POPUP"

--- a/jupr_app/domain/schedule.py
+++ b/jupr_app/domain/schedule.py
@@ -66,13 +66,17 @@ def get_match_schedule(format_type: str, players: list[Any], custom_text: str | 
         ]
 
     if format_type == "6-Player":
-        # Expected games: 5
+        # Expected games: 9
         return [
-            {"t1": [p[0], p[1]], "t2": [p[2], p[4]], "desc": "R1"},
-            {"t1": [p[2], p[5]], "t2": [p[0], p[4]], "desc": "R2"},
-            {"t1": [p[1], p[3]], "t2": [p[4], p[5]], "desc": "R3"},
-            {"t1": [p[0], p[5]], "t2": [p[1], p[2]], "desc": "R4"},
-            {"t1": [p[0], p[3]], "t2": [p[1], p[4]], "desc": "R5"},
+            {"t1": [p[0], p[5]], "t2": [p[1], p[3]], "desc": "Rnd 1"},
+            {"t1": [p[3], p[4]], "t2": [p[0], p[2]], "desc": "Rnd 2"},
+            {"t1": [p[2], p[4]], "t2": [p[1], p[5]], "desc": "Rnd 3"},
+            {"t1": [p[2], p[5]], "t2": [p[0], p[1]], "desc": "Rnd 4"},
+            {"t1": [p[0], p[4]], "t2": [p[3], p[5]], "desc": "Rnd 5"},
+            {"t1": [p[0], p[3]], "t2": [p[1], p[2]], "desc": "Rnd 6"},
+            {"t1": [p[3], p[4]], "t2": [p[1], p[5]], "desc": "Rnd 7"},
+            {"t1": [p[2], p[3]], "t2": [p[4], p[5]], "desc": "Rnd 8"},
+            {"t1": [p[1], p[4]], "t2": [p[0], p[2]], "desc": "Rnd 9"},
         ]
 
     if format_type == "8-Player":

--- a/jupr_app/ui/pages/match_uploader.py
+++ b/jupr_app/ui/pages/match_uploader.py
@@ -316,7 +316,7 @@ def render(ctx):
         format_expected_games = {
             "4-Player": 3,
             "5-Player": 5,
-            "6-Player": 5,
+            "6-Player": 9,
             "8-Player": 14,
             "9-Player": 18,
             "12-Player": 33,

--- a/tests/test_schedule_6_player.py
+++ b/tests/test_schedule_6_player.py
@@ -1,0 +1,12 @@
+from jupr_app.domain.schedule import get_match_schedule
+
+
+def test_6_player_schedule_has_9_matches_with_expected_key_rounds():
+    players = [1, 2, 3, 4, 5, 6]
+
+    matches = get_match_schedule("6-Player", players)
+
+    assert len(matches) == 9
+    assert matches[0] == {"t1": [1, 6], "t2": [2, 4], "desc": "Rnd 1"}
+    assert matches[3] == {"t1": [3, 6], "t2": [1, 2], "desc": "Rnd 4"}
+    assert matches[8] == {"t1": [2, 5], "t2": [1, 3], "desc": "Rnd 9"}

--- a/tests/test_weekly_recap_tournament_classification.py
+++ b/tests/test_weekly_recap_tournament_classification.py
@@ -11,8 +11,9 @@ def test_match_with_tournament_week_tag_is_tournament():
     assert _resolve_event_key(match) is None
 
 
-def test_popup_with_tournament_id_is_tournament_not_rr():
+def test_popup_with_tournament_id_is_tournament_not_rr_even_if_popup_flagged():
     match = {
+        "is_popup": True,
         "match_type": "PopUp",
         "tournament_id": "tour-2",
         "context_type": None,
@@ -20,3 +21,13 @@ def test_popup_with_tournament_id_is_tournament_not_rr():
         "week_tag": "Friday",
     }
     assert _resolve_event_key(match) is None
+
+
+def test_context_event_match_is_classified_as_popup_rr():
+    match = {
+        "match_type": "League",
+        "context_type": "event",
+        "context_id": "event-123",
+        "league": "Alpha",
+    }
+    assert _resolve_event_key(match) == ("RR", "event-123")


### PR DESCRIPTION
### Motivation
- Implement the 6-person pop-up round-robin schedule to match the provided 9-round score sheet so pop-up socials generate the correct 6-player pairings. 
- Ensure UI/listing of "Pop-Up Round Robins" only includes true pop-up event matches and does not show tournament round-robins that happen to involve 6 teams or be flagged as pop-ups.

### Description
- Replaced the `6-Player` schedule template with a 9-game pop-up RR template in `jupr_app/domain/schedule.py` and kept the 6-team tournament RR logic untouched. 
- Updated the Match Uploader expected-game mapping for `6-Player` from `5` to `9` in `jupr_app/ui/pages/match_uploader.py`. 
- Added shared classification helpers `is_tournament_match` and `is_popup_event_match` to `jupr_app/domain/match_filters.py` and used them in `jupr_app/domain/recaps/weekly_recap.py` so pop-up RR grouping only treats rows with `(match_type == "PopUp" OR context_type == "event")` as pop-ups and explicitly excludes any match with tournament indicators (`context_type == "TOURNAMENT"`, non-null `tournament_id`, or `match_type == "Tournament"`). 
- Added unit tests `tests/test_schedule_6_player.py` for the 6-player template and extended `tests/test_weekly_recap_tournament_classification.py` to assert tournament rows are excluded from pop-up RR grouping while event-context matches are included.

### Testing
- Ran `pytest -q tests/test_schedule_6_player.py tests/test_weekly_recap_tournament_classification.py tests/test_match_filter_audit.py` and all tests passed. 
- The new schedule test verifies `get_match_schedule("6-Player", [1..6])` returns 9 matches and asserts R1, R4, and R9 pairings. 
- The weekly recap classification tests confirm tournament matches are excluded from pop-up RR listings even when flagged as pop-up and that `context_type == "event"` rows are classified as pop-up RR events.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a233cfa3a083268d4a2200fc7219ad)