### PR TITLE
Handle missing Club Social Supabase tables gracefully

### DIFF
--- a/jupr_app/domain/live_social.py
+++ b/jupr_app/domain/live_social.py
@@ -20,6 +20,47 @@ from jupr_app.domain.live_beta_engine import (
 )
 
 SOCIAL_SKILL_LEVEL_OPTIONS = SKILL_LEVEL_OPTIONS
+SOCIAL_TABLES_INSTALL_MESSAGE = (
+    "Club Social tables are not installed in Supabase yet. Apply the social live events migration first."
+)
+_SOCIAL_TABLE_NAMES = ("club_people", "live_events", "live_event_participants", "live_event_matches")
+
+
+class SocialTablesNotInstalledError(RuntimeError):
+    """Raised when Club Social persistence tables are missing in Supabase."""
+
+
+def _error_payload_text(exc: Exception) -> str:
+    pieces = [str(exc)]
+    for attr in ("code", "message", "details", "hint"):
+        value = getattr(exc, attr, None)
+        if value:
+            pieces.append(str(value))
+    response = getattr(exc, "response", None)
+    if response is not None:
+        for attr in ("text",):
+            value = getattr(response, attr, None)
+            if value:
+                pieces.append(str(value))
+        json_fn = getattr(response, "json", None)
+        if callable(json_fn):
+            try:
+                payload = json_fn()
+            except Exception:
+                payload = None
+            if payload:
+                pieces.append(str(payload))
+    return " | ".join(pieces).lower()
+
+
+def is_missing_social_tables_error(exc: Exception) -> bool:
+    payload = _error_payload_text(exc)
+    if not payload:
+        return False
+    has_missing_code = "pgrst205" in payload or "42p01" in payload
+    has_table_marker = "table" in payload or "relation" in payload
+    mentions_social_table = any(table in payload for table in _SOCIAL_TABLE_NAMES)
+    return has_missing_code and has_table_marker and mentions_social_table
 
 
 def normalize_person_name(value: object) -> str:
@@ -456,136 +497,141 @@ def save_social_live_event(
     linked_existing_players_count = 0
     participant_rows: list[dict] = []
 
-    for participant in participants:
-        display_name = str(participant.get("name") or participant.get("id") or "")
-        club_person, created_new, matched_player = resolve_or_create_club_person(
-            ctx,
-            display_name=display_name,
-            event_date=event_date,
-            club_id=club_id,
-        )
-        created_people_count += int(bool(created_new))
-        linked_existing_players_count += int(bool(matched_player))
-        participant_rows.append(
-            {
-                "participant_key": str(participant.get("id")),
-                "club_person_id": club_person["id"],
-                "linked_player_id": club_person.get("linked_player_id"),
-                "display_name_snapshot": display_name,
-                "seed": participant.get("seed"),
-            }
-        )
-
-    match_rows = (
-        social_round_robin_match_rows_from_event(event)
-        if event_type == "round_robin"
-        else social_league_match_rows_from_event(event)
-    )
-    default_date_tags = derive_default_date_tags(event_date=event_date)
-    normalized_event_tags = merge_event_tags(
-        event.get("event_tags"),
-        {
-            "skill_levels": skill_levels if skill_levels is not None else None,
-            "date_tags": [*(event.get("event_tags") or {}).get("date_tags", []), *default_date_tags],
-        },
-        default_skill_all=True,
-    )
-    summary_json = build_social_event_summary(
-        event,
-        match_count=len(match_rows),
-        event_tags=normalized_event_tags,
-    )
-    normalized_submission_mode = str(submission_mode or "").strip().lower() or "public"
-    status = _status_for_submission_mode(normalized_submission_mode)
-    submitted_by = normalize_name(host_name) or ("admin" if status == "saved" else "guest")
-    moderated_at = datetime.now(timezone.utc).isoformat() if status == "saved" else None
-    moderated_by = _moderated_by(ctx) if status == "saved" else None
-
-    upsert_payload = {
-        "club_id": club_id,
-        "source_event_uid": source_event_uid,
-        "name": str(event.get("name") or "JUPR Live Club Social"),
-        "event_type": event_type,
-        "result_mode": "social_unrated",
-        "event_date": event_date,
-        "status": status,
-        "submission_mode": normalized_submission_mode,
-        "submitted_by_name": submitted_by,
-        "moderated_at": moderated_at,
-        "moderated_by": moderated_by,
-        "rejection_reason": None,
-        "raw_event_json": {**event, "event_tags": normalized_event_tags},
-        "summary_json": summary_json,
-    }
-
-    supabase.table("live_events").upsert(
-        upsert_payload,
-        on_conflict="club_id,source_event_uid",
-    ).execute()
-
-    event_rows = (
-        supabase.table("live_events")
-        .select("id")
-        .eq("club_id", club_id)
-        .eq("source_event_uid", source_event_uid)
-        .execute()
-        .data
-        or []
-    )
-    if not event_rows:
-        raise RuntimeError("Unable to resolve saved live_events row.")
-    event_id = str(event_rows[0]["id"])
-
-    supabase.table("live_event_matches").delete().eq("event_id", event_id).execute()
-    supabase.table("live_event_participants").delete().eq("event_id", event_id).execute()
-
-    if participant_rows:
-        supabase.table("live_event_participants").insert(
-            [{**row, "event_id": event_id} for row in participant_rows]
-        ).execute()
-
-    participants_saved = (
-        supabase.table("live_event_participants")
-        .select("id,participant_key")
-        .eq("event_id", event_id)
-        .execute()
-        .data
-        or []
-    )
-    participant_key_to_id = {str(row["participant_key"]): str(row["id"]) for row in participants_saved}
-
-    if match_rows:
-        payloads = []
-        for row in match_rows:
-            payloads.append(
+    try:
+        for participant in participants:
+            display_name = str(participant.get("name") or participant.get("id") or "")
+            club_person, created_new, matched_player = resolve_or_create_club_person(
+                ctx,
+                display_name=display_name,
+                event_date=event_date,
+                club_id=club_id,
+            )
+            created_people_count += int(bool(created_new))
+            linked_existing_players_count += int(bool(matched_player))
+            participant_rows.append(
                 {
-                    "event_id": event_id,
-                    "match_key": row["match_key"],
-                    "played_on": row["played_on"],
-                    "round_number": row["round_number"],
-                    "court_number": row["court_number"],
-                    "mini_round_number": row["mini_round_number"],
-                    "t1_p1_participant_id": participant_key_to_id[row["t1_p1_key"]],
-                    "t1_p2_participant_id": participant_key_to_id[row["t1_p2_key"]],
-                    "t2_p1_participant_id": participant_key_to_id[row["t2_p1_key"]],
-                    "t2_p2_participant_id": participant_key_to_id[row["t2_p2_key"]],
-                    "score_t1": row["score_t1"],
-                    "score_t2": row["score_t2"],
+                    "participant_key": str(participant.get("id")),
+                    "club_person_id": club_person["id"],
+                    "linked_player_id": club_person.get("linked_player_id"),
+                    "display_name_snapshot": display_name,
+                    "seed": participant.get("seed"),
                 }
             )
-        supabase.table("live_event_matches").insert(payloads).execute()
 
-    return {
-        "event_id": event_id,
-        "status": status,
-        "submission_mode": normalized_submission_mode,
-        "submitted_by_name": submitted_by,
-        "saved_rounds": _saved_rounds(event),
-        "participant_count": len(participant_rows),
-        "match_count": len(match_rows),
-        "created_people_count": created_people_count,
-        "linked_existing_players_count": linked_existing_players_count,
-    }
+        match_rows = (
+            social_round_robin_match_rows_from_event(event)
+            if event_type == "round_robin"
+            else social_league_match_rows_from_event(event)
+        )
+        default_date_tags = derive_default_date_tags(event_date=event_date)
+        normalized_event_tags = merge_event_tags(
+            event.get("event_tags"),
+            {
+                "skill_levels": skill_levels if skill_levels is not None else None,
+                "date_tags": [*(event.get("event_tags") or {}).get("date_tags", []), *default_date_tags],
+            },
+            default_skill_all=True,
+        )
+        summary_json = build_social_event_summary(
+            event,
+            match_count=len(match_rows),
+            event_tags=normalized_event_tags,
+        )
+        normalized_submission_mode = str(submission_mode or "").strip().lower() or "public"
+        status = _status_for_submission_mode(normalized_submission_mode)
+        submitted_by = normalize_name(host_name) or ("admin" if status == "saved" else "guest")
+        moderated_at = datetime.now(timezone.utc).isoformat() if status == "saved" else None
+        moderated_by = _moderated_by(ctx) if status == "saved" else None
+
+        upsert_payload = {
+            "club_id": club_id,
+            "source_event_uid": source_event_uid,
+            "name": str(event.get("name") or "JUPR Live Club Social"),
+            "event_type": event_type,
+            "result_mode": "social_unrated",
+            "event_date": event_date,
+            "status": status,
+            "submission_mode": normalized_submission_mode,
+            "submitted_by_name": submitted_by,
+            "moderated_at": moderated_at,
+            "moderated_by": moderated_by,
+            "rejection_reason": None,
+            "raw_event_json": {**event, "event_tags": normalized_event_tags},
+            "summary_json": summary_json,
+        }
+
+        supabase.table("live_events").upsert(
+            upsert_payload,
+            on_conflict="club_id,source_event_uid",
+        ).execute()
+
+        event_rows = (
+            supabase.table("live_events")
+            .select("id")
+            .eq("club_id", club_id)
+            .eq("source_event_uid", source_event_uid)
+            .execute()
+            .data
+            or []
+        )
+        if not event_rows:
+            raise RuntimeError("Unable to resolve saved live_events row.")
+        event_id = str(event_rows[0]["id"])
+
+        supabase.table("live_event_matches").delete().eq("event_id", event_id).execute()
+        supabase.table("live_event_participants").delete().eq("event_id", event_id).execute()
+
+        if participant_rows:
+            supabase.table("live_event_participants").insert(
+                [{**row, "event_id": event_id} for row in participant_rows]
+            ).execute()
+
+        participants_saved = (
+            supabase.table("live_event_participants")
+            .select("id,participant_key")
+            .eq("event_id", event_id)
+            .execute()
+            .data
+            or []
+        )
+        participant_key_to_id = {str(row["participant_key"]): str(row["id"]) for row in participants_saved}
+
+        if match_rows:
+            payloads = []
+            for row in match_rows:
+                payloads.append(
+                    {
+                        "event_id": event_id,
+                        "match_key": row["match_key"],
+                        "played_on": row["played_on"],
+                        "round_number": row["round_number"],
+                        "court_number": row["court_number"],
+                        "mini_round_number": row["mini_round_number"],
+                        "t1_p1_participant_id": participant_key_to_id[row["t1_p1_key"]],
+                        "t1_p2_participant_id": participant_key_to_id[row["t1_p2_key"]],
+                        "t2_p1_participant_id": participant_key_to_id[row["t2_p1_key"]],
+                        "t2_p2_participant_id": participant_key_to_id[row["t2_p2_key"]],
+                        "score_t1": row["score_t1"],
+                        "score_t2": row["score_t2"],
+                    }
+                )
+            supabase.table("live_event_matches").insert(payloads).execute()
+
+        return {
+            "event_id": event_id,
+            "status": status,
+            "submission_mode": normalized_submission_mode,
+            "submitted_by_name": submitted_by,
+            "saved_rounds": _saved_rounds(event),
+            "participant_count": len(participant_rows),
+            "match_count": len(match_rows),
+            "created_people_count": created_people_count,
+            "linked_existing_players_count": linked_existing_players_count,
+        }
+    except Exception as exc:
+        if is_missing_social_tables_error(exc):
+            raise SocialTablesNotInstalledError(SOCIAL_TABLES_INSTALL_MESSAGE) from exc
+        raise
 
 
 def save_social_round_robin(ctx, event: dict, *, saved_by: str = "admin") -> dict:

--- a/jupr_app/ui/pages/jupr_live.py
+++ b/jupr_app/ui/pages/jupr_live.py
@@ -4,6 +4,8 @@ import streamlit as st
 
 from jupr_app.domain.live_social import (
     SOCIAL_SKILL_LEVEL_OPTIONS,
+    SOCIAL_TABLES_INSTALL_MESSAGE,
+    SocialTablesNotInstalledError,
     normalize_skill_levels,
     save_social_live_event,
 )
@@ -89,14 +91,18 @@ def _save_social(ctx, state: dict, event: dict) -> bool:
 
     skill_levels = normalize_skill_levels(st.session_state.get(SOCIAL_SKILL_LEVELS_KEY))
     submission_mode = "admin" if admin_logged_in else "public"
-    result = save_social_live_event(
-        ctx,
-        event,
-        target_club_id=club_id,
-        submission_mode=submission_mode,
-        host_name=host_name,
-        skill_levels=skill_levels,
-    )
+    try:
+        result = save_social_live_event(
+            ctx,
+            event,
+            target_club_id=club_id,
+            submission_mode=submission_mode,
+            host_name=host_name,
+            skill_levels=skill_levels,
+        )
+    except SocialTablesNotInstalledError:
+        st.error(SOCIAL_TABLES_INSTALL_MESSAGE)
+        return False
     state["last_saved_rounds"] = list(result.get("saved_rounds") or [])
     event["saved_rounds"] = list(result.get("saved_rounds") or [])
     st.session_state["force_data_refresh"] = True

--- a/tests/test_jupr_live_modes.py
+++ b/tests/test_jupr_live_modes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from jupr_app.ui.live.shared import LivePageConfig, _maybe_save_league_before_advance
+from jupr_app.ui.pages import jupr_live
 from jupr_app.ui.pages.jupr_live import CLUB_SOCIAL_CONFIG, QUICK_SESSION_CONFIG
 
 
@@ -35,3 +36,37 @@ def test_non_official_league_finalize_calls_callback_when_present():
 
     _maybe_save_league_before_advance(_Ctx(admin_logged_in=False), {}, {}, cfg, _save)
     assert called["value"] is True
+
+
+class _FakeSt:
+    def __init__(self):
+        self.session_state = {jupr_live.SOCIAL_SKILL_LEVELS_KEY: ["All"]}
+        self.errors: list[str] = []
+        self.successes: list[str] = []
+
+    def error(self, msg: str):
+        self.errors.append(msg)
+
+    def success(self, msg: str):
+        self.successes.append(msg)
+
+
+def test_club_social_save_handles_missing_tables_gracefully(monkeypatch):
+    class _TablesMissing(jupr_live.SocialTablesNotInstalledError):
+        pass
+
+    fake_st = _FakeSt()
+
+    monkeypatch.setattr(jupr_live, "st", fake_st)
+    monkeypatch.setattr(
+        jupr_live,
+        "save_social_live_event",
+        lambda *args, **kwargs: (_ for _ in ()).throw(_TablesMissing("missing")),
+    )
+
+    ctx = type("Ctx", (), {"club_id": "club-1", "admin_logged_in": True})()
+    ok = jupr_live._save_social(ctx, {}, {"type": "round_robin", "participants": []})
+
+    assert ok is False
+    assert fake_st.errors == [jupr_live.SOCIAL_TABLES_INSTALL_MESSAGE]
+    assert not fake_st.successes

--- a/tests/test_live_social.py
+++ b/tests/test_live_social.py
@@ -7,6 +7,7 @@ from jupr_app.domain.live_social import (
     auto_link_exact_matches,
     find_exact_player_link_candidates,
     list_social_submissions_for_review,
+    is_missing_social_tables_error,
     moderate_social_submission,
     normalized_player_name_map,
     resolve_or_create_club_person,
@@ -567,3 +568,18 @@ def test_social_person_rollup_rows_counts_events_and_matches():
     rows = social_person_rollup_rows(supabase, "club-1")
     assert rows[0]["social_event_count"] == 2
     assert rows[0]["social_match_count"] == 1
+
+
+class _MissingTableError(Exception):
+    def __init__(self):
+        super().__init__("PGRST205: Could not find the table 'public.club_people' in the schema cache")
+        self.code = "PGRST205"
+
+
+def test_detects_missing_social_tables_error_codes():
+    assert is_missing_social_tables_error(_MissingTableError()) is True
+
+
+def test_ignores_unrelated_errors_for_social_table_detection():
+    err = RuntimeError("network timeout")
+    assert is_missing_social_tables_error(err) is False


### PR DESCRIPTION
### Motivation
- Club Social saves were raising Supabase/PostgREST missing-table errors (e.g. `PGRST205` / `42P01`) which surfaced tracebacks in the UI instead of a clear actionable message.  
- The app should remain usable when Club Social persistence is unavailable and guide operators to install the required schema.  
- Ensure the domain and UI layers detect and convert missing-table conditions into a friendly Streamlit error without leaking stack traces.

### Description
- Audited migrations and confirmed the Club Social schema is provided by `migrations/20260329_live_social_events.sql` (creates `club_people`, `live_events`, `live_event_participants`, `live_event_matches`) and `migrations/20260330_live_social_moderation_columns.sql` (adds moderation/submission columns and review index); apply `20260329_live_social_events.sql` first, then `20260330_live_social_moderation_columns.sql`.
- Added a typed error and helpers in `jupr_app/domain/live_social.py`: `SocialTablesNotInstalledError`, `SOCIAL_TABLES_INSTALL_MESSAGE`, `_error_payload_text`, and `is_missing_social_tables_error` to detect PostgREST/Postgres missing-relation responses scoped to social table names.
- Wrapped the persistence flow in `save_social_live_event` with a `try/except` that converts detected missing-table exceptions into `SocialTablesNotInstalledError` while re-raising unrelated exceptions.
- Updated the Club Social UI in `jupr_app/ui/pages/jupr_live.py` to catch `SocialTablesNotInstalledError` and show the user-facing message: `Club Social tables are not installed in Supabase yet. Apply the social live events migration first.` without dumping the traceback.
- Added automated tests: detection test in `tests/test_live_social.py` and a UI-handling test in `tests/test_jupr_live_modes.py` to prevent regressions.

### Testing
- Ran `pytest -q tests/test_live_social.py tests/test_jupr_live_modes.py` and all tests passed (`23 passed`).
- The added unit tests verify missing-table detection logic and that the UI save flow surfaces the clear install message instead of raising an exception.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc21c26eb08326b6f4275cac655550)