### PR TITLE
Add tournaments.start_date/end_date with safe day generation and UI validation

### DIFF
--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -146,6 +146,32 @@ def _date_rows(start_date: Any, end_date: Any) -> list[dict[str, Any]]:
     return rows
 
 
+def _date_window_message(start_date: Any, end_date: Any) -> tuple[str, str]:
+    start = _parse_date(start_date)
+    end = _parse_date(end_date)
+    if not start or not end:
+        return (
+            "warning",
+            "Tournament dates are missing. Add start and end dates to auto-generate the default day schedule.",
+        )
+    if end < start:
+        return ("error", "End date cannot be before start date. Fix dates before generating days.")
+    day_count = (end - start).days + 1
+    return ("info", f"Date window: {start.isoformat()} → {end.isoformat()} ({day_count} day{'s' if day_count != 1 else ''}).")
+
+def _update_tournament_shell(supabase, tournament_id: str, *, name: str, start_date: date | None, end_date: date | None) -> None:
+    payload = {
+        "name": name.strip(),
+        "start_date": start_date.isoformat() if start_date else None,
+        "end_date": end_date.isoformat() if end_date else None,
+    }
+    try:
+        supabase.table("tournaments").update(payload).eq("id", tournament_id).execute()
+        return
+    except Exception:
+        pass
+    supabase.table("tournaments").update({"name": name.strip()}).eq("id", tournament_id).execute()
+
 def _coerce_bool(value: Any, default: bool = False) -> bool:
     if isinstance(value, bool):
         return value
@@ -199,7 +225,7 @@ def _seed_days(days: list[dict[str, Any]], tournament: dict[str, Any]) -> pd.Dat
 
     generated = _date_rows(tournament.get("start_date"), tournament.get("end_date"))
     if not generated:
-        generated = [{"event_date": None, "label": "Day 1", "enabled": True}]
+        return pd.DataFrame(columns=["event_date", "label", "enabled"])
     rows = [{"id": _uid("day"), **row} for row in generated]
     return _df_with_hidden_ids(rows, "id", ["event_date", "label", "enabled"])
 
@@ -621,35 +647,41 @@ def render(ctx):
             refund = st.text_area("Refund policy", value=_safe_text(settings.get("refund_policy_markdown")), height=90)
         notes = st.text_area("Rules / registration notes", value=_safe_text(settings.get("rules_markdown")), height=140)
 
+        window_level, window_message = _date_window_message(start_date, end_date)
+        getattr(st, window_level)(window_message)
+
         if st.button("Save tournament info", type="primary"):
-            supabase.table("tournaments").update(
-                {
-                    "name": name.strip(),
-                    "start_date": start_date.isoformat() if start_date else None,
-                    "end_date": end_date.isoformat() if end_date else None,
-                }
-            ).eq("id", tournament_id).execute()
-            upsert_registration_settings(
-                supabase,
-                {
-                    "id": settings.get("id"),
-                    "tournament_id": tournament_id,
-                    "registration_slug": slug or None,
-                    "locale": locale,
-                    "registration_status": status,
-                    "registration_open_at": _parse_local_dt(reg_open),
-                    "registration_close_at": _parse_local_dt(reg_close),
-                    "sponsor_markdown": sponsor,
-                    "refund_policy_markdown": refund,
-                    "rules_markdown": notes,
-                    "waitlist_enabled": True,
-                    "partner_board_enabled": True,
-                },
-            )
-            if not days and not structure_locked:
-                st.session_state[f"tm_days_seed_{tournament_id}"] = _seed_days([], {"start_date": start_date.isoformat(), "end_date": end_date.isoformat()})
-            st.success("Tournament info saved.")
-            st.rerun()
+            if end_date and start_date and end_date < start_date:
+                st.error("End date cannot be before start date.")
+            else:
+                _update_tournament_shell(
+                    supabase,
+                    tournament_id,
+                    name=name,
+                    start_date=start_date,
+                    end_date=end_date,
+                )
+                upsert_registration_settings(
+                    supabase,
+                    {
+                        "id": settings.get("id"),
+                        "tournament_id": tournament_id,
+                        "registration_slug": slug or None,
+                        "locale": locale,
+                        "registration_status": status,
+                        "registration_open_at": _parse_local_dt(reg_open),
+                        "registration_close_at": _parse_local_dt(reg_close),
+                        "sponsor_markdown": sponsor,
+                        "refund_policy_markdown": refund,
+                        "rules_markdown": notes,
+                        "waitlist_enabled": True,
+                        "partner_board_enabled": True,
+                    },
+                )
+                if not days and not structure_locked:
+                    st.session_state[f"tm_days_seed_{tournament_id}"] = _seed_days([], {"start_date": start_date.isoformat(), "end_date": end_date.isoformat()})
+                st.success("Tournament info saved.")
+                st.rerun()
 
     days_seed_key = f"tm_days_seed_{tournament_id}"
     if days_seed_key not in st.session_state:
@@ -658,6 +690,8 @@ def render(ctx):
     with tabs[1]:
         st.subheader("Days")
         st.caption("Days are created from the tournament date range. Relabel them to match how you actually talk about the schedule, such as 'Mixed Doubles Day' or 'Championship Sunday'.")
+        if not _date_rows(tournament.get("start_date"), tournament.get("end_date")):
+            st.warning("No tournament date range is saved yet. You can add days manually, or save dates in Tournament Info to auto-generate days.")
         if structure_locked:
             st.caption("Days are view-only because registrations already exist.")
         days_df = st.data_editor(
@@ -675,7 +709,11 @@ def render(ctx):
         )
         st.session_state[days_seed_key] = days_df.copy()
         if st.button("Regenerate days from tournament dates", disabled=structure_locked):
-            st.session_state[days_seed_key] = _seed_days([], tournament)
+            generated = _seed_days([], tournament)
+            if generated.empty:
+                st.warning("Cannot regenerate days yet. Save both start and end dates first.")
+            else:
+                st.session_state[days_seed_key] = generated
             st.rerun()
 
     event_seed_df = _seed_event_templates(event_options)

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -53,6 +53,14 @@ def _parse_optional_date(value: Any) -> str | None:
     return text or None
 
 
+
+
+def _tournament_date_window_text(tournament: dict[str, Any]) -> str | None:
+    start = _safe_text(tournament.get("start_date"))
+    end = _safe_text(tournament.get("end_date"))
+    if not start or not end:
+        return None
+    return f"{start} → {end}"
 def _resolve_player_id(name: str, name_to_id: dict[str, Any], id_to_name: dict[Any, str]) -> Any:
     if name in name_to_id:
         return name_to_id[name]
@@ -364,6 +372,11 @@ def render(ctx):
         "Configured divisions",
         len((registration_bridge or {}).get("events") or []),
     )
+    date_window = _tournament_date_window_text(tournament)
+    if date_window:
+        st.caption(f"Tournament date window: {date_window}. Tournament Manager can auto-generate day rows from this range.")
+    else:
+        st.info("This tournament has no saved start/end dates yet. Add dates in Tournament Manager to auto-generate the default day schedule.")
     st.link_button("Open Tournament Manager", f"?page=tournament_manager&tournament_id={tournament_id}")
 
     draws = _list_draws(supabase, tournament_id)

--- a/migrations/20261011_tournament_dates.sql
+++ b/migrations/20261011_tournament_dates.sql
@@ -1,0 +1,10 @@
+-- Add canonical tournament date window fields.
+-- Backward-compatible: nullable columns, no destructive changes.
+
+ALTER TABLE public.tournaments
+  ADD COLUMN IF NOT EXISTS start_date date,
+  ADD COLUMN IF NOT EXISTS end_date date;
+
+-- Helpful for date-range filtering in admin/reporting queries.
+CREATE INDEX IF NOT EXISTS idx_tournaments_start_date ON public.tournaments (start_date);
+CREATE INDEX IF NOT EXISTS idx_tournaments_end_date ON public.tournaments (end_date);


### PR DESCRIPTION
### Motivation
- Fix crashes caused by the UI writing `start_date`/`end_date` when those columns did not exist in the DB schema and make tournament date windows first-class data owned by the `tournaments` table. 
- Make day auto-generation safe, predictable, and backward-compatible so legacy tournaments without dates continue to work and admins see clear guidance.

### Description
- Add a non-destructive migration `migrations/20261011_tournament_dates.sql` that uses `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` to add `start_date date` and `end_date date` plus optional indexes `idx_tournaments_start_date` and `idx_tournaments_end_date`.
- Update `jupr_app/ui/pages/tournament_manager.py` to validate date windows, show clear date-window messages, prevent saving an invalid range, provide `_update_tournament_shell` with a safe fallback when date columns are not present, and make day seeding null-safe (do not fabricate a placeholder day when no valid date window exists). 
- Change day regeneration to warn when dates are missing and only auto-generate day rows when a valid inclusive date range exists; preserve existing saved day rows until the admin explicitly regenerates/saves changes. 
- Update `jupr_app/ui/pages/tournaments.py` to display a friendly caption indicating whether a canonical tournament date window exists and that Tournament Manager can auto-generate day rows from it.
- Kept registration settings separate (no changes to registration settings ownership or schema), and avoided any destructive column drops or schema mutations.

### Testing
- Compiled modified modules successfully with `python -m py_compile jupr_app/ui/pages/tournament_manager.py jupr_app/ui/pages/tournaments.py jupr_app/domain/tournament_registration_repo.py` (succeeded).
- Confirmed code changes and committed files: `jupr_app/ui/pages/tournament_manager.py`, `jupr_app/ui/pages/tournaments.py`, and `migrations/20261011_tournament_dates.sql` (commit completed locally).
- Attempted a browser UI snapshot using Playwright but the app endpoint was not running in the environment so the screenshot step failed (this does not affect the code-level validation above).
- Manual QA checklist to run after deployment: apply migration file, run `NOTIFY pgrst, 'reload schema';` if using PostgREST, create a tournament with dates and verify days auto-generate, confirm legacy tournaments with null dates still load and do not crash, and verify repeated saves/regenerations do not duplicate existing persisted day rows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a6272b048326899d4dfeb2134672)