### PR TITLE
Make live ladder week list dynamic from league schedule config

### DIFF
--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -171,6 +171,21 @@ def _extract_court_board_defaults(meta_row: dict | None) -> dict:
     }
 
 
+def _league_week_options(meta_row: dict | None, default_weeks: int = 20) -> list[str]:
+    max_weeks = default_weeks
+    schedule_cfg = _safe_json_load((meta_row or {}).get("schedule_config"), {}) or {}
+    if isinstance(schedule_cfg, dict):
+        try:
+            parsed_weeks = int(schedule_cfg.get("weeks"))
+        except Exception:
+            parsed_weeks = None
+        if parsed_weeks is not None and parsed_weeks > 0:
+            max_weeks = parsed_weeks
+    if max_weeks < 1:
+        max_weeks = default_weeks
+    return [f"Week {i}" for i in range(1, max_weeks + 1)] + ["Playoffs"]
+
+
 def _seed_rating_for_player(pid: int, league_name: str, df_players_all: pd.DataFrame, df_leagues: pd.DataFrame) -> float:
     # League rating if exists, else overall
     if df_leagues is not None and not df_leagues.empty:
@@ -279,7 +294,7 @@ def render(ctx):
                     value=int(st.session_state.get("ladder_game_format_time", 15)),
                     key="ladder_game_format_time",
                 )
-            week_select = st.selectbox("Week", [f"Week {i}" for i in range(1, 13)] + ["Playoffs"], key="ladder_wk")
+            week_select = st.selectbox("Week", _league_week_options(meta_row), key="ladder_wk")
             num_rounds = st.number_input(
                 "Total Rounds to Play",
                 1, 20,


### PR DESCRIPTION
### Motivation
- Replace the hardcoded Week 1–12 dropdown with a dynamic weeks list derived from a league's schedule so leagues with different lengths are supported while preserving the existing Playoffs option.

### Description
- Added `_league_week_options(meta_row: dict | None, default_weeks: int = 20)` which safely reads `schedule_config` (supports dict or JSON string via `_safe_json_load`), coerces `weeks` to an integer with guardrails (minimum valid value 1), falls back to `default_weeks` when missing/invalid, and returns `["Week 1".."Week N"] + ["Playoffs"]`, and replaced the hardcoded selectbox with `st.selectbox("Week", _league_week_options(meta_row), key="ladder_wk")` preserving the `key` and Playoffs behavior.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/league_manager.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c97e9c982883269c1133e1b6f856b8)