### PR TITLE
Make Overall Match History Explain links clickable with Streamlit LinkColumn

### DIFF
--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -1874,6 +1874,20 @@ def render(ctx):
             show["Overall Δ"] = show["delta_raw"].map(lambda x: f"{float(x):+.4f}" if pd.notna(x) else "")
             show["Overall After"] = show["Overall After"].map(lambda x: f"{float(x):.3f}" if pd.notna(x) else "")
 
+            # Render Overall history with a native LinkColumn so Explain links are clickable.
+            if title_prefix == "Overall":
+                show = show.rename(columns={"Explain": "EXPLAIN"})
+                show = show[["date", "League", "Score", "Result", "match_type", "Overall Δ", "Overall After", "EXPLAIN"]]
+                st.dataframe(
+                    show,
+                    use_container_width=True,
+                    hide_index=True,
+                    column_config={
+                        "EXPLAIN": st.column_config.LinkColumn("Explain", display_text="Explain"),
+                    },
+                )
+                return
+
             def result_badge(result: str) -> str:
                 label = str(result or "").strip().upper() or "—"
                 normalized = label.upper()

--- a/tests/test_players_explain_linkcolumn.py
+++ b/tests/test_players_explain_linkcolumn.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+PLAYERS_PAGE = Path("jupr_app/ui/pages/players.py")
+
+
+def test_players_page_uses_linkcolumn_for_explain() -> None:
+    contents = PLAYERS_PAGE.read_text(encoding="utf-8")
+    assert "LinkColumn" in contents
+    assert '"EXPLAIN": st.column_config.LinkColumn("Explain", display_text="Explain")' in contents
+
+
+def test_players_page_does_not_use_markdown_explain_links() -> None:
+    contents = PLAYERS_PAGE.read_text(encoding="utf-8")
+    assert "[Explain](" not in contents


### PR DESCRIPTION
### Motivation
- The `Explain` column in the Overall Match History rendered like a link but was not interactive when shown via the page table, so users couldn't open the match-explorer from the table. 
- Add a small regression check to prevent reverting to markdown-style `Explain` text which is not clickable in `st.dataframe` contexts.

### Description
- Updated the Overall Match History render block in `jupr_app/ui/pages/players.py` to detect the `Overall` view and render the table with `st.dataframe` using a native LinkColumn for the explain column. 
- Renamed the explain column to `EXPLAIN` for the table and added `column_config={"EXPLAIN": st.column_config.LinkColumn("Explain", display_text="Explain")}` so the label stays `Explain` but is clickable. 
- Continued to use the existing URL generation pipeline (`build_match_explorer_link(...)`) so link targets are unchanged. 
- Left non-Overall render paths unchanged (they still produce the HTML table fallback used elsewhere).

### Testing
- Added `tests/test_players_explain_linkcolumn.py` which asserts `LinkColumn` usage exists in `jupr_app/ui/pages/players.py` and that markdown-style `"[Explain]("` patterns are not present. 
- Ran `pytest -q tests/test_players_explain_linkcolumn.py` and it passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a68dbe1c83269266ddfab0c64f16)