### PR TITLE
Fix badge queue error visibility and ensure tournament podium trophies appear on profiles

### DIFF
--- a/jupr_app/domain/gamification/badge_worker.py
+++ b/jupr_app/domain/gamification/badge_worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import time
+import traceback
 from types import SimpleNamespace
 from typing import Any
 
@@ -59,7 +60,13 @@ def process_badge_eval_queue(
             ack_badge_eval(supabase, job_id=str(job.get("id")), status="done")
             processed += 1
         except Exception as exc:  # noqa: BLE001 - worker should record failures
-            ack_badge_eval(supabase, job_id=str(job.get("id")), status="error", error=str(exc))
+            details = f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}".strip()
+            ack_badge_eval(
+                supabase,
+                job_id=str(job.get("id")),
+                status="error",
+                error=details[:2000],
+            )
             errored += 1
 
     return {"processed": processed, "errored": errored}

--- a/jupr_app/domain/tournament_podium.py
+++ b/jupr_app/domain/tournament_podium.py
@@ -113,7 +113,18 @@ def build_tournament_podium_candidates(
 
 
 def award_tournament_trophies_from_podium(ctx: Any, tournament_id: str, tournament_name: str | None) -> list[BadgeCandidate]:
-    return mint_tournament_podium_badges(ctx, tournament_id, tournament_name)
+    supabase = getattr(ctx, "supabase", None)
+    club_id = str(getattr(ctx, "club_id", "") or "")
+    if supabase is None or not club_id or not tournament_id:
+        return []
+
+    candidates = build_tournament_podium_candidates(ctx, tournament_id, tournament_name)
+    if not candidates:
+        return []
+
+    from jupr_app.domain.gamification.badges_repo import upsert_player_badges
+
+    return upsert_player_badges(supabase, club_id, candidates, awarded_by="engine")
 
 
 def mint_tournament_podium_badges(ctx: Any, tournament_id: str, tournament_name: str | None) -> list[BadgeCandidate]:

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -13,7 +13,6 @@ from jupr_app.domain.gamification.badge_state import ALLOWED_BADGE_STATES, can_t
 from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
 from jupr_app.ui.layout import page_shell
 
-
 def _get_api_error_code(exc: APIError) -> str | None:
     code = getattr(exc, "code", None)
     if code:
@@ -22,6 +21,25 @@ def _get_api_error_code(exc: APIError) -> str | None:
         return exc.args[0].get("code")
     return None
 
+def _badge_queue_preflight(supabase, club_id: str) -> bool:
+    try:
+        supabase.table("badge_eval_queue").select("id").eq("club_id", club_id).limit(1).execute()
+        supabase.table("player_badge_facts").select("id").eq("club_id", club_id).limit(1).execute()
+        return True
+    except APIError as exc:
+        st.error("Badge queue prerequisites are missing or inaccessible.")
+        st.code(
+            "-- Apply migrations/20260705_badge_eval_queue.sql (tables)\n"
+            "-- Apply migrations/20260801_badge_queue_and_facts_grants.sql (grants)\n"
+            "NOTIFY pgrst, 'reload schema';",
+            language="sql",
+        )
+        st.caption(f"Details: {_get_api_error_code(exc) or 'unknown'} | {exc}")
+        return False
+    except Exception as exc:  # noqa: BLE001 - diagnostics only
+        st.error("Could not verify badge queue prerequisites.")
+        st.exception(exc)
+        return False
 
 def render(ctx):
     mode_label = "Public" if bool(ctx.public_mode) else "Admin"
@@ -77,29 +95,73 @@ def render(ctx):
     # -------------------------
     st.subheader("🧵 Badge Eval Queue")
     st.caption("Process queued badge evaluations without blocking the UI (short time budget).")
+    badge_queue_ready = _badge_queue_preflight(supabase, club_id)
+
+    col_pending, col_jobs = st.columns(2)
+    with col_pending:
+        if st.button("Show pending queue count", key="badge_eval_queue_pending_count") and badge_queue_ready:
+            pending_resp = (
+                supabase.table("badge_eval_queue")
+                .select("id", count="exact")
+                .eq("club_id", club_id)
+                .eq("status", "pending")
+                .execute()
+            )
+            st.info(f"Pending jobs: {int(pending_resp.count or 0)}")
+    with col_jobs:
+        if st.button("Show last 10 pending jobs", key="badge_eval_queue_pending_jobs") and badge_queue_ready:
+            pending_rows = (
+                supabase.table("badge_eval_queue")
+                .select("id,created_at,event_type,match_id,attempts,player_ids,context_id")
+                .eq("club_id", club_id)
+                .eq("status", "pending")
+                .order("created_at", desc=True)
+                .limit(10)
+                .execute()
+            )
+            st.dataframe(pd.DataFrame(pending_rows.data or []), use_container_width=True, hide_index=True)
+
     if st.button("Process queued badge evaluations", key="badge_eval_queue_process"):
-        with st.spinner("Processing queued badge evaluations..."):
-            try:
-                result = process_badge_eval_queue(supabase, max_jobs=5, time_budget_seconds=2)
-            except APIError as exc:
-                code = _get_api_error_code(exc)
-                if code in {"PGRST205", "42P01"}:
-                    st.error(
-                        "Missing table badge_eval_queue; apply migrations/20260705_badge_eval_queue.sql and "
-                        "run NOTIFY pgrst, 'reload schema';"
-                    )
-                    st.code(
-                        "-- Apply migrations/20260705_badge_eval_queue.sql\nNOTIFY pgrst, 'reload schema';",
-                        language="sql",
-                    )
-                else:
+        if not badge_queue_ready:
+            st.info("Run required queue migrations before processing jobs.")
+        else:
+            with st.spinner("Processing queued badge evaluations..."):
+                try:
+                    result = process_badge_eval_queue(supabase, max_jobs=5, time_budget_seconds=2)
+                except APIError as exc:
+                    code = _get_api_error_code(exc)
+                    if code in {"PGRST205", "42P01"}:
+                        st.error(
+                            "Missing table badge_eval_queue; apply migrations/20260705_badge_eval_queue.sql and "
+                            "run NOTIFY pgrst, 'reload schema';"
+                        )
+                        st.code(
+                            "-- Apply migrations/20260705_badge_eval_queue.sql\nNOTIFY pgrst, 'reload schema';",
+                            language="sql",
+                        )
+                    else:
+                        st.error("Failed to process queued badge evaluations.")
+                        st.exception(exc)
+                except Exception as exc:  # noqa: BLE001 - UI should not crash
                     st.error("Failed to process queued badge evaluations.")
                     st.exception(exc)
-            except Exception as exc:  # noqa: BLE001 - UI should not crash
-                st.error("Failed to process queued badge evaluations.")
-                st.exception(exc)
-            else:
-                st.success(f"Processed {result['processed']} job(s); {result['errored']} error(s).")
+                else:
+                    st.success(f"Processed {result['processed']} job(s); {result['errored']} error(s).")
+                    if int(result.get("errored") or 0) > 0:
+                        errored_rows = (
+                            supabase.table("badge_eval_queue")
+                            .select("id,created_at,event_type,match_id,attempts,last_error")
+                            .eq("club_id", club_id)
+                            .eq("status", "error")
+                            .order("created_at", desc=True)
+                            .limit(5)
+                            .execute()
+                        )
+                        rows = errored_rows.data or []
+                        if rows:
+                            st.warning("Recent queue errors")
+                            st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+                            st.code(str(rows[0].get("last_error") or ""), language="text")
 
     # -------------------------
     # Replay History
@@ -131,7 +193,6 @@ def render(ctx):
         st.success("Replay complete.")
         time.sleep(0.6)
         st.rerun()
-
 
     st.divider()
 

--- a/tests/test_badge_worker.py
+++ b/tests/test_badge_worker.py
@@ -199,6 +199,7 @@ def test_worker_error_marks_queue(monkeypatch):
     rows = storage.get("badge_eval_queue", [])
     assert rows[0]["status"] == "error"
     assert rows[0]["attempts"] == 1
+    assert "RuntimeError" in str(rows[0].get("last_error") or "")
 
 
 def test_enqueue_badge_eval_missing_table_is_ignored():

--- a/tests/test_tournament_podium.py
+++ b/tests/test_tournament_podium.py
@@ -1,7 +1,10 @@
 from types import SimpleNamespace
 
-from jupr_app.domain.tournament_podium import mint_tournament_podium_badges, upsert_tournament_podium
-
+from jupr_app.domain.tournament_podium import (
+    award_tournament_trophies_from_podium,
+    mint_tournament_podium_badges,
+    upsert_tournament_podium,
+)
 
 class DummyTable:
     def __init__(self) -> None:
@@ -14,7 +17,6 @@ class DummyTable:
     def execute(self):
         return self
 
-
 class DummySupabase:
     def __init__(self) -> None:
         self.last_table = None
@@ -23,7 +25,6 @@ class DummySupabase:
     def table(self, name: str):
         self.last_table = name
         return self.table_obj
-
 
 class FakeTable:
     def __init__(self, storage, name):
@@ -79,14 +80,12 @@ class FakeTable:
             data = sorted(data, key=lambda row: row.get(column), reverse=bool(desc))
         return SimpleNamespace(data=data)
 
-
 class FakeSupabase:
     def __init__(self, storage=None):
         self.storage = storage if storage is not None else {}
 
     def table(self, name):
         return FakeTable(self.storage, name)
-
 
 def test_upsert_tournament_podium_is_idempotent():
     supabase = DummySupabase()
@@ -104,6 +103,40 @@ def test_upsert_tournament_podium_is_idempotent():
         assert call["payload"] == payload
         assert call["on_conflict"] == "tournament_id,placement"
 
+def test_award_tournament_trophies_from_podium_is_idempotent_and_profile_compatible():
+    storage = {
+        "pg_indexes": [
+            {
+                "schemaname": "public",
+                "tablename": "player_badges",
+                "indexname": "player_badges_unique",
+                "indexdef": "CREATE UNIQUE INDEX player_badges_unique ON public.player_badges USING btree (club_id, player_id, badge_id, context_id)",
+            }
+        ],
+        "tournament_podium": [
+            {"tournament_id": "tour1", "placement": 1, "team_id": "team1", "source": "PLAYOFF"},
+            {"tournament_id": "tour1", "placement": 2, "team_id": "team2", "source": "PLAYOFF"},
+            {"tournament_id": "tour1", "placement": 3, "team_id": "team3", "source": "PLAYOFF"},
+        ],
+        "tournament_teams": [
+            {"id": "team1", "team_number": 1, "player1_id": 101, "player2_id": 102},
+            {"id": "team2", "team_number": 2, "player1_id": 103, "player2_id": 104},
+            {"id": "team3", "team_number": 3, "player1_id": 105, "player2_id": 106},
+        ],
+        "player_badges": [],
+    }
+    supabase = FakeSupabase(storage)
+    ctx = SimpleNamespace(supabase=supabase, club_id="club1")
+
+    created_once = award_tournament_trophies_from_podium(ctx, "tour1", "Spring Open")
+    created_twice = award_tournament_trophies_from_podium(ctx, "tour1", "Spring Open")
+
+    assert len(created_once) == 6
+    assert created_twice == []
+    rows = storage["player_badges"]
+    assert len(rows) == 6
+    assert {row["context_type"] for row in rows} == {"tournament"}
+    assert all(":podium:" in row["context_id"] for row in rows)
 
 def test_mint_tournament_podium_badges_is_idempotent_and_profile_compatible():
     storage = {


### PR DESCRIPTION
### Motivation
- Improve observability when the badge eval worker fails by persisting actionable error text and surfacing recent failing jobs in the Admin UI. 
- Ensure tournament podium trophies always create profile-compatible `player_badges` rows so Tournament Trophies populate on player profiles. 
- Provide clear, actionable guidance when DB schema prerequisites for the badge queue are missing. 

### Description
- Persist richer error details in `badge_eval_queue.last_error` from `process_badge_eval_queue` by storing `ExceptionType: message` plus `traceback.format_exc()` (truncated to ~2000 chars) while keeping `status='error'` and attempts increment. 
- Add Admin Tools preflight ` _badge_queue_preflight` that probes `badge_eval_queue` and `player_badge_facts` and displays migration/grants guidance (`migrations/20260705_badge_eval_queue.sql` and `migrations/20260801_badge_queue_and_facts_grants.sql` with `NOTIFY pgrst, 'reload schema';`). 
- Add Admin UI controls to show pending queue count and last 10 pending jobs, and after processing show up to 5 recent errored jobs and the top `last_error` for quick debugging. 
- Change `award_tournament_trophies_from_podium` to directly persist podium candidates by calling `upsert_player_badges(supabase, club_id, candidates, awarded_by="engine")`, ensuring `context_type='tournament'` and `context_id='{tournament_id}:podium:{placement}'` rows are created idempotently under the existing uniqueness contract. 

### Testing
- Ran static compile checks with `python -m py_compile` for modified modules and they succeeded. 
- Ran unit tests with `pytest -q tests/test_badge_worker.py tests/test_tournament_podium.py` and all tests passed (`7 passed`). 
- Tests added/updated include asserting that worker error rows include the exception type in `last_error` and that `award_tournament_trophies_from_podium` directly creates idempotent `player_badges` rows with `:podium:` in `context_id`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a354c101f88326aecfa8484e0998ee)