### PR TITLE
Fix Supabase password recovery flow for token_hash callbacks

### DIFF
--- a/jupr_app/ui/admin_auth.py
+++ b/jupr_app/ui/admin_auth.py
@@ -211,8 +211,18 @@ def establish_recovery_session(client, params: dict[str, str] | None = None) -> 
     """
     query = params or get_recovery_query_params()
 
+    def _response_has_session(response) -> bool:
+        return bool(getattr(response, "session", None))
+
+    def _has_usable_session() -> bool:
+        try:
+            existing = client.auth.get_session()
+        except Exception:
+            return False
+        return bool(getattr(existing, "session", None))
+
     try:
-        if client.auth.get_session() is not None:
+        if _has_usable_session():
             return True
     except Exception:
         pass
@@ -227,7 +237,21 @@ def establish_recovery_session(client, params: dict[str, str] | None = None) -> 
             response = client.auth.set_session(access_token, refresh_token)
         except Exception:
             return False
-        return bool(getattr(response, "session", None))
+        return _response_has_session(response)
+
+    token_hash = query.get("token_hash", "")
+    otp_type = str(query.get("type", "")).strip().lower()
+    if token_hash and otp_type:
+        try:
+            response = client.auth.verify_otp(
+                {
+                    "token_hash": token_hash,
+                    "type": otp_type,
+                }
+            )
+        except Exception:
+            return False
+        return _response_has_session(response)
 
     auth_code = query.get("code", "")
     if auth_code:
@@ -235,7 +259,7 @@ def establish_recovery_session(client, params: dict[str, str] | None = None) -> 
             response = client.auth.exchange_code_for_session({"auth_code": auth_code})
         except Exception:
             return False
-        return bool(getattr(response, "session", None))
+        return _response_has_session(response)
 
     return False
 


### PR DESCRIPTION
### Motivation
- Password reset links that include `token_hash` and `type=recovery` were rejected as "invalid or expired" because `establish_recovery_session(...)` did not handle the token_hash recovery flow. 
- The recovery flow must call Supabase's OTP verification to exchange the `token_hash` for a usable session and only proceed when a real session object is present.

### Description
- Added helper checks `_response_has_session` and `_has_usable_session` so the function only returns `True` when a real `session` object exists. 
- Implemented a `token_hash` + `type` branch in `establish_recovery_session` that calls `client.auth.verify_otp({"token_hash": token_hash, "type": otp_type})` and validates the returned session. 
- Preserved the existing `access_token`/`refresh_token` (`set_session`) and `code` (`exchange_code_for_session`) branches while standardizing success checks across all branches. 
- Kept error handling conservative by returning `False` on auth exchange failures and avoiding any fake success responses.

### Testing
- Compiled the modified file with `python -m compileall jupr_app/ui/admin_auth.py` and it succeeded. 
- Inspected the installed Supabase auth client to confirm the `verify_otp` signature via a small Python introspection script that printed `SyncGoTrueClient.verify_otp` and its signature. 
- Validated locally that the `verify_otp` call expects `{"token_hash": ..., "type": ...}` by inspecting `supabase_auth.types` definitions and the `SyncGoTrueClient.verify_otp` implementation, and these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05862d79c8326835b7dd3da817139)