### PR TITLE
Harden badge queue drain, Supabase HTTP/1.1 client, and awarded_by uuid fallback

### DIFF
--- a/jupr_app/data/client.py
+++ b/jupr_app/data/client.py
@@ -18,13 +18,9 @@ def make_supabase(url: str, key: str):
     )
 
     options = ClientOptions(
+        httpx_client=http_client,
         postgrest_client_timeout=60,
         storage_client_timeout=60,
     )
 
-    client = create_client(url, key, options=options)
-
-    # Override underlying session for HTTP/2 control
-    client.postgrest._session = http_client
-
-    return client
+    return create_client(url, key, options=options)

--- a/jupr_app/domain/gamification/badge_worker.py
+++ b/jupr_app/domain/gamification/badge_worker.py
@@ -6,6 +6,7 @@ import traceback
 from types import SimpleNamespace
 from typing import Any, Callable
 
+import httpx
 import pandas as pd
 
 from jupr_app.data.load import load_data
@@ -23,40 +24,18 @@ def process_badge_eval_queue(
     ctx: Any | None = None,
     match_limit: int = 5000,
 ) -> dict[str, int]:
-    started = time.time()
+    deadline = time.monotonic() + float(time_budget_seconds)
     processed = 0
     errored = 0
 
-    while processed < max_jobs and (time.time() - started) < time_budget_seconds:
+    while processed < max_jobs:
+        if time.monotonic() >= deadline:
+            break
         job = dequeue_badge_eval(supabase)
         if not job:
             break
         try:
-            job_club_id = str(job.get("club_id") or "")
-            context = _resolve_context(ctx, supabase, job_club_id, match_limit)
-            event_type = str(job.get("event_type") or "")
-            player_ids = [int(pid) for pid in (job.get("player_ids") or [])]
-            context_id = str(job.get("context_id") or "overall")
-
-            badge_ids = _badge_ids_for_trigger(context, event_type)
-            if badge_ids and player_ids:
-                _update_incremental_facts(supabase, job, player_ids, context_id)
-                candidates = []
-                for pid in player_ids:
-                    candidates.extend(
-                        [
-                            c
-                            for c in compute_candidates_for_player(job_club_id, pid, ctx=context)
-                            if str(c.badge_id) in badge_ids
-                        ]
-                    )
-                if candidates:
-                    upsert_player_badges(
-                        supabase,
-                        job_club_id,
-                        candidates,
-                        awarded_by="engine",
-                    )
+            _process_job_with_retry(supabase, job, ctx=ctx, match_limit=match_limit)
             ack_badge_eval(supabase, job_id=str(job.get("id")), status="done")
             processed += 1
         except Exception as exc:  # noqa: BLE001 - worker should record failures
@@ -69,6 +48,8 @@ def process_badge_eval_queue(
                 error=details[:2000],
             )
             errored += 1
+        if time.monotonic() >= deadline:
+            break
 
     return {"processed": processed, "errored": errored}
 
@@ -84,19 +65,26 @@ def process_badge_eval_queue_until_empty(
     max_errors: int = 10,
     progress_cb: Callable[[dict[str, int | float | str]], None] | None = None,
 ) -> dict[str, int | float | str]:
-    started = time.time()
+    started = time.monotonic()
+    drain_deadline = started + float(max_wall_clock_seconds)
     loops = 0
     total_processed = 0
     total_errored = 0
     stopped_reason = "max_wall_clock"
     error_only_loops = 0
 
-    while (time.time() - started) < max_wall_clock_seconds:
+    while True:
+        now = time.monotonic()
+        remaining = drain_deadline - now
+        if remaining <= 0:
+            break
+
         loops += 1
+        batch_budget = min(float(per_batch_time_budget_seconds), max(0.1, remaining))
         batch = process_badge_eval_queue(
             supabase,
             max_jobs=batch_max_jobs,
-            time_budget_seconds=per_batch_time_budget_seconds,
+            time_budget_seconds=batch_budget,
         )
         processed = int(batch.get("processed") or 0)
         errored = int(batch.get("errored") or 0)
@@ -116,7 +104,7 @@ def process_badge_eval_queue_until_empty(
                     "errored": errored,
                     "total_processed": total_processed,
                     "total_errored": total_errored,
-                    "duration_seconds": time.time() - started,
+                    "duration_seconds": time.monotonic() - started,
                 }
             )
 
@@ -138,8 +126,67 @@ def process_badge_eval_queue_until_empty(
         "total_errored": total_errored,
         "loops": loops,
         "stopped_reason": stopped_reason,
-        "duration_seconds": round(time.time() - started, 3),
+        "duration_seconds": round(time.monotonic() - started, 3),
     }
+
+
+def _process_job_with_retry(
+    supabase: Any,
+    job: dict[str, Any],
+    *,
+    ctx: Any | None,
+    match_limit: int,
+) -> None:
+    retry_delays = [0.5, 1.0]
+    for attempt in range(len(retry_delays) + 1):
+        try:
+            _process_job(supabase, job, ctx=ctx, match_limit=match_limit)
+            return
+        except Exception as exc:  # noqa: BLE001 - worker retries transient read errors
+            if attempt >= len(retry_delays) or not _is_transient_read_error(exc):
+                raise
+            time.sleep(retry_delays[attempt])
+
+
+def _is_transient_read_error(exc: Exception) -> bool:
+    if isinstance(exc, httpx.ReadError):
+        return True
+    exc_type = type(exc)
+    return exc_type.__name__ == "ReadError" and "http" in exc_type.__module__.lower()
+
+
+def _process_job(
+    supabase: Any,
+    job: dict[str, Any],
+    *,
+    ctx: Any | None,
+    match_limit: int,
+) -> None:
+    job_club_id = str(job.get("club_id") or "")
+    context = _resolve_context(ctx, supabase, job_club_id, match_limit)
+    event_type = str(job.get("event_type") or "")
+    player_ids = [int(pid) for pid in (job.get("player_ids") or [])]
+    context_id = str(job.get("context_id") or "overall")
+
+    badge_ids = _badge_ids_for_trigger(context, event_type)
+    if badge_ids and player_ids:
+        _update_incremental_facts(supabase, job, player_ids, context_id)
+        candidates = []
+        for pid in player_ids:
+            candidates.extend(
+                [
+                    c
+                    for c in compute_candidates_for_player(job_club_id, pid, ctx=context)
+                    if str(c.badge_id) in badge_ids
+                ]
+            )
+        if candidates:
+            upsert_player_badges(
+                supabase,
+                job_club_id,
+                candidates,
+                awarded_by="engine",
+            )
 
 
 def _resolve_context(ctx: Any | None, supabase: Any, club_id: str, match_limit: int) -> Any:
@@ -188,11 +235,7 @@ def _badge_ids_for_trigger(ctx: Any, event_type: str) -> set[str]:
     else:
         for badge in BADGE_DEFINITIONS:
             triggers_by_id[badge.badge_id] = list(badge.eval_triggers)
-    return {
-        badge_id
-        for badge_id, triggers in triggers_by_id.items()
-        if event_type in triggers
-    }
+    return {badge_id for badge_id, triggers in triggers_by_id.items() if event_type in triggers}
 
 
 def _normalize_triggers(value: Any) -> list[str]:

--- a/jupr_app/domain/gamification/badges_repo.py
+++ b/jupr_app/domain/gamification/badges_repo.py
@@ -162,9 +162,9 @@ def _upsert_player_badges_chunk(supabase: Any, rows: list[dict[str, Any]]) -> No
             ).execute()
         elif _is_awarded_by_uuid_error(exc):
             logger.warning(
-                "player_badges.awarded_by appears to be uuid in schema; retrying upsert without provenance fields."
+                "player_badges.awarded_by appears to be uuid in schema; retrying upsert without awarded_by."
             )
-            stripped = [_strip_optional_columns(row, _PLAYER_BADGES_OPTIONAL_COLUMNS) for row in rows]
+            stripped = [_strip_optional_columns(row, ("awarded_by",)) for row in rows]
             supabase.table("player_badges").upsert(
                 stripped,
                 on_conflict=PLAYER_BADGES_CONFLICT_KEY,

--- a/migrations/20260810_player_badges_awarded_by_text.sql
+++ b/migrations/20260810_player_badges_awarded_by_text.sql
@@ -1,0 +1,16 @@
+-- Normalize player_badges.awarded_by to text with a stable engine default.
+ALTER TABLE public.player_badges
+  ALTER COLUMN awarded_by TYPE text
+  USING COALESCE(awarded_by::text, 'engine');
+
+ALTER TABLE public.player_badges
+  ALTER COLUMN awarded_by SET DEFAULT 'engine';
+
+UPDATE public.player_badges
+SET awarded_by = 'engine'
+WHERE awarded_by IS NULL;
+
+ALTER TABLE public.player_badges
+  ALTER COLUMN awarded_by SET NOT NULL;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/test_badge_worker.py
+++ b/tests/test_badge_worker.py
@@ -268,3 +268,69 @@ def test_worker_drain_until_empty_trips_error_circuit_breaker(monkeypatch):
     assert result["total_errored"] == 3
     assert result["loops"] == 3
     assert result["stopped_reason"] == "error_circuit_breaker"
+
+
+def test_worker_respects_time_budget_deadline(monkeypatch):
+    clock = {"now": 0.0}
+    jobs = [
+        {"id": "j1", "club_id": "club", "event_type": "match_recorded", "player_ids": [1], "context_id": "overall"},
+        {"id": "j2", "club_id": "club", "event_type": "match_recorded", "player_ids": [1], "context_id": "overall"},
+        {"id": "j3", "club_id": "club", "event_type": "match_recorded", "player_ids": [1], "context_id": "overall"},
+    ]
+    acked: list[str] = []
+
+    def fake_monotonic():
+        return clock["now"]
+
+    def fake_dequeue(_supabase):
+        return jobs.pop(0) if jobs else None
+
+    def fake_ack(_supabase, job_id, status, error=None):
+        if status == "done":
+            acked.append(str(job_id))
+
+    monkeypatch.setattr("jupr_app.domain.gamification.badge_worker.time.monotonic", fake_monotonic)
+    monkeypatch.setattr("jupr_app.domain.gamification.badge_worker.dequeue_badge_eval", fake_dequeue)
+    monkeypatch.setattr("jupr_app.domain.gamification.badge_worker.ack_badge_eval", fake_ack)
+    monkeypatch.setattr("jupr_app.domain.gamification.badge_worker._resolve_context", lambda *_a, **_k: _build_ctx())
+    monkeypatch.setattr("jupr_app.domain.gamification.badge_worker._update_incremental_facts", lambda *_a, **_k: None)
+
+    def fake_compute(*_args, **_kwargs):
+        clock["now"] += 0.7
+        return []
+
+    monkeypatch.setattr("jupr_app.domain.gamification.badge_worker.compute_candidates_for_player", fake_compute)
+
+    result = process_badge_eval_queue(object(), max_jobs=10, time_budget_seconds=1.0, ctx=_build_ctx())
+
+    assert result["processed"] == 2
+    assert acked == ["j1", "j2"]
+
+
+def test_worker_drain_stops_on_max_wall_clock(monkeypatch):
+    clock = {"now": 0.0}
+    budgets: list[float] = []
+
+    def fake_monotonic():
+        return clock["now"]
+
+    def fake_batch(*_args, **kwargs):
+        budget = float(kwargs["time_budget_seconds"])
+        budgets.append(budget)
+        clock["now"] += budget + 0.25
+        return {"processed": 1, "errored": 0}
+
+    monkeypatch.setattr("jupr_app.domain.gamification.badge_worker.time.monotonic", fake_monotonic)
+    monkeypatch.setattr("jupr_app.domain.gamification.badge_worker.process_badge_eval_queue", fake_batch)
+
+    result = process_badge_eval_queue_until_empty(
+        supabase=object(),
+        club_id="club",
+        batch_max_jobs=10,
+        per_batch_time_budget_seconds=0.9,
+        max_wall_clock_seconds=1.0,
+    )
+
+    assert result["stopped_reason"] == "max_wall_clock"
+    assert result["loops"] == 1
+    assert budgets == [0.9]

--- a/tests/test_player_badges_contract.py
+++ b/tests/test_player_badges_contract.py
@@ -168,3 +168,5 @@ def test_player_badges_upsert_retries_when_awarded_by_uuid_cast_fails(monkeypatc
     assert len(calls) == 2
     assert "awarded_by" in calls[0][0]
     assert "awarded_by" not in calls[1][0]
+    assert "rule_version" in calls[1][0]
+    assert "eval_run_id" in calls[1][0]


### PR DESCRIPTION
### Motivation
- Prevent badge upserts from failing when `player_badges.awarded_by` is unexpectedly a `uuid` and contains the string `engine` (error `22P02`).
- Avoid intermittent `httpx/httpcore ReadError` on HTTP/2 by forcing HTTP/1.1 with controlled timeouts and connection limits for Supabase clients.
- Ensure the badge-queue drain honors configured time budgets and `max_wall_clock` limits deterministically and idempotently.

### Description
- In `jupr_app/domain/gamification/badges_repo.py` updated `_upsert_player_badges_chunk` to detect `22P02` UUID-cast errors and retry the upsert once after stripping only the `awarded_by` field while preserving other provenance columns. (`_is_awarded_by_uuid_error` + targeted `_strip_optional_columns`).
- Added a migration `migrations/20260810_player_badges_awarded_by_text.sql` to normalize `public.player_badges.awarded_by` to `text`, set default `'engine'`, update NULLs, set `NOT NULL`, and `NOTIFY pgrst` to reload schema.
- In `jupr_app/data/client.py` made `make_supabase` construct an `httpx.Client(http2=False, timeout=60s, connect=10s, limits max_connections=5, keepalive=2)` and pass it via `ClientOptions(httpx_client=...)` so Supabase uses HTTP/1.1 and bounded pool/timeouts.
- In `jupr_app/domain/gamification/badge_worker.py` switched to monotonic deadline checks and tightened loop logic: `process_badge_eval_queue` computes `deadline = time.monotonic() + time_budget_seconds` and checks before dequeue and after each job, and `process_badge_eval_queue_until_empty` computes a `drain_deadline`, clamps per-batch budgets to `min(configured, max(0.1, remaining))`, and stops when remaining time is exhausted.
- Added transient network resilience by wrapping per-job processing with `_process_job_with_retry` that retries transient `ReadError` (httpx/httpcore) up to 2 times with small backoffs (0.5s, 1.0s), plus helper `_is_transient_read_error` and `_process_job` to isolate job logic.
- Tests updated/added to assert `22P02` retry removes only `awarded_by` while keeping `rule_version`/`eval_run_id`, to verify `process_badge_eval_queue` respects the time budget deadline, and to verify `process_badge_eval_queue_until_empty` respects `max_wall_clock` and per-batch budget clamping.

### Testing
- Ran unit tests: `pytest -q tests/test_player_badges_contract.py tests/test_badge_worker.py` and all tests passed (`12 passed`).
- Added tests that validate the `22P02` retry path, worker per-job deadline behavior, and drain `max_wall_clock` enforcement, which succeeded in CI-local run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3624856d483269ad92d119bc76d1c)