### PR TITLE
Fix reset-password hash bridge to update parent app URL

### DIFF
--- a/jupr_app/ui/pages/reset_password.py
+++ b/jupr_app/ui/pages/reset_password.py
@@ -29,25 +29,29 @@ def _inject_hash_to_query_bridge() -> None:
         """
         <script>
         (function () {
-          const hash = window.location.hash || "";
+          const appWindow = window.parent || window;
+          const currentUrl = new URL(appWindow.location.href);
+          const hash = appWindow.location.hash || "";
           if (!hash || hash.length <= 1) return;
 
           const hashParams = new URLSearchParams(hash.substring(1));
-          const hasRecoveryFields = ["access_token", "refresh_token", "type", "code", "token_hash"]
+          const recoveryKeys = ["access_token", "refresh_token", "type", "code", "token_hash"];
+          const hasRecoveryFields = recoveryKeys
             .some((k) => !!hashParams.get(k));
           if (!hasRecoveryFields) return;
 
-          const url = new URL(window.location.href);
-          if (url.searchParams.get("_recovery_hash_bridge") === "1") return;
+          if (currentUrl.searchParams.get("_recovery_hash_bridge") === "1") return;
 
-          hashParams.forEach((value, key) => {
-            if (value && !url.searchParams.get(key)) {
-              url.searchParams.set(key, value);
+          recoveryKeys.forEach((key) => {
+            const value = hashParams.get(key);
+            if (value && !currentUrl.searchParams.get(key)) {
+              currentUrl.searchParams.set(key, value);
             }
           });
-          url.searchParams.set("_recovery_hash_bridge", "1");
+          currentUrl.searchParams.set("_recovery_hash_bridge", "1");
+          currentUrl.hash = "";
 
-          window.location.replace(url.pathname + "?" + url.searchParams.toString());
+          appWindow.location.replace(currentUrl.toString());
         })();
         </script>
         """,


### PR DESCRIPTION
### Motivation
- Supabase recovery links return tokens in the URL hash which were being written into the iframe URL by the previous bridge, so the main Streamlit app never received recovery query params and valid recovery links were rejected as invalid/expired.

### Description
- Rewrote `_inject_hash_to_query_bridge()` in `jupr_app/ui/pages/reset_password.py` to operate on the parent app window by using `const appWindow = window.parent || window` and `new URL(appWindow.location.href)`.
- Parse the hash from the parent (`appWindow.location.hash`) and only promote Supabase recovery keys (`access_token`, `refresh_token`, `type`, `code`, `token_hash`) into `currentUrl.searchParams` when they are present and not already set.
- Add `_recovery_hash_bridge=1`, clear the hash via `currentUrl.hash = ""`, and redirect once using `appWindow.location.replace(currentUrl.toString())` to avoid iframe-only navigation and reload loops.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/reset_password.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05a1892d48326b40e842d0f41e583)