### PR TITLE
Add sidebar "Forgot password?" reset-email flow

### DIFF
--- a/jupr_app/ui/admin_auth.py
+++ b/jupr_app/ui/admin_auth.py
@@ -150,6 +150,25 @@ def login_admin(email: str, password: str) -> dict:
     return {"user": user, "session": session}
 
 
+def send_password_reset_email(email: str, *, redirect_to: str) -> None:
+    """
+    Send a password reset email via Supabase Auth without leaking account existence.
+    Raises AdminAuthError only for malformed input or operational failures.
+    """
+    clean_email = _normalize_email(email)
+    if not clean_email:
+        raise AdminAuthError("Enter your email address.")
+
+    client = make_supabase_auth_client()
+    try:
+        client.auth.reset_password_email(
+            clean_email,
+            options={"redirect_to": redirect_to},
+        )
+    except Exception:
+        raise AdminAuthError("Unable to send reset email right now. Please try again.")
+
+
 def get_recovery_query_params() -> dict[str, str]:
     """
     Collect Supabase recovery-related params from URL query params.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -21,6 +21,7 @@ from jupr_app.ui.admin_auth import (
     load_admin_allowlist,
     login_admin,
     logout_admin,
+    send_password_reset_email,
 )
 from jupr_app.ui.context import AppContext
 from jupr_app.ui.page_registry import (
@@ -43,6 +44,7 @@ CLUB_ID = "tres_palapas"
 
 # Public base URL used for share links + link buttons (Streamlit Cloud)
 PUBLIC_BASE_URL = "https://juprtrespalapas.streamlit.app"
+RESET_PASSWORD_REDIRECT_URL = f"{PUBLIC_BASE_URL}/?page=reset_password"
 
 
 # -------------------------
@@ -181,6 +183,7 @@ def main():
                 with st.sidebar.expander("🔒 Admin Login"):
                     email = st.text_input("Email", key="admin_email")
                     password = st.text_input("Password", type="password", key="admin_pwd")
+                    show_forgot_password = st.session_state.get("show_forgot_password", False)
 
                     if st.button("Login", key="admin_login_btn"):
                         if not admin_allowlist:
@@ -199,6 +202,27 @@ def main():
                                 auth_config_error = str(exc)
                             except AdminAuthError as exc:
                                 st.sidebar.error(str(exc))
+
+                    if st.button("Forgot password?", key="admin_forgot_password_btn"):
+                        st.session_state["show_forgot_password"] = not show_forgot_password
+                        st.rerun()
+
+                    if st.session_state.get("show_forgot_password", False):
+                        reset_email = st.text_input("Email for reset link", key="admin_reset_email")
+                        if st.button("Send reset email", key="admin_send_reset_email_btn"):
+                            try:
+                                send_password_reset_email(
+                                    reset_email,
+                                    redirect_to=RESET_PASSWORD_REDIRECT_URL,
+                                )
+                            except AdminAuthConfigError as exc:
+                                auth_config_error = str(exc)
+                            except AdminAuthError as exc:
+                                st.sidebar.error(str(exc))
+                            else:
+                                st.sidebar.success(
+                                    "If that email exists, a reset link has been sent."
+                                )
 
                 if auth_config_error:
                     st.sidebar.error(auth_config_error)


### PR DESCRIPTION
### Motivation
- Provide a minimal, non-leaking admin password reset flow directly in the sidebar so admins can request a reset email without exposing whether an address exists.
- Use Supabase Auth (existing Python client) to send the reset email and route users back into the app's `reset_password` page via a configurable redirect URL.
- No AGENTS skills from `AGENTS.md` were used for this change.

### Description
- Added `send_password_reset_email(email, *, redirect_to)` to `jupr_app/ui/admin_auth.py` which calls `client.auth.reset_password_email(...)` with `options={"redirect_to": redirect_to}` and generic error handling.
- Extended the sidebar admin login UI in `streamlit_app.py` to include a `Forgot password?` toggle, an email input (`admin_reset_email`) and a `Send reset email` button that invokes `send_password_reset_email` with `RESET_PASSWORD_REDIRECT_URL` set to `https://juprtrespalapas.streamlit.app/?page=reset_password`.
- The UI shows the non-leaking success message `If that email exists, a reset link has been sent.` and avoids hardcoding reset query params into the email template, preserving the existing `{{ .ConfirmationURL }}` template usage.
- The flow uses session state (`show_forgot_password`) for toggle visibility and preserves existing auth error handling paths.

### Testing
- Ran `python -m pytest tests/test_imports.py tests/test_page_registry.py`, and the suite passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e056f304288326bcd339fae2ab971e)