### PR TITLE
Fix text contrast for JUPR Live scoring cards

### DIFF
--- a/jupr_app/ui/live/shared.py
+++ b/jupr_app/ui/live/shared.py
@@ -130,10 +130,11 @@ def inject_styles() -> None:
             border-radius: 18px;
             padding: 0.9rem 1rem;
             background: #fff;
+            color: #0f172a;
             margin-bottom: 0.9rem;
         }
-        .jupr-live-team { font-weight: 700; font-size: 1rem; }
-        .jupr-live-vs { text-align: center; font-size: 0.9rem; font-weight: 700; color: #64748b; margin-top: 1.9rem; }
+        .jupr-live-team { color: #0f172a; font-weight: 700; font-size: 1rem; }
+        .jupr-live-vs { text-align: center; font-size: 0.9rem; font-weight: 700; color: #475569; margin-top: 1.9rem; }
         .jupr-live-actions button[kind="primary"] {
             min-height: 3rem;
             font-weight: 700;
@@ -152,10 +153,11 @@ def inject_styles() -> None:
             font-size: 0.72rem;
             text-transform: uppercase;
             letter-spacing: 0.06em;
-            color: #64748b;
+            color: #475569;
             margin-bottom: 0.15rem;
         }
         .jupr-live-slot-name {
+            color: #0f172a;
             font-weight: 700;
             font-size: 0.98rem;
             line-height: 1.3;


### PR DESCRIPTION
### Motivation
- Player names and key scoring text on the public JUPR Live page were inheriting low-contrast shell/theme colors and became hard to read, so the live scoring UI needs explicit readable text colors.

### Description
- Updated `inject_styles()` in `jupr_app/ui/live/shared.py` to force explicit readable text colors for live scoring elements and keep layout unchanged.
- Changed/added color rules for `.jupr-live-score-shell`, `.jupr-live-team`, and `.jupr-live-slot-name` to `#0f172a`, and adjusted `.jupr-live-slot-label` and `.jupr-live-vs` to a muted readable `#475569` so important text does not rely on inherited theme colors.
- No skill file was used for this change because it is a small, targeted CSS edit inside an existing UI file.

### Testing
- Ran `python -m compileall jupr_app/ui/live/shared.py` and compilation succeeded without errors.
- Verified the diff contains styling-only changes and no event/save/update logic was modified by reviewing the updated `jupr_app/ui/live/shared.py` file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf9a94f6c83269ad58dc389aac784)