### PR TITLE
Harden tournament setup + registration so the feature is operational, not just scaffolded

### DIFF
--- a/jupr_app/domain/tournament_registration_repo.py
+++ b/jupr_app/domain/tournament_registration_repo.py
@@ -13,6 +13,8 @@ REGISTRATION_STATUS_OPTIONS = ["draft", "open", "closed"]
 EVENT_TYPE_OPTIONS = ["SINGLES", "GENDER_DOUBLES", "MIXED_DOUBLES"]
 GENDER_RESTRICTION_OPTIONS = ["ANY", "MEN", "WOMEN", "MIXED"]
 PARTNER_MODE_OPTIONS = ["NONE", "HAS_PARTNER", "NEEDS_PARTNER"]
+ADMIN_REGISTRATION_STATUS_OPTIONS = ["pending", "confirmed", "waitlist", "cancelled"]
+ADMIN_PAYMENT_STATUS_OPTIONS = ["unpaid", "paid", "refunded"]
 
 
 
@@ -65,11 +67,22 @@ def _now_iso() -> str:
 
 
 def registration_feature_available(supabase) -> tuple[bool, str | None]:
-    try:
-        supabase.table("tournament_registration_settings").select("id").limit(1).execute()
-        return True, None
-    except Exception as exc:
-        return False, str(exc)
+    required_tables = [
+        "tournament_registration_settings",
+        "tournament_registration_days",
+        "tournament_event_options",
+        "tournament_registrations",
+        "tournament_registration_selections",
+    ]
+    failures: list[str] = []
+    for table_name in required_tables:
+        try:
+            supabase.table(table_name).select("id").limit(1).execute()
+        except Exception as exc:
+            failures.append(f"{table_name}: {exc}")
+    if failures:
+        return False, "Registration tables unavailable: " + " | ".join(failures)
+    return True, None
 
 
 def list_existing_tournaments(supabase, club_id: str) -> list[dict[str, Any]]:
@@ -195,31 +208,63 @@ def replace_registration_configuration(
             "This tournament already has registrations. Freeze the current registration form or create a new tournament before replacing days and events."
         )
 
-    (
-        supabase.table("tournament_event_options")
-        .delete()
-        .eq("tournament_id", str(tournament_id))
-        .execute()
-    )
-    (
-        supabase.table("tournament_registration_days")
-        .delete()
-        .eq("tournament_id", str(tournament_id))
-        .execute()
-    )
+    day_ids: set[str] = set()
+    for idx, day in enumerate(days, start=1):
+        day_id = str(day.get("id") or "").strip()
+        day_tournament_id = str(day.get("tournament_id") or "").strip()
+        if not day_id:
+            raise ValueError(f"Invalid day payload at row {idx}: missing id.")
+        if not day_tournament_id:
+            raise ValueError(f"Invalid day payload at row {idx}: missing tournament_id.")
+        if day_tournament_id != str(tournament_id):
+            raise ValueError(f"Invalid day payload at row {idx}: tournament_id mismatch.")
+        day_ids.add(day_id)
 
-    if days:
-        (
-            supabase.table("tournament_registration_days")
-            .insert(days)
-            .execute()
-        )
-    if event_options:
+    for idx, event in enumerate(event_options, start=1):
+        event_id = str(event.get("id") or "").strip()
+        event_tournament_id = str(event.get("tournament_id") or "").strip()
+        registration_day_id = str(event.get("registration_day_id") or "").strip()
+        if not event_id:
+            raise ValueError(f"Invalid event payload at row {idx}: missing id.")
+        if not event_tournament_id:
+            raise ValueError(f"Invalid event payload at row {idx}: missing tournament_id.")
+        if event_tournament_id != str(tournament_id):
+            raise ValueError(f"Invalid event payload at row {idx}: tournament_id mismatch.")
+        if not registration_day_id:
+            raise ValueError(f"Invalid event payload at row {idx}: missing registration_day_id.")
+        if registration_day_id not in day_ids:
+            raise ValueError(
+                f"Invalid event payload at row {idx}: registration_day_id '{registration_day_id}' is not present in day payload."
+            )
+
+    try:
         (
             supabase.table("tournament_event_options")
-            .insert(event_options)
+            .delete()
+            .eq("tournament_id", str(tournament_id))
             .execute()
         )
+        (
+            supabase.table("tournament_registration_days")
+            .delete()
+            .eq("tournament_id", str(tournament_id))
+            .execute()
+        )
+
+        if days:
+            (
+                supabase.table("tournament_registration_days")
+                .insert(days)
+                .execute()
+            )
+        if event_options:
+            (
+                supabase.table("tournament_event_options")
+                .insert(event_options)
+                .execute()
+            )
+    except Exception as exc:
+        raise ValueError(f"Failed to replace registration configuration for tournament {tournament_id}: {exc}") from exc
 
 
 def list_registrations(supabase, tournament_id: str) -> list[dict[str, Any]]:
@@ -231,6 +276,39 @@ def list_registrations(supabase, tournament_id: str) -> list[dict[str, Any]]:
         .execute()
     )
     return _safe_data(resp)
+
+
+def update_registration_admin_fields(
+    supabase,
+    *,
+    tournament_id: str,
+    registration_id: str,
+    status: str,
+    payment_status: str,
+) -> dict[str, Any]:
+    clean_status = str(status or "").strip().lower()
+    clean_payment_status = str(payment_status or "").strip().lower()
+    if clean_status not in ADMIN_REGISTRATION_STATUS_OPTIONS:
+        raise ValueError(f"Invalid registration status: {status}")
+    if clean_payment_status not in ADMIN_PAYMENT_STATUS_OPTIONS:
+        raise ValueError(f"Invalid payment status: {payment_status}")
+
+    payload = {
+        "status": clean_status,
+        "payment_status": clean_payment_status,
+        "updated_at": _now_iso(),
+    }
+    resp = (
+        supabase.table("tournament_registrations")
+        .update(payload)
+        .eq("tournament_id", str(tournament_id))
+        .eq("id", str(registration_id))
+        .execute()
+    )
+    updated = _safe_first(resp)
+    if not updated:
+        raise ValueError("Registration not found for this tournament.")
+    return updated
 
 
 def list_registration_selections(supabase, tournament_id: str) -> list[dict[str, Any]]:

--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -11,6 +11,8 @@ import streamlit as st
 from jupr_app.domain.event_tags import derive_default_date_tags, normalize_event_tags
 from jupr_app.domain.tournament_registration_exports import build_registration_workbook
 from jupr_app.domain.tournament_registration_repo import (
+    ADMIN_PAYMENT_STATUS_OPTIONS,
+    ADMIN_REGISTRATION_STATUS_OPTIONS,
     REGISTRATION_STATUS_OPTIONS,
     build_public_urls,
     build_registration_state,
@@ -19,9 +21,11 @@ from jupr_app.domain.tournament_registration_repo import (
     get_tournament_record,
     list_event_options,
     list_existing_tournaments,
+    list_registrations,
     list_registration_days,
     registration_feature_available,
     replace_registration_configuration,
+    update_registration_admin_fields,
     upsert_registration_settings,
 )
 from jupr_app.ui.layout import page_shell
@@ -292,6 +296,8 @@ def _sync_days_with_date_range(
 def _clear_tournament_manager_state(tournament_id: str) -> None:
     stale_keys = [
         f"tm_days_seed_{tournament_id}",
+        f"tm_events_seed_{tournament_id}",
+        f"tm_divisions_seed_{tournament_id}",
         f"tm_days_editor_{tournament_id}",
         f"tm_events_editor_{tournament_id}",
         f"tm_divisions_editor_{tournament_id}",
@@ -333,6 +339,37 @@ def _seed_event_templates(event_options: list[dict[str, Any]]) -> pd.DataFrame:
             "default_partner_board",
         ],
     )
+
+
+def _standard_event_templates_df() -> pd.DataFrame:
+    rows = [{"id": _uid("evt"), **row} for row in STANDARD_EVENT_TEMPLATES]
+    return _df_with_hidden_ids(
+        rows,
+        "id",
+        [
+            "event_family",
+            "participant_type",
+            "gender_restriction",
+            "default_format",
+            "default_scoring",
+            "default_waitlist",
+            "default_partner_board",
+        ],
+    )
+
+
+def _sanitize_divisions_for_event_families(divisions_df: pd.DataFrame, event_families: list[str]) -> pd.DataFrame:
+    if divisions_df.empty:
+        return divisions_df
+    valid_families = [_safe_text(family) for family in event_families if _safe_text(family)]
+    if not valid_families:
+        return divisions_df
+    fallback = valid_families[0]
+    out = divisions_df.copy()
+    out["event_family"] = out["event_family"].apply(
+        lambda value: value if _safe_text(value) in valid_families else fallback
+    )
+    return out
 
 
 def _parse_age_rules(raw_value: Any) -> dict[str, Any]:
@@ -810,6 +847,9 @@ def render(ctx):
     days_seed_key = f"tm_days_seed_{tournament_id}"
     if days_seed_key not in st.session_state:
         st.session_state[days_seed_key] = _seed_days(days, tournament)
+    events_seed_key = f"tm_events_seed_{tournament_id}"
+    if events_seed_key not in st.session_state:
+        st.session_state[events_seed_key] = _seed_event_templates(event_options)
 
     with tabs[1]:
         st.subheader("Days")
@@ -840,14 +880,13 @@ def render(ctx):
                 st.session_state[days_seed_key] = generated
             st.rerun()
 
-    event_seed_df = _seed_event_templates(event_options)
     with tabs[2]:
         st.subheader("Event Families")
         st.caption("Create the event families first. These hold the default format, scoring, and partner settings that the divisions inherit.")
         if structure_locked:
             st.caption("Event families are view-only because registrations already exist.")
         events_df = st.data_editor(
-            event_seed_df,
+            st.session_state[events_seed_key],
             hide_index=True,
             num_rows="dynamic",
             key=f"tm_events_editor_{tournament_id}",
@@ -863,12 +902,27 @@ def render(ctx):
             },
             use_container_width=True,
         )
+        st.session_state[events_seed_key] = events_df.copy()
         if st.button("Reset to standard event families", disabled=structure_locked):
+            st.session_state[events_seed_key] = _standard_event_templates_df()
+            existing_divisions = st.session_state.get(f"tm_divisions_seed_{tournament_id}")
+            if isinstance(existing_divisions, pd.DataFrame):
+                st.session_state[f"tm_divisions_seed_{tournament_id}"] = _sanitize_divisions_for_event_families(
+                    existing_divisions,
+                    [row.get("event_family") for row in STANDARD_EVENT_TEMPLATES],
+                )
             st.session_state.pop(f"tm_events_editor_{tournament_id}", None)
             st.rerun()
         st.caption("Typical default: all doubles divisions can inherit Round Robin + Playoff and Games to 15, while individual divisions override only when needed.")
 
-    divisions_seed_df = _seed_divisions(days_df, events_df, event_options)
+    divisions_seed_key = f"tm_divisions_seed_{tournament_id}"
+    if divisions_seed_key not in st.session_state:
+        st.session_state[divisions_seed_key] = _seed_divisions(days_df, events_df, event_options)
+    divisions_seed_df = _sanitize_divisions_for_event_families(
+        st.session_state[divisions_seed_key],
+        [family for family in events_df["event_family"].tolist() if _safe_text(family)],
+    )
+    st.session_state[divisions_seed_key] = divisions_seed_df.copy()
     day_label_options = [label for label in days_df[days_df["enabled"] == True]["label"].tolist()] or days_df["label"].tolist() or ["Day 1"]
     event_family_options = [family for family in events_df["event_family"].tolist() if _safe_text(family)] or ["Men's Doubles"]
     with tabs[3]:
@@ -906,6 +960,7 @@ def render(ctx):
             },
             use_container_width=True,
         )
+        st.session_state[divisions_seed_key] = divisions_df.copy()
         for mode, help_text in AGE_MODE_HELP.items():
             st.caption(f"**{mode.replace('_', ' ').title()}** — {help_text}")
 
@@ -961,6 +1016,7 @@ def render(ctx):
         )
         registrations = state.get("registrations", [])
         issues = state.get("issues", [])
+        summary = state.get("summary", {})
         st.metric("Registrations received", len(registrations))
         if issues:
             st.caption(f"Current registration issues: {len(issues)}")
@@ -972,3 +1028,87 @@ def render(ctx):
                 file_name=f"{_safe_text(tournament.get('name') or 'tournament').replace(' ', '_')}_registration.xlsx",
                 mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             )
+
+        st.divider()
+        st.markdown("#### Registration issues and roster status")
+        st.caption(f"Issue count: {summary.get('issue_count', 0)}")
+        if issues:
+            issue_rows = [
+                {
+                    "Severity": row.get("severity"),
+                    "Type": row.get("issue_type"),
+                    "Message": row.get("message"),
+                    "Event Option ID": row.get("event_option_id"),
+                    "Registration ID": row.get("registration_id"),
+                }
+                for row in issues
+            ]
+            st.dataframe(pd.DataFrame(issue_rows), hide_index=True, use_container_width=True)
+        else:
+            st.success("No derived registration issues right now.")
+
+        status_rows: list[dict[str, Any]] = []
+        for roster in state.get("event_rosters", []):
+            status_counts = {"CONFIRMED": 0, "REVIEW": 0, "WAITLIST": 0, "NEEDS_PARTNER": 0, "PARTNER_MISSING": 0}
+            for entry in roster.get("entries", []):
+                status = _safe_text(entry.get("status")).upper()
+                if status in status_counts:
+                    status_counts[status] += 1
+            status_rows.append(
+                {
+                    "Event": roster.get("event_label"),
+                    "Division": roster.get("event_label"),
+                    "Confirmed": status_counts["CONFIRMED"],
+                    "Review": status_counts["REVIEW"],
+                    "Waitlist": status_counts["WAITLIST"],
+                    "Needs Partner": status_counts["NEEDS_PARTNER"],
+                    "Partner Missing": status_counts["PARTNER_MISSING"],
+                }
+            )
+        if status_rows:
+            st.dataframe(pd.DataFrame(status_rows), hide_index=True, use_container_width=True)
+
+        st.divider()
+        st.markdown("#### Registration admin review")
+        raw_regs = list_registrations(supabase, tournament_id)
+        if not raw_regs:
+            st.info("No registration submissions to review yet.")
+        else:
+            options = {
+                f"{_safe_text(row.get('display_name') or row.get('email') or row.get('id'))} · {_safe_text(row.get('status'))}/{_safe_text(row.get('payment_status'))} · {row.get('submitted_at') or 'no timestamp'}": row
+                for row in raw_regs
+            }
+            selected_label = st.selectbox("Select registration to review", list(options.keys()), key=f"tm_admin_pick_{tournament_id}")
+            selected_reg = options[selected_label]
+            with st.form(f"tm_admin_review_{tournament_id}"):
+                st.text_input("Display name", value=_safe_text(selected_reg.get("display_name")), disabled=True)
+                st.text_input("Email", value=_safe_text(selected_reg.get("email")), disabled=True)
+                admin_status = st.selectbox(
+                    "Registration status",
+                    ADMIN_REGISTRATION_STATUS_OPTIONS,
+                    index=ADMIN_REGISTRATION_STATUS_OPTIONS.index(_safe_text(selected_reg.get("status")).lower())
+                    if _safe_text(selected_reg.get("status")).lower() in ADMIN_REGISTRATION_STATUS_OPTIONS
+                    else 0,
+                )
+                admin_payment_status = st.selectbox(
+                    "Payment status",
+                    ADMIN_PAYMENT_STATUS_OPTIONS,
+                    index=ADMIN_PAYMENT_STATUS_OPTIONS.index(_safe_text(selected_reg.get("payment_status")).lower())
+                    if _safe_text(selected_reg.get("payment_status")).lower() in ADMIN_PAYMENT_STATUS_OPTIONS
+                    else 0,
+                )
+                save_admin = st.form_submit_button("Save registration admin fields", use_container_width=True)
+            if save_admin:
+                try:
+                    update_registration_admin_fields(
+                        supabase,
+                        tournament_id=tournament_id,
+                        registration_id=str(selected_reg.get("id")),
+                        status=admin_status,
+                        payment_status=admin_payment_status,
+                    )
+                    st.success("Registration admin fields updated.")
+                    st.session_state[f"tm_refresh_{tournament_id}"] = True
+                    st.rerun()
+                except Exception as exc:
+                    st.error(f"Could not update registration: {exc}")

--- a/jupr_app/ui/pages/tournament_registration.py
+++ b/jupr_app/ui/pages/tournament_registration.py
@@ -6,6 +6,7 @@ import uuid
 import streamlit as st
 
 from jupr_app.domain.tournament_registration_repo import (
+    build_registration_state,
     build_public_urls,
     get_public_tournament_bundle,
     list_open_public_tournaments,
@@ -297,6 +298,37 @@ def render(ctx):
                     st.stop()
 
         try:
+            state_before_submit = build_registration_state(supabase, tournament, settings, days, event_options)
+        except Exception:
+            state_before_submit = {}
+        event_lookup = {str(row.get("id")): row for row in event_options}
+        roster_lookup = {str(row.get("event_option_id")): row for row in (state_before_submit.get("event_rosters") or [])}
+        at_capacity_warnings: list[str] = []
+        for selection in selections:
+            event_option_id = str(selection.get("event_option_id") or "")
+            event = event_lookup.get(event_option_id) or {}
+            capacity = event.get("capacity_teams")
+            if not capacity:
+                continue
+            try:
+                cap_value = int(capacity)
+            except Exception:
+                continue
+            entries = (roster_lookup.get(event_option_id) or {}).get("entries") or []
+            occupied_slots = sum(
+                1
+                for row in entries
+                if _safe_text(row.get("status")).upper() not in {"NEEDS_PARTNER", "PARTNER_MISSING"}
+            )
+            if occupied_slots >= cap_value:
+                at_capacity_warnings.append(_safe_text(event.get("division_name") or event.get("label") or event_option_id))
+        if at_capacity_warnings:
+            st.warning(
+                "Heads up: these divisions appear full and this registration will likely be waitlisted: "
+                + ", ".join(sorted(set(at_capacity_warnings)))
+            )
+
+        try:
             result = save_registration(
                 supabase,
                 tournament_id=str(tournament.get("id")),
@@ -318,7 +350,7 @@ def render(ctx):
                 },
             )
             st.success(
-                f"Registration saved. Confirmation record: {result.get('registration_id')}. Submitting again with the same email updates your registration."
+                f"Registration saved. Confirmation record: {result.get('registration_id')}. Submitting again with the same email updates your registration. Final placement may still change after partner matching and waitlist review."
             )
             st.link_button("Open partner board", public_urls["partner_board"])
         except Exception as exc:

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -531,9 +531,23 @@ def render(ctx):
                         event_option_id=_safe_text(selected_event_option_id),
                         registration_day_id=_safe_text(selected_day_id),
                     ) or {}
-                    entries = [row for row in (roster.get("entries") or []) if _safe_text(row.get("status")) == "CONFIRMED"]
+                    roster_entries = roster.get("entries") or []
+                    entries = [row for row in roster_entries if _safe_text(row.get("status")) == "CONFIRMED"]
                     if not entries:
-                        st.info("No confirmed registration entries are ready for this division.")
+                        unresolved_partner_count = sum(
+                            1
+                            for row in roster_entries
+                            if _safe_text(row.get("status")).upper() in {"REVIEW", "NEEDS_PARTNER", "PARTNER_MISSING"}
+                        )
+                        if not roster_entries:
+                            st.info("No registration entries exist for this division yet.")
+                        elif unresolved_partner_count:
+                            st.warning(
+                                "No confirmed roster entries are ready yet because partner/roster issues still need admin review."
+                            )
+                            st.caption("Hint: Open Tournament Manager → Publish & QA → Registration admin review to resolve statuses.")
+                        else:
+                            st.info("No confirmed roster entries are ready for this division.")
                     else:
                         if import_mode == "Replace":
                             _scoped_query(supabase.table("tournament_teams").delete(), tournament_id, selected_draw_id).execute()
@@ -564,7 +578,8 @@ def render(ctx):
                                 }
                             )
                         if unresolved_names:
-                            st.error("Some registration names could not be matched to JUPR players: " + ", ".join(sorted(set(unresolved_names))))
+                            st.error("Some confirmed registration names could not be matched to JUPR players: " + ", ".join(sorted(set(unresolved_names))))
+                            st.caption("Hint: fix display names or player mappings first, then rerun this import.")
                         else:
                             supabase.table("tournament_teams").upsert(payload, on_conflict="tournament_id,draw_id,team_number").execute()
                             total_slots = max(draw_size, start_slot + len(payload) - 1)


### PR DESCRIPTION
### Motivation
- The registration feature was fragile: the preflight only checked a single table and other required registration tables could be missing or inaccessible, causing confusing failures.
- The Event Families reset button only cleared widget state and did not restore the standard templates for editing, leaving divisions referencing missing families.
- There was no admin review flow to correct registration `status`/`payment_status` or resolve partner matching issues before importing into ops draws.
- Structural operations were risky: configuration replacement deleted rows before validating payloads and capacity/waitlist state was not surfaced to registrants.

### Description
- Strengthened registration preflight by replacing `registration_feature_available()` with a multi-table probe that `select("id").limit(1).execute()` for each required table and returns `(False, detail)` with aggregated, table-specific diagnostics when any probe fails. (`jupr_app/domain/tournament_registration_repo.py`)
- Hardened `replace_registration_configuration(...)` to validate day and event payloads (IDs, `tournament_id` consistency, event→day FK existence) before any destructive deletes and wrapped delete/insert steps to raise clear `ValueError` on failure. (`jupr_app/domain/tournament_registration_repo.py`)
- Added admin helpers and constants: `ADMIN_REGISTRATION_STATUS_OPTIONS`, `ADMIN_PAYMENT_STATUS_OPTIONS`, and `update_registration_admin_fields(...)` to allow safe, tournament-scoped updates of `status` and `payment_status`. (`jupr_app/domain/tournament_registration_repo.py`)
- Made “Reset to standard event families” actually reseed the event-families editor using session-state seeds, sanitized divisions to valid families after a reset, and preserved the behavior of not auto-saving to the DB until the builder is explicitly saved. (`jupr_app/ui/pages/tournament_manager.py`)
- Added a form-first registration admin review UI in Tournament Manager (Publish & QA) that shows derived issues, roster status summaries, lets admins pick a registration, edit `status` and `payment_status`, and persist via the repo helper with a clean refresh. (`jupr_app/ui/pages/tournament_manager.py`)
- Improved public registration UX to compute derived state before save and warn when selected divisions appear at capacity (advisory only), and updated success copy to note that placement may change after partner/waitlist review. (`jupr_app/ui/pages/tournament_registration.py`)
- Tightened the ops import messaging in Tournaments so the "Build draw from confirmed registrations" flow explains why nothing was imported (no entries, unresolved partner/roster issues, or unresolved name→player mapping) and points back to Tournament Manager for remediation. (`jupr_app/ui/pages/tournaments.py`)
- All changes were implemented surgically and schema-neutral (no migrations or major refactors).

### Testing
- Ran Python byte-compile validation with `python -m py_compile jupr_app/domain/tournament_registration_repo.py jupr_app/ui/pages/tournament_manager.py jupr_app/ui/pages/tournament_registration.py jupr_app/ui/pages/tournaments.py` and the files compiled successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e029e6c8d08326b31acff11abb6882)