### PR TITLE
Register JUPR Live in public navigation

### DIFF
--- a/jupr_app/ui/page_registry.py
+++ b/jupr_app/ui/page_registry.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PageDefinition:
+    key: str
+    label: str
+    public: bool = False
+    admin_only: bool = False
+
+
+PAGE_DEFINITIONS: tuple[PageDefinition, ...] = (
+    PageDefinition("leaderboards", "🏆 Leaderboards", public=True),
+    PageDefinition("league_results", "📊 League Results", public=True),
+    PageDefinition("league_printout", "🖨️ League Night Printout", admin_only=True),
+    PageDefinition("match_explorer", "🎯 Match Explorer", public=True),
+    PageDefinition("players", "🔍 Player Search", public=True),
+    PageDefinition("badge_codex", "📼 Badge Codex", public=True),
+    PageDefinition("badge_debug", "🧪 Badge Debug", admin_only=True),
+    PageDefinition("challenge_ladder", "🪜 Challenge Ladder", public=True),
+    PageDefinition("faqs", "❓ FAQs", public=True),
+    PageDefinition("league_manager", "🏟️ League Manager", admin_only=True),
+    PageDefinition("match_uploader", "📝 Match Uploader", admin_only=True),
+    PageDefinition("match_log", "📝 Match Log", admin_only=True),
+    PageDefinition("player_editor", "👥 Player Editor", admin_only=True),
+    PageDefinition("admin_tools", "⚙️ Admin Tools", admin_only=True),
+    PageDefinition("admin_guide", "📘 Admin Guide", admin_only=True),
+    PageDefinition(
+        "challenge_ladder_admin",
+        "🛠️ Challenge Ladder Admin",
+        admin_only=True,
+    ),
+    PageDefinition("moneyball", "💰 Moneyball", admin_only=True),
+    PageDefinition("jupr_live", "🔴 JUPR Live", public=True),
+    PageDefinition("jupr_live_admin", "🔴 JUPR Live Admin", admin_only=True),
+    PageDefinition("theme_qa", "🎨 Theme QA", admin_only=True),
+    PageDefinition("tournaments", "🏆 Tournaments", admin_only=True),
+    PageDefinition("tournament_manager", "🏆 Tournament Manager", admin_only=True),
+    PageDefinition("tournament_registration", "📝 Tournament Registration", public=True),
+    PageDefinition("tournament_partner_board", "🤝 Partner Board", public=True),
+    PageDefinition("weekly_recap", "🗞️ Weekly Recap", public=True),
+    PageDefinition("top_players_printable", "🧾 Top Active Players PDF", admin_only=True),
+    PageDefinition("weekly_recap_admin", "🗞️ Weekly Recap Admin", admin_only=True),
+)
+
+PAGE_KEY_TO_LABEL = {page.key: page.label for page in PAGE_DEFINITIONS}
+LABEL_TO_PAGE_KEY = {page.label: page.key for page in PAGE_DEFINITIONS}
+ADMIN_ONLY_PAGE_KEYS = frozenset(
+    page.key for page in PAGE_DEFINITIONS if page.admin_only
+)
+ADMIN_ONLY_LABELS = frozenset(
+    page.label for page in PAGE_DEFINITIONS if page.admin_only
+)
+PUBLIC_NAV_KEYS = (
+    "leaderboards",
+    "league_results",
+    "weekly_recap",
+    "tournament_registration",
+    "tournament_partner_board",
+    "match_explorer",
+    "players",
+    "badge_codex",
+    "jupr_live",
+    "challenge_ladder",
+    "faqs",
+)
+
+
+def labels_for_keys(page_keys: list[str] | tuple[str, ...]) -> list[str]:
+    return [PAGE_KEY_TO_LABEL[key] for key in page_keys if key in PAGE_KEY_TO_LABEL]

--- a/jupr_app/ui/public_nav.py
+++ b/jupr_app/ui/public_nav.py
@@ -1,52 +1,64 @@
-# jupr_app/ui/public_nav.py
 from __future__ import annotations
 
 import streamlit as st
+
+from jupr_app.ui.page_registry import (
+    LABEL_TO_PAGE_KEY,
+    PAGE_KEY_TO_LABEL,
+    PUBLIC_NAV_KEYS,
+)
 from jupr_app.ui.url import qp_get
 
 
-PUBLIC_NAV = [
-    ("leaderboards", "🏆 Leaderboards"),
-    ("match_explorer", "🎯 Match Explorer"),
-    ("players", "🔎 Player Search"),
-    ("challenge_ladder", "🪜 Challenge Ladder"),
-    ("faqs", "❓ FAQs"),
-]
-
-def render_public_top_nav(*, default_page: str = "leaderboards") -> str:
+def render_public_top_nav(
+    *,
+    labels_in_order: list[str] | None = None,
+    current_label: str | None = None,
+    default_page: str = "leaderboards",
+) -> str:
     """
-    Renders a horizontal, top-of-page navigation for PUBLIC_MODE.
-    Returns the selected page key.
+    Render the horizontal public navigation and return the selected label.
+
+    If callers do not provide a label list, the shared public-page registry drives the nav.
     """
-    # Read current page from query params (supports deep links)
-    current = (qp_get("page", "") or "").strip() or default_page
+    if labels_in_order is None:
+        labels_in_order = [
+            PAGE_KEY_TO_LABEL[key]
+            for key in PUBLIC_NAV_KEYS
+            if key in PAGE_KEY_TO_LABEL
+        ]
 
-    keys = [k for k, _ in PUBLIC_NAV]
-    labels = [label for _, label in PUBLIC_NAV]
+    if not labels_in_order:
+        return PAGE_KEY_TO_LABEL.get(default_page, default_page)
 
-    # Pick selected index (safe fallback)
-    try:
-        idx = keys.index(current)
-    except ValueError:
-        idx = keys.index(default_page) if default_page in keys else 0
+    if current_label is None:
+        current_page = (qp_get("page", "") or "").strip() or default_page
+        current_label = PAGE_KEY_TO_LABEL.get(current_page, labels_in_order[0])
 
     st.markdown("**Go to:**")
+
+    try:
+        idx = labels_in_order.index(current_label)
+    except ValueError:
+        idx = 0
+
     selected_label = st.radio(
         label="public_nav",
-        options=labels,
+        options=labels_in_order,
         index=idx,
         horizontal=True,
         label_visibility="collapsed",
         key="public_top_nav_radio",
     )
 
-    selected_key = keys[labels.index(selected_label)]
+    selected_key = LABEL_TO_PAGE_KEY.get(
+        selected_label,
+        qp_get("page", default_page).strip() or default_page,
+    )
 
-    # Keep URL in sync (so links copy/paste nicely)
-    # Note: Streamlit reruns automatically; no need to force a rerun.
     try:
         st.query_params["page"] = selected_key
     except Exception:
         pass
 
-    return selected_key
+    return selected_label

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -15,6 +15,14 @@ from jupr_app.data.load import load_data
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
 from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
 from jupr_app.ui.context import AppContext
+from jupr_app.ui.public_nav import render_public_top_nav
+from jupr_app.ui.page_registry import (
+    ADMIN_ONLY_LABELS,
+    LABEL_TO_PAGE_KEY,
+    PAGE_KEY_TO_LABEL,
+    PUBLIC_NAV_KEYS,
+    labels_for_keys,
+)
 from jupr_app.ui.theme_clean import apply_clean_theme
 from jupr_app.ui.url import qp_get
 
@@ -165,29 +173,6 @@ def hide_sidebar_and_header_for_public():
         "</style>",
         unsafe_allow_html=True,
     )
-
-
-def render_public_top_nav(*, labels_in_order: list[str], current_label: str) -> str:
-    """
-    Public mode top navigation (horizontal radio).
-    Returns the selected label.
-    """
-    st.markdown("**Go to:**")
-
-    try:
-        idx = labels_in_order.index(current_label)
-    except ValueError:
-        idx = 0
-
-    sel = st.radio(
-        label="public_top_nav",
-        options=labels_in_order,
-        index=idx,
-        horizontal=True,
-        key="public_top_nav_radio",
-        label_visibility="collapsed",
-    )
-    return sel
 
 
 def main():
@@ -386,58 +371,6 @@ def main():
             "🗞️ Weekly Recap Admin": weekly_recap_admin,
         }
 
-        PAGE_KEY_TO_LABEL = {
-            "leaderboards": "🏆 Leaderboards",
-            "league_results": "📊 League Results",
-            "league_printout": "🖨️ League Night Printout",
-            "match_explorer": "🎯 Match Explorer",
-            "players": "🔍 Player Search",
-            "badge_codex": "📼 Badge Codex",
-            "badge_debug": "🧪 Badge Debug",
-            "challenge_ladder": "🪜 Challenge Ladder",
-            "faqs": "❓ FAQs",
-            # Admin-only deep links
-            "league_manager": "🏟️ League Manager",
-            "match_uploader": "📝 Match Uploader",
-            "match_log": "📝 Match Log",
-            "player_editor": "👥 Player Editor",
-            "admin_tools": "⚙️ Admin Tools",
-            "admin_guide": "📘 Admin Guide",
-            "challenge_ladder_admin": "🛠️ Challenge Ladder Admin",
-            "moneyball": "💰 Moneyball",
-            "jupr_live": "🔴 JUPR Live",
-            "jupr_live_admin": "🔴 JUPR Live Admin",
-            "theme_qa": "🎨 Theme QA",
-            "tournaments": "🏆 Tournaments",
-            "tournament_manager": "🏆 Tournament Manager",
-            "tournament_registration": "📝 Tournament Registration",
-            "tournament_partner_board": "🤝 Partner Board",
-            "weekly_recap": "🗞️ Weekly Recap",
-            "top_players_printable": "🧾 Top Active Players PDF",
-            # Admin-only deep links
-            "weekly_recap_admin": "🗞️ Weekly Recap Admin",
-        }
-        LABEL_TO_PAGE_KEY = {v: k for k, v in PAGE_KEY_TO_LABEL.items()}
-
-        ADMIN_ONLY_LABELS = {
-            "🖨️ League Night Printout",
-            "🏟️ League Manager",
-            "📝 Match Uploader",
-            "📝 Match Log",
-            "👥 Player Editor",
-            "⚙️ Admin Tools",
-            "📘 Admin Guide",
-            "🛠️ Challenge Ladder Admin",
-            "💰 Moneyball",
-            "🔴 JUPR Live Admin",
-            "🎨 Theme QA",
-            "🏆 Tournaments",
-            "🏆 Tournament Manager",
-            "🧪 Badge Debug",
-            "🗞️ Weekly Recap Admin",
-            "🧾 Top Active Players PDF",
-        }
-
         # Visible labels based on auth
         all_labels = list(PAGES.keys())
         if not admin_logged_in:
@@ -445,23 +378,7 @@ def main():
         else:
             visible_labels = all_labels
 
-        # Public nav order (old UX)
-        PUBLIC_NAV_KEYS = [
-            "leaderboards",
-            "league_results",
-            "weekly_recap",
-            "tournament_registration",
-            "tournament_partner_board",
-            "match_explorer",
-            "players",
-            "badge_codex",
-            "jupr_live",
-            "challenge_ladder",
-            "faqs",
-        ]
-        public_labels_in_order = [
-            PAGE_KEY_TO_LABEL[k] for k in PUBLIC_NAV_KEYS if PAGE_KEY_TO_LABEL.get(k)
-        ]
+        public_labels_in_order = labels_for_keys(PUBLIC_NAV_KEYS)
 
         # -------------------------
         # Deep link resolution

--- a/tests/test_page_registry.py
+++ b/tests/test_page_registry.py
@@ -1,0 +1,37 @@
+from jupr_app.ui.page_registry import (
+    LABEL_TO_PAGE_KEY,
+    PAGE_KEY_TO_LABEL,
+    PUBLIC_NAV_KEYS,
+    labels_for_keys,
+)
+
+
+def test_jupr_live_is_registered_as_public_page():
+    public_labels = labels_for_keys(PUBLIC_NAV_KEYS)
+
+    assert "jupr_live" in PUBLIC_NAV_KEYS
+    assert "jupr_live_admin" not in PUBLIC_NAV_KEYS
+    assert PAGE_KEY_TO_LABEL["jupr_live"] == "🔴 JUPR Live"
+    assert PAGE_KEY_TO_LABEL["jupr_live_admin"] == "🔴 JUPR Live Admin"
+    assert LABEL_TO_PAGE_KEY["🔴 JUPR Live"] == "jupr_live"
+    assert LABEL_TO_PAGE_KEY["🔴 JUPR Live Admin"] == "jupr_live_admin"
+    assert "🔴 JUPR Live" in public_labels
+    assert "🔴 JUPR Live Admin" not in public_labels
+
+
+def test_existing_public_pages_remain_in_shared_public_nav():
+    public_labels = labels_for_keys(PUBLIC_NAV_KEYS)
+
+    assert public_labels == [
+        "🏆 Leaderboards",
+        "📊 League Results",
+        "🗞️ Weekly Recap",
+        "📝 Tournament Registration",
+        "🤝 Partner Board",
+        "🎯 Match Explorer",
+        "🔍 Player Search",
+        "📼 Badge Codex",
+        "🔴 JUPR Live",
+        "🪜 Challenge Ladder",
+        "❓ FAQs",
+    ]


### PR DESCRIPTION
### Motivation
- The public navigation was driven by scattered/local definitions so `JUPR Live` was missing from the public button row despite having a public page implementation. 
- The goal was to make `JUPR Live` a first-class public page while keeping `JUPR Live Admin` admin-only and avoiding admin save controls for public users. 

### Description
- Add a centralized page registry in `jupr_app/ui/page_registry.py` that defines page keys, labels, `public`/`admin_only` flags, slug mappings, and the ordered `PUBLIC_NAV_KEYS`. 
- Wire the public top-nav to the shared registry by updating `jupr_app/ui/public_nav.py` so the public button row and deep-link behavior come from the same source of truth. 
- Update `streamlit_app.py` to consume the shared registry (`PAGE_KEY_TO_LABEL`, `LABEL_TO_PAGE_KEY`, `ADMIN_ONLY_LABELS`, and `PUBLIC_NAV_KEYS`) and use `labels_for_keys` for public nav ordering and admin filtering, removing duplicated in-file mappings. 
- Add regression tests in `tests/test_page_registry.py` to assert `jupr_live` is public, `jupr_live_admin` is not in the public nav, and the public nav ordering includes the existing pages; keep `jupr_app/ui/pages/jupr_live.py` and `jupr_app/ui/pages/jupr_live_admin.py` behavior unchanged so public pages disable official saves and admin page still requires admin login. 
- Files changed: `jupr_app/ui/page_registry.py`, `jupr_app/ui/public_nav.py`, `streamlit_app.py`, and `tests/test_page_registry.py`.

### Testing
- Ran `pytest tests/test_imports.py tests/test_page_registry.py` and all tests passed. 
- Ran `python -m compileall streamlit_app.py jupr_app/ui/public_nav.py jupr_app/ui/page_registry.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb2af8b3a483268c756744ba1a2a59)