### PR TITLE
Harden recovery session rehydration and Supabase auth signature fallbacks

### DIFF
--- a/jupr_app/ui/admin_auth.py
+++ b/jupr_app/ui/admin_auth.py
@@ -98,6 +98,84 @@ def _get_stashed_recovery_session() -> dict[str, str] | None:
     }
 
 
+def _set_auth_session(client, access_token: str, refresh_token: str):
+    """Set auth session across Supabase client signature variants."""
+    auth = getattr(client, "auth", None)
+    if auth is None:
+        raise AttributeError("Supabase client is missing auth")
+
+    attempts = (
+        (
+            "set_session(access_token, refresh_token)",
+            lambda: auth.set_session(access_token, refresh_token),
+        ),
+        (
+            "set_session({access_token, refresh_token})",
+            lambda: auth.set_session(
+                {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                }
+            ),
+        ),
+        (
+            "set_session(session={access_token, refresh_token})",
+            lambda: auth.set_session(
+                session={
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                }
+            ),
+        ),
+    )
+
+    last_exc: Exception | None = None
+    for label, attempt in attempts:
+        try:
+            return attempt()
+        except Exception as exc:
+            last_exc = exc
+            logger.warning("Supabase auth %s failed: %s", label, exc)
+
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("Unable to set auth session")
+
+
+def _exchange_auth_code_for_session(client, auth_code: str):
+    """Exchange auth code for session across Supabase client signature variants."""
+    auth = getattr(client, "auth", None)
+    if auth is None:
+        raise AttributeError("Supabase client is missing auth")
+
+    attempts = (
+        (
+            "exchange_code_for_session({auth_code})",
+            lambda: auth.exchange_code_for_session({"auth_code": auth_code}),
+        ),
+        (
+            "exchange_code_for_session(auth_code)",
+            lambda: auth.exchange_code_for_session(auth_code),
+        ),
+        (
+            "exchange_code_for_session(code=auth_code)",
+            lambda: auth.exchange_code_for_session(code=auth_code),
+        ),
+    )
+
+    last_exc: Exception | None = None
+    for label, attempt in attempts:
+        try:
+            return attempt()
+        except Exception as exc:
+            last_exc = exc
+            logger.warning("Supabase auth %s failed: %s", label, exc)
+
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("Unable to exchange auth code for session")
+
+
 def load_admin_allowlist() -> set[str]:
     """
     Load allowlisted admin emails from either:
@@ -352,6 +430,20 @@ def establish_recovery_session(client, params: dict[str, str] | None = None) -> 
     except Exception:
         pass
 
+    recovery_session = _get_stashed_recovery_session()
+    if recovery_session:
+        try:
+            response = _set_auth_session(
+                client,
+                recovery_session["access_token"],
+                recovery_session["refresh_token"],
+            )
+        except Exception as exc:
+            logger.warning("Recovery stashed session rehydrate failed: %s", exc)
+        else:
+            if _response_has_session(response):
+                return True
+
     if query.get("error") or query.get("error_code"):
         return False
 
@@ -359,7 +451,7 @@ def establish_recovery_session(client, params: dict[str, str] | None = None) -> 
     refresh_token = query.get("refresh_token", "")
     if access_token and refresh_token:
         try:
-            response = client.auth.set_session(access_token, refresh_token)
+            response = _set_auth_session(client, access_token, refresh_token)
         except Exception as exc:
             logger.warning("Recovery set_session failed: %s", exc)
             return False
@@ -383,7 +475,7 @@ def establish_recovery_session(client, params: dict[str, str] | None = None) -> 
     auth_code = query.get("code", "")
     if auth_code:
         try:
-            response = client.auth.exchange_code_for_session({"auth_code": auth_code})
+            response = _exchange_auth_code_for_session(client, auth_code)
         except Exception as exc:
             logger.warning("Recovery exchange_code_for_session failed: %s", exc)
             return False
@@ -400,7 +492,8 @@ def update_recovered_user_password(client, new_password: str) -> None:
     recovery_session = _get_stashed_recovery_session()
     if recovery_session:
         try:
-            client.auth.set_session(
+            _set_auth_session(
+                client,
                 recovery_session["access_token"],
                 recovery_session["refresh_token"],
             )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -44,7 +44,7 @@ CLUB_ID = "tres_palapas"
 
 # Public base URL used for share links + link buttons (Streamlit Cloud)
 PUBLIC_BASE_URL = "https://juprtrespalapas.streamlit.app"
-RESET_PASSWORD_REDIRECT_URL = f"{PUBLIC_BASE_URL}/?page=reset_password"
+RESET_PASSWORD_REDIRECT_URL = f"{PUBLIC_BASE_URL}/?page=reset_password&public=1"
 
 
 # -------------------------

--- a/tests/test_admin_auth_session_helpers.py
+++ b/tests/test_admin_auth_session_helpers.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import pytest
+
+from jupr_app.ui.admin_auth import _exchange_auth_code_for_session, _set_auth_session
+
+
+class _SetSessionAuth:
+    def __init__(self, succeed_on: int):
+        self.calls = []
+        self._succeed_on = succeed_on
+
+    def set_session(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        if len(self.calls) < self._succeed_on:
+            raise TypeError(f"attempt {len(self.calls)} failed")
+        return {"ok": True, "attempt": len(self.calls)}
+
+
+class _ExchangeCodeAuth:
+    def __init__(self, succeed_on: int):
+        self.calls = []
+        self._succeed_on = succeed_on
+
+    def exchange_code_for_session(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        if len(self.calls) < self._succeed_on:
+            raise TypeError(f"attempt {len(self.calls)} failed")
+        return {"ok": True, "attempt": len(self.calls)}
+
+
+def test_set_auth_session_falls_back_in_order():
+    auth = _SetSessionAuth(succeed_on=3)
+    client = SimpleNamespace(auth=auth)
+
+    response = _set_auth_session(client, "a-token", "r-token")
+
+    assert response["ok"] is True
+    assert auth.calls == [
+        (("a-token", "r-token"), {}),
+        (({"access_token": "a-token", "refresh_token": "r-token"},), {}),
+        ((), {"session": {"access_token": "a-token", "refresh_token": "r-token"}}),
+    ]
+
+
+def test_set_auth_session_raises_last_exception_if_all_attempts_fail():
+    auth = _SetSessionAuth(succeed_on=999)
+    client = SimpleNamespace(auth=auth)
+
+    with pytest.raises(TypeError, match="attempt 3 failed"):
+        _set_auth_session(client, "a-token", "r-token")
+
+    assert len(auth.calls) == 3
+
+
+def test_exchange_auth_code_for_session_falls_back_in_order():
+    auth = _ExchangeCodeAuth(succeed_on=3)
+    client = SimpleNamespace(auth=auth)
+
+    response = _exchange_auth_code_for_session(client, "abc123")
+
+    assert response["ok"] is True
+    assert auth.calls == [
+        (({"auth_code": "abc123"},), {}),
+        (("abc123",), {}),
+        ((), {"code": "abc123"}),
+    ]
+
+
+def test_exchange_auth_code_for_session_raises_last_exception_if_all_attempts_fail():
+    auth = _ExchangeCodeAuth(succeed_on=999)
+    client = SimpleNamespace(auth=auth)
+
+    with pytest.raises(TypeError, match="attempt 3 failed"):
+        _exchange_auth_code_for_session(client, "abc123")
+
+    assert len(auth.calls) == 3


### PR DESCRIPTION
### Motivation
- Fix a password-reset flow where submitting a new password failed due to recovery-session rehydration issues and Supabase client signature drift.
- Ensure the reset flow works across Supabase variants that expose different `set_session` / `exchange_code_for_session` signatures and across Streamlit reruns.

### Description
- Added `_set_auth_session(client, access_token, refresh_token)` to `jupr_app/ui/admin_auth.py` which tries `set_session` in ordered fallbacks (`positional`, dict, `session=`) and logs warnings on failures.
- Added `_exchange_auth_code_for_session(client, auth_code)` to `jupr_app/ui/admin_auth.py` which tries `exchange_code_for_session` in ordered fallbacks (`{auth_code:...}`, positional, `code=`) and logs warnings on failures.
- Updated `establish_recovery_session(...)` to attempt rehydration from `_get_stashed_recovery_session()` immediately after checking for an existing usable session, and to use the new helpers for token-pair and code-exchange branches.
- Updated `update_recovered_user_password(...)` to reattach the stashed recovery session via `_set_auth_session(...)` before running the existing `update_user(...)` multi-variant fallbacks.
- Updated `RESET_PASSWORD_REDIRECT_URL` in `streamlit_app.py` to include the public marker (`...?page=reset_password&public=1`) while preserving the hidden/public reset-page architecture.
- Added unit tests `tests/test_admin_auth_session_helpers.py` to validate fallback order and all-attempts-fail behavior for both new helpers.

### Testing
- Ran `pytest -q tests/test_admin_auth_session_helpers.py` and all tests passed (`4 passed`).
- Ran `python -m py_compile jupr_app/ui/admin_auth.py streamlit_app.py tests/test_admin_auth_session_helpers.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e131d2bfd483268c3c3f4b2b4c85df)