### PR TITLE
Normalize player_badges.awarded_by to text and retry on uuid cast errors

### DIFF
--- a/jupr_app/domain/gamification/badges_repo.py
+++ b/jupr_app/domain/gamification/badges_repo.py
@@ -160,6 +160,15 @@ def _upsert_player_badges_chunk(supabase: Any, rows: list[dict[str, Any]]) -> No
                 stripped,
                 on_conflict=PLAYER_BADGES_CONFLICT_KEY,
             ).execute()
+        elif _is_awarded_by_uuid_error(exc):
+            logger.warning(
+                "player_badges.awarded_by appears to be uuid in schema; retrying upsert without provenance fields."
+            )
+            stripped = [_strip_optional_columns(row, _PLAYER_BADGES_OPTIONAL_COLUMNS) for row in rows]
+            supabase.table("player_badges").upsert(
+                stripped,
+                on_conflict=PLAYER_BADGES_CONFLICT_KEY,
+            ).execute()
         else:
             raise
 
@@ -176,6 +185,13 @@ def _is_missing_column_error(exc: APIError, columns: Iterable[str]) -> bool:
         return False
     message = str(exc)
     return any(col in message for col in columns)
+
+
+def _is_awarded_by_uuid_error(exc: APIError) -> bool:
+    if getattr(exc, "code", None) != "22P02":
+        return False
+    message = str(exc).lower()
+    return "uuid" in message and "engine" in message
 
 
 def _fetch_existing_keys(

--- a/migrations/20260805_player_badges_awarded_by_text.sql
+++ b/migrations/20260805_player_badges_awarded_by_text.sql
@@ -1,0 +1,16 @@
+-- Normalize player_badges.awarded_by to text with a stable engine default.
+ALTER TABLE public.player_badges
+  ALTER COLUMN awarded_by TYPE text
+  USING COALESCE(awarded_by::text, 'engine');
+
+ALTER TABLE public.player_badges
+  ALTER COLUMN awarded_by SET DEFAULT 'engine';
+
+UPDATE public.player_badges
+SET awarded_by = 'engine'
+WHERE awarded_by IS NULL;
+
+ALTER TABLE public.player_badges
+  ALTER COLUMN awarded_by SET NOT NULL;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/test_player_badges_contract.py
+++ b/tests/test_player_badges_contract.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+from postgrest.exceptions import APIError
 
 from jupr_app.domain.gamification.badge_types import BadgeCandidate
 from jupr_app.domain.gamification.badges_repo import ensure_player_badges_contract, upsert_player_badges
@@ -126,3 +127,44 @@ def test_player_badges_contract_check_rejects_wrong_index(monkeypatch):
     monkeypatch.setenv("BADGE_DEBUG", "1")
     with pytest.raises(RuntimeError):
         ensure_player_badges_contract(supabase)
+
+
+def test_player_badges_upsert_retries_when_awarded_by_uuid_cast_fails(monkeypatch):
+    monkeypatch.setattr("jupr_app.domain.gamification.badges_repo._PLAYER_BADGES_CONTRACT_CHECKED", True)
+
+    calls: list[list[dict[str, object]]] = []
+
+    class _RetryTable:
+        def upsert(self, rows, on_conflict=None):
+            calls.append(rows)
+            if len(calls) == 1:
+                raise APIError(
+                    {
+                        "code": "22P02",
+                        "message": 'invalid input syntax for type uuid: "engine"',
+                    }
+                )
+            return self
+
+        def execute(self):
+            return SimpleNamespace(data=[])
+
+    class _RetrySupabase:
+        def table(self, _name):
+            return _RetryTable()
+
+    candidate = BadgeCandidate(
+        badge_id="participant",
+        player_id=1,
+        club_id="club",
+        context_type="overall",
+        context_id="overall",
+        match_id=None,
+        value_json={"games": 1},
+    )
+
+    upsert_player_badges(_RetrySupabase(), "club", [candidate])
+
+    assert len(calls) == 2
+    assert "awarded_by" in calls[0][0]
+    assert "awarded_by" not in calls[1][0]


### PR DESCRIPTION
### Motivation
- Fix failures where `player_badges.awarded_by` schema drift to `uuid` caused PostgREST `22P02` errors when writing the string value `"engine"`.
- Ensure worker resilience so badge upserts succeed even when schema is temporarily inconsistent between `uuid` and `text` for `awarded_by`.
- Provide a one-off migration to normalize the column to `text` with a stable default to prevent future occurrences.

### Description
- Add a migration `migrations/20260805_player_badges_awarded_by_text.sql` that casts `awarded_by` to `text` using `COALESCE(awarded_by::text, 'engine')`, sets the default to `'engine'`, backfills nulls, sets `NOT NULL`, and notifies PostgREST to reload schema.
- Update `_upsert_player_badges_chunk` in `jupr_app/domain/gamification/badges_repo.py` to detect `22P02` uuid parse errors involving `"engine"` via a new helper `_is_awarded_by_uuid_error` and retry the upsert after stripping the optional provenance columns (`awarded_by`, `rule_version`, `eval_run_id`).
- Preserve the existing `42703` missing-column retry behavior unchanged.
- Add a regression test `test_player_badges_upsert_retries_when_awarded_by_uuid_cast_fails` in `tests/test_player_badges_contract.py` that simulates an initial `APIError(code='22P02')` and verifies the second upsert call omits `awarded_by`.

### Testing
- Ran `pytest -q tests/test_player_badges_contract.py` which executed the updated suite and the new regression test, resulting in `4 passed`.
- The new test verifies the retry path by asserting two upsert attempts occurred and that the retried payload no longer contains `awarded_by`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3588c6abc8326ab083913edede5cc)