### PR TITLE
Prevent silent tournament match write failures and add admin backfill

### DIFF
--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -282,7 +282,26 @@ def process_matches(
         CHUNK_M = 300
         for i in range(0, len(db_matches), CHUNK_M):
             chunk = db_matches[i : i + CHUNK_M]
-            sb_retry(lambda chunk=chunk: supabase.table("matches").insert(chunk).execute())
+            insert_result = sb_retry(lambda chunk=chunk: supabase.table("matches").insert(chunk).execute())
+            inserted_rows = getattr(insert_result, "data", None) if insert_result is not None else None
+            if not inserted_rows:
+                error_obj = getattr(insert_result, "error", None) if insert_result is not None else None
+                sample = chunk[0] if chunk else {}
+                debug_payload = {
+                    "club_id": sample.get("club_id"),
+                    "league": sample.get("league"),
+                    "t1_p1": sample.get("t1_p1"),
+                    "t1_p2": sample.get("t1_p2"),
+                    "t2_p1": sample.get("t2_p1"),
+                    "t2_p2": sample.get("t2_p2"),
+                    "score_t1": sample.get("score_t1"),
+                    "score_t2": sample.get("score_t2"),
+                    "tournament_game_id": sample.get("tournament_game_id"),
+                }
+                raise RuntimeError(
+                    "Failed to insert match rows into matches table; "
+                    f"error={error_obj!r}; sample_row={debug_payload}"
+                )
 
         if supabase is not None and has_non_popup_match:
             queued = enqueue_badge_eval(

--- a/jupr_app/domain/tournament_match_payload.py
+++ b/jupr_app/domain/tournament_match_payload.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def build_tournament_match_payload(tournament, game, teams_by_id, *, score_a: int, score_b: int) -> dict:
+    team_a = teams_by_id.get(game.get("team_a_id"))
+    team_b = teams_by_id.get(game.get("team_b_id"))
+
+    return {
+        "t1_p1": team_a.get("player1_id") if team_a else None,
+        "t1_p2": team_a.get("player2_id") if team_a else None,
+        "t2_p1": team_b.get("player1_id") if team_b else None,
+        "t2_p2": team_b.get("player2_id") if team_b else None,
+        "s1": int(score_a),
+        "s2": int(score_b),
+        "score_t1": int(score_a),
+        "score_t2": int(score_b),
+        "date": datetime.now(timezone.utc).isoformat(),
+        "league": tournament.get("name", "Tournament"),
+        "match_type": "Tournament",
+        "week_tag": "Tournament",
+        "is_popup": False,
+        "context_type": "TOURNAMENT",
+        "context_id": tournament["id"],
+        "tournament_id": tournament["id"],
+        "tournament_game_id": game["id"],
+    }

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -8,6 +8,8 @@ from postgrest.exceptions import APIError
 
 from jupr_app.domain.ratings import calculate_hybrid_elo
 from jupr_app.domain.constants import DEFAULT_K_FACTOR
+from jupr_app.domain.match_processing import process_matches
+from jupr_app.domain.tournament_match_payload import build_tournament_match_payload
 from jupr_app.domain.gamification.ensure_badges import ensure_badges
 from jupr_app.domain.gamification.badge_state import ALLOWED_BADGE_STATES, can_transition_badge_state
 from jupr_app.domain.gamification.badge_worker import (
@@ -356,6 +358,26 @@ def render(ctx):
     st.divider()
 
     # -------------------------
+    # Tournament Match Backfill
+    # -------------------------
+    st.subheader("🛠️ Tournament Match Backfill")
+    st.caption("Insert missing public match rows for finalized tournament games.")
+
+    if st.button("Backfill Missing Tournament Matches", key="tournament_match_backfill"):
+        summary = _run_tournament_match_backfill(ctx)
+        st.info(
+            "Backfill summary: "
+            f"attempted={summary['attempted']}, "
+            f"inserted={summary['inserted']}, "
+            f"skipped_incomplete={summary['skipped_incomplete']}, "
+            f"skipped_empty={summary['skipped_empty']}, "
+            f"errors={summary['errors']}"
+        )
+
+
+    st.divider()
+
+    # -------------------------
     # Badge Backfill
     # -------------------------
     st.subheader("🎖️ Badge Backfill")
@@ -455,3 +477,104 @@ def render(ctx):
                 except Exception as exc:
                     st.error("Failed to update badge state.")
                     st.exception(exc)
+
+
+
+def _run_tournament_match_backfill(ctx):
+    supabase = ctx.supabase
+    club_id = str(ctx.club_id)
+    df_players_all = ctx.df_players_all
+    df_leagues = ctx.df_leagues
+    df_meta = ctx.df_meta
+    name_to_id = ctx.name_to_id
+
+    missing_games = _load_finalized_tournament_games_missing_matches(supabase, club_id)
+    attempted = len(missing_games)
+    inserted = 0
+    skipped_incomplete = 0
+    skipped_empty = 0
+    errors = 0
+
+    for game in missing_games:
+        tournament_id = game.get("tournament_id")
+        if not tournament_id:
+            skipped_incomplete += 1
+            continue
+
+        tournament_resp = supabase.table("tournaments").select("id,name").eq("id", tournament_id).limit(1).execute()
+        tournaments = tournament_resp.data or []
+        if not tournaments:
+            skipped_incomplete += 1
+            continue
+        tournament = tournaments[0]
+
+        teams_resp = supabase.table("tournament_teams").select("*").eq("tournament_id", tournament_id).execute()
+        teams = teams_resp.data or []
+        teams_by_id = {row["id"]: row for row in teams if row.get("id")}
+
+        score_a = int(game.get("score_a") or 0)
+        score_b = int(game.get("score_b") or 0)
+        if score_a + score_b <= 0:
+            skipped_empty += 1
+            continue
+
+        payload = build_tournament_match_payload(
+            tournament,
+            game,
+            teams_by_id,
+            score_a=score_a,
+            score_b=score_b,
+        )
+
+        if any(payload.get(k) is None for k in ("t1_p1", "t1_p2", "t2_p1", "t2_p2")):
+            skipped_incomplete += 1
+            continue
+
+        try:
+            result = process_matches(
+                [payload],
+                supabase=supabase,
+                club_id=club_id,
+                name_to_id=name_to_id,
+                df_players_all=df_players_all,
+                df_leagues=df_leagues,
+                df_meta=df_meta,
+            )
+        except Exception as exc:
+            errors += 1
+            st.error(f"Backfill failed for tournament game {game.get('id')}: {exc}")
+            continue
+
+        inserted += int(result.get("inserted", 0) or 0)
+        skipped_incomplete += int(result.get("skipped_incomplete", 0) or 0)
+        skipped_empty += int(result.get("skipped_empty", 0) or 0)
+
+    return {
+        "attempted": attempted,
+        "inserted": inserted,
+        "skipped_incomplete": skipped_incomplete,
+        "skipped_empty": skipped_empty,
+        "errors": errors,
+    }
+
+
+def _load_finalized_tournament_games_missing_matches(supabase, club_id: str) -> list[dict]:
+    games_resp = (
+        supabase.table("tournament_games")
+        .select("id,tournament_id,team_a_id,team_b_id,score_a,score_b,finalized_at")
+        .execute()
+    )
+    games = [row for row in (games_resp.data or []) if row.get("finalized_at") is not None]
+    if not games:
+        return []
+
+    game_ids = [row.get("id") for row in games if row.get("id")]
+    matches_resp = (
+        supabase.table("matches")
+        .select("tournament_game_id")
+        .eq("club_id", club_id)
+        .in_("tournament_game_id", game_ids)
+        .execute()
+    )
+    existing_ids = {row.get("tournament_game_id") for row in (matches_resp.data or []) if row.get("tournament_game_id")}
+    return [row for row in games if row.get("id") not in existing_ids]

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
 import pandas as pd
 import streamlit as st
 
 from jupr_app.domain.match_processing import process_matches
+from jupr_app.domain.tournament_match_payload import build_tournament_match_payload
 from jupr_app.domain.tournaments import (
     build_playoff_games,
     SUPPORTED_TEAM_COUNTS,
@@ -611,8 +610,6 @@ def _save_games(ctx, tournament, teams_by_id, game_map, stage: str):
         except ValueError:
             continue
 
-        supabase.table("tournament_games").update(finalize_payload).eq("id", game_id).execute()
-
         match_payload = _build_match_payload(
             tournament,
             game,
@@ -620,15 +617,21 @@ def _save_games(ctx, tournament, teams_by_id, game_map, stage: str):
             score_a=score_a,
             score_b=score_b,
         )
-        process_matches(
-            [match_payload],
-            supabase=supabase,
-            club_id=str(ctx.club_id),
-            name_to_id=name_to_id,
-            df_players_all=df_players_all,
-            df_leagues=df_leagues,
-            df_meta=df_meta,
-        )
+        try:
+            process_matches(
+                [match_payload],
+                supabase=supabase,
+                club_id=str(ctx.club_id),
+                name_to_id=name_to_id,
+                df_players_all=df_players_all,
+                df_leagues=df_leagues,
+                df_meta=df_meta,
+            )
+        except Exception as exc:
+            st.error(f"Could not create public match row for tournament game {game_id}: {exc}")
+            raise
+
+        supabase.table("tournament_games").update(finalize_payload).eq("id", game_id).execute()
 
         if stage == "PLAYOFF":
             playoff_games_resp = (
@@ -650,26 +653,13 @@ def _save_games(ctx, tournament, teams_by_id, game_map, stage: str):
 
 
 def _build_match_payload(tournament, game, teams_by_id, *, score_a: int, score_b: int) -> dict:
-    team_a = teams_by_id.get(game.get("team_a_id"))
-    team_b = teams_by_id.get(game.get("team_b_id"))
-
-    return {
-        "t1_p1": team_a.get("player1_id") if team_a else None,
-        "t1_p2": team_a.get("player2_id") if team_a else None,
-        "t2_p1": team_b.get("player1_id") if team_b else None,
-        "t2_p2": team_b.get("player2_id") if team_b else None,
-        "s1": int(score_a),
-        "s2": int(score_b),
-        "date": datetime.now(timezone.utc).isoformat(),
-        "league": tournament.get("name", "Tournament"),
-        "match_type": "Tournament",
-        "week_tag": "Tournament",
-        "is_popup": False,
-        "context_type": "TOURNAMENT",
-        "context_id": tournament["id"],
-        "tournament_id": tournament["id"],
-        "tournament_game_id": game["id"],
-    }
+    return build_tournament_match_payload(
+        tournament,
+        game,
+        teams_by_id,
+        score_a=score_a,
+        score_b=score_b,
+    )
 
 
 def _score_key(stage: str, side: str, game_id: str) -> str:

--- a/tests/test_tournament_match_insert_guards.py
+++ b/tests/test_tournament_match_insert_guards.py
@@ -1,0 +1,107 @@
+import pandas as pd
+import pytest
+
+from jupr_app.domain.match_processing import process_matches
+
+
+class _Result:
+    def __init__(self, data=None, error=None):
+        self.data = data
+        self.error = error
+
+
+class _Query:
+    def __init__(self, supabase, table_name):
+        self.supabase = supabase
+        self.table_name = table_name
+        self.payload = None
+
+    def insert(self, payload):
+        self.payload = payload
+        return self
+
+    def update(self, payload):
+        self.payload = payload
+        return self
+
+    def eq(self, *_args, **_kwargs):
+        return self
+
+    def execute(self):
+        return self.supabase.execute(self.table_name, self.payload)
+
+
+class _FakeSupabase:
+    def __init__(self, *, matches_data, matches_error=None):
+        self.matches_data = matches_data
+        self.matches_error = matches_error
+        self.inserted_matches = []
+
+    def table(self, table_name):
+        return _Query(self, table_name)
+
+    def execute(self, table_name, payload):
+        if table_name == "matches":
+            self.inserted_matches.extend(payload or [])
+            return _Result(data=self.matches_data, error=self.matches_error)
+        if table_name == "players":
+            return _Result(data=[{"ok": True}])
+        return _Result(data=[])
+
+
+def _players_df():
+    return pd.DataFrame(
+        [
+            {"id": 1, "rating": 1200.0, "wins": 0, "losses": 0, "matches_played": 0},
+            {"id": 2, "rating": 1200.0, "wins": 0, "losses": 0, "matches_played": 0},
+            {"id": 3, "rating": 1200.0, "wins": 0, "losses": 0, "matches_played": 0},
+            {"id": 4, "rating": 1200.0, "wins": 0, "losses": 0, "matches_played": 0},
+        ]
+    )
+
+
+def _match_payload():
+    return {
+        "league": "Valentine",
+        "t1_p1": 1,
+        "t1_p2": 2,
+        "t2_p1": 3,
+        "t2_p2": 4,
+        "score_t1": 21,
+        "score_t2": 19,
+        "tournament_game_id": "game-123",
+        "match_type": "PopUp",
+        "is_popup": True,
+    }
+
+
+def test_process_matches_raises_when_match_insert_returns_no_data():
+    supabase = _FakeSupabase(matches_data=None, matches_error={"message": "insert failed"})
+
+    with pytest.raises(RuntimeError, match="Failed to insert match rows"):
+        process_matches(
+            [_match_payload()],
+            supabase=supabase,
+            club_id="club-1",
+            name_to_id={},
+            df_players_all=_players_df(),
+            df_leagues=pd.DataFrame(),
+            df_meta=pd.DataFrame(),
+        )
+
+
+def test_process_matches_inserts_rows_when_match_insert_succeeds():
+    supabase = _FakeSupabase(matches_data=[{"id": "m1"}])
+
+    result = process_matches(
+        [_match_payload()],
+        supabase=supabase,
+        club_id="club-1",
+        name_to_id={},
+        df_players_all=_players_df(),
+        df_leagues=pd.DataFrame(),
+        df_meta=pd.DataFrame(),
+    )
+
+    assert result["inserted"] == 1
+    assert len(supabase.inserted_matches) == 1


### PR DESCRIPTION
### Motivation
- Prevent finalized tournament games from ever being left without corresponding `public.matches` rows by failing loudly when match inserts don't actually persist. 
- Ensure tournaments are only finalized after the public match rows and snapshot writes succeed, and provide an admin tool to backfill any historical gaps.

### Description
- Added strict insert-result checking in `jupr_app/domain/match_processing.py`: capture `insert_result = sb_retry(lambda ...: supabase.table("matches").insert(chunk).execute())`, verify `insert_result.data` is present, and raise `RuntimeError` with the backend `error` plus the first row's identifying fields (`club_id`, `league`, `t1_p1/t1_p2/t2_p1/t2_p2`, `score_t1/score_t2`, `tournament_game_id`) when no rows are returned. 
- Updated tournament finalization flow in `jupr_app/ui/pages/tournaments.py` so `_save_games()` now updates scores, builds the match payload, calls `process_matches()` inside a `try/except` and shows `st.error(...)` on failure, and only applies the `finalize_payload` to `tournament_games` after `process_matches()` succeeds. 
- Factored tournament match payload construction into `jupr_app/domain/tournament_match_payload.py` via `build_tournament_match_payload()` and wired it into both the tournaments UI and the admin backfill to ensure payload parity. 
- Added an admin UI backfill in `jupr_app/ui/pages/admin_tools.py` with a button `Backfill Missing Tournament Matches` and helper functions `_run_tournament_match_backfill()` and `_load_finalized_tournament_games_missing_matches()` that locate finalized tournament games lacking `matches.tournament_game_id`, rebuild payloads, call `process_matches()` for each eligible game, and return a summary (`attempted`, `inserted`, `skipped_incomplete`, `skipped_empty`, `errors`). 
- Added regression tests `tests/test_tournament_match_insert_guards.py` that mock `supabase` behavior and assert `process_matches()` raises when a `matches.insert(...).execute()` returns no data and succeeds when data is returned.

### Testing
- Ran `pytest -q tests/test_tournament_match_insert_guards.py tests/test_tournaments.py` and observed all tests passing (`8 passed`).
- Ran `python -m py_compile jupr_app/domain/match_processing.py jupr_app/ui/pages/tournaments.py jupr_app/ui/pages/admin_tools.py jupr_app/domain/tournament_match_payload.py tests/test_tournament_match_insert_guards.py` and found no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3915f8d388326b4f18ed981d5c66d)