### PR TITLE
Fix Overall Match History Explain links to use relative URLs

### DIFF
--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -4,6 +4,7 @@ import logging
 import math
 import re
 import textwrap
+from urllib.parse import urlencode
 
 import streamlit as st
 import pandas as pd
@@ -13,7 +14,6 @@ from jupr_app.domain.gamification.badge_copy import build_badge_copy_plain
 from jupr_app.ui.components.badge_cards import render_inline_badge_text
 from jupr_app.ui.helpers import (
     qp_get,
-    build_match_explorer_link,
     display_requirement_text,
 )
 from jupr_app.ui.layout import page_shell
@@ -1657,16 +1657,19 @@ def render(ctx):
             if partner is None or opp1 is None or opp2 is None:
                 return ""
 
-            return build_match_explorer_link(
-                ctx="OVERALL",
-                me=int(pid),
-                partner=int(partner),
-                opp1=int(opp1),
-                opp2=int(opp2),
-                sy=int(sy),
-                so=int(so),
-                public=bool(ctx.public_mode),
-            )
+            params = {
+                "page": "match_explorer",
+                "ctx": "OVERALL",
+                "me": int(pid),
+                "partner": int(partner),
+                "opp1": int(opp1),
+                "opp2": int(opp2),
+                "sy": int(sy),
+                "so": int(so),
+            }
+            if bool(ctx.public_mode):
+                params["public"] = 1
+            return f"/?{urlencode(params)}"
 
         def get_overall_snap(r: dict, pid_: int):
             pid_ = int(pid_)

--- a/tests/test_players_explain_link_is_relative.py
+++ b/tests/test_players_explain_link_is_relative.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_players_page_uses_linkcolumn_and_no_localhost_explain_links():
+    content = Path("jupr_app/ui/pages/players.py").read_text(encoding="utf-8")
+
+    assert "LinkColumn" in content
+    assert "localhost:8501" not in content


### PR DESCRIPTION
### Motivation
- The "Explain" links in the Overall Match History were rendering clickable links that opened `http://localhost:8501/...` in production because `build_match_explorer_link()` fell back to localhost, so links must resolve on the current host instead.

### Description
- In `jupr_app/ui/pages/players.py` replaced the call to `build_match_explorer_link()` inside `explain_link()` with code that builds a relative URL using `urlencode` and returns `"/?{...}"`, including `page=match_explorer`, `ctx=OVERALL`, `me`, `partner`, `opp1`, `opp2`, `sy`, `so`, and `public=1` when appropriate.
- Removed the local import of `build_match_explorer_link` from that file and added `from urllib.parse import urlencode` to support the new relative URL construction.
- The Overall Match History table still renders the `EXPLAIN` column as a Streamlit `LinkColumn("Explain", display_text="Explain")` so links remain clickable in the dataframe UI.
- Added a minimal regression test `tests/test_players_explain_link_is_relative.py` that string-scans `jupr_app/ui/pages/players.py` and asserts `LinkColumn` is present and `localhost:8501` is not present.

### Testing
- Ran `pytest -q tests/test_players_explain_link_is_relative.py`, which succeeded (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4aaa56af88326b0f7c5a287e7bb3e)