### PR TITLE
Fix admin auth browser bridge persistence across refresh

### DIFF
--- a/jupr_app/ui/admin_auth.py
+++ b/jupr_app/ui/admin_auth.py
@@ -17,6 +17,8 @@ _RECOVERY_SESSION_KEY = "admin_recovery_session"
 _BROWSER_ACCESS_TOKEN_KEY = "jupr_admin_access_token"
 _BROWSER_REFRESH_TOKEN_KEY = "jupr_admin_refresh_token"
 _BROWSER_RESTORE_FLAG_KEY = "jupr_admin_restore_from_storage"
+_BROWSER_SYNC_PAYLOAD_KEY = "_admin_browser_sync_payload"
+_BROWSER_CLEAR_PENDING_KEY = "_admin_browser_clear_pending"
 
 
 class AdminAuthError(RuntimeError):
@@ -257,24 +259,67 @@ def get_current_admin_user():
 
 
 def persist_admin_browser_session(access_token: str, refresh_token: str) -> None:
-    """Persist auth tokens into browser localStorage via a tiny JS bridge."""
+    """Queue browser token persistence for render-time JS bridge execution."""
     access = str(access_token or "").strip()
     refresh = str(refresh_token or "").strip()
     if not access or not refresh:
+        return
+
+    st.session_state[_BROWSER_SYNC_PAYLOAD_KEY] = {
+        "access_token": access,
+        "refresh_token": refresh,
+        "action": "persist",
+    }
+    st.session_state.pop(_BROWSER_CLEAR_PENDING_KEY, None)
+    logger.info("Pending browser token persist queued")
+
+
+def render_admin_browser_session_bridge() -> None:
+    """Render browser storage bridge once per pending persist/clear action."""
+    payload = st.session_state.get(_BROWSER_SYNC_PAYLOAD_KEY)
+    clear_pending = bool(st.session_state.get(_BROWSER_CLEAR_PENDING_KEY))
+
+    persist_access = ""
+    persist_refresh = ""
+    persist_requested = False
+    if isinstance(payload, dict) and str(payload.get("action", "")).strip() == "persist":
+        persist_access = str(payload.get("access_token", "")).strip()
+        persist_refresh = str(payload.get("refresh_token", "")).strip()
+        persist_requested = bool(persist_access and persist_refresh)
+
+    if not persist_requested and not clear_pending:
         return
 
     components.html(
         f"""
         <script>
         try {{
-          localStorage.setItem("{_BROWSER_ACCESS_TOKEN_KEY}", {access!r});
-          localStorage.setItem("{_BROWSER_REFRESH_TOKEN_KEY}", {refresh!r});
+          const appWindow = window.parent || window;
+          const persistRequested = {str(persist_requested).lower()};
+          const clearPending = {str(clear_pending).lower()};
+
+          if (persistRequested) {{
+            appWindow.localStorage.setItem("{_BROWSER_ACCESS_TOKEN_KEY}", {persist_access!r});
+            appWindow.localStorage.setItem("{_BROWSER_REFRESH_TOKEN_KEY}", {persist_refresh!r});
+          }}
+
+          if (clearPending) {{
+            appWindow.localStorage.removeItem("{_BROWSER_ACCESS_TOKEN_KEY}");
+            appWindow.localStorage.removeItem("{_BROWSER_REFRESH_TOKEN_KEY}");
+          }}
         }} catch (e) {{}}
         </script>
         """,
         height=0,
     )
-    logger.info("Admin login tokens persisted to browser storage")
+
+    if persist_requested:
+        logger.info("Browser token persist bridge rendered")
+        st.session_state.pop(_BROWSER_SYNC_PAYLOAD_KEY, None)
+
+    if clear_pending:
+        logger.info("Browser token clear bridge rendered")
+        st.session_state.pop(_BROWSER_CLEAR_PENDING_KEY, None)
 
 
 def _clear_sensitive_query_params() -> None:
@@ -306,16 +351,17 @@ def restore_admin_browser_session() -> dict[str, str] | None:
         f"""
         <script>
         try {{
-          const access = localStorage.getItem("{_BROWSER_ACCESS_TOKEN_KEY}") || "";
-          const refresh = localStorage.getItem("{_BROWSER_REFRESH_TOKEN_KEY}") || "";
-          const params = new URLSearchParams(window.location.search);
+          const appWindow = window.parent || window;
+          const access = appWindow.localStorage.getItem("{_BROWSER_ACCESS_TOKEN_KEY}") || "";
+          const refresh = appWindow.localStorage.getItem("{_BROWSER_REFRESH_TOKEN_KEY}") || "";
+          const appUrl = new URL(appWindow.location.href);
+          const params = appUrl.searchParams;
           const hasHandshake = params.get("{_BROWSER_RESTORE_FLAG_KEY}") === "1";
           if (access && refresh && !hasHandshake) {{
             params.set("jupr_admin_access_token", access);
             params.set("jupr_admin_refresh_token", refresh);
             params.set("{_BROWSER_RESTORE_FLAG_KEY}", "1");
-            const next = `${{window.location.pathname}}?${{params.toString()}}${{window.location.hash}}`;
-            window.location.replace(next);
+            appWindow.location.replace(appUrl.toString());
           }}
         }} catch (e) {{}}
         </script>
@@ -326,18 +372,9 @@ def restore_admin_browser_session() -> dict[str, str] | None:
 
 
 def clear_admin_browser_session() -> None:
-    components.html(
-        f"""
-        <script>
-        try {{
-          localStorage.removeItem("{_BROWSER_ACCESS_TOKEN_KEY}");
-          localStorage.removeItem("{_BROWSER_REFRESH_TOKEN_KEY}");
-        }} catch (e) {{}}
-        </script>
-        """,
-        height=0,
-    )
-    logger.info("Persisted browser tokens cleared")
+    st.session_state[_BROWSER_CLEAR_PENDING_KEY] = True
+    st.session_state.pop(_BROWSER_SYNC_PAYLOAD_KEY, None)
+    logger.info("Browser token clear queued")
 
 
 def maybe_restore_admin_login_from_browser() -> bool:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -22,6 +22,7 @@ from jupr_app.ui.admin_auth import (
     login_admin,
     logout_admin,
     maybe_restore_admin_login_from_browser,
+    render_admin_browser_session_bridge,
     send_password_reset_email,
 )
 from jupr_app.ui.context import AppContext
@@ -152,6 +153,7 @@ def main():
         # Admin auth uses Supabase email/password + allowlist and can restore
         # a previously persisted browser token pair after refresh.
         bootstrap_admin_auth()
+        render_admin_browser_session_bridge()
         maybe_restore_admin_login_from_browser()
 
         admin_allowlist = load_admin_allowlist()


### PR DESCRIPTION
### Motivation
- Admin sessions were lost on full browser refresh because JS bridge writes used the component iframe context and immediate writes during login could be dropped when `st.rerun()` ran. 
- The intent is to target the parent app window for storage/URL work and to defer browser writes to a safe render-time bridge so persists/clears reliably flush.

### Description
- Queue browser sync actions by adding session-state keys `_admin_browser_sync_payload` and `_admin_browser_clear_pending` and change `persist_admin_browser_session()` to store a pending payload instead of emitting JS immediately. 
- Add `render_admin_browser_session_bridge()` which, when a persist/clear is pending, renders a single `components.html` snippet that uses `const appWindow = window.parent || window;` to `setItem`/`removeItem` on the parent page `localStorage` and then clears the pending flags. 
- Update `restore_admin_browser_session()` to use the parent window (`appWindow.localStorage`) and `new URL(appWindow.location.href)` and to call `appWindow.location.replace(...)` for the URL handshake while keeping Python-side sensitive query param scrubbing. 
- Change `clear_admin_browser_session()` to queue a clear action in session state instead of emitting JS immediately and keep `logout_admin()` clearing local Streamlit auth state while relying on the bridge to clear browser storage. 
- Wire `streamlit_app.py` startup order to call `bootstrap_admin_auth()`, then `render_admin_browser_session_bridge()`, then `maybe_restore_admin_login_from_browser()` to ensure pending browser writes/clears are flushed before restoration. 
- Add concise, non-sensitive logs for queued/rendered persist/clear and for restore attempt/success/failure without logging token values.

### Testing
- Ran `python -m py_compile streamlit_app.py jupr_app/ui/admin_auth.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1728e63548326af517cf0baaa399c)