### PR TITLE
Add CSV download for Top 50 previous-month admin report

### DIFF
--- a/jupr_app/ui/pages/top_players_printable.py
+++ b/jupr_app/ui/pages/top_players_printable.py
@@ -97,6 +97,53 @@ def _build_ranked_rows(df_matches: pd.DataFrame, id_to_name: dict[int, str], rat
     return top
 
 
+def build_top50_previous_month_df(ctx, now_utc: datetime | None = None) -> pd.DataFrame:
+    now_utc = now_utc or datetime.now(timezone.utc)
+    start_dt, end_dt = _previous_month_window(now_utc)
+
+    df_matches = ctx.df_matches.copy() if ctx.df_matches is not None else pd.DataFrame()
+    df_players_all = ctx.df_players_all.copy() if ctx.df_players_all is not None else pd.DataFrame()
+    id_to_name = dict(getattr(ctx, "id_to_name", {}) or {})
+
+    columns = ["rank", "player_id", "player_name", "jupr", "wins", "losses", "games", "wl"]
+    if df_matches.empty:
+        return pd.DataFrame(columns=columns)
+
+    if "date_dt" in df_matches.columns:
+        df_matches["date_dt"] = pd.to_datetime(df_matches["date_dt"], errors="coerce", utc=True)
+    else:
+        df_matches["date_dt"] = pd.to_datetime(df_matches.get("date"), errors="coerce", utc=True)
+
+    df_matches["score_t1"] = pd.to_numeric(df_matches.get("score_t1"), errors="coerce").fillna(0)
+    df_matches["score_t2"] = pd.to_numeric(df_matches.get("score_t2"), errors="coerce").fillna(0)
+
+    df_recent = df_matches[(df_matches["score_t1"] + df_matches["score_t2"]) > 0].copy()
+    df_recent = df_recent[(df_recent["date_dt"] >= start_dt) & (df_recent["date_dt"] < end_dt)].copy()
+
+    if df_recent.empty:
+        return pd.DataFrame(columns=columns)
+
+    rating_map = _build_rating_map(df_players_all)
+    top_rows = _build_ranked_rows(df_recent, id_to_name, rating_map)
+    if not top_rows:
+        return pd.DataFrame(columns=columns)
+
+    rows_out = [
+        {
+            "rank": int(row["rank"]),
+            "player_id": int(row["player_id"]),
+            "player_name": str(row["name"]),
+            "jupr": str(row["jupr_str"]),
+            "wins": int(row["wins"]),
+            "losses": int(row["losses"]),
+            "games": int(row["games"]),
+            "wl": str(row["wl_str"]),
+        }
+        for row in top_rows
+    ]
+    return pd.DataFrame(rows_out, columns=columns)
+
+
 def _build_page_content(rows: list[dict], title: str, subtitle: str) -> bytes:
     page_w = 792.0
     page_h = 612.0
@@ -258,46 +305,44 @@ def render(ctx):
         return
 
     now_utc = datetime.now(timezone.utc)
-    start_dt, end_dt = _previous_month_window(now_utc)
+    start_dt, _ = _previous_month_window(now_utc)
+    month_label = start_dt.strftime("%B %Y")
+    month_slug = month_label.replace(" ", "_")
 
-    df_matches = ctx.df_matches.copy() if ctx.df_matches is not None else pd.DataFrame()
-    df_players_all = ctx.df_players_all.copy() if ctx.df_players_all is not None else pd.DataFrame()
-    id_to_name = dict(getattr(ctx, "id_to_name", {}) or {})
-
-    if df_matches.empty:
-        st.info("No active players found in the previous calendar month.")
-        return
-
-    if "date_dt" in df_matches.columns:
-        df_matches["date_dt"] = pd.to_datetime(df_matches["date_dt"], errors="coerce", utc=True)
-    else:
-        df_matches["date_dt"] = pd.to_datetime(df_matches.get("date"), errors="coerce", utc=True)
-
-    df_matches["score_t1"] = pd.to_numeric(df_matches.get("score_t1"), errors="coerce").fillna(0)
-    df_matches["score_t2"] = pd.to_numeric(df_matches.get("score_t2"), errors="coerce").fillna(0)
-
-    df_recent = df_matches[(df_matches["score_t1"] + df_matches["score_t2"]) > 0].copy()
-    df_recent = df_recent[(df_recent["date_dt"] >= start_dt) & (df_recent["date_dt"] < end_dt)].copy()
-
-    if df_recent.empty:
-        st.info("No active players found in the previous calendar month.")
-        return
-
-    rating_map = _build_rating_map(df_players_all)
-    top_rows = _build_ranked_rows(df_recent, id_to_name, rating_map)
-
-    if top_rows:
-        preview_df = pd.DataFrame(top_rows)
-        st.dataframe(preview_df[["rank", "name", "jupr_str", "wins", "losses", "wl_str"]], use_container_width=True, hide_index=True)
-    else:
-        st.info("No eligible active players (min 10 games in previous calendar month).")
-
+    df_out = build_top50_previous_month_df(ctx, now_utc=now_utc)
     subtitle = _previous_month_subtitle(now_utc)
+    top_rows = []
+    if not df_out.empty:
+        top_rows = [
+            {
+                "rank": int(row["rank"]),
+                "name": str(row["player_name"]),
+                "jupr_str": str(row["jupr"]),
+                "wins": int(row["wins"]),
+                "losses": int(row["losses"]),
+                "wl_str": str(row["wl"]),
+            }
+            for _, row in df_out.iterrows()
+        ]
+        st.dataframe(df_out, use_container_width=True, hide_index=True)
+    else:
+        st.info(f"No eligible players for {month_label} (min 10 games).")
+
+    if df_out.empty:
+        return
+
     pdf_bytes = _build_top_players_pdf(top_rows, "Tres Palapas -- Top 50 Players", subtitle)
+    csv_bytes = df_out.to_csv(index=False).encode("utf-8")
 
     st.download_button(
         "Download PDF",
         data=pdf_bytes,
-        file_name="top_50_active_players.pdf",
+        file_name=f"tres_palapas_top_50_players_{month_slug}.pdf",
         mime="application/pdf",
+    )
+    st.download_button(
+        "Download CSV",
+        data=csv_bytes,
+        file_name=f"tres_palapas_top_50_players_{month_slug}.csv",
+        mime="text/csv",
     )

--- a/tests/test_top_players_printable_pdf.py
+++ b/tests/test_top_players_printable_pdf.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import pandas as pd
 
@@ -7,6 +8,7 @@ from jupr_app.ui.pages.top_players_printable import (
     _build_top_players_pdf,
     _previous_month_subtitle,
     _previous_month_window,
+    build_top50_previous_month_df,
 )
 
 
@@ -87,3 +89,50 @@ def test_single_page_pdf_contains_previous_month_subtitle_jupr_and_no_generated_
 def test_previous_month_subtitle_uses_calendar_month_and_year():
     assert _previous_month_subtitle(datetime(2026, 3, 15, tzinfo=timezone.utc)) == "February 2026"
     assert _previous_month_subtitle(datetime(2026, 1, 2, tzinfo=timezone.utc)) == "December 2025"
+
+
+def test_build_top50_previous_month_df_applies_window_min_games_and_csv_shape():
+    now_utc = datetime(2026, 3, 15, 9, 30, tzinfo=timezone.utc)
+    prior_month_match = {
+        "date_dt": datetime(2026, 2, 14, 12, 0, tzinfo=timezone.utc),
+        "t1_p1": 1,
+        "t1_p2": 2,
+        "t2_p1": 3,
+        "t2_p2": 4,
+        "score_t1": 11,
+        "score_t2": 8,
+    }
+    current_month_match = {
+        "date_dt": datetime(2026, 3, 2, 12, 0, tzinfo=timezone.utc),
+        "t1_p1": 1,
+        "t1_p2": 2,
+        "t2_p1": 3,
+        "t2_p2": 4,
+        "score_t1": 11,
+        "score_t2": 9,
+    }
+
+    matches = [prior_month_match for _ in range(10)] + [current_month_match for _ in range(20)]
+    ctx = SimpleNamespace(
+        df_matches=pd.DataFrame(matches),
+        df_players_all=pd.DataFrame(
+            [
+                {"id": 1, "elo": 2000},
+                {"id": 2, "elo": 1800},
+                {"id": 3, "elo": 1600},
+                {"id": 4, "elo": 1200},
+            ]
+        ),
+        id_to_name={1: "Alice", 2: "Bob", 3: "Carla", 4: "Diego"},
+    )
+
+    df_out = build_top50_previous_month_df(ctx, now_utc=now_utc)
+
+    assert list(df_out.columns) == ["rank", "player_id", "player_name", "jupr", "wins", "losses", "games", "wl"]
+    assert set(df_out["player_id"].tolist()) == {1, 2, 3, 4}
+    assert (df_out["games"] >= 10).all()
+    assert "5.000" in df_out["jupr"].tolist()
+
+    csv_text = df_out.to_csv(index=False)
+    assert csv_text.splitlines()[0] == "rank,player_id,player_name,jupr,wins,losses,games,wl"
+    assert "5.000" in csv_text


### PR DESCRIPTION
### Motivation
- Provide an identical CSV export for the existing "Tres Palapas -- Top 50 Players" previous-calendar-month admin report so users can download the same dataset as the PDF.
- Centralize the previous-month dataset computation so both PDF and CSV use the exact same rows/values and the min-10-games eligibility is enforced consistently.

### Description
- Added a pure helper `build_top50_previous_month_df(ctx, now_utc=None)` that returns a `pd.DataFrame` with columns `rank, player_id, player_name, jupr, wins, losses, games, wl` computed using the UTC previous-calendar-month window, scored-match filter, min 10 games, JUPR formatting and Top-50 sorting/limit.
- Updated the existing page `render` path to consume `df_out = build_top50_previous_month_df(...)`, convert those rows for the existing PDF renderer, and generate `csv_bytes = df_out.to_csv(index=False).encode("utf-8")` for CSV export.
- Added a Streamlit `Download CSV` button alongside the existing `Download PDF` button and changed filenames to use the month label (e.g. `tres_palapas_top_50_players_February_2026.pdf` and `.csv`).
- Preserved original PDF layout/semantics and added empty-state behavior that shows `st.info("No eligible players for <Month> (min 10 games).")` and hides/disables downloads when there are no eligible rows.

### Testing
- Ran `pytest -q tests/test_top_players_printable_pdf.py` which executed the updated and existing assertions and completed successfully (`4 passed`).
- Launched the app with `streamlit run streamlit_app.py` for visual verification which started successfully and served the page.
- Captured a Playwright screenshot of the page for visual confirmation and produced an artifact image successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c15372188326ac6eddf62021d30a)