### PR TITLE
Introduce canonical event_tags helpers and wire social/leagues/tournaments/recap

### DIFF
--- a/jupr_app/domain/event_tags.py
+++ b/jupr_app/domain/event_tags.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Any
+
+SKILL_LEVEL_OPTIONS = ["2.5", "3.0", "3.5", "4.0", "4.5", "5.0", "All"]
+
+
+def _as_date(value: object) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text).date()
+    except Exception:
+        return None
+
+
+def _season_tag(value: date) -> str:
+    month = int(value.month)
+    if month in {12, 1, 2}:
+        season = "Winter"
+    elif month in {3, 4, 5}:
+        season = "Spring"
+    elif month in {6, 7, 8}:
+        season = "Summer"
+    else:
+        season = "Fall"
+    return f"{season} {value.year}"
+
+
+def normalize_skill_levels(values: object, *, default_all: bool = False) -> list[str]:
+    if isinstance(values, str):
+        raw_values = [values]
+    elif isinstance(values, (list, tuple, set)):
+        raw_values = list(values)
+    else:
+        raw_values = []
+
+    normalized: list[str] = []
+    for value in raw_values:
+        text = str(value or "").strip()
+        if not text or text not in SKILL_LEVEL_OPTIONS:
+            continue
+        if text not in normalized:
+            normalized.append(text)
+
+    if "All" in normalized:
+        return ["All"]
+    if normalized:
+        return normalized
+    return ["All"] if default_all else []
+
+
+def normalize_date_tags(values: object) -> list[str]:
+    if isinstance(values, str):
+        raw_values = [values]
+    elif isinstance(values, (list, tuple, set)):
+        raw_values = list(values)
+    else:
+        raw_values = []
+
+    normalized: list[str] = []
+    for value in raw_values:
+        text = str(value or "").strip()
+        if text and text not in normalized:
+            normalized.append(text)
+    return normalized
+
+
+def derive_default_date_tags(event_date: object = None, start_date: object = None, end_date: object = None) -> list[str]:
+    event_day = _as_date(event_date)
+    start_day = _as_date(start_date)
+    end_day = _as_date(end_date)
+
+    if event_day:
+        monday = event_day - timedelta(days=event_day.weekday())
+        return normalize_date_tags(
+            [
+                f"Week of {monday.isoformat()}",
+                event_day.strftime("%B %Y"),
+            ]
+        )
+
+    if not start_day and end_day:
+        start_day = end_day
+    if not end_day and start_day:
+        end_day = start_day
+    if not start_day or not end_day:
+        return []
+
+    if end_day < start_day:
+        start_day, end_day = end_day, start_day
+
+    month_tags: list[str] = []
+    cursor = date(start_day.year, start_day.month, 1)
+    end_cursor = date(end_day.year, end_day.month, 1)
+    while cursor <= end_cursor:
+        month_tags.append(cursor.strftime("%B %Y"))
+        if cursor.month == 12:
+            cursor = date(cursor.year + 1, 1, 1)
+        else:
+            cursor = date(cursor.year, cursor.month + 1, 1)
+
+    season_tags = []
+    start_season = _season_tag(start_day)
+    end_season = _season_tag(end_day)
+    season_tags.append(start_season)
+    if end_season != start_season:
+        season_tags.append(end_season)
+
+    return normalize_date_tags(month_tags + season_tags)
+
+
+def normalize_event_tags(tags: object, *, default_skill_all: bool = False) -> dict[str, list[str]]:
+    payload = tags if isinstance(tags, dict) else {}
+    return {
+        "skill_levels": normalize_skill_levels(payload.get("skill_levels"), default_all=default_skill_all),
+        "date_tags": normalize_date_tags(payload.get("date_tags")),
+    }
+
+
+def merge_event_tags(existing: object, updates: object, *, default_skill_all: bool = False) -> dict[str, list[str]]:
+    normalized_existing = normalize_event_tags(existing, default_skill_all=default_skill_all)
+    update_payload = updates if isinstance(updates, dict) else {}
+
+    if "skill_levels" in update_payload:
+        normalized_existing["skill_levels"] = normalize_skill_levels(
+            update_payload.get("skill_levels"),
+            default_all=default_skill_all,
+        )
+    if "date_tags" in update_payload:
+        normalized_existing["date_tags"] = normalize_date_tags(update_payload.get("date_tags"))
+    return normalized_existing
+
+
+def get_event_tags(payload: dict[str, Any], *, default_skill_all: bool = False) -> dict[str, list[str]]:
+    data = payload if isinstance(payload, dict) else {}
+    return normalize_event_tags(data.get("event_tags"), default_skill_all=default_skill_all)
+
+
+def get_event_skill_levels(payload: dict[str, Any], default_all: bool = False) -> list[str]:
+    return get_event_tags(payload, default_skill_all=default_all).get("skill_levels", [])
+
+
+def get_event_date_tags(payload: dict[str, Any]) -> list[str]:
+    return get_event_tags(payload).get("date_tags", [])

--- a/jupr_app/domain/leagues.py
+++ b/jupr_app/domain/leagues.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping
 import pandas as pd
 
 from jupr_app.domain.awards import TOP_PERFORMER_SPECS, compute_top_performer_awards
+from jupr_app.domain.event_tags import get_event_tags
 from jupr_app.domain.gamification.top_performer_awards import (
     TOP_PERFORMER_BADGE_IDS,
     _build_league_standings,
@@ -36,6 +37,11 @@ def get_league_meta_row(df_meta: pd.DataFrame | None, league_id: str) -> dict[st
         return None
     return hit.iloc[0].to_dict()
 
+
+
+def get_league_event_tags(meta_row: Mapping[str, Any] | None) -> dict[str, list[str]]:
+    payload = meta_row if isinstance(meta_row, Mapping) else {}
+    return get_event_tags(dict(payload), default_skill_all=False)
 
 def normalize_league_status(meta_row: Mapping[str, Any] | None) -> str:
     if not meta_row:

--- a/jupr_app/domain/live_social.py
+++ b/jupr_app/domain/live_social.py
@@ -5,6 +5,12 @@ from uuid import uuid4
 
 import pandas as pd
 
+from jupr_app.domain.event_tags import (
+    SKILL_LEVEL_OPTIONS,
+    derive_default_date_tags,
+    merge_event_tags,
+    normalize_skill_levels,
+)
 from jupr_app.domain.live_beta_engine import (
     league_aggregate_standings,
     match_is_scored,
@@ -13,26 +19,7 @@ from jupr_app.domain.live_beta_engine import (
     round_robin_standings,
 )
 
-SOCIAL_SKILL_LEVEL_OPTIONS = ["2.5", "3.0", "3.5", "4.0", "4.5", "5.0", "All"]
-
-
-def normalize_skill_levels(values: object) -> list[str]:
-    if isinstance(values, str):
-        raw_values = [values]
-    elif isinstance(values, (list, tuple, set)):
-        raw_values = list(values)
-    else:
-        raw_values = []
-    normalized: list[str] = []
-    for value in raw_values:
-        text = str(value or "").strip()
-        if not text:
-            continue
-        if text in SOCIAL_SKILL_LEVEL_OPTIONS and text not in normalized:
-            normalized.append(text)
-    if "All" in normalized:
-        return ["All"]
-    return normalized or ["All"]
+SOCIAL_SKILL_LEVEL_OPTIONS = SKILL_LEVEL_OPTIONS
 
 
 def normalize_person_name(value: object) -> str:
@@ -376,7 +363,13 @@ def social_league_match_rows_from_event(event: dict) -> list[dict]:
     return rows
 
 
-def build_social_event_summary(event: dict, *, match_count: int, skill_levels: list[str] | None = None) -> dict:
+def build_social_event_summary(
+    event: dict,
+    *,
+    match_count: int,
+    event_tags: dict | None = None,
+    skill_levels: list[str] | None = None,
+) -> dict:
     event_type = str(event.get("type") or "")
     standings = (
         round_robin_standings(event)
@@ -389,7 +382,13 @@ def build_social_event_summary(event: dict, *, match_count: int, skill_levels: l
         "match_count": int(match_count),
         "event_type": event_type,
         "schedule_mode": str(event.get("scheduleMode") or ""),
-        "skill_levels": normalize_skill_levels(skill_levels if skill_levels is not None else event.get("skill_levels")),
+        "event_tags": merge_event_tags(
+            event.get("event_tags"),
+            event_tags
+            if isinstance(event_tags, dict)
+            else {"skill_levels": skill_levels if skill_levels is not None else None},
+            default_skill_all=True,
+        ),
         "leader": (
             {
                 "name": leader.get("name"),
@@ -482,11 +481,19 @@ def save_social_live_event(
         if event_type == "round_robin"
         else social_league_match_rows_from_event(event)
     )
-    normalized_skill_levels = normalize_skill_levels(skill_levels if skill_levels is not None else event.get("skill_levels"))
+    default_date_tags = derive_default_date_tags(event_date=event_date)
+    normalized_event_tags = merge_event_tags(
+        event.get("event_tags"),
+        {
+            "skill_levels": skill_levels if skill_levels is not None else None,
+            "date_tags": [*(event.get("event_tags") or {}).get("date_tags", []), *default_date_tags],
+        },
+        default_skill_all=True,
+    )
     summary_json = build_social_event_summary(
         event,
         match_count=len(match_rows),
-        skill_levels=normalized_skill_levels,
+        event_tags=normalized_event_tags,
     )
     normalized_submission_mode = str(submission_mode or "").strip().lower() or "public"
     status = _status_for_submission_mode(normalized_submission_mode)
@@ -507,7 +514,7 @@ def save_social_live_event(
         "moderated_at": moderated_at,
         "moderated_by": moderated_by,
         "rejection_reason": None,
-        "raw_event_json": {**event, "skill_levels": normalized_skill_levels},
+        "raw_event_json": {**event, "event_tags": normalized_event_tags},
         "summary_json": summary_json,
     }
 

--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -8,6 +8,12 @@ from zoneinfo import ZoneInfo
 import pandas as pd
 
 from jupr_app.data.sb_safe import safe_execute
+from jupr_app.domain.event_tags import (
+    SKILL_LEVEL_OPTIONS,
+    derive_default_date_tags,
+    get_event_date_tags,
+    get_event_skill_levels,
+)
 from jupr_app.domain.match_filters import is_popup_event_match, is_tournament_match
 
 
@@ -46,7 +52,7 @@ RECAP_CATEGORY_CONFIG = {
     "TOP_PERFORMER": {"label": "Top Performer", "max_featured": MAX_FEATURED_PER_CATEGORY},
     "BIGGEST_JUMP": {"label": "Biggest Jump", "max_featured": MAX_FEATURED_PER_CATEGORY},
 }
-SOCIAL_SKILL_BUCKETS = ("2.5", "3.0", "3.5", "4.0", "4.5", "5.0", "All")
+SOCIAL_SKILL_BUCKETS = tuple(SKILL_LEVEL_OPTIONS)
 
 
 def normalize_date_range(start_date: date, end_date: date) -> tuple[date, date]:
@@ -142,18 +148,17 @@ def _social_display_name(row: dict, id_to_name: dict[int, str]) -> str:
 
 
 def social_event_skill_levels(event_row: dict) -> list[str]:
-    summary_json = event_row.get("summary_json") if isinstance(event_row, dict) else None
-    raw_values = summary_json.get("skill_levels") if isinstance(summary_json, dict) else None
-    values: list[str] = []
-    if isinstance(raw_values, str):
-        values = [raw_values]
-    elif isinstance(raw_values, (list, tuple, set)):
-        values = [str(item or "").strip() for item in raw_values]
-    normalized = [item for item in values if item in SOCIAL_SKILL_BUCKETS]
-    if "All" in normalized:
-        return ["All"]
-    normalized_specific = [item for item in normalized if item != "All"]
-    return normalized_specific or ["All"]
+    summary_json = event_row.get("summary_json") if isinstance(event_row, dict) else {}
+    levels = get_event_skill_levels(summary_json if isinstance(summary_json, dict) else {}, default_all=True)
+    return levels or ["All"]
+
+
+def social_event_date_tags(event_row: dict) -> list[str]:
+    summary_json = event_row.get("summary_json") if isinstance(event_row, dict) else {}
+    date_tags = get_event_date_tags(summary_json if isinstance(summary_json, dict) else {})
+    if date_tags:
+        return date_tags
+    return derive_default_date_tags(event_date=event_row.get("event_date"))
 
 
 def _compute_weekly_recap_payload(
@@ -293,6 +298,11 @@ def _compute_social_stats(social_data: dict, id_to_name: dict[int, str]) -> tupl
 
     event_lookup = {str(event.get("id")): event for event in events if event.get("id")}
     participant_lookup = {str(row.get("id")): row for row in participants if row.get("id")}
+    event_tags_by_id: dict[str, dict[str, list[str]]] = {}
+    for event_id, event_row in event_lookup.items():
+        levels = social_event_skill_levels(event_row)
+        date_tags = social_event_date_tags(event_row)
+        event_tags_by_id[event_id] = {"skill_levels": levels, "date_tags": date_tags}
 
     stats: dict[tuple[str, int | str], dict] = {}
     skill_stats: dict[str, dict[tuple[str, int | str], dict]] = {}
@@ -309,13 +319,25 @@ def _compute_social_stats(social_data: dict, id_to_name: dict[int, str]) -> tupl
                 "points_against": 0,
                 "differential": 0,
                 "event_ids": set(),
+                "event_tags": {"skill_levels": ["All"], "date_tags": []},
+                "date_tags": [],
             }
         stats[identity]["event_ids"].add(event_id)
+        event_tags = event_tags_by_id.get(event_id, {"skill_levels": ["All"], "date_tags": []})
+        existing_date_tags = list(stats[identity].get("date_tags") or [])
+        merged_date_tags = [*existing_date_tags, *(event_tags.get("date_tags") or [])]
+        deduped_date_tags = []
+        for tag in merged_date_tags:
+            if tag and tag not in deduped_date_tags:
+                deduped_date_tags.append(tag)
+        stats[identity]["date_tags"] = deduped_date_tags
+        stats[identity]["event_tags"] = {"skill_levels": ["All"], "date_tags": deduped_date_tags}
 
     def apply_match(identity: tuple[str, int | str], display_name: str, *, event_id: str, won: bool, pf: int, pa: int) -> None:
         overall = stats[identity]
         ensure_identity(identity, display_name, event_id)
-        event_levels = social_event_skill_levels(event_lookup.get(event_id, {}))
+        event_tags = event_tags_by_id.get(event_id, {"skill_levels": ["All"], "date_tags": []})
+        event_levels = event_tags.get("skill_levels") or ["All"]
         target_skill_levels = ["All"] if event_levels == ["All"] else [level for level in event_levels if level != "All"]
         for skill_level in target_skill_levels:
             by_skill = skill_stats.setdefault(skill_level, {})
@@ -329,14 +351,38 @@ def _compute_social_stats(social_data: dict, id_to_name: dict[int, str]) -> tupl
                     "points_for": 0,
                     "points_against": 0,
                     "differential": 0,
+                    "event_tags": {"skill_levels": [skill_level], "date_tags": []},
+                    "date_tags": [],
                 }
-        for target in [overall] + [skill_stats[level][identity] for level in target_skill_levels]:
+        event_date_tags = event_tags.get("date_tags") or []
+
+        overall["games"] += 1
+        overall["wins"] += int(bool(won))
+        overall["losses"] += int(not won)
+        overall["points_for"] += pf
+        overall["points_against"] += pa
+        overall["differential"] = overall["points_for"] - overall["points_against"]
+        overall_tags = []
+        for tag in [*(overall.get("date_tags") or []), *event_date_tags]:
+            if tag and tag not in overall_tags:
+                overall_tags.append(tag)
+        overall["date_tags"] = overall_tags
+        overall["event_tags"] = {"skill_levels": ["All"], "date_tags": overall_tags}
+
+        for skill_level in target_skill_levels:
+            target = skill_stats[skill_level][identity]
             target["games"] += 1
             target["wins"] += int(bool(won))
             target["losses"] += int(not won)
             target["points_for"] += pf
             target["points_against"] += pa
             target["differential"] = target["points_for"] - target["points_against"]
+            level_tags = []
+            for tag in [*(target.get("date_tags") or []), *event_date_tags]:
+                if tag and tag not in level_tags:
+                    level_tags.append(tag)
+            target["date_tags"] = level_tags
+            target["event_tags"] = {"skill_levels": [skill_level], "date_tags": level_tags}
 
     for row in matches:
         event_id = str(row.get("event_id") or "")
@@ -461,6 +507,8 @@ def _build_social_around_club(social_skill_stats: dict[str, dict]) -> list[dict]
                     "event_name": "Club Social",
                     "event_type": "social_unrated",
                     "event_type_label": f"Social {skill_level}",
+                    "event_tags": {"skill_levels": [skill_level], "date_tags": []},
+                    "date_tags": [],
                     "highlights": highlights[:2],
                 }
             )

--- a/jupr_app/domain/tournament_registration_repo.py
+++ b/jupr_app/domain/tournament_registration_repo.py
@@ -5,6 +5,8 @@ from typing import Any
 import re
 import uuid
 
+from jupr_app.domain.event_tags import derive_default_date_tags, normalize_event_tags
+
 from .tournament_registration_compiler import compile_tournament_registration_state
 
 REGISTRATION_STATUS_OPTIONS = ["draft", "open", "closed"]
@@ -12,6 +14,18 @@ EVENT_TYPE_OPTIONS = ["SINGLES", "GENDER_DOUBLES", "MIXED_DOUBLES"]
 GENDER_RESTRICTION_OPTIONS = ["ANY", "MEN", "WOMEN", "MIXED"]
 PARTNER_MODE_OPTIONS = ["NONE", "HAS_PARTNER", "NEEDS_PARTNER"]
 
+
+
+def _with_normalized_event_tags(row: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not row:
+        return row
+    tags = normalize_event_tags(row.get("event_tags"))
+    if not tags.get("date_tags"):
+        tags = normalize_event_tags({
+            "skill_levels": tags.get("skill_levels"),
+            "date_tags": derive_default_date_tags(start_date=row.get("start_date"), end_date=row.get("end_date")),
+        })
+    return {**row, "event_tags": tags}
 
 def _uid(prefix: str) -> str:
     return f"{prefix}_{uuid.uuid4().hex[:12]}"
@@ -66,7 +80,7 @@ def list_existing_tournaments(supabase, club_id: str) -> list[dict[str, Any]]:
         .order("created_at", desc=True)
         .execute()
     )
-    return _safe_data(resp)
+    return [_with_normalized_event_tags(row) or row for row in _safe_data(resp)]
 
 
 def get_tournament_record(supabase, tournament_id: str) -> dict[str, Any] | None:
@@ -77,7 +91,7 @@ def get_tournament_record(supabase, tournament_id: str) -> dict[str, Any] | None
         .limit(1)
         .execute()
     )
-    return _safe_first(resp)
+    return _with_normalized_event_tags(_safe_first(resp))
 
 
 def get_registration_settings(supabase, tournament_id: str, *, tournament_name: str | None = None) -> dict[str, Any]:

--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -12,6 +12,7 @@ import streamlit as st
 from jupr_court_board import court_board
 
 from jupr_app.domain.constants import DEFAULT_K_FACTOR
+from jupr_app.domain.event_tags import derive_default_date_tags, normalize_event_tags
 from jupr_app.domain.live_ladder import build_movement_preview, compute_round_stats, validate_courts
 from jupr_app.domain.league_night_roster import (
     RosterChangeError,
@@ -1165,6 +1166,7 @@ def render(ctx):
                     "k_factor": int(k_factor or default_k),
                     "is_active": False,
                     "status": "draft",
+                    "event_tags": normalize_event_tags({"skill_levels": [], "date_tags": []}),
                 }
 
                 try:
@@ -1286,6 +1288,10 @@ def render(ctx):
                 "default_depth": award_defaults,
                 "categories": categories,
             }
+            default_date_tags = derive_default_date_tags(
+                start_date=schedule_payload.get("start_date"),
+                end_date=schedule_payload.get("end_date") or schedule_payload.get("start_date"),
+            )
             payload = {
                 "description": str(st.session_state.get("le_desc", "") or ""),
                 "min_games": min_games_val,
@@ -1294,6 +1300,7 @@ def render(ctx):
                 "court_board_defaults": court_payload,
                 "rules_config": rules_payload,
                 "awards_config": awards_payload,
+                "event_tags": normalize_event_tags({"skill_levels": [], "date_tags": default_date_tags}),
             }
             if status_override is not None:
                 payload["status"] = status_override
@@ -1330,6 +1337,7 @@ def render(ctx):
                 "court_board_defaults": court_cfg,
                 "rules_config": rules_cfg,
                 "awards_config": awards_cfg,
+                "event_tags": normalize_event_tags(meta_row.get("event_tags")),
             }
             ctx.supabase.table("leagues_metadata").insert(payload).execute()
             st.session_state["force_data_refresh"] = True

--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -8,6 +8,7 @@ from typing import Any
 import pandas as pd
 import streamlit as st
 
+from jupr_app.domain.event_tags import derive_default_date_tags, normalize_event_tags
 from jupr_app.domain.tournament_registration_exports import build_registration_workbook
 from jupr_app.domain.tournament_registration_repo import (
     REGISTRATION_STATUS_OPTIONS,
@@ -164,6 +165,10 @@ def _update_tournament_shell(supabase, tournament_id: str, *, name: str, start_d
         "name": name.strip(),
         "start_date": start_date.isoformat() if start_date else None,
         "end_date": end_date.isoformat() if end_date else None,
+        "event_tags": normalize_event_tags({
+            "skill_levels": [],
+            "date_tags": derive_default_date_tags(start_date=start_date, end_date=end_date),
+        }),
     }
     try:
         supabase.table("tournaments").update(payload).eq("id", tournament_id).execute()

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -7,6 +7,7 @@ from typing import Any
 import pandas as pd
 import streamlit as st
 
+from jupr_app.domain.event_tags import derive_default_date_tags, normalize_event_tags
 from jupr_app.domain.match_processing import process_matches
 from jupr_app.domain.tournament_match_payload import build_tournament_match_payload
 from jupr_app.domain.tournaments import (
@@ -288,6 +289,10 @@ def render(ctx):
                 "locale": locale,
                 "registration_open_at": _parse_optional_date(reg_open_at),
                 "registration_close_at": _parse_optional_date(reg_close_at),
+                "event_tags": normalize_event_tags({
+                    "skill_levels": [],
+                    "date_tags": derive_default_date_tags(start_date=start_date, end_date=end_date),
+                }),
             }
             _insert_tournament_shell(supabase, payload)
             created = (


### PR DESCRIPTION
### Motivation
- Establish a single, stable tagging contract (`event_tags`) for skill-level and date grouping across JUPR Live social events, leagues, and tournaments to enable consistent reporting and Weekly Recap grouping.
- Prefer a small deployable step that uses existing JSON/metadata columns and avoids schema migrations or duplicate `skill_levels` fields.

### Description
- Add a shared helper module `jupr_app/domain/event_tags.py` with `SKILL_LEVEL_OPTIONS`, normalization/merge/get helpers, and `derive_default_date_tags` for week/month/season tags.
- Refactor social save and summary generation (`jupr_app/domain/live_social.py`) to persist normalized `event_tags` (in `summary_json.event_tags` and `raw_event_json.event_tags`) and to derive default date tags from `event_date` when saving club social events.
- Update weekly recap aggregation (`jupr_app/domain/recaps/weekly_recap.py`) to read skill levels and date tags via the shared helpers, to default social skill levels to `[

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1a0b0a848326a48975fcfd68eabb)