### PR TITLE
Align public-shell JUPR Live behavior with guest flow

### DIFF
--- a/jupr_app/ui/public_nav.py
+++ b/jupr_app/ui/public_nav.py
@@ -2,11 +2,7 @@ from __future__ import annotations
 
 import streamlit as st
 
-from jupr_app.ui.page_registry import (
-    LABEL_TO_PAGE_KEY,
-    PAGE_KEY_TO_LABEL,
-    PUBLIC_NAV_KEYS,
-)
+from jupr_app.ui.page_registry import PAGE_KEY_TO_LABEL, PUBLIC_NAV_KEYS
 from jupr_app.ui.url import qp_get
 
 
@@ -50,15 +46,5 @@ def render_public_top_nav(
         label_visibility="collapsed",
         key="public_top_nav_radio",
     )
-
-    selected_key = LABEL_TO_PAGE_KEY.get(
-        selected_label,
-        qp_get("page", default_page).strip() or default_page,
-    )
-
-    try:
-        st.query_params["page"] = selected_key
-    except Exception:
-        pass
 
     return selected_label

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -438,9 +438,15 @@ def main():
         # Keep URL synced (canonical deep links)
         # -------------------------
         try:
-            st.query_params["page"] = LABEL_TO_PAGE_KEY.get(sel, "leaderboards")
+            target_page = LABEL_TO_PAGE_KEY.get(sel, "leaderboards")
+            current_page = qp_get("page", "").strip()
+            if current_page != target_page:
+                st.query_params["page"] = target_page
+
+            current_public = qp_get("public", "").strip().lower()
             if PUBLIC_MODE:
-                st.query_params["public"] = "1"
+                if current_public != "1":
+                    st.query_params["public"] = "1"
             else:
                 if "public" in st.query_params:
                     st.query_params.pop("public", None)


### PR DESCRIPTION
### Motivation
- Public JUPR Live was behaving differently from the non-public guest flow due to navigation/query-parameter writes from multiple places which could trigger extra reruns and session-state churn. 
- The goal is to preserve the public shell UI while making `?public=1&page=jupr_live` operate identically to the guest-side JUPR Live experience (same mode selector, event creation, scoring, progression, and session persistence) without exposing admin-only features.

### Description
- Stop mutating `st.query_params` inside the public navigation component by removing query-param writes from `render_public_top_nav`, so the nav only returns the selected label. 
- Update the app-level URL sync in `streamlit_app.py` to set `page` and `public` query parameters only when the values actually differ, preventing unnecessary query-param writes on every rerun. 
- Preserve sticky `public=1` in public mode and keep admin-only features gated by existing admin checks. 
- Files changed: `streamlit_app.py`, `jupr_app/ui/public_nav.py`.

### Testing
- Compiled the modified files with `python -m compileall streamlit_app.py jupr_app/ui/public_nav.py` and the compilation succeeded. 
- Inspected diffs to confirm only query-param/nav handling was changed and no JUPR Live renderer logic was modified. 
- No automated UI tests available; manual acceptance steps recommended (open `/?public=1&page=jupr_live`, create Quick Session, enter names, score matches, progress rounds) to validate behavior matches guest-side flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf2dffc2483269ebfa3d15c57606e)