### PR TITLE
Fix reset-password hash probe race and add auth fallback tests

### DIFF
--- a/jupr_app/ui/pages/reset_password.py
+++ b/jupr_app/ui/pages/reset_password.py
@@ -19,11 +19,18 @@ from jupr_app.ui.layout import page_shell
 _MIN_PASSWORD_LENGTH = 8
 
 
-def _inject_hash_to_query_bridge() -> None:
+def _query_param_text(key: str) -> str:
+    value = st.query_params.get(key, "")
+    if isinstance(value, list):
+        value = value[0] if value else ""
+    return str(value or "").strip()
+
+
+def _inject_hash_to_query_probe_bridge() -> None:
     """
     Supabase recovery links can return tokens in URL hash fragment.
-    Streamlit server code can't read hash values, so this tiny bridge moves
-    recovery fields into query params once, removes the hash, and reloads.
+    Streamlit server code can't read hash values, so this probe marks when
+    hash inspection happened and moves recovery fields into query params once.
     """
     components.html(
         """
@@ -31,24 +38,28 @@ def _inject_hash_to_query_bridge() -> None:
         (function () {
           const appWindow = window.parent || window;
           const currentUrl = new URL(appWindow.location.href);
-          const hash = appWindow.location.hash || "";
-          if (!hash || hash.length <= 1) return;
-
-          const hashParams = new URLSearchParams(hash.substring(1));
           const recoveryKeys = ["access_token", "refresh_token", "type", "code", "token_hash"];
-          const hasRecoveryFields = recoveryKeys
-            .some((k) => !!hashParams.get(k));
-          if (!hasRecoveryFields) return;
+          const hasRecoveryQuery = recoveryKeys.some((k) => !!currentUrl.searchParams.get(k));
+          const probeReady = currentUrl.searchParams.get("_recovery_probe") === "1";
+          if (hasRecoveryQuery || probeReady) return;
 
-          if (currentUrl.searchParams.get("_recovery_hash_bridge") === "1") return;
+          const hash = appWindow.location.hash || "";
+          const hashParams = hash && hash.length > 1
+            ? new URLSearchParams(hash.substring(1))
+            : new URLSearchParams();
 
-          recoveryKeys.forEach((key) => {
-            const value = hashParams.get(key);
-            if (value && !currentUrl.searchParams.get(key)) {
-              currentUrl.searchParams.set(key, value);
-            }
-          });
-          currentUrl.searchParams.set("_recovery_hash_bridge", "1");
+          const hasRecoveryHash = recoveryKeys.some((k) => !!hashParams.get(k));
+
+          if (hasRecoveryHash) {
+            recoveryKeys.forEach((key) => {
+              const value = hashParams.get(key);
+              if (value && !currentUrl.searchParams.get(key)) {
+                currentUrl.searchParams.set(key, value);
+              }
+            });
+          }
+
+          currentUrl.searchParams.set("_recovery_probe", "1");
           currentUrl.hash = "";
 
           appWindow.location.replace(currentUrl.toString());
@@ -59,6 +70,10 @@ def _inject_hash_to_query_bridge() -> None:
     )
 
 
+def _should_wait_for_probe(has_recovery_query: bool, recovery_probe: str) -> bool:
+    return (not has_recovery_query) and recovery_probe != "1"
+
+
 def render(ctx):
     page_shell(
         "🔐 Reset Password",
@@ -66,7 +81,7 @@ def render(ctx):
         mode_label="Public",
     )
 
-    _inject_hash_to_query_bridge()
+    _inject_hash_to_query_probe_bridge()
 
     try:
         client = make_supabase_auth_client()
@@ -75,7 +90,13 @@ def render(ctx):
         st.stop()
 
     recovery_params = get_recovery_query_params()
+    recovery_probe = _query_param_text("_recovery_probe")
     has_recovery_query = is_recovery_flow_query(recovery_params)
+
+    if _should_wait_for_probe(has_recovery_query, recovery_probe):
+        st.info("Preparing reset link...")
+        st.stop()
+
     recovery_session_ready = establish_recovery_session(client, recovery_params)
 
     if not has_recovery_query or not recovery_session_ready:

--- a/tests/test_admin_auth_recovery_fallbacks.py
+++ b/tests/test_admin_auth_recovery_fallbacks.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+from jupr_app.ui.admin_auth import _exchange_auth_code_for_session, _set_auth_session
+from jupr_app.ui.pages.reset_password import _should_wait_for_probe
+
+
+class _FakeAuth:
+    def __init__(self, failures_before_success: int = 0):
+        self.failures_before_success = failures_before_success
+        self.calls = []
+
+    def set_session(self, *args, **kwargs):
+        self.calls.append(("set_session", args, kwargs))
+        if len(self.calls) <= self.failures_before_success:
+            raise TypeError(f"set_session failure {len(self.calls)}")
+        return {"ok": True, "args": args, "kwargs": kwargs}
+
+    def exchange_code_for_session(self, *args, **kwargs):
+        self.calls.append(("exchange_code_for_session", args, kwargs))
+        if len(self.calls) <= self.failures_before_success:
+            raise TypeError(f"exchange failure {len(self.calls)}")
+        return {"ok": True, "args": args, "kwargs": kwargs}
+
+
+class _FakeClient:
+    def __init__(self, auth):
+        self.auth = auth
+
+
+def test_set_auth_session_fallback_order_uses_second_signature():
+    auth = _FakeAuth(failures_before_success=1)
+    client = _FakeClient(auth)
+
+    response = _set_auth_session(client, "a", "r")
+
+    assert response["ok"] is True
+    assert auth.calls == [
+        ("set_session", ("a", "r"), {}),
+        (
+            "set_session",
+            ({"access_token": "a", "refresh_token": "r"},),
+            {},
+        ),
+    ]
+
+
+def test_set_auth_session_raises_last_exception_when_all_variants_fail():
+    auth = _FakeAuth(failures_before_success=3)
+    client = _FakeClient(auth)
+
+    with pytest.raises(TypeError, match="set_session failure 3"):
+        _set_auth_session(client, "a", "r")
+
+    assert len(auth.calls) == 3
+    assert auth.calls[2] == (
+        "set_session",
+        (),
+        {"session": {"access_token": "a", "refresh_token": "r"}},
+    )
+
+
+def test_exchange_auth_code_for_session_fallback_order_uses_third_signature():
+    auth = _FakeAuth(failures_before_success=2)
+    client = _FakeClient(auth)
+
+    response = _exchange_auth_code_for_session(client, "abc")
+
+    assert response["ok"] is True
+    assert auth.calls == [
+        ("exchange_code_for_session", ({"auth_code": "abc"},), {}),
+        ("exchange_code_for_session", ("abc",), {}),
+        ("exchange_code_for_session", (), {"code": "abc"}),
+    ]
+
+
+def test_exchange_auth_code_for_session_raises_last_exception_when_all_variants_fail():
+    auth = _FakeAuth(failures_before_success=3)
+    client = _FakeClient(auth)
+
+    with pytest.raises(TypeError, match="exchange failure 3"):
+        _exchange_auth_code_for_session(client, "abc")
+
+    assert len(auth.calls) == 3
+
+
+@pytest.mark.parametrize(
+    "has_recovery_query,recovery_probe,expected",
+    [
+        (False, "", True),
+        (False, "0", True),
+        (False, "1", False),
+        (True, "", False),
+        (True, "1", False),
+    ],
+)
+def test_should_wait_for_probe(has_recovery_query, recovery_probe, expected):
+    assert _should_wait_for_probe(has_recovery_query, recovery_probe) is expected


### PR DESCRIPTION
### Motivation
- Prevent a brief false “invalid/expired” flash on the reset page caused by the URL-hash→query bridge race during first render.  
- Make recovery session reattachment and auth-code exchange robust across Supabase client signature variants so password updates succeed on the first submit.  
- Preserve existing recovery modes (hash tokens, `token_hash`, PKCE `code`) while avoiding client/server timing issues.

### Description
- Added compatibility helpers `
_set_auth_session(client, access_token, refresh_token)
` and `
_exchange_auth_code_for_session(client, auth_code)
` that try multiple Supabase client signatures, log warnings on failures, and raise the last exception if all variants fail.  
- Updated `establish_recovery_session(...)` to rehydrate a stashed recovery session early (before consuming query params) and to use the new helpers for `set_session` and `exchange_code_for_session` paths, keeping the existing `verify_otp(...)` token_hash flow.  
- Updated `update_recovered_user_password(...)` to reattach the stashed session via `
_set_auth_session
` and improved logging so the final exception is preserved when `update_user(...)` variants fail.  
- Replaced the single-phase hash bridge in `jupr_app/ui/pages/reset_password.py` with a two-phase probe that sets `_recovery_probe=1`, added `
_query_param_text
` and `
_should_wait_for_probe
`, and show a neutral "Preparing reset link..." state while the client inspects the hash to avoid false error flashes.  
- Ensured the reset redirect is in the public shell via `RESET_PASSWORD_REDIRECT_URL = f"{PUBLIC_BASE_URL}/?page=reset_password&public=1"`.  
- Added tests in `tests/test_admin_auth_recovery_fallbacks.py` covering the fallback orders and error propagation for the new helpers and the probe decision logic.

### Testing
- Ran `pytest -q tests/test_admin_auth_recovery_fallbacks.py`, and the tests passed.  
- Ran `python -m py_compile jupr_app/ui/admin_auth.py jupr_app/ui/pages/reset_password.py streamlit_app.py` to validate syntax, and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e134935f20832697beaf0623a77ae2)