### PR TITLE
Top 50 PDF: JUPR ratings, 30-day eligibility, Helvetica layout

### DIFF
--- a/jupr_app/ui/pages/top_players_printable.py
+++ b/jupr_app/ui/pages/top_players_printable.py
@@ -30,6 +30,12 @@ def _truncate_name(name: str, width: int) -> str:
     return text[: width - 1] + "…"
 
 
+def _previous_month_subtitle(now_utc: datetime) -> str:
+    first_day_current_month = now_utc.replace(day=1)
+    previous_month_date = first_day_current_month - timedelta(days=1)
+    return previous_month_date.strftime("%B %Y")
+
+
 def _build_top_players_pdf(rows: list[dict], title: str, subtitle: str) -> bytes:
     line_rows = [
         title,
@@ -248,7 +254,8 @@ def render(ctx):
         hide_index=True,
     )
 
-    pdf_bytes = _build_top_players_pdf(top, "Tres Palapas -- Top 50 Players", "Month of February")
+    subtitle = _previous_month_subtitle(now_utc)
+    pdf_bytes = _build_top_players_pdf(top, "Tres Palapas -- Top 50 Players", subtitle)
 
     st.download_button(
         "Download Top 50 Active Players PDF",

--- a/jupr_app/ui/pages/top_players_printable.py
+++ b/jupr_app/ui/pages/top_players_printable.py
@@ -30,24 +30,23 @@ def _truncate_name(name: str, width: int) -> str:
     return text[: width - 1] + "…"
 
 
-def _build_top_players_pdf(rows: list[dict], title: str, generated_at_iso: str) -> bytes:
+def _build_top_players_pdf(rows: list[dict], title: str, subtitle: str) -> bytes:
     line_rows = [
         title,
-        "Active = match recorded in last 30 days",
-        f"Generated: {generated_at_iso}",
+        subtitle,
         "",
-        "Rank  Player                         Rating    W-L",
-        "----  ------------------------------  --------  -----",
+        "Rank  Player                         JUPR      W-L",
+        "----  ------------------------------  ------    -----",
     ]
 
     for row in rows:
         rank = int(row.get("rank", 0) or 0)
         name = _truncate_name(str(row.get("name", "")), 30)
-        rating = float(row.get("rating", 1200.0) or 1200.0)
+        jupr = float(row.get("jupr", 3.000) or 3.000)
         wins = int(row.get("wins", 0) or 0)
         losses = int(row.get("losses", 0) or 0)
         record = f"{wins}-{losses}"
-        line_rows.append(f"{rank:>4}  {name:<30}  {rating:>8.2f}  {record:>5}")
+        line_rows.append(f"{rank:>4}  {name:<30}  {jupr:>6.3f}    {record:>5}")
 
     lines_per_page = 52
     pages: list[list[str]] = [line_rows[i : i + lines_per_page] for i in range(0, len(line_rows), lines_per_page)]
@@ -62,13 +61,19 @@ def _build_top_players_pdf(rows: list[dict], title: str, generated_at_iso: str) 
     objects.append(b"2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n")
 
     font_obj_num = 3
-    objects.append(b"3 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Courier >>\nendobj\n")
+    objects.append(b"3 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n")
 
     next_obj_num = 4
     for page_lines in pages:
-        text_commands = ["BT", "/F1 10 Tf", "54 760 Td", "12 TL"]
+        text_commands = ["BT", "54 760 Td", "12 TL"]
         for idx, line in enumerate(page_lines):
             safe_line = _pdf_escape(str(line)).encode("latin-1", "replace").decode("latin-1")
+            if idx == 0:
+                text_commands.append("/F1 16 Tf")
+            elif idx == 1:
+                text_commands.append("/F1 12 Tf")
+            else:
+                text_commands.append("/F1 10 Tf")
             text_commands.append(f"({safe_line}) Tj")
             if idx < len(page_lines) - 1:
                 text_commands.append("T*")
@@ -191,6 +196,11 @@ def render(ctx):
         expanded.groupby("player_id", as_index=False)
         .agg(wins=("wins", "sum"), losses=("losses", "sum"), games=("games", "sum"))
     )
+    stats = stats[stats["games"] >= 10].copy()
+
+    if stats.empty:
+        st.info("No active players found in the last 30 days.")
+        return
 
     rating_col = "rating" if "rating" in df_players_all.columns else ("elo" if "elo" in df_players_all.columns else None)
     rating_map: dict[int, float] = {}
@@ -207,19 +217,21 @@ def render(ctx):
         wins = int(item["wins"])
         losses = int(item["losses"])
         games = int(item["games"])
-        rating = float(rating_map.get(pid, 1200.0))
+        rating_elo = float(rating_map.get(pid, 1200.0))
+        jupr = rating_elo / 400.0
         rows.append(
             {
                 "player_id": pid,
                 "name": id_to_name.get(pid, f"#{pid}"),
-                "rating": rating,
+                "rating_elo": rating_elo,
+                "jupr": jupr,
                 "wins": wins,
                 "losses": losses,
                 "games": games,
             }
         )
 
-    top = sorted(rows, key=lambda r: (r["rating"], r["games"], r["wins"]), reverse=True)[:50]
+    top = sorted(rows, key=lambda r: (r["jupr"], r["games"], r["wins"]), reverse=True)[:50]
 
     for idx, row in enumerate(top, start=1):
         row["rank"] = idx
@@ -231,13 +243,12 @@ def render(ctx):
         return
 
     st.dataframe(
-        top_df[["rank", "name", "rating", "wins", "losses", "record_str"]],
+        top_df[["rank", "name", "jupr", "wins", "losses", "record_str"]],
         use_container_width=True,
         hide_index=True,
     )
 
-    generated_at_iso = now_utc.replace(microsecond=0).isoformat()
-    pdf_bytes = _build_top_players_pdf(top, "Top 50 Active Players", generated_at_iso)
+    pdf_bytes = _build_top_players_pdf(top, "Tres Palapas -- Top 50 Players", "Month of February")
 
     st.download_button(
         "Download Top 50 Active Players PDF",

--- a/tests/test_top_players_printable_pdf.py
+++ b/tests/test_top_players_printable_pdf.py
@@ -1,15 +1,19 @@
 from jupr_app.ui.pages.top_players_printable import _build_top_players_pdf
 
 
-def test_build_top_players_pdf_contains_expected_strings():
+def test_build_top_players_pdf_contains_new_header_and_jupr_values():
     rows = [
-        {"rank": 1, "name": "Alice", "rating": 1420.25, "wins": 10, "losses": 2},
-        {"rank": 2, "name": "Bob", "rating": 1388.5, "wins": 8, "losses": 4},
+        {"rank": 1, "name": "Alice", "rating_elo": 2000.0, "jupr": 5.000, "wins": 10, "losses": 2},
+        {"rank": 2, "name": "Bob", "rating_elo": 1880.0, "jupr": 4.700, "wins": 8, "losses": 4},
     ]
 
-    pdf_bytes = _build_top_players_pdf(rows, "Top 50 Active Players", "2026-02-08T12:00:00+00:00")
+    pdf_bytes = _build_top_players_pdf(rows, "Tres Palapas -- Top 50 Players", "Month of February")
     text = pdf_bytes.decode("latin-1")
 
-    assert "Top 50 Active Players" in text
+    assert "Tres Palapas -- Top 50 Players" in text
+    assert "Month of February" in text
+    assert "Generated:" not in text
     assert "Rank  Player" in text
+    assert "5.000" in text
+    assert "2000.00" not in text
     assert "Alice" in text

--- a/tests/test_top_players_printable_pdf.py
+++ b/tests/test_top_players_printable_pdf.py
@@ -1,4 +1,6 @@
-from jupr_app.ui.pages.top_players_printable import _build_top_players_pdf
+from datetime import datetime, timezone
+
+from jupr_app.ui.pages.top_players_printable import _build_top_players_pdf, _previous_month_subtitle
 
 
 def test_build_top_players_pdf_contains_new_header_and_jupr_values():
@@ -7,13 +9,18 @@ def test_build_top_players_pdf_contains_new_header_and_jupr_values():
         {"rank": 2, "name": "Bob", "rating_elo": 1880.0, "jupr": 4.700, "wins": 8, "losses": 4},
     ]
 
-    pdf_bytes = _build_top_players_pdf(rows, "Tres Palapas -- Top 50 Players", "Month of February")
+    pdf_bytes = _build_top_players_pdf(rows, "Tres Palapas -- Top 50 Players", "February 2026")
     text = pdf_bytes.decode("latin-1")
 
     assert "Tres Palapas -- Top 50 Players" in text
-    assert "Month of February" in text
+    assert "February 2026" in text
     assert "Generated:" not in text
     assert "Rank  Player" in text
     assert "5.000" in text
     assert "2000.00" not in text
     assert "Alice" in text
+
+
+def test_previous_month_subtitle_uses_calendar_month_and_year():
+    assert _previous_month_subtitle(datetime(2026, 3, 15, tzinfo=timezone.utc)) == "February 2026"
+    assert _previous_month_subtitle(datetime(2026, 1, 2, tzinfo=timezone.utc)) == "December 2025"


### PR DESCRIPTION
### Motivation
- Display ratings as JUPR (Elo / 400) with three decimals instead of raw Elo to match existing Player Search behavior.  
- Restrict "active" players to a true rolling 30-day UTC window and require sufficient recent activity (minimum games) for the Top 50.  
- Improve printable PDF legibility and meet the requested header/subtitle/column layout and font requirements.

### Description
- Convert rating display to JUPR by computing `jupr = rating_elo / 400.0` and show it formatted to three decimals in the PDF and displayed dataframe; `rating_elo` is preserved for lookup; sorting is by `jupr`, then `games`, then `wins`.  
- Enforce active eligibility by filtering matches to UTC `date_dt >= cutoff` (30 days back from `datetime.now(timezone.utc)`), include only scored matches (`score_t1 + score_t2 > 0`), expand matches to per-player rows and aggregate wins/losses/games, then require `games >= 10`.  
- Update PDF builder (`_build_top_players_pdf` in `jupr_app/ui/pages/top_players_printable.py`) to use Helvetica, render the new title `Tres Palapas -- Top 50 Players` and subtitle `Month of February`, remove the `Generated:` timestamp line, and change the table header/rows to `Rank | Player | JUPR | W–L` with JUPR formatted like `4.823`.  
- Keep existing match expansion/W–L logic and name truncation, and update the Streamlit output and download button to use the new PDF call site and arguments; tests updated in `tests/test_top_players_printable_pdf.py`.

### Testing
- Ran `pytest -q tests/test_top_players_printable_pdf.py` which passed (`1 passed`).  
- The test asserts presence of `Tres Palapas -- Top 50 Players` and `Month of February`, asserts that `Generated:` is not present, asserts a sample JUPR value (`5.000` for Elo `2000.0`) is present, and asserts the legacy Elo string is not present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b5f5d53c832691810662dcc7450a)