### PR TITLE
Fix leaderboards story HTML warning signature (add player_id)

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -118,6 +118,7 @@ def _story_has_html(raw: str | None) -> bool:
 
 def _log_story_html_warning(
     raw_story: str | None,
+    player_id: int,
     source: str,
     admin_logged_in: bool,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Align `_log_story_html_warning` signature with its call site to prevent a `TypeError` when rendering player stories that include HTML.

### Description
- Add a `player_id: int` parameter to `_log_story_html_warning` and use it in the warning message in `jupr_app/ui/pages/leaderboards.py`.

### Testing
- Ran `pytest -q tests/test_leaderboards_story_escape.py` and all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a336b5be288326b859f46e46896922)