### PR TITLE
Badge Eval Queue — add “Drain Queue” one-click processing with progress and safeguards

### DIFF
--- a/jupr_app/domain/gamification/badge_worker.py
+++ b/jupr_app/domain/gamification/badge_worker.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 import time
 import traceback
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Callable
 
 import pandas as pd
 
@@ -71,6 +71,75 @@ def process_badge_eval_queue(
             errored += 1
 
     return {"processed": processed, "errored": errored}
+
+
+def process_badge_eval_queue_until_empty(
+    supabase: Any,
+    club_id: str,
+    *,
+    max_total_jobs: int = 500,
+    batch_max_jobs: int = 10,
+    per_batch_time_budget_seconds: float = 2.0,
+    max_wall_clock_seconds: float = 90.0,
+    max_errors: int = 10,
+    progress_cb: Callable[[dict[str, int | float | str]], None] | None = None,
+) -> dict[str, int | float | str]:
+    started = time.time()
+    loops = 0
+    total_processed = 0
+    total_errored = 0
+    stopped_reason = "max_wall_clock"
+    error_only_loops = 0
+
+    while (time.time() - started) < max_wall_clock_seconds:
+        loops += 1
+        batch = process_badge_eval_queue(
+            supabase,
+            max_jobs=batch_max_jobs,
+            time_budget_seconds=per_batch_time_budget_seconds,
+        )
+        processed = int(batch.get("processed") or 0)
+        errored = int(batch.get("errored") or 0)
+        total_processed += processed
+        total_errored += errored
+
+        if errored > 0 and processed == 0:
+            error_only_loops += 1
+        else:
+            error_only_loops = 0
+
+        if progress_cb is not None:
+            progress_cb(
+                {
+                    "loop": loops,
+                    "processed": processed,
+                    "errored": errored,
+                    "total_processed": total_processed,
+                    "total_errored": total_errored,
+                    "duration_seconds": time.time() - started,
+                }
+            )
+
+        if processed == 0 and errored == 0:
+            stopped_reason = "empty"
+            break
+        if (total_processed + total_errored) >= max_total_jobs:
+            stopped_reason = "max_total_jobs"
+            break
+        if total_errored >= max_errors:
+            stopped_reason = "max_errors"
+            break
+        if error_only_loops >= 3:
+            stopped_reason = "error_circuit_breaker"
+            break
+
+    return {
+        "total_processed": total_processed,
+        "total_errored": total_errored,
+        "loops": loops,
+        "stopped_reason": stopped_reason,
+        "duration_seconds": round(time.time() - started, 3),
+    }
 
 
 def _resolve_context(ctx: Any | None, supabase: Any, club_id: str, match_limit: int) -> Any:

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -10,7 +10,10 @@ from jupr_app.domain.ratings import calculate_hybrid_elo
 from jupr_app.domain.constants import DEFAULT_K_FACTOR
 from jupr_app.domain.gamification.ensure_badges import ensure_badges
 from jupr_app.domain.gamification.badge_state import ALLOWED_BADGE_STATES, can_transition_badge_state
-from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
+from jupr_app.domain.gamification.badge_worker import (
+    process_badge_eval_queue,
+    process_badge_eval_queue_until_empty,
+)
 from jupr_app.ui.layout import page_shell
 
 def _get_api_error_code(exc: APIError) -> str | None:
@@ -139,6 +142,25 @@ def render(ctx):
             )
             st.dataframe(pd.DataFrame(pending_rows.data or []), use_container_width=True, hide_index=True)
 
+    drain_col1, drain_col2 = st.columns(2)
+    with drain_col1:
+        drain_wall_clock = st.selectbox(
+            "Drain max wall clock",
+            options=[30, 60, 90],
+            index=2,
+            format_func=lambda v: f"{int(v)}s",
+            key="badge_eval_queue_drain_max_wall_clock",
+            disabled=not badge_queue_ready,
+        )
+    with drain_col2:
+        drain_batch_size = st.selectbox(
+            "Drain batch size",
+            options=[5, 10, 20],
+            index=1,
+            key="badge_eval_queue_drain_batch_size",
+            disabled=not badge_queue_ready,
+        )
+
     if st.button("Process queued badge evaluations", key="badge_eval_queue_process"):
         if not badge_queue_ready:
             st.info("Run required queue migrations before processing jobs.")
@@ -180,6 +202,76 @@ def render(ctx):
                             st.warning("Recent queue errors")
                             st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
                             st.code(str(rows[0].get("last_error") or ""), language="text")
+
+    if st.button("Drain badge queue (run all)", key="badge_eval_queue_drain"):
+        if not badge_queue_ready:
+            st.info("Run required queue migrations before processing jobs.")
+        else:
+            try:
+                pending_resp = (
+                    supabase.table("badge_eval_queue")
+                    .select("id", count="exact")
+                    .eq("club_id", club_id)
+                    .eq("status", "pending")
+                    .execute()
+                )
+                pending_count = int(pending_resp.count or 0)
+                st.info(f"Pending jobs before drain: {pending_count}")
+
+                progress = st.progress(0.0)
+                progress_line = st.empty()
+                target = max(1, pending_count)
+
+                def _on_progress(payload: dict[str, int | float | str]) -> None:
+                    processed_total = int(payload.get("total_processed") or 0)
+                    errored_total = int(payload.get("total_errored") or 0)
+                    completed_total = processed_total + errored_total
+                    ratio = min(1.0, completed_total / target)
+                    progress.progress(ratio)
+                    progress_line.write(
+                        f"Loop {int(payload.get('loop') or 0)}: processed {completed_total}/{target}, "
+                        f"errors {errored_total}"
+                    )
+
+                drain_result = process_badge_eval_queue_until_empty(
+                    supabase,
+                    club_id,
+                    max_total_jobs=500,
+                    batch_max_jobs=int(drain_batch_size),
+                    per_batch_time_budget_seconds=2.0,
+                    max_wall_clock_seconds=float(drain_wall_clock),
+                    max_errors=10,
+                    progress_cb=_on_progress,
+                )
+                progress.progress(1.0)
+                st.success(
+                    "Drain complete: "
+                    f"processed {int(drain_result.get('total_processed') or 0)}, "
+                    f"errors {int(drain_result.get('total_errored') or 0)}, "
+                    f"loops {int(drain_result.get('loops') or 0)}, "
+                    f"reason {drain_result.get('stopped_reason')}, "
+                    f"duration {float(drain_result.get('duration_seconds') or 0):.2f}s."
+                )
+
+                if int(drain_result.get("total_errored") or 0) > 0:
+                    errored_rows = (
+                        supabase.table("badge_eval_queue")
+                        .select("id,event_type,attempts,last_error")
+                        .eq("club_id", club_id)
+                        .eq("status", "error")
+                        .order("created_at", desc=True)
+                        .limit(5)
+                        .execute()
+                    )
+                    rows = errored_rows.data or []
+                    st.warning("Last 5 errored jobs")
+                    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+            except APIError as exc:
+                st.error("Failed to drain badge queue.")
+                st.exception(exc)
+            except Exception as exc:  # noqa: BLE001 - UI should not crash
+                st.error("Failed to drain badge queue.")
+                st.exception(exc)
 
     # -------------------------
     # Replay History

--- a/tests/test_badge_worker.py
+++ b/tests/test_badge_worker.py
@@ -7,7 +7,10 @@ import pandas as pd
 from postgrest.exceptions import APIError
 
 from jupr_app.domain.gamification.badge_queue import BADGE_QUEUE_TABLE, enqueue_badge_eval
-from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
+from jupr_app.domain.gamification.badge_worker import (
+    process_badge_eval_queue,
+    process_badge_eval_queue_until_empty,
+)
 
 
 class FakeTable:
@@ -213,3 +216,55 @@ def test_enqueue_badge_eval_missing_table_is_ignored():
         match_id="m1",
     )
     assert storage.get(BADGE_QUEUE_TABLE) is None
+
+
+def test_worker_drain_until_empty_stops_on_empty(monkeypatch):
+    results = iter([
+        {"processed": 10, "errored": 0},
+        {"processed": 10, "errored": 0},
+        {"processed": 10, "errored": 0},
+        {"processed": 0, "errored": 0},
+    ])
+
+    monkeypatch.setattr(
+        "jupr_app.domain.gamification.badge_worker.process_badge_eval_queue",
+        lambda *_args, **_kwargs: next(results),
+    )
+
+    result = process_badge_eval_queue_until_empty(
+        supabase=object(),
+        club_id="club",
+        batch_max_jobs=10,
+        max_wall_clock_seconds=10.0,
+    )
+
+    assert result["total_processed"] == 30
+    assert result["total_errored"] == 0
+    assert result["loops"] == 4
+    assert result["stopped_reason"] == "empty"
+
+
+def test_worker_drain_until_empty_trips_error_circuit_breaker(monkeypatch):
+    results = iter([
+        {"processed": 0, "errored": 1},
+        {"processed": 0, "errored": 1},
+        {"processed": 0, "errored": 1},
+    ])
+
+    monkeypatch.setattr(
+        "jupr_app.domain.gamification.badge_worker.process_badge_eval_queue",
+        lambda *_args, **_kwargs: next(results),
+    )
+
+    result = process_badge_eval_queue_until_empty(
+        supabase=object(),
+        club_id="club",
+        batch_max_jobs=10,
+        max_wall_clock_seconds=10.0,
+        max_errors=10,
+    )
+
+    assert result["total_processed"] == 0
+    assert result["total_errored"] == 3
+    assert result["loops"] == 3
+    assert result["stopped_reason"] == "error_circuit_breaker"


### PR DESCRIPTION
### Motivation
- The existing opportunistic worker button processes only a handful of jobs per click due to a short per-run time budget, forcing repeated clicks to clear large pending queues. 
- We need a one-click "drain" action that safely processes all pending jobs while preserving the existing quick-button behavior. 
- Draining should provide progress feedback and stop safely on errors or limits to avoid UI hangs.

### Description
- Added `process_badge_eval_queue_until_empty` in `jupr_app/domain/gamification/badge_worker.py` that loops calling `process_badge_eval_queue` in batches, accumulates totals, supports an optional `progress_cb`, and stops on `empty`, `max_total_jobs`, `max_errors`, `max_wall_clock_seconds`, or an `error_circuit_breaker` after repeated error-only loops. 
- Updated `jupr_app/ui/pages/admin_tools.py` to add UI controls `Drain max wall clock` and `Drain batch size` and a new button `Drain badge queue (run all)` which shows the pending count, updates `st.progress` and per-loop messages via a progress callback, and displays a final summary (processed, errors, loops, stopped reason, duration). 
- Kept the existing `Process queued badge evaluations` button behavior unchanged (short budget quick runs) and preserved its error diagnostics. 
- Added unit tests in `tests/test_badge_worker.py` for drain loop behavior covering stop-on-empty and the error-circuit-breaker cases.

### Testing
- Ran `pytest -q tests/test_badge_worker.py` which passed (`6 passed`).
- Attempted an automated Playwright page capture of the Admin Tools UI at `http://127.0.0.1:8501`, which failed with `net::ERR_EMPTY_RESPONSE` because no app server was running for the capture.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35bd9e560832680608ee5f876b94f)