### PR TITLE
Stabilize badge award pipeline: queue draining, grants, and UI refresh

### DIFF
--- a/jupr_app/domain/bulk_match_editor.py
+++ b/jupr_app/domain/bulk_match_editor.py
@@ -6,6 +6,7 @@ import json
 import pandas as pd
 
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
+from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
 
 def compute_recompute_scope(patches: List[Dict[str, Any]]) -> Dict[str, bool]:
     """
@@ -261,7 +262,7 @@ def apply_bulk_match_edits(
 
     if updated_ids and supabase is not None:
         for match_id in updated_ids:
-            enqueue_badge_eval(
+            queued = enqueue_badge_eval(
                 supabase,
                 club_id=str(club_id),
                 event_type="match_updated",
@@ -269,6 +270,8 @@ def apply_bulk_match_edits(
                 match_id=str(match_id),
                 payload={"updated_ids": updated_ids[:50]},
             )
+            if queued:
+                process_badge_eval_queue(supabase, max_jobs=1, time_budget_seconds=2)
 
     return {
         "updated_count": len(updated_ids),

--- a/jupr_app/domain/gamification/badge_queue.py
+++ b/jupr_app/domain/gamification/badge_queue.py
@@ -22,9 +22,9 @@ def enqueue_badge_eval(
     context_id: str | None = None,
     match_id: str | None = None,
     payload: dict[str, Any] | None = None,
-) -> None:
+) -> bool:
     if supabase is None or not club_id or not event_type:
-        return
+        return False
     payload_json = dict(payload or {})
     row = {
         "club_id": str(club_id),
@@ -52,16 +52,17 @@ def enqueue_badge_eval(
                 code,
                 message,
             )
-            return
+            return False
         logger.warning(
             "Failed to enqueue badge evaluation (code=%s message=%s). Skipping badge enqueue.",
             code,
             message,
         )
-        return
+        return False
     except Exception as exc:  # noqa: BLE001 - badge enqueue should never crash uploads
         logger.warning("Unexpected error while enqueueing badge evaluation: %s", exc)
-        return
+        return False
+    return True
 
 
 def dequeue_badge_eval(supabase: Any) -> dict[str, Any] | None:

--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -12,6 +12,7 @@ from jupr_app.domain.player_activity import (
     max_activity_time,
 )
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
+from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
 
 
 def process_matches(
@@ -284,13 +285,15 @@ def process_matches(
             sb_retry(lambda chunk=chunk: supabase.table("matches").insert(chunk).execute())
 
         if supabase is not None and has_non_popup_match:
-            enqueue_badge_eval(
+            queued = enqueue_badge_eval(
                 supabase,
                 club_id=str(club_id),
                 event_type="match_recorded",
                 player_ids=sorted(affected_players),
                 payload={"match_count": len(db_matches), "matches": match_payloads[:10]},
             )
+            if queued:
+                process_badge_eval_queue(supabase, max_jobs=1, time_budget_seconds=2)
 
     # -------------------------
     # Update overall player rows

--- a/jupr_app/ui/pages/challenge_ladder_admin.py
+++ b/jupr_app/ui/pages/challenge_ladder_admin.py
@@ -881,6 +881,7 @@ def render(ctx):
                             if int(pm_result.get("inserted", 0)) != 2:
                                 st.warning(f"Expected 2 inserted matches; got {pm_result}.")
                             else:
+                                st.session_state["force_data_refresh"] = True
                                 st.success("Challenge result recorded. 2 matches inserted and OVERALL ratings updated.")
                             st.rerun()
 

--- a/jupr_app/ui/pages/match_uploader.py
+++ b/jupr_app/ui/pages/match_uploader.py
@@ -197,6 +197,7 @@ def render(ctx):
                 df_meta=df_meta,
             )
             st.success("✅ Processed!")
+            st.session_state["force_data_refresh"] = True
             time.sleep(0.8)
             st.rerun()
 
@@ -523,5 +524,6 @@ def render(ctx):
 
                     if "mu_lc_schedule" in st.session_state:
                         del st.session_state.mu_lc_schedule
+                    st.session_state["force_data_refresh"] = True
                     time.sleep(0.8)
                     st.rerun()

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -645,6 +645,7 @@ def _save_games(ctx, tournament, teams_by_id, game_map, stage: str):
 
     if updated_any:
         st.success("Scores saved.")
+        st.session_state["force_data_refresh"] = True
         st.rerun()
 
 

--- a/migrations/20260801_badge_queue_and_facts_grants.sql
+++ b/migrations/20260801_badge_queue_and_facts_grants.sql
@@ -1,0 +1,5 @@
+-- Ensure badge async infrastructure is writable from app clients.
+-- This keeps queue/facts persistence aligned with player_badges behavior.
+
+grant select, insert, update on public.badge_eval_queue to anon, authenticated;
+grant select, insert, update on public.player_badge_facts to anon, authenticated;

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -13,6 +13,7 @@ import pandas as pd  # kept because pages may rely on it
 from jupr_app.data.client import make_supabase
 from jupr_app.data.load import load_data
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
+from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
 from jupr_app.ui.context import AppContext
 from jupr_app.ui.theme_clean import apply_clean_theme
 from jupr_app.ui.url import qp_get
@@ -299,7 +300,7 @@ def main():
             player_ids = []
             if df_players_all is not None and not df_players_all.empty and "id" in df_players_all.columns:
                 player_ids = df_players_all["id"].dropna().astype(int).tolist()
-            enqueue_badge_eval(
+            queued = enqueue_badge_eval(
                 supabase,
                 club_id=CLUB_ID,
                 event_type="match_recorded",
@@ -307,6 +308,8 @@ def main():
                 match_id=f"initial_load:{CLUB_ID}",
                 payload={"initial_load": True},
             )
+            if queued:
+                process_badge_eval_queue(supabase, max_jobs=2, time_budget_seconds=2)
 
         # -------------------------
         # LAZY IMPORT PAGES (prevents import-time KeyError crashes)


### PR DESCRIPTION
### Motivation

- Badges were intermittently not persisting or showing because enqueueing jobs often never triggered evaluation, table permissions for async artifacts were incomplete, and the UI cache could show stale badge state after writes.  
- The intent is to provide minimal, deterministic fixes that preserve existing schema and idempotency guarantees.  

### Description

- Make `enqueue_badge_eval(...)` return a `bool` so callers can detect success/failure instead of silently swallowing errors (file: `jupr_app/domain/gamification/badge_queue.py`).  
- Opportunistically drain the async queue immediately after successful enqueues on core mutation paths by calling `process_badge_eval_queue(...)` for short budgets from `process_matches(...)`, the bulk editor, and the app bootstrap (files: `jupr_app/domain/match_processing.py`, `jupr_app/domain/bulk_match_editor.py`, `streamlit_app.py`).  
- Improve UI freshness by setting `st.session_state['force_data_refresh']=True` in common match write flows so cached `get_data` results are refreshed after writes (files: `jupr_app/ui/pages/match_uploader.py`, `jupr_app/ui/pages/tournaments.py`, `jupr_app/ui/pages/challenge_ladder_admin.py`).  
- Add a small backward-compatible migration to grant `select/insert/update` on `public.badge_eval_queue` and `public.player_badge_facts` to `anon` and `authenticated` roles to avoid RLS/grant-related enqueue failures (file: `migrations/20260801_badge_queue_and_facts_grants.sql`).  

### Testing

- Ran targeted unit tests: `pytest -q tests/test_badge_worker.py tests/test_badge_engine.py tests/test_player_badges_contract.py` and all tests passed (`12 passed`).  
- Verified diffs touched only opportunistic worker calls, the enqueue return contract, UI refresh flags, and an additive migration; no destructive schema changes were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a23ce7c03483269037f894f81e29d3)