### PR TITLE
Refactor tournaments to registration-first shell creation & improve Tournament Manager UX

### DIFF
--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -111,19 +111,75 @@ def _events_editor_seed(days: list[dict[str, Any]], events: list[dict[str, Any]]
         default_day = str((days[0].get("id") or days[0].get("day_key"))) if days else "day_1"
         rows = [
             {
-                "event_key": "event_1",
+                "event_key": "event_mens_doubles",
                 "day_key": default_day,
                 "day_label": day_lookup.get(default_day, "Day 1"),
-                "label": "Women's Doubles 3.5",
+                "label": "Men's Doubles",
                 "event_type": "GENDER_DOUBLES",
-                "gender_restriction": "WOMEN",
-                "skill_label": "3.5",
-                "age_label": None,
+                "gender_restriction": "MEN",
+                "skill_label": "Open",
+                "age_label": "All Ages",
                 "partner_required": True,
                 "capacity_teams": 8,
                 "public_partner_board": True,
                 "price_usd": None,
-            }
+            },
+            {
+                "event_key": "event_womens_doubles",
+                "day_key": default_day,
+                "day_label": day_lookup.get(default_day, "Day 1"),
+                "label": "Women's Doubles",
+                "event_type": "GENDER_DOUBLES",
+                "gender_restriction": "WOMEN",
+                "skill_label": "Open",
+                "age_label": "All Ages",
+                "partner_required": True,
+                "capacity_teams": 8,
+                "public_partner_board": True,
+                "price_usd": None,
+            },
+            {
+                "event_key": "event_mixed_doubles",
+                "day_key": default_day,
+                "day_label": day_lookup.get(default_day, "Day 1"),
+                "label": "Mixed Doubles",
+                "event_type": "MIXED_DOUBLES",
+                "gender_restriction": "MIXED",
+                "skill_label": "Open",
+                "age_label": "All Ages",
+                "partner_required": True,
+                "capacity_teams": 8,
+                "public_partner_board": True,
+                "price_usd": None,
+            },
+            {
+                "event_key": "event_mens_singles",
+                "day_key": default_day,
+                "day_label": day_lookup.get(default_day, "Day 1"),
+                "label": "Men's Singles",
+                "event_type": "SINGLES",
+                "gender_restriction": "MEN",
+                "skill_label": "Open",
+                "age_label": "All Ages",
+                "partner_required": False,
+                "capacity_teams": 16,
+                "public_partner_board": False,
+                "price_usd": None,
+            },
+            {
+                "event_key": "event_womens_singles",
+                "day_key": default_day,
+                "day_label": day_lookup.get(default_day, "Day 1"),
+                "label": "Women's Singles",
+                "event_type": "SINGLES",
+                "gender_restriction": "WOMEN",
+                "skill_label": "Open",
+                "age_label": "All Ages",
+                "partner_required": False,
+                "capacity_teams": 16,
+                "public_partner_board": False,
+                "price_usd": None,
+            },
         ]
     return pd.DataFrame(rows)
 
@@ -223,8 +279,21 @@ def render(ctx):
 
     tournaments = list_existing_tournaments(supabase, club_id)
     if not tournaments:
-        st.info("No tournaments exist yet. Create one on the Tournaments page first.")
+        st.info("Create a tournament first on the Tournaments page.")
         st.stop()
+
+    st.markdown("### Admin Setup Steps")
+    st.markdown(
+        """
+1. **Pick tournament** (created on the **Tournaments** page).
+2. **Configure registration settings** (slug, status, open/close dates, locale, waitlist).
+3. **Define tournament days** (Day 1, Day 2, etc.).
+4. **Define event options** (doubles/singles, gender, skill/age labels, partner rules, capacity, pricing).
+5. **Publish registration links** for players and partner board.
+6. **Monitor registrations and compiled rosters**. Once registrations exist, structural day/event edits are locked.
+        """
+    )
+    st.caption("This page configures registration for the selected tournament. Tournament shell creation and live bracket operations happen on the Tournaments page.")
 
     preselected = str(st.query_params.get("tournament_id", "")).strip()
     labels = [f"{row.get('name')} ({row.get('status')})" for row in tournaments]
@@ -258,7 +327,7 @@ def render(ctx):
         st.text_input("Public partner board", value=links["partner_board"], key=f"board_link_{tournament_id}")
         st.text_input("Admin operations", value=links["admin_operations"], key=f"ops_link_{tournament_id}")
 
-    tabs = st.tabs(["Setup", "Days & Events", "Registrations", "Partner Board", "Issues & Rosters"])
+    tabs = st.tabs(["Step 2: Settings", "Step 3-4: Days & Events", "Step 5: Publish & Registrations", "Partner Board", "Step 6: Issues & Rosters"])
 
     with tabs[0]:
         st.subheader("Registration settings")
@@ -346,6 +415,7 @@ def render(ctx):
 
     with tabs[1]:
         st.subheader("Days and event options")
+        st.caption("Once registrations are submitted, structural day/event changes are locked to preserve data integrity.")
         registration_count = count_tournament_registrations(supabase, tournament_id)
         if registration_count:
             st.warning(
@@ -380,11 +450,11 @@ def render(ctx):
                 "day_key": st.column_config.SelectboxColumn("Day key", options=day_key_options or ["day_1"]),
                 "day_label": st.column_config.TextColumn("Day label", disabled=True),
                 "label": st.column_config.TextColumn("Event label"),
-                "event_type": st.column_config.SelectboxColumn("Type", options=EVENT_TYPE_OPTIONS),
-                "gender_restriction": st.column_config.SelectboxColumn("Gender", options=GENDER_RESTRICTION_OPTIONS),
+                "event_type": st.column_config.SelectboxColumn("Event format", options=EVENT_TYPE_OPTIONS),
+                "gender_restriction": st.column_config.SelectboxColumn("Eligible gender", options=GENDER_RESTRICTION_OPTIONS),
                 "skill_label": st.column_config.TextColumn("Skill label"),
                 "age_label": st.column_config.TextColumn("Age label"),
-                "partner_required": st.column_config.CheckboxColumn("Partner required"),
+                "partner_required": st.column_config.CheckboxColumn("Partner required at registration"),
                 "capacity_teams": st.column_config.NumberColumn("Capacity", step=1, min_value=1),
                 "public_partner_board": st.column_config.CheckboxColumn("Public partner board"),
                 "price_usd": st.column_config.NumberColumn("Price USD", step=1),
@@ -415,7 +485,7 @@ def render(ctx):
                 st.error(f"Could not replace registration configuration: {exc}")
 
     with tabs[2]:
-        st.subheader("Registrations")
+        st.subheader("Publish links and registrations")
         _render_metrics(state)
         regs = state.get("registrations", [])
         if not regs:

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -25,7 +25,37 @@ from jupr_app.domain.tournament_registration_repo import (
     list_event_options as list_registration_event_options,
     list_registration_days,
     registration_feature_available,
+    upsert_registration_settings,
 )
+
+
+LEGACY_DEFAULT_TEAM_COUNT = 4
+TOURNAMENT_STATUS_OPTIONS = ["DRAFT", "REGISTRATION", "REGISTRATION_OPEN", "REGISTRATION_CLOSED"]
+TOURNAMENT_LOCALE_OPTIONS = ["en", "es", "bilingual"]
+
+
+def _parse_optional_date(value):
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _insert_tournament_shell(supabase, payload: dict) -> None:
+    try:
+        supabase.table("tournaments").insert(payload).execute()
+        return
+    except Exception:
+        pass
+
+    fallback_payload = {
+        "club_id": payload["club_id"],
+        "name": payload["name"],
+        "status": payload.get("status") or "DRAFT",
+        # team_count is required by the legacy tournament bracket schema.
+        "team_count": int(payload.get("team_count") or LEGACY_DEFAULT_TEAM_COUNT),
+    }
+    supabase.table("tournaments").insert(fallback_payload).execute()
 
 
 def render(ctx):
@@ -52,27 +82,71 @@ def render(ctx):
 
     player_names = sorted(df_players_all["name"].dropna().astype(str).tolist())
 
-    st.subheader("Create Tournament")
-    c1, c2, c3 = st.columns([3, 2, 1])
+    st.subheader("Create Tournament Shell")
+    st.caption("Stage 1 of 3: Create a tournament shell here. Configure registration details in Tournament Manager, then run brackets and scoring in Tournament Operations.")
+    c1, c2 = st.columns(2)
     with c1:
-        tournament_name = st.text_input("Tournament name", key="tourney_create_name")
+        tournament_name = st.text_input("Tournament name *", key="tourney_create_name")
+        start_date = st.text_input("Start date (recommended, YYYY-MM-DD)", key="tourney_create_start")
+        end_date = st.text_input("End date (recommended, YYYY-MM-DD)", key="tourney_create_end")
+        registration_enabled = st.checkbox("Registration enabled", value=True, key="tourney_create_reg_enabled")
     with c2:
-        team_count = st.selectbox("Team count", SUPPORTED_TEAM_COUNTS, key="tourney_create_team_count")
-    with c3:
-        if st.button("Create", type="primary"):
-            if not tournament_name.strip():
-                st.error("Tournament name is required.")
-            else:
-                supabase.table("tournaments").insert(
-                    {
-                        "club_id": str(club_id),
-                        "name": tournament_name.strip(),
-                        "status": "DRAFT",
-                        "team_count": int(team_count),
-                    }
-                ).execute()
-                st.success("Tournament created.")
-                st.rerun()
+        status = st.selectbox("Status", TOURNAMENT_STATUS_OPTIONS, index=0, key="tourney_create_status")
+        public_slug = st.text_input("Public slug (optional)", key="tourney_create_slug")
+        locale = st.selectbox("Locale", TOURNAMENT_LOCALE_OPTIONS, index=0, key="tourney_create_locale")
+        reg_open_at = st.text_input("Registration open at (optional ISO)", key="tourney_create_reg_open")
+        reg_close_at = st.text_input("Registration close at (optional ISO)", key="tourney_create_reg_close")
+
+    if st.button("Create Tournament", type="primary"):
+        if not tournament_name.strip():
+            st.error("Tournament name is required.")
+        else:
+            payload = {
+                "club_id": str(club_id),
+                "name": tournament_name.strip(),
+                "status": status,
+                # Legacy tournament ops compatibility: bracket engine still expects this.
+                "team_count": LEGACY_DEFAULT_TEAM_COUNT,
+                "start_date": _parse_optional_date(start_date),
+                "end_date": _parse_optional_date(end_date),
+                "registration_enabled": bool(registration_enabled),
+                "public_slug": str(public_slug or "").strip() or None,
+                "locale": locale,
+                "registration_open_at": _parse_optional_date(reg_open_at),
+                "registration_close_at": _parse_optional_date(reg_close_at),
+            }
+            _insert_tournament_shell(supabase, payload)
+            created = (
+                supabase.table("tournaments")
+                .select("id,name")
+                .eq("club_id", str(club_id))
+                .eq("name", tournament_name.strip())
+                .order("created_at", desc=True)
+                .limit(1)
+                .execute()
+            )
+            created_row = (created.data or [None])[0]
+            if created_row:
+                reg_available, _ = registration_feature_available(supabase)
+                if reg_available:
+                    try:
+                        upsert_registration_settings(
+                            supabase,
+                            {
+                                "tournament_id": created_row["id"],
+                                "registration_slug": str(public_slug or "").strip() or None,
+                                "locale": locale,
+                                "registration_status": "open" if registration_enabled else "draft",
+                                "registration_open_at": _parse_optional_date(reg_open_at),
+                                "registration_close_at": _parse_optional_date(reg_close_at),
+                            },
+                        )
+                    except Exception:
+                        pass
+            st.success("Tournament shell created.")
+            st.info("Next step: open Tournament Manager and configure registration days/events.")
+            st.link_button("Configure Registration", f"?page=tournament_manager&tournament_id={(created_row or {}).get('id','')}")
+            st.rerun()
 
     st.divider()
 
@@ -94,6 +168,14 @@ def render(ctx):
     selected_idx = tournament_labels.index(selected_label)
     tournament = tournaments[selected_idx]
     tournament_id = tournament["id"]
+
+    st.subheader("Tournament Shell / Overview")
+    st.caption("Stage 1: shell metadata • Stage 2: registration setup in Tournament Manager • Stage 3: operations below.")
+    meta_cols = st.columns(4)
+    meta_cols[0].metric("Status", str(tournament.get("status") or "DRAFT"))
+    meta_cols[1].metric("Legacy team count", int(tournament.get("team_count") or LEGACY_DEFAULT_TEAM_COUNT))
+    meta_cols[2].metric("Start", str(tournament.get("start_date") or "—"))
+    meta_cols[3].metric("End", str(tournament.get("end_date") or "—"))
 
     teams_resp = (
         supabase.table("tournament_teams")
@@ -168,7 +250,7 @@ def render(ctx):
 
     st.divider()
 
-    tabs = st.tabs(["Teams", "Round Robin", "Standings", "Playoffs"])
+    tabs = st.tabs(["Tournament Operations (Teams)", "Round Robin", "Standings", "Playoffs"])
 
     with tabs[0]:
         st.subheader("Teams")
@@ -177,7 +259,7 @@ def render(ctx):
 
         c1, c2 = st.columns([2, 1])
         with c1:
-            st.caption("Team count is locked once games are generated.")
+            st.caption("Team count is a legacy/manual operations setting used for bracket generation. It is not part of tournament shell creation and locks once games are generated.")
         with c2:
             new_team_count = st.selectbox(
                 "Team count",
@@ -377,9 +459,11 @@ def render(ctx):
 
 
 def _render_registration_bridge(tournament: dict, registration_bridge: dict | None) -> None:
-    st.subheader("Registration Bridge")
+    st.subheader("Registration Bridge (Stage 2)")
     if not registration_bridge:
-        st.caption("Registration module not configured for this tournament yet.")
+        st.warning("Registration is not configured for this tournament yet.")
+        st.info("Use Tournament Manager to define days, events, skill/age labels, and partner requirements.")
+        st.link_button("Configure Registration", f"?page=tournament_manager&tournament_id={tournament.get('id')}")
         return
 
     settings = registration_bridge.get("settings") or {}
@@ -397,7 +481,8 @@ def _render_registration_bridge(tournament: dict, registration_bridge: dict | No
     c3.metric("Needs partner", summary.get("needs_partner_entries", 0))
     c4.metric("Issues", summary.get("issue_count", 0))
 
-    st.caption("Use Tournament Manager for registration setup and partner-board publishing. Use this page for live operations once divisions are ready.")
+    st.caption("Use Tournament Manager for registration setup and partner-board publishing. Return here once registrations are finalized to run teams, rounds, brackets, standings, and scoring.")
+    st.link_button("Configure Registration", f"?page=tournament_manager&tournament_id={tournament.get('id')}")
     with st.expander("Registration links"):
         st.text_input("Registration setup", value=links["admin_manager"], key=f"ops_reg_admin_{tournament.get('id')}")
         st.text_input("Public registration", value=links["registration"], key=f"ops_reg_public_{tournament.get('id')}")


### PR DESCRIPTION
### Motivation
- The previous tournament creation UI forced admins to pick a `team_count` up-front, tightly coupling creation to bracket-first operations and blocking a registration-first workflow.
- The product direction is to support a 3-stage flow (tournament shell → registration configuration → tournament operations) so admins can create shells, configure registration/events, then convert confirmed entries to bracket operations.
- Changes must preserve existing tournament operations and database compatibility while improving guidance and defaults for non-technical admins.

### Description
- Reworked tournament creation in `tournaments.py` into a tournament shell form collecting `name`, `start_date`, `end_date`, `status`, `registration_enabled`, `public_slug`, `locale`, and optional registration open/close values while no longer exposing `team_count` at creation time, and added `Configure Registration` affordance that deep-links to Tournament Manager.
- Added `_insert_tournament_shell` helper that attempts to insert the extended shell row but falls back to a legacy-safe insert shape that includes a default `team_count` (keeps bracket tooling compatible) and added `_parse_optional_date` for optional date fields.
- Kept operations code (teams, RR, playoffs, standings, podium, score saving) intact but re-framed the UI so `team_count` is shown and editable only in the operations area and clearly marked as a legacy/manual-ops setting; the tournaments page now shows a shell overview and registration bridge with stage guidance.
- Updated `tournament_manager.py` UX to be registration-focused by adding a top-level step guide, clearer message when no tournaments exist, renamed tabs to step-oriented labels, improved column labels (`Event format`, `Eligible gender`, `Partner required at registration`), and seeded default event options to include `Men’s Doubles`, `Women’s Doubles`, `Mixed Doubles`, `Men’s Singles`, and `Women’s Singles` for easier admin onboarding; structural day/event edits are locked once registrations exist.
- Files changed: `jupr_app/ui/pages/tournaments.py` and `jupr_app/ui/pages/tournament_manager.py`; the changes aim to be non-breaking and maintain backward compatibility with existing `tournaments.team_count`-dependent features.
- Schema assumptions and follow-ups: no DB migration was applied; the code assumes `tournaments.team_count` may still be required by legacy schemas and provides a safe default; shell-style fields (`start_date`, `end_date`, `registration_enabled`, `public_slug`, etc.) are stored when possible and otherwise the insert falls back to legacy shape; consider adding an explicit migration later if you want guaranteed persistence of shell fields on `tournaments`.

### Testing
- Compiled the modified pages with `python -m compileall jupr_app/ui/pages/tournaments.py jupr_app/ui/pages/tournament_manager.py`, which succeeded without syntax errors.
- Launched a local Streamlit instance with `streamlit run streamlit_app.py` and verified the UI pages load and the new shell creation and Tournament Manager pages render (manual smoke test); interactions produced no immediate runtime exceptions during the smoke sequence.
- Captured a headless screenshot of the UI flow via a Playwright script to validate layout and messaging (artifact produced).
- Summary of before vs after, files changed, schema assumptions, and manual follow-ups: "Before" required `team_count` during creation and encouraged a bracket-first flow; "After" creates a tournament shell with optional metadata and moves team/bracket concerns to the operations stage; changed files are `jupr_app/ui/pages/tournaments.py` and `jupr_app/ui/pages/tournament_manager.py`; schema assumption is that `tournaments.team_count` may still be required and is preserved with a default fallback; manual follow-ups are to validate deep-linking (`?page=tournament_manager&tournament_id=...`) in the deployed router and optionally add a DB migration if you want to persist new shell columns on `tournaments` across all environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af63371b688326b7401f0347be7dd9)