### PR TITLE
Fix pandas dtype error in weekly recap match dedupe

### DIFF
--- a/jupr_app/domain/recaps/weekly_recap.py
+++ b/jupr_app/domain/recaps/weekly_recap.py
@@ -587,7 +587,7 @@ def _dedupe_matches(df: pd.DataFrame) -> pd.DataFrame:
         with_id = deduped.loc[has_id].copy()
         without_id = deduped.loc[~has_id].copy()
         if not with_id.empty:
-            with_id.loc[:, "id"] = id_str.loc[has_id]
+            with_id = with_id.assign(id=id_str.loc[has_id].astype("string"))
             with_id = with_id.drop_duplicates(subset=["id"], keep="last")
     else:
         with_id = deduped.iloc[0:0].copy()


### PR DESCRIPTION
### Motivation
- Prevent a pandas TypeError in `_dedupe_matches()` when string-normalized IDs are written back into an `int64` `id` column by ensuring the `id` column is string-compatible before assignment.

### Description
- In `jupr_app/domain/recaps/weekly_recap.py` change the `with_id` update to `with_id = with_id.assign(id=id_str.loc[has_id].astype("string"))` so normalized IDs are assigned with a string dtype and existing dedupe behavior is preserved.

### Testing
- Ran `python -m py_compile jupr_app/domain/recaps/weekly_recap.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc509bb2c48326a49ae545d76b11ce)