### PR TITLE
Add searchable current-player picker to JUPR Live setup

### DIFF
--- a/jupr_app/ui/live/shared.py
+++ b/jupr_app/ui/live/shared.py
@@ -76,6 +76,7 @@ def _default_state(config: LivePageConfig) -> dict:
         "event_name": "Saturday Event",
         "participant_count": 8,
         "participant_text": "",
+        "selected_existing_players": [],
         "league_rounds": 3,
         "official_league": "",
         "official_week_tag": "Week 1",
@@ -208,6 +209,26 @@ def _participant_lines(value: str) -> list[str]:
         if normalize_name(x)
     ]
 
+
+def _dedupe_names(names: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for raw_name in names:
+        clean = normalize_name(raw_name)
+        if not clean:
+            continue
+        key = clean.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(clean)
+    return deduped
+
+
+def _merge_participant_text(participant_text: str, selected_names: list[str]) -> str:
+    existing_lines = _participant_lines(participant_text)
+    merged_lines = _dedupe_names(existing_lines + list(selected_names or []))
+    return "\n".join(merged_lines)
 
 def _team_entry_lines(value: str) -> list[dict[str, str]]:
     entries: list[dict[str, str]] = []
@@ -368,12 +389,33 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
             help_text = "League / Ladder currently requires an exact 4-player / 5-player court fit."
         placeholder = "Amy\nBrooke\nChris\nDana"
     st.caption(help_text)
+    player_options, _ = _player_directory(ctx)
+    selected_players_key = f"{config.state_key}_selected_existing_players"
+    participants_key = f"{config.state_key}_participants"
+    if selected_players_key not in st.session_state:
+        st.session_state[selected_players_key] = state.get("selected_existing_players", [])
+    selected_existing_players = st.multiselect(
+        "Add from current players",
+        options=player_options,
+        key=selected_players_key,
+        help="Search and select existing player names to quickly add them to the roster.",
+    )
+    state["selected_existing_players"] = list(selected_existing_players)
+    st.caption(
+        "Search current players to add them quickly. You can still type guest names below."
+    )
+    merged_participant_text = _merge_participant_text(
+        state["participant_text"], state["selected_existing_players"]
+    )
+    if merged_participant_text != state["participant_text"]:
+        state["participant_text"] = merged_participant_text
+        st.session_state[participants_key] = merged_participant_text
     state["participant_text"] = st.text_area(
         "Names or roster entry",
         value=state["participant_text"],
         height=180,
         placeholder=placeholder,
-        key=f"{config.state_key}_participants",
+        key=participants_key,
     )
     if state["type_label"] == "League / Ladder":
         state["league_rounds"] = int(


### PR DESCRIPTION
### Motivation
- Reduce misspellings and name mismatches when building JUPR Live rosters by letting users search and pick existing players while keeping manual guest entry available.
- Reuse the existing player directory and name normalization so selected names integrate cleanly with the current event-creation flow.

### Description
- Added a new session state field `selected_existing_players` to the default state and persisted it under `config.state_key` so picker state is scoped with the rest of the setup state.
- Added helper functions `_dedupe_names` and `_merge_participant_text` that reuse `normalize_name` and perform case-insensitive deduplication when merging selected players into the roster text.
- Inserted a searchable `multiselect` labeled `Add from current players` in `render_setup(...)` powered by `_player_directory(ctx)`, and merged selections into the existing `Names or roster entry` text area without duplicating names.
- Kept the text area as the editable source of truth and left Tournament team-line parsing (`Player 1 / Player 2`) unchanged, using a one-way assisted-append merge model from picker → `participant_text`.

### Testing
- Ran `python -m compileall jupr_app/ui/live/shared.py` and the file compiled successfully.
- No additional automated UI tests were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc2013e4288326bb2f509d3b531052)