### PR TITLE
Add admin club_people linking tools and exact-match auto-linking

### DIFF
--- a/jupr_app/domain/live_social.py
+++ b/jupr_app/domain/live_social.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import uuid4
 
+import pandas as pd
+
 from jupr_app.domain.live_beta_engine import normalize_name, round_robin_standings
 
 
@@ -25,6 +27,152 @@ def _normalized_name_to_player_id(name_to_id: dict[object, object]) -> dict[str,
             continue
         result[key] = int(raw_id)
     return result
+
+
+def normalized_player_name_map(df_players_all: pd.DataFrame | None) -> dict[str, list[dict[str, object]]]:
+    result: dict[str, list[dict[str, object]]] = {}
+    if df_players_all is None or df_players_all.empty:
+        return result
+    for _, row in df_players_all.iterrows():
+        player_id = row.get("id")
+        if pd.isna(player_id):
+            continue
+        normalized = normalize_person_name(row.get("name"))
+        if not normalized:
+            continue
+        result.setdefault(normalized, []).append(
+            {
+                "id": int(player_id),
+                "name": str(row.get("name") or "").strip(),
+            }
+        )
+    return result
+
+
+def find_exact_player_link_candidates(
+    club_people_rows: list[dict],
+    player_name_map: dict[str, list[dict[str, object]]],
+) -> dict[str, int]:
+    matches: dict[str, int] = {}
+    for row in club_people_rows or []:
+        if row.get("linked_player_id") is not None:
+            continue
+        club_person_id = row.get("id")
+        if club_person_id is None:
+            continue
+        normalized = normalize_person_name(row.get("normalized_name") or row.get("display_name"))
+        candidates = player_name_map.get(normalized, [])
+        if len(candidates) == 1:
+            matches[str(club_person_id)] = int(candidates[0]["id"])
+    return matches
+
+
+def auto_link_exact_matches(
+    supabase,
+    *,
+    club_id: str,
+    club_people_rows: list[dict],
+    df_players_all: pd.DataFrame | None,
+) -> dict[str, int]:
+    player_map = normalized_player_name_map(df_players_all)
+    candidates = find_exact_player_link_candidates(club_people_rows, player_map)
+    linked_count = 0
+    for club_person_id, player_id in candidates.items():
+        supabase.table("club_people").update({"linked_player_id": int(player_id)}).eq("club_id", club_id).eq(
+            "id", club_person_id
+        ).execute()
+        linked_count += 1
+    return {
+        "linked_count": linked_count,
+        "candidate_count": len(candidates),
+        "skipped_count": max(0, len(club_people_rows or []) - len(candidates)),
+    }
+
+
+def social_person_rollup_rows(supabase, club_id: str) -> list[dict]:
+    club_people = (
+        supabase.table("club_people")
+        .select("id,display_name,normalized_name,linked_player_id,first_seen_on,last_seen_on")
+        .eq("club_id", club_id)
+        .order("last_seen_on", desc=True)
+        .execute()
+        .data
+        or []
+    )
+    if not club_people:
+        return []
+
+    cp_ids = [str(row["id"]) for row in club_people if row.get("id")]
+    participants = (
+        supabase.table("live_event_participants")
+        .select("id,event_id,club_person_id")
+        .in_("club_person_id", cp_ids)
+        .execute()
+        .data
+        or []
+    )
+    participant_ids = [str(row["id"]) for row in participants if row.get("id")]
+    matches = []
+    if participant_ids:
+        matches = (
+            supabase.table("live_event_matches")
+            .select(
+                "id,t1_p1_participant_id,t1_p2_participant_id,t2_p1_participant_id,t2_p2_participant_id,score_t1,score_t2"
+            )
+            .or_(
+                ",".join(
+                    [
+                        f"t1_p1_participant_id.in.({','.join(participant_ids)})",
+                        f"t1_p2_participant_id.in.({','.join(participant_ids)})",
+                        f"t2_p1_participant_id.in.({','.join(participant_ids)})",
+                        f"t2_p2_participant_id.in.({','.join(participant_ids)})",
+                    ]
+                )
+            )
+            .execute()
+            .data
+            or []
+        )
+
+    participant_to_person = {
+        str(row["id"]): str(row["club_person_id"])
+        for row in participants
+        if row.get("id") and row.get("club_person_id")
+    }
+    event_sets: dict[str, set[str]] = {str(cp["id"]): set() for cp in club_people if cp.get("id")}
+    for row in participants:
+        cp_id = str(row.get("club_person_id") or "")
+        event_id = str(row.get("event_id") or "")
+        if cp_id and event_id:
+            event_sets.setdefault(cp_id, set()).add(event_id)
+
+    match_counts: dict[str, int] = {str(cp["id"]): 0 for cp in club_people if cp.get("id")}
+    for row in matches:
+        scored = (int(row.get("score_t1") or 0) + int(row.get("score_t2") or 0)) > 0
+        if not scored:
+            continue
+        seen_people: set[str] = set()
+        for key in ("t1_p1_participant_id", "t1_p2_participant_id", "t2_p1_participant_id", "t2_p2_participant_id"):
+            participant_id = str(row.get(key) or "")
+            cp_id = participant_to_person.get(participant_id)
+            if cp_id:
+                seen_people.add(cp_id)
+        for cp_id in seen_people:
+            match_counts[cp_id] = match_counts.get(cp_id, 0) + 1
+
+    rows: list[dict] = []
+    for cp in club_people:
+        cp_id = str(cp.get("id") or "")
+        if not cp_id:
+            continue
+        rows.append(
+            {
+                **cp,
+                "social_event_count": len(event_sets.get(cp_id, set())),
+                "social_match_count": int(match_counts.get(cp_id, 0)),
+            }
+        )
+    return rows
 
 
 def resolve_or_create_club_person(

--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -4,6 +4,7 @@ import time
 from datetime import datetime, timezone
 
 from jupr_app.ui.layout import page_shell
+from jupr_app.domain.live_social import auto_link_exact_matches, social_person_rollup_rows
 from jupr_app.domain.player_ops import safe_add_player
 
 def render(ctx):
@@ -249,3 +250,99 @@ def render(ctx):
         st.success("Merge completed. Now run Admin Tools → Replay History → ALL.")
         time.sleep(0.4)
         st.rerun()
+
+    st.divider()
+
+    # -------------------------
+    # Social Identity Linking
+    # -------------------------
+    st.subheader("🧩 Social Identity Linking")
+    st.caption("Review club_people rows and explicitly link social-only identities to existing players.")
+
+    rollup_rows = social_person_rollup_rows(supabase, club_id)
+    if not rollup_rows:
+        st.info("No social club_people rows found yet.")
+        return
+
+    id_to_player = {}
+    player_options = []
+    for _, player in df_players_all.sort_values(by=["name"]).iterrows():
+        pid = int(player["id"])
+        label = f"{str(player.get('name') or '').strip()} (#{pid})"
+        player_options.append(label)
+        id_to_player[label] = pid
+
+    c1, c2 = st.columns([1, 2])
+    with c1:
+        if st.button("Auto-link exact matches", key="club_people_auto_link_exact"):
+            result = auto_link_exact_matches(
+                supabase,
+                club_id=club_id,
+                club_people_rows=rollup_rows,
+                df_players_all=df_players_all,
+            )
+            st.success(
+                f"Linked {result['linked_count']} rows. "
+                f"Skipped {result['skipped_count']} (already linked, unmatched, or ambiguous)."
+            )
+            time.sleep(0.2)
+            st.rerun()
+    with c2:
+        st.caption("Auto-link only applies exact normalized-name matches with one unique player candidate.")
+
+    table_df = pd.DataFrame(rollup_rows)
+    if not table_df.empty:
+        table_df = table_df.rename(
+            columns={
+                "linked_player_id": "linked_player_id",
+                "first_seen_on": "first_seen_on",
+                "last_seen_on": "last_seen_on",
+                "social_event_count": "social_event_count",
+                "social_match_count": "social_match_count",
+            }
+        )
+        st.dataframe(
+            table_df[
+                [
+                    "display_name",
+                    "normalized_name",
+                    "linked_player_id",
+                    "first_seen_on",
+                    "last_seen_on",
+                    "social_event_count",
+                    "social_match_count",
+                ]
+            ],
+            use_container_width=True,
+            hide_index=True,
+        )
+
+    unlinked_rows = [row for row in rollup_rows if row.get("linked_player_id") in (None, "")]
+    if not unlinked_rows:
+        st.success("All club_people rows are linked.")
+        return
+
+    st.markdown("#### Manual link controls (unlinked only)")
+    for row in unlinked_rows:
+        person_id = str(row.get("id"))
+        name = str(row.get("display_name") or "Unknown")
+        with st.form(f"manual_link_{person_id}"):
+            st.write(f"**{name}**  \nNormalized: `{row.get('normalized_name') or ''}`")
+            selection = st.selectbox(
+                "Link to player",
+                options=[""] + player_options,
+                index=0,
+                key=f"manual_link_pick_{person_id}",
+            )
+            submitted = st.form_submit_button("Save Link")
+            if submitted:
+                if not selection:
+                    st.warning("Pick a player before saving.")
+                else:
+                    player_id = int(id_to_player[selection])
+                    supabase.table("club_people").update({"linked_player_id": player_id}).eq("club_id", club_id).eq(
+                        "id", person_id
+                    ).execute()
+                    st.success(f"Linked {name} to {selection}.")
+                    time.sleep(0.2)
+                    st.rerun()

--- a/tests/test_live_social.py
+++ b/tests/test_live_social.py
@@ -4,10 +4,15 @@ from dataclasses import dataclass
 from uuid import uuid4
 
 from jupr_app.domain.live_social import (
+    auto_link_exact_matches,
+    find_exact_player_link_candidates,
+    normalized_player_name_map,
     resolve_or_create_club_person,
     save_social_round_robin,
+    social_person_rollup_rows,
     social_round_robin_match_rows_from_event,
 )
+import pandas as pd
 
 
 class _Resp:
@@ -29,6 +34,17 @@ class _TableQuery:
 
     def eq(self, key: str, value: object):
         self._filters.append((key, value))
+        return self
+
+    def in_(self, key: str, values: list[object]):
+        self._filters.append((key, ("__in__", set(values))))
+        return self
+
+    def order(self, _key: str, desc: bool = False):
+        self._order = (_key, desc)
+        return self
+
+    def or_(self, _expr: str):
         return self
 
     def insert(self, payload):
@@ -53,7 +69,14 @@ class _TableQuery:
     def _filtered(self) -> list[dict]:
         rows = list(self.store.setdefault(self.name, []))
         for key, value in self._filters:
-            rows = [row for row in rows if row.get(key) == value]
+            if isinstance(value, tuple) and value and value[0] == "__in__":
+                rows = [row for row in rows if row.get(key) in value[1]]
+            else:
+                rows = [row for row in rows if row.get(key) == value]
+        order = getattr(self, "_order", None)
+        if order:
+            key, desc = order
+            rows = sorted(rows, key=lambda r: str(r.get(key) or ""), reverse=bool(desc))
         return rows
 
     def execute(self):
@@ -215,3 +238,73 @@ def test_resave_replaces_children_instead_of_duplicating():
     assert len(participants) == 4
     assert len(matches) == 1
     assert matches[0]["score_t2"] == 2
+
+
+def test_exact_match_auto_link_only_links_unambiguous_matches():
+    players = pd.DataFrame(
+        [
+            {"id": 10, "name": "Alice"},
+            {"id": 11, "name": "Bob"},
+        ]
+    )
+    club_people = [
+        {"id": "cp-1", "display_name": "Alice", "normalized_name": "alice", "linked_player_id": None},
+        {"id": "cp-2", "display_name": "No Match", "normalized_name": "no match", "linked_player_id": None},
+    ]
+    player_map = normalized_player_name_map(players)
+    matches = find_exact_player_link_candidates(club_people, player_map)
+    assert matches == {"cp-1": 10}
+
+
+def test_exact_match_auto_link_skips_ambiguous_same_names():
+    players = pd.DataFrame(
+        [
+            {"id": 10, "name": "Sam"},
+            {"id": 11, "name": "Sam"},
+        ]
+    )
+    club_people = [{"id": "cp-1", "display_name": "Sam", "normalized_name": "sam", "linked_player_id": None}]
+    player_map = normalized_player_name_map(players)
+    matches = find_exact_player_link_candidates(club_people, player_map)
+    assert matches == {}
+
+
+def test_auto_link_exact_matches_updates_database_rows():
+    supabase = _FakeSupabase()
+    supabase.store["club_people"] = [
+        {"id": "cp-1", "club_id": "club-1", "display_name": "Alice", "normalized_name": "alice", "linked_player_id": None}
+    ]
+    players = pd.DataFrame([{"id": 10, "name": "Alice"}])
+    result = auto_link_exact_matches(
+        supabase,
+        club_id="club-1",
+        club_people_rows=supabase.store["club_people"],
+        df_players_all=players,
+    )
+    assert result["linked_count"] == 1
+    assert supabase.store["club_people"][0]["linked_player_id"] == 10
+
+
+def test_social_person_rollup_rows_counts_events_and_matches():
+    supabase = _FakeSupabase()
+    supabase.store["club_people"] = [
+        {"id": "cp-1", "club_id": "club-1", "display_name": "Alice", "normalized_name": "alice", "linked_player_id": None},
+    ]
+    supabase.store["live_event_participants"] = [
+        {"id": "p-1", "event_id": "evt-1", "club_person_id": "cp-1"},
+        {"id": "p-2", "event_id": "evt-2", "club_person_id": "cp-1"},
+    ]
+    supabase.store["live_event_matches"] = [
+        {
+            "id": "m-1",
+            "t1_p1_participant_id": "p-1",
+            "t1_p2_participant_id": "p-1",
+            "t2_p1_participant_id": "p-1",
+            "t2_p2_participant_id": "p-1",
+            "score_t1": 11,
+            "score_t2": 8,
+        }
+    ]
+    rows = social_person_rollup_rows(supabase, "club-1")
+    assert rows[0]["social_event_count"] == 2
+    assert rows[0]["social_match_count"] == 1

--- a/tests/test_page_registry.py
+++ b/tests/test_page_registry.py
@@ -39,3 +39,10 @@ def test_existing_public_pages_remain_in_shared_public_nav():
         "🪜 Challenge Ladder",
         "❓ FAQs",
     ]
+
+
+def test_player_editor_remains_admin_only():
+    public_labels = labels_for_keys(PUBLIC_NAV_KEYS)
+    assert "player_editor" not in PUBLIC_NAV_KEYS
+    assert PAGE_KEY_TO_LABEL["player_editor"] == "👥 Player Editor"
+    assert "👥 Player Editor" not in public_labels

--- a/tests/test_weekly_recap_social.py
+++ b/tests/test_weekly_recap_social.py
@@ -42,6 +42,7 @@ def test_social_spotlight_candidates_rank_correctly():
 def test_linked_player_identity_dedupes_total_players():
     social_stats, _, social_meta = _compute_social_stats(_social_fixture(), {10: "Alex Linked"})
     assert social_stats[("player", 10)]["display_name"] == "Alex Linked"
+    assert ("person", "cp-a") not in social_stats
 
     numbers = _build_numbers(
         df_week=pd.DataFrame([{"id": 1}]),


### PR DESCRIPTION
### Motivation
- Provide admin tooling to keep social/community identities hygienic without requiring user accounts by linking social-only `club_people` rows to canonical competitive `players` when appropriate.
- Ensure weekly recaps and future reports canonicalize social identities to the linked player when available so counts and spotlight items do not double-count duplicates.

### Description
- Added helper utilities in `jupr_app/domain/live_social.py`: `normalized_player_name_map`, `find_exact_player_link_candidates`, `auto_link_exact_matches`, and `social_person_rollup_rows` to discover exact unambiguous matches and produce review rows including social event/match counts.
- Added an admin-only "Social Identity Linking" section to `jupr_app/ui/pages/player_editor.py` that displays a review table (`display_name`, `normalized_name`, `linked_player_id`, `first_seen_on`, `last_seen_on`, `social_event_count`, `social_match_count`), an explicit `Auto-link exact matches` button, and per-person manual link controls wrapped in `st.form` with a `Save Link` button (no auto-save on select change).
- Preserved canonicalization-on-read behavior for weekly recap paths so `linked_player_id` is preferred when present and historical social rows are not destructively rewritten.
- Added unit tests and small test harness enhancements to validate exact-match linking, ambiguous-name skipping, social rollups, and admin-only page visibility.

### Testing
- Ran targeted pytest: `pytest -q tests/test_live_social.py tests/test_weekly_recap_social.py tests/test_page_registry.py` and all tests passed (`14 passed`).
- New/updated tests include assertions that auto-link only links unambiguous exact matches, ambiguous same-name candidates are skipped, recap canonicalization prefers linked player identity, social rollup counts are computed, and the player editor remains admin-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9a2efc0bc83269ba2a8dbb07c9a73)