### PR TITLE
Add weekly recap date-range debug panel for admin debugging

### DIFF
--- a/jupr_app/ui/pages/weekly_recap_admin.py
+++ b/jupr_app/ui/pages/weekly_recap_admin.py
@@ -11,6 +11,7 @@ from jupr_app.domain.recaps.weekly_recap import (
     DEFAULT_SPOTLIGHT_DESCRIPTIONS,
     SPOTLIGHT_DEFAULT_ORDER,
     compute_weekly_recap,
+    get_date_range_bounds,
     get_spotlight_candidates,
 )
 from jupr_app.ui.components.weekly_recap_layout import render_podium_layout, render_weekly_recap
@@ -105,6 +106,33 @@ def _normalize_overrides(overrides: dict, generated_spotlight: list[dict]) -> di
     return normalized
 
 
+def _load_debug_matches(supabase, club_id: str, start_dt_utc: datetime, end_dt_utc: datetime, limit: int = 50) -> list[dict]:
+    columns = [
+        "id",
+        "date",
+        "league",
+        "match_type",
+        "week_tag",
+        "t1_p1",
+        "t1_p2",
+        "t2_p1",
+        "t2_p2",
+        "score_t1",
+        "score_t2",
+    ]
+    response = (
+        supabase.table("matches")
+        .select(",".join(columns))
+        .eq("club_id", club_id)
+        .gte("date", start_dt_utc.isoformat())
+        .lte("date", end_dt_utc.isoformat())
+        .order("date", desc=True)
+        .limit(limit)
+        .execute()
+    )
+    return response.data or []
+
+
 def _apply_edits(generated_json: dict, edits_json: dict, candidates: dict[str, list[dict]]) -> dict:
     recap = deepcopy(generated_json or {})
     if not recap:
@@ -185,6 +213,16 @@ def render(ctx):
         st.error("Date range cannot exceed 60 days.")
         date_range_valid = False
 
+    with st.expander("Debug: date-range inputs", expanded=False):
+        st.write(
+            {
+                "start_date": start_date.isoformat(),
+                "end_date": end_date.isoformat(),
+                "day_span": day_span,
+                "timezone": tz_name,
+            }
+        )
+
     try:
         row = _load_weekly_row(supabase, club_id, start_date, end_date)
     except APIError as exc:
@@ -198,6 +236,34 @@ def render(ctx):
     if st.button("Generate Draft", disabled=not date_range_valid):
         with st.spinner("Generating weekly recap..."):
             recap = compute_weekly_recap(ctx, start_date=start_date, end_date=end_date, include_tournaments=True, tz_name=tz_name)
+            start_dt_utc, end_dt_utc = get_date_range_bounds(start_date, end_date, tz_name)
+
+            with st.expander("Debug: recap match window", expanded=True):
+                st.write(
+                    {
+                        "start_dt_utc": start_dt_utc.isoformat(),
+                        "end_dt_utc": end_dt_utc.isoformat(),
+                        "recap_matches": (recap.get("numbers") or {}).get("matches", 0),
+                    }
+                )
+                try:
+                    debug_rows = _load_debug_matches(supabase, club_id, start_dt_utc, end_dt_utc, limit=50)
+                except APIError as exc:
+                    st.warning(f"Unable to load debug matches: {exc}")
+                else:
+                    if debug_rows:
+                        row_dates = [str(row.get("date")) for row in debug_rows if row.get("date")]
+                        st.caption(f"Fetched {len(debug_rows)} rows (latest 50 by date).")
+                        st.write(
+                            {
+                                "min_date": min(row_dates) if row_dates else None,
+                                "max_date": max(row_dates) if row_dates else None,
+                            }
+                        )
+                        st.dataframe(debug_rows, use_container_width=True, hide_index=True)
+                    else:
+                        st.info("No matches found within computed bounds.")
+
             payload = {
                 "club_id": club_id,
                 "week_start": start_date.isoformat(),


### PR DESCRIPTION
### Motivation
- Make it easy to verify the exact date-range and UTC bounds used by the weekly recap engine when generating drafts. 
- Surface the actual match rows used (or excluded) so incorrect stored `date` values are obvious without DB access. 
- Keep debug information admin-only and reuse the recap engine's date-boundary logic to avoid divergence.

### Description
- Imported and reused `get_date_range_bounds` from `jupr_app.domain.recaps.weekly_recap` so the debug view uses the exact same UTC window logic.  
- Added a new helper `_load_debug_matches(...)` that queries Supabase `matches` with the exact UTC bounds, ordered by `date` descending and limited to 50 rows, selecting `id,date,league,match_type,week_tag,t1_p1,t1_p2,t2_p1,t2_p2,score_t1,score_t2`.  
- Added an admin-only `st.expander("Debug: date-range inputs")` that prints `start_date`, `end_date`, computed `day_span`, and the timezone name.  
- On `Generate Draft`, compute `start_dt_utc`/`end_dt_utc` via `get_date_range_bounds`, show them in `st.expander("Debug: recap match window")`, display `recap["numbers"]["matches"]`, run the debug query, and surface `min(date)`/`max(date)` and the fetched rows in a table.

### Testing
- Ran `python -m compileall jupr_app/ui/pages/weekly_recap_admin.py` which completed successfully.  
- Attempted a Playwright screenshot test against `http://127.0.0.1:8501` which failed with `ERR_EMPTY_RESPONSE` because no local Streamlit server was running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a35e5b188326a3be63e73ef8ace5)