### PR TITLE
Fix leaderboards story HTML warning helper signature

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -118,9 +118,9 @@ def _story_has_html(raw: str | None) -> bool:
 
 def _log_story_html_warning(
     raw_story: str | None,
-    player_id: int,
+    player_id: int | None,
     source: str,
-    admin_logged_in: bool,
+    admin_logged_in: bool = False,
 ) -> None:
     if not admin_logged_in or not raw_story:
         return


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError` when rendering leaderboards by making the story-warning helper accept both legacy 3-arg and current 4-arg call sites.

### Description
- Updated the `_log_story_html_warning` signature to allow `player_id` to be `None` and made `admin_logged_in` optional with a default of `False`, restoring compatibility with callers.

### Testing
- Ran `python -m py_compile /workspace/JUPR/jupr_app/ui/pages/leaderboards.py` and it succeeded.
- Performed a smoke test by invoking `_log_story_html_warning` with both 3 and 4 positional arguments in a small Python script, and both calls succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a34292557083269c2ed5f6922bf64c)