### PR TITLE
Add Club Social skill-level tagging and Weekly Recap skill-bucket rollups

### DIFF
--- a/jupr_app/domain/live_social.py
+++ b/jupr_app/domain/live_social.py
@@ -13,6 +13,27 @@ from jupr_app.domain.live_beta_engine import (
     round_robin_standings,
 )
 
+SOCIAL_SKILL_LEVEL_OPTIONS = ["2.5", "3.0", "3.5", "4.0", "4.5", "5.0", "All"]
+
+
+def normalize_skill_levels(values: object) -> list[str]:
+    if isinstance(values, str):
+        raw_values = [values]
+    elif isinstance(values, (list, tuple, set)):
+        raw_values = list(values)
+    else:
+        raw_values = []
+    normalized: list[str] = []
+    for value in raw_values:
+        text = str(value or "").strip()
+        if not text:
+            continue
+        if text in SOCIAL_SKILL_LEVEL_OPTIONS and text not in normalized:
+            normalized.append(text)
+    if "All" in normalized:
+        return ["All"]
+    return normalized or ["All"]
+
 
 def normalize_person_name(value: object) -> str:
     return normalize_name(value).casefold()
@@ -355,7 +376,7 @@ def social_league_match_rows_from_event(event: dict) -> list[dict]:
     return rows
 
 
-def build_social_event_summary(event: dict, *, match_count: int) -> dict:
+def build_social_event_summary(event: dict, *, match_count: int, skill_levels: list[str] | None = None) -> dict:
     event_type = str(event.get("type") or "")
     standings = (
         round_robin_standings(event)
@@ -368,6 +389,7 @@ def build_social_event_summary(event: dict, *, match_count: int) -> dict:
         "match_count": int(match_count),
         "event_type": event_type,
         "schedule_mode": str(event.get("scheduleMode") or ""),
+        "skill_levels": normalize_skill_levels(skill_levels if skill_levels is not None else event.get("skill_levels")),
         "leader": (
             {
                 "name": leader.get("name"),
@@ -418,6 +440,7 @@ def save_social_live_event(
     target_club_id: str,
     submission_mode: str,
     host_name: str,
+    skill_levels: object = None,
 ) -> dict:
     event_type = str(event.get("type") or "")
     if event_type not in {"round_robin", "league"}:
@@ -459,7 +482,12 @@ def save_social_live_event(
         if event_type == "round_robin"
         else social_league_match_rows_from_event(event)
     )
-    summary_json = build_social_event_summary(event, match_count=len(match_rows))
+    normalized_skill_levels = normalize_skill_levels(skill_levels if skill_levels is not None else event.get("skill_levels"))
+    summary_json = build_social_event_summary(
+        event,
+        match_count=len(match_rows),
+        skill_levels=normalized_skill_levels,
+    )
     normalized_submission_mode = str(submission_mode or "").strip().lower() or "public"
     status = _status_for_submission_mode(normalized_submission_mode)
     submitted_by = normalize_name(host_name) or ("admin" if status == "saved" else "guest")
@@ -479,7 +507,7 @@ def save_social_live_event(
         "moderated_at": moderated_at,
         "moderated_by": moderated_by,
         "rejection_reason": None,
-        "raw_event_json": event,
+        "raw_event_json": {**event, "skill_levels": normalized_skill_levels},
         "summary_json": summary_json,
     }
 

--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -46,6 +46,7 @@ RECAP_CATEGORY_CONFIG = {
     "TOP_PERFORMER": {"label": "Top Performer", "max_featured": MAX_FEATURED_PER_CATEGORY},
     "BIGGEST_JUMP": {"label": "Biggest Jump", "max_featured": MAX_FEATURED_PER_CATEGORY},
 }
+SOCIAL_SKILL_BUCKETS = ("2.5", "3.0", "3.5", "4.0", "4.5", "5.0", "All")
 
 
 def normalize_date_range(start_date: date, end_date: date) -> tuple[date, date]:
@@ -140,6 +141,21 @@ def _social_display_name(row: dict, id_to_name: dict[int, str]) -> str:
     return str(row.get("display_name_snapshot") or "Community Player").strip() or "Community Player"
 
 
+def social_event_skill_levels(event_row: dict) -> list[str]:
+    summary_json = event_row.get("summary_json") if isinstance(event_row, dict) else None
+    raw_values = summary_json.get("skill_levels") if isinstance(summary_json, dict) else None
+    values: list[str] = []
+    if isinstance(raw_values, str):
+        values = [raw_values]
+    elif isinstance(raw_values, (list, tuple, set)):
+        values = [str(item or "").strip() for item in raw_values]
+    normalized = [item for item in values if item in SOCIAL_SKILL_BUCKETS]
+    if "All" in normalized:
+        return ["All"]
+    normalized_specific = [item for item in normalized if item != "All"]
+    return normalized_specific or ["All"]
+
+
 def _compute_weekly_recap_payload(
     ctx,
     start_date: date,
@@ -175,7 +191,7 @@ def _compute_weekly_recap_payload(
     )
 
     social_data = _load_social_live_data(supabase, club_id, start_date, end_date)
-    social_stats, social_event_stats, social_meta = _compute_social_stats(social_data, id_to_name)
+    social_stats, social_skill_stats, social_meta = _compute_social_stats(social_data, id_to_name)
 
     spotlight_candidates = _build_spotlight_candidates(
         stats, giant_slayer_candidates, id_to_name
@@ -202,7 +218,7 @@ def _compute_weekly_recap_payload(
         id_to_name,
         supabase,
     )
-    community_events = _build_social_around_club(social_event_stats, social_meta["events"])
+    community_events = _build_social_around_club(social_skill_stats)
     around_club["community_events"] = community_events
     around_club["social_round_robins"] = community_events
 
@@ -241,7 +257,7 @@ def _load_social_live_data(supabase, club_id: str, start_date: date, end_date: d
 
     events_response = safe_execute(
         supabase.table("live_events")
-        .select("id,name,event_type,event_date,status,result_mode")
+        .select("id,name,event_type,event_date,status,result_mode,summary_json")
         .eq("club_id", club_id)
         .eq("result_mode", "social_unrated")
         .eq("status", "saved")
@@ -279,9 +295,9 @@ def _compute_social_stats(social_data: dict, id_to_name: dict[int, str]) -> tupl
     participant_lookup = {str(row.get("id")): row for row in participants if row.get("id")}
 
     stats: dict[tuple[str, int | str], dict] = {}
-    event_stats: dict[str, dict[tuple[str, int | str], dict]] = {}
+    skill_stats: dict[str, dict[tuple[str, int | str], dict]] = {}
 
-    def ensure_identity(identity: tuple[str, int | str], display_name: str, event_id: str) -> dict:
+    def ensure_identity(identity: tuple[str, int | str], display_name: str, event_id: str) -> None:
         if identity not in stats:
             stats[identity] = {
                 "identity": identity,
@@ -296,24 +312,25 @@ def _compute_social_stats(social_data: dict, id_to_name: dict[int, str]) -> tupl
             }
         stats[identity]["event_ids"].add(event_id)
 
-        by_event = event_stats.setdefault(event_id, {})
-        if identity not in by_event:
-            by_event[identity] = {
-                "identity": identity,
-                "display_name": display_name,
-                "games": 0,
-                "wins": 0,
-                "losses": 0,
-                "points_for": 0,
-                "points_against": 0,
-                "differential": 0,
-            }
-        return by_event[identity]
-
     def apply_match(identity: tuple[str, int | str], display_name: str, *, event_id: str, won: bool, pf: int, pa: int) -> None:
         overall = stats[identity]
-        per_event = ensure_identity(identity, display_name, event_id)
-        for target in (overall, per_event):
+        ensure_identity(identity, display_name, event_id)
+        event_levels = social_event_skill_levels(event_lookup.get(event_id, {}))
+        target_skill_levels = ["All"] if event_levels == ["All"] else [level for level in event_levels if level != "All"]
+        for skill_level in target_skill_levels:
+            by_skill = skill_stats.setdefault(skill_level, {})
+            if identity not in by_skill:
+                by_skill[identity] = {
+                    "identity": identity,
+                    "display_name": display_name,
+                    "games": 0,
+                    "wins": 0,
+                    "losses": 0,
+                    "points_for": 0,
+                    "points_against": 0,
+                    "differential": 0,
+                }
+        for target in [overall] + [skill_stats[level][identity] for level in target_skill_levels]:
             target["games"] += 1
             target["wins"] += int(bool(won))
             target["losses"] += int(not won)
@@ -353,7 +370,7 @@ def _compute_social_stats(social_data: dict, id_to_name: dict[int, str]) -> tupl
                 apply_match(identity, display_name, event_id=event_id, won=not team1_won, pf=s2, pa=s1)
 
     canonical_identities = set(stats.keys())
-    return stats, event_stats, {
+    return stats, skill_stats, {
         "events": event_lookup,
         "social_match_count": int(sum(1 for row in matches if (_safe_int(row.get("score_t1")) or 0) + (_safe_int(row.get("score_t2")) or 0) > 0)),
         "social_event_count": len(event_lookup),
@@ -423,13 +440,13 @@ def _build_social_spotlight_candidates(social_stats: dict[tuple[str, int | str],
     return candidates
 
 
-def _build_social_around_club(social_event_stats: dict[str, dict], events: dict[str, dict]) -> list[dict]:
+def _build_social_around_club(social_skill_stats: dict[str, dict]) -> list[dict]:
     rows: list[dict] = []
-    for event_id, event_players in sorted(
-        social_event_stats.items(),
-        key=lambda item: (str(events.get(item[0], {}).get("event_date") or ""), str(events.get(item[0], {}).get("name") or "")),
-    ):
-        candidates = _build_social_spotlight_candidates(event_players)
+    for skill_level in SOCIAL_SKILL_BUCKETS:
+        skill_players = social_skill_stats.get(skill_level) or {}
+        if not skill_players:
+            continue
+        candidates = _build_social_spotlight_candidates(skill_players)
         highlights: list[dict] = []
         standout = (candidates.get("COMMUNITY_STANDOUT_WEEK") or [])[:1]
         grinder = (candidates.get("SOCIAL_GRIND_WEEK") or [])[:1]
@@ -438,14 +455,12 @@ def _build_social_around_club(social_event_stats: dict[str, dict], events: dict[
         if grinder and (not standout or grinder[0].candidate_id != standout[0].candidate_id):
             highlights.append({"key": "SOCIAL_GRIND_WEEK", "display": f"Social Grinder: {grinder[0].display}"})
         if highlights:
-            event_type = str(events.get(event_id, {}).get("event_type") or "round_robin")
-            event_type_label = "Social Ladder" if event_type == "league" else "Social RR"
             rows.append(
                 {
-                    "event_id": event_id,
-                    "event_name": str(events.get(event_id, {}).get("name") or "Club Social Event"),
-                    "event_type": event_type,
-                    "event_type_label": event_type_label,
+                    "skill_level": skill_level,
+                    "event_name": "Club Social",
+                    "event_type": "social_unrated",
+                    "event_type_label": f"Social {skill_level}",
                     "highlights": highlights[:2],
                 }
             )

--- a/jupr_app/ui/components/weekly_recap_layout.py
+++ b/jupr_app/ui/components/weekly_recap_layout.py
@@ -374,7 +374,10 @@ def render_weekly_recap(recap: dict, *, print_view: bool, title_override: str | 
         community_items = around.get("social_round_robins", [])
     for item in community_items or []:
         type_label = str(item.get("event_type_label") or "Community Event").strip()
-        title_text = f"{str(item.get('event_name', 'Community Event'))} ({type_label})"
+        if item.get("skill_level"):
+            title_text = type_label
+        else:
+            title_text = f"{str(item.get('event_name', 'Community Event'))} ({type_label})"
         rows = [
             str((highlight or {}).get("display", "")).strip()
             for highlight in item.get("highlights", []) or []

--- a/jupr_app/ui/pages/jupr_live.py
+++ b/jupr_app/ui/pages/jupr_live.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import streamlit as st
 
-from jupr_app.domain.live_social import save_social_live_event
+from jupr_app.domain.live_social import (
+    SOCIAL_SKILL_LEVEL_OPTIONS,
+    normalize_skill_levels,
+    save_social_live_event,
+)
 from jupr_app.ui.layout import page_shell
 from jupr_app.ui.live import LivePageConfig, render_live_page
 
@@ -38,6 +42,7 @@ CLUB_SOCIAL_CONFIG = LivePageConfig(
 MODE_OPTIONS = ("Quick Session", "Club Social")
 MODE_KEY = "jupr_live_mode"
 PREFILL_MODE_KEY = "jupr_live_prefill_mode"
+SOCIAL_SKILL_LEVELS_KEY = "jupr_live_social_skill_levels"
 
 
 def _mode_selector() -> str:
@@ -82,6 +87,7 @@ def _save_social(ctx, state: dict, event: dict) -> bool:
     if admin_logged_in and not host_name:
         host_name = "admin"
 
+    skill_levels = normalize_skill_levels(st.session_state.get(SOCIAL_SKILL_LEVELS_KEY))
     submission_mode = "admin" if admin_logged_in else "public"
     result = save_social_live_event(
         ctx,
@@ -89,6 +95,7 @@ def _save_social(ctx, state: dict, event: dict) -> bool:
         target_club_id=club_id,
         submission_mode=submission_mode,
         host_name=host_name,
+        skill_levels=skill_levels,
     )
     state["last_saved_rounds"] = list(result.get("saved_rounds") or [])
     event["saved_rounds"] = list(result.get("saved_rounds") or [])
@@ -109,6 +116,8 @@ def _render_club_social_mode(ctx) -> None:
     admin_logged_in = bool(getattr(ctx, "admin_logged_in", False))
     if "jupr_live_social_host_name" not in st.session_state:
         st.session_state["jupr_live_social_host_name"] = _default_host_name(ctx)
+    if SOCIAL_SKILL_LEVELS_KEY not in st.session_state:
+        st.session_state[SOCIAL_SKILL_LEVELS_KEY] = ["All"]
 
     if club_id:
         label = club_name or club_id
@@ -131,6 +140,17 @@ def _render_club_social_mode(ctx) -> None:
             "Admins default to 'admin'."
         ),
     )
+    selected_skill_levels = st.multiselect(
+        "Skill level tags",
+        options=SOCIAL_SKILL_LEVEL_OPTIONS,
+        key=SOCIAL_SKILL_LEVELS_KEY,
+        help="Used for Weekly Recap social grouping (for example, Social 3.5, Social 4.0, or Social All).",
+    )
+    normalized_skill_levels = normalize_skill_levels(selected_skill_levels)
+    if normalized_skill_levels != selected_skill_levels:
+        st.session_state[SOCIAL_SKILL_LEVELS_KEY] = normalized_skill_levels
+        st.rerun()
+    st.caption(f"Weekly Recap grouping tags: {', '.join(normalized_skill_levels)}")
 
     if not club_id:
         render_live_page(ctx, CLUB_SOCIAL_CONFIG)


### PR DESCRIPTION
### Motivation
- Hosts running JUPR Live Club Social events need to tag events by one or more skill levels so Weekly Recap can summarize community highlights by skill bucket rather than by every individual event.
- Recap aggregation should support multi-select levels, normalize `All` to a single bucket, count multi-tagged events into each selected specific bucket, and remain backward compatible with older events (treat missing tags as `All`).

### Description
- Added a Club Social multiselect UI in `jupr_app/ui/pages/jupr_live.py` with exact options `['2.5','3.0','3.5','4.0','4.5','5.0','All']`, a `jupr_live_social_skill_levels` session key, normalization on change, and passing the normalized list into the save flow via `save_social_live_event`.
- Introduced `SOCIAL_SKILL_LEVEL_OPTIONS` and `normalize_skill_levels(values)` in `jupr_app/domain/live_social.py`, and persisted normalized tags to `summary_json.skill_levels` (source of truth) while mirroring into `raw_event_json.skill_levels` when saving an event.
- Updated weekly recap loading and aggregation in `jupr_app/domain/recaps/weekly_recap.py` to select `summary_json`, added `social_event_skill_levels(...)`, changed internal rollup to build `social_skill_stats` per bucket (`2.5`..`5.0`, `All`), and made `_build_social_around_club` emit skill-level entries labeled as `Social <skill>`.
- Adjusted recap rendering in `jupr_app/ui/components/weekly_recap_layout.py` to prefer the skill-group label for skill-bucket rows; changed files: `jupr_app/ui/pages/jupr_live.py`, `jupr_app/domain/live_social.py`, `jupr_app/domain/recaps/weekly_recap.py`, and `jupr_app/ui/components/weekly_recap_layout.py`.

### Testing
- Ran Python bytecode checks with `python -m compileall jupr_app/domain/live_social.py jupr_app/ui/pages/jupr_live.py jupr_app/domain/recaps/weekly_recap.py jupr_app/ui/components/weekly_recap_layout.py` which completed successfully.
- No additional automated unit tests exist for these flows in this change, so runtime/UX verification in a staging environment is recommended to confirm UI behavior and recap grouping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc179b1d80832695f6aa1dd6d9999c)