### PR TITLE
Persist Starting JUPR in Player Editor

### DIFF
--- a/jupr_app/ui/pages/player_editor.py
+++ b/jupr_app/ui/pages/player_editor.py
@@ -100,10 +100,22 @@ def render(ctx):
     with st.form("edit_player_form"):
         new_name = st.text_input("Name", value=str(row.get("name", "")))
         new_rating = st.number_input("Overall JUPR", 1.0, 7.0, float(row.get("rating", 1200.0) or 1200.0) / 400.0, step=0.01)
+        new_starting_rating = st.number_input(
+            "Starting JUPR",
+            1.0,
+            7.0,
+            float(row.get("starting_rating", row.get("rating", 1200.0)) or row.get("rating", 1200.0) or 1200.0) / 400.0,
+            step=0.01,
+        )
         active = st.checkbox("Active", value=bool(row.get("active", True)))
         if st.form_submit_button("Save Player"):
             supabase.table("players").update(
-                {"name": new_name.strip(), "rating": float(new_rating) * 400.0, "active": bool(active)}
+                {
+                    "name": new_name.strip(),
+                    "rating": float(new_rating) * 400.0,
+                    "starting_rating": float(new_starting_rating) * 400.0,
+                    "active": bool(active),
+                }
             ).eq("club_id", club_id).eq("id", pid).execute()
             st.success("Saved. Use Refresh in sidebar if leaderboards still show old values.")
             time.sleep(0.4)


### PR DESCRIPTION
### Motivation
- Replay History seeds use `players.starting_rating`, but the Player Editor edit form only updated `players.rating`, so admin corrections to starting ratings were not persisted and replays reverted to stale seeds. 
- The change ensures the Player Editor is the single source-of-truth for a player’s starting rating so replays and rebuilds reflect admin edits.

### Description
- Added a `Starting JUPR` number input to the `edit_player_form` and labeled it `Starting JUPR` to match app language. 
- Prefilled the field from `row["starting_rating"] / 400.0` when present, falling back to `row["rating"] / 400.0` when `starting_rating` is null. 
- On save, updated the `players` table to persist `starting_rating` (saved as `float(new_starting_rating) * 400.0`) alongside `name`, `rating`, and `active`. 
- Preserved the existing `st.form(...)` / `st.form_submit_button(...)` behavior and the existing success message and rerun flow.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/player_editor.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4d1c232883268ccdfca4f03317c1)