### PR TITLE
Deduplicate matches in weekly recap to prevent double-counting

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -196,7 +196,8 @@ def _load_matches(
             frames.append(in_range)
 
     if supabase is None:
-        return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+        combined = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+        return _dedupe_matches(combined)
 
     select_cols = [
         "id",
@@ -231,8 +232,53 @@ def _load_matches(
         .lte("date", end_dt.isoformat())
     )
     frames.append(pd.DataFrame(response.data or []))
+    combined = pd.concat([df for df in frames if not df.empty], ignore_index=True) if frames else pd.DataFrame()
+    return _dedupe_matches(combined)
 
-    return pd.concat([df for df in frames if not df.empty], ignore_index=True) if frames else pd.DataFrame()
+
+def _dedupe_matches(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty:
+        return pd.DataFrame() if df is None else df
+
+    deduped = df.copy()
+    if "id" in deduped.columns:
+        id_str = deduped["id"].astype("string").str.strip()
+        has_id = id_str.notna() & (id_str != "")
+        with_id = deduped.loc[has_id].copy()
+        without_id = deduped.loc[~has_id].copy()
+        if not with_id.empty:
+            with_id.loc[:, "id"] = id_str.loc[has_id]
+            with_id = with_id.drop_duplicates(subset=["id"], keep="last")
+    else:
+        with_id = deduped.iloc[0:0].copy()
+        without_id = deduped.copy()
+
+    fallback_cols = [
+        "date",
+        "league",
+        "match_type",
+        "week_tag",
+        "t1_p1",
+        "t1_p2",
+        "t2_p1",
+        "t2_p2",
+        "score_t1",
+        "score_t2",
+    ]
+    available_cols = [col for col in fallback_cols if col in without_id.columns]
+    if available_cols and not without_id.empty:
+        # Local + Supabase loading can overlap for the same date range; dedupe keeps recap stats deterministic.
+        fallback_key = (
+            without_id[available_cols]
+            .astype("string")
+            .fillna("")
+            .agg("|".join, axis=1)
+        )
+        without_id = without_id.assign(_fallback_key=fallback_key).drop_duplicates(
+            subset=["_fallback_key"], keep="last"
+        ).drop(columns=["_fallback_key"])
+
+    return pd.concat([with_id, without_id], ignore_index=True)
 
 
 


### PR DESCRIPTION
### Motivation
- The weekly recap could double-count matches because local `ctx.df_matches` rows and Supabase query results were concatenated without deduplication, causing inflated player records and numbers.

### Description
- Added a `_dedupe_matches(df: pd.DataFrame) -> pd.DataFrame` helper that normalizes `id` to a trimmed string and drops duplicates by `id` (keeping the last row).
- For rows missing or blank `id`, the helper builds a fallback composite key from `date, league, match_type, week_tag, t1_p1, t1_p2, t2_p1, t2_p2, score_t1, score_t2` and drops duplicates by that key (keeping the last row).
- Updated `_load_matches()` to run the combined dataframe through `_dedupe_matches()` on both the `supabase is None` path and the Supabase-loaded path while preserving existing date filtering and all columns.
- Added a short inline comment explaining that local and Supabase sources can overlap and deduplication is necessary so recap stats remain deterministic.

### Testing
- Ran `python -m compileall jupr_app/domain/recaps/weekly_recap.py` which completed successfully.
- Searched for other raw concatenation points with `rg "pd\.concat|concat\(" jupr_app/domain/recaps/weekly_recap.py` and verified `_load_matches()` was the concatenation site and is now routed through the dedupe helper.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c99039d93c83269a5e3a73bb7ecbad)