### PR TITLE
Mint tournament podium badges directly so tournament trophies appear in player profiles

### DIFF
--- a/jupr_app/domain/tournament_podium.py
+++ b/jupr_app/domain/tournament_podium.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from jupr_app.domain.gamification.badge_types import BadgeCandidate
-
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +49,8 @@ def upsert_tournament_podium(
 def build_tournament_podium_candidates(
     ctx: Any, tournament_id: str, tournament_name: str | None
 ) -> list[BadgeCandidate]:
+    from jupr_app.domain.gamification.badge_types import BadgeCandidate
+
     supabase = getattr(ctx, "supabase", None)
     club_id = str(getattr(ctx, "club_id", "") or "")
     if supabase is None or not club_id or not tournament_id:
@@ -113,12 +113,19 @@ def build_tournament_podium_candidates(
 
 
 def award_tournament_trophies_from_podium(ctx: Any, tournament_id: str, tournament_name: str | None) -> list[BadgeCandidate]:
-    from jupr_app.domain.gamification.ensure_badges import ensure_badges
+    return mint_tournament_podium_badges(ctx, tournament_id, tournament_name)
 
-    return ensure_badges(
-        ctx,
-        tournament_id=tournament_id,
-        tournament_name=tournament_name,
-        award_timing="manual",
-        status="live",
-    )
+
+def mint_tournament_podium_badges(ctx: Any, tournament_id: str, tournament_name: str | None) -> list[BadgeCandidate]:
+    supabase = getattr(ctx, "supabase", None)
+    club_id = str(getattr(ctx, "club_id", "") or "")
+    if supabase is None or not club_id or not tournament_id:
+        return []
+
+    candidates = build_tournament_podium_candidates(ctx, tournament_id, tournament_name)
+    if not candidates:
+        return []
+
+    from jupr_app.domain.gamification.badges_repo import upsert_player_badges
+
+    return upsert_player_badges(supabase, club_id, candidates)

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -126,6 +126,7 @@ def fetch_player_badges(_supabase, club_id: str, pid: int) -> pd.DataFrame:
     return pb_df.merge(badges_df, on="badge_id", how="left")
 
 
+# Keep this cache short so newly finalized tournament podium trophies appear quickly.
 @st.cache_data(ttl=60)
 def fetch_player_tournament_trophies(_supabase, club_id: str, pid: int) -> list[dict]:
     return get_player_tournament_trophies(_supabase, club_id, pid)

--- a/tests/test_tournament_podium.py
+++ b/tests/test_tournament_podium.py
@@ -1,4 +1,6 @@
-from jupr_app.domain.tournament_podium import upsert_tournament_podium
+from types import SimpleNamespace
+
+from jupr_app.domain.tournament_podium import mint_tournament_podium_badges, upsert_tournament_podium
 
 
 class DummyTable:
@@ -23,6 +25,69 @@ class DummySupabase:
         return self.table_obj
 
 
+class FakeTable:
+    def __init__(self, storage, name):
+        self.storage = storage
+        self.name = name
+        self.filters = []
+        self.ordering = None
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, column, value):
+        self.filters.append(("eq", column, value))
+        return self
+
+    def in_(self, column, values):
+        self.filters.append(("in", column, set(values)))
+        return self
+
+    def like(self, column, pattern):
+        self.filters.append(("like", column, pattern))
+        return self
+
+    def order(self, column, desc=False):
+        self.ordering = (column, desc)
+        return self
+
+    def upsert(self, rows, on_conflict=None):
+        existing = self.storage.setdefault(self.name, [])
+        keys = [c.strip() for c in str(on_conflict or "").split(",") if c.strip()]
+        existing_keys = {tuple(row.get(k) for k in keys) for row in existing} if keys else set()
+        for row in rows:
+            key = tuple(row.get(k) for k in keys) if keys else None
+            if key is not None and key in existing_keys:
+                continue
+            existing.append(dict(row))
+            if key is not None:
+                existing_keys.add(key)
+        return self
+
+    def execute(self):
+        data = list(self.storage.get(self.name, []))
+        for op, column, value in self.filters:
+            if op == "eq":
+                data = [row for row in data if str(row.get(column)) == str(value)]
+            elif op == "in":
+                data = [row for row in data if row.get(column) in value]
+            elif op == "like":
+                needle = str(value).replace("%", "")
+                data = [row for row in data if needle in str(row.get(column) or "")]
+        if self.ordering:
+            column, desc = self.ordering
+            data = sorted(data, key=lambda row: row.get(column), reverse=bool(desc))
+        return SimpleNamespace(data=data)
+
+
+class FakeSupabase:
+    def __init__(self, storage=None):
+        self.storage = storage if storage is not None else {}
+
+    def table(self, name):
+        return FakeTable(self.storage, name)
+
+
 def test_upsert_tournament_podium_is_idempotent():
     supabase = DummySupabase()
     payload = [
@@ -38,3 +103,62 @@ def test_upsert_tournament_podium_is_idempotent():
     for call in supabase.table_obj.upsert_calls:
         assert call["payload"] == payload
         assert call["on_conflict"] == "tournament_id,placement"
+
+
+def test_mint_tournament_podium_badges_is_idempotent_and_profile_compatible():
+    storage = {
+        "pg_indexes": [
+            {
+                "schemaname": "public",
+                "tablename": "player_badges",
+                "indexname": "player_badges_unique",
+                "indexdef": "CREATE UNIQUE INDEX player_badges_unique ON public.player_badges USING btree (club_id, player_id, badge_id, context_id)",
+            }
+        ],
+        "tournament_podium": [
+            {"tournament_id": "tour1", "placement": 1, "team_id": "team1", "source": "PLAYOFF"},
+            {"tournament_id": "tour1", "placement": 2, "team_id": "team2", "source": "PLAYOFF"},
+            {"tournament_id": "tour1", "placement": 3, "team_id": "team3", "source": "PLAYOFF"},
+        ],
+        "tournament_teams": [
+            {"id": "team1", "team_number": 1, "player1_id": 101, "player2_id": 102},
+            {"id": "team2", "team_number": 2, "player1_id": 103, "player2_id": 104},
+            {"id": "team3", "team_number": 3, "player1_id": 105, "player2_id": 106},
+        ],
+        "player_badges": [],
+    }
+    supabase = FakeSupabase(storage)
+    ctx = SimpleNamespace(supabase=supabase, club_id="club1")
+
+    created_once = mint_tournament_podium_badges(ctx, "tour1", "Spring Open")
+    created_twice = mint_tournament_podium_badges(ctx, "tour1", "Spring Open")
+
+    assert len(created_once) == 6
+    assert created_twice == []
+
+    rows = storage["player_badges"]
+    assert len(rows) == 6
+    assert {row["context_type"] for row in rows} == {"tournament"}
+    assert all(":podium:" in row["context_id"] for row in rows)
+    assert {row["badge_id"] for row in rows} == {
+        "tournament_champion",
+        "tournament_runner_up",
+        "tournament_third_place",
+    }
+    assert all(row.get("earned_at") for row in rows)
+
+    profile_rows = [
+        row
+        for row in rows
+        if str(row.get("context_type")) == "tournament" and ":podium:" in str(row.get("context_id") or "")
+    ]
+    assert len(profile_rows) == 6
+
+    for row in rows:
+        assert row["value_num"] in {1.0, 2.0, 3.0}
+        value_json = row.get("value_json") or {}
+        assert value_json.get("tournament_id") == "tour1"
+        assert value_json.get("tournament_name") == "Spring Open"
+        assert value_json.get("placement") in {1, 2, 3}
+        assert value_json.get("team_id") in {"team1", "team2", "team3"}
+        assert value_json.get("team_number") in {1, 2, 3}


### PR DESCRIPTION
### Motivation
- Tournament finalize flow called a club-wide badge evaluation path that can return no candidates when match-history context is missing, causing player profile “Tournament Trophies” to show empty despite a podium existing.
- The goal was to make podium trophies reliably create `player_badges` rows with the exact `context_type`/`context_id` contract used by the profile query while keeping the change minimal and idempotent.

### Description
- Added a direct tournament-specific minting path `mint_tournament_podium_badges(ctx, tournament_id, tournament_name)` in `jupr_app/domain/tournament_podium.py` that builds podium `BadgeCandidate`s via `build_tournament_podium_candidates(...)` and persists them with `upsert_player_badges(...)`, relying on the existing uniqueness contract `(club_id,player_id,badge_id,context_id)` for idempotency.  The minted `context_id` is exactly `"{tournament_id}:podium:{placement}"` and `context_type` is `"tournament"`.
- Replaced the previous delegation in `award_tournament_trophies_from_podium(...)` so it now calls the new `mint_tournament_podium_badges(...)` (function name retained to minimize call-site changes).
- Left `upsert_player_badges(...)` to populate `earned_at`, `tape_excerpt`, and `tape_title` as before; ensured `value_json` includes `tournament_id`, `tournament_name`, `placement`, `team_id`, and `team_number` when building candidates.
- Added a brief code comment in `jupr_app/ui/pages/players.py` near `fetch_player_tournament_trophies` to note the cache TTL (kept at 60s to avoid UI redesign).
- Added tests in `tests/test_tournament_podium.py` that exercise the new minting path, assert idempotency, and verify inserted rows satisfy the profile query contract (`context_type='tournament'` and `context_id` containing `:podium:`).
- Included a simple post-deploy sanity check (SQL) to inspect `player_badges` rows matching tournament podium contexts: `select * from player_badges where context_type='tournament' and context_id like '%:podium:%' order by earned_at desc;`.

### Testing
- Ran `pytest -q tests/test_tournament_podium.py tests/test_tournament_trophies.py` and all tests passed (`4 passed`).
- Ran `pytest -q tests/test_badge_engine.py::test_ensure_badges_is_idempotent` and the test passed (`1 passed`).
- The new tests validate creation of podium badges, idempotency on repeated runs, and compatibility with the player-profile query and they succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a351d959e88326a1fb543ecda6e9a4)