### PR TITLE
Add safe tournament archiving and empty-draft deletion controls

### DIFF
--- a/jupr_app/domain/tournament_registration_repo.py
+++ b/jupr_app/domain/tournament_registration_repo.py
@@ -106,15 +106,90 @@ def registration_feature_available(supabase) -> tuple[bool, str | None]:
     return True, None
 
 
-def list_existing_tournaments(supabase, club_id: str) -> list[dict[str, Any]]:
-    resp = (
+def list_existing_tournaments(supabase, club_id: str, *, include_archived: bool = False) -> list[dict[str, Any]]:
+    query = (
         supabase.table("tournaments")
         .select("*")
         .eq("club_id", str(club_id))
-        .order("created_at", desc=True)
+    )
+    if not include_archived:
+        query = query.neq("status", "ARCHIVED")
+    resp = query.order("created_at", desc=True).execute()
+    return [_with_normalized_event_tags(row) or row for row in _safe_data(resp)]
+
+
+def _count_table_rows(supabase, table_name: str, tournament_id: str) -> int:
+    resp = (
+        supabase.table(table_name)
+        .select("id", count="exact")
+        .eq("tournament_id", str(tournament_id))
         .execute()
     )
-    return [_with_normalized_event_tags(row) or row for row in _safe_data(resp)]
+    try:
+        return int(resp.count or 0)
+    except Exception:
+        return len(_safe_data(resp))
+
+
+def get_tournament_usage_summary(supabase, tournament_id: str) -> dict[str, int]:
+    tournament_id = str(tournament_id)
+    return {
+        "registrations": _count_table_rows(supabase, "tournament_registrations", tournament_id),
+        "registration_selections": _count_table_rows(supabase, "tournament_registration_selections", tournament_id),
+        "event_draws": _count_table_rows(supabase, "tournament_event_draws", tournament_id),
+        "teams": _count_table_rows(supabase, "tournament_teams", tournament_id),
+        "games": _count_table_rows(supabase, "tournament_games", tournament_id),
+        "podium": _count_table_rows(supabase, "tournament_podium", tournament_id),
+    }
+
+
+def tournament_can_be_deleted(supabase, tournament: dict[str, Any]) -> tuple[bool, dict[str, int], str | None]:
+    status = str((tournament or {}).get("status") or "").upper()
+    tournament_id = str((tournament or {}).get("id") or "").strip()
+    summary = get_tournament_usage_summary(supabase, tournament_id) if tournament_id else {}
+    if status != "DRAFT":
+        return False, summary, "Delete Draft is only available when tournament status is DRAFT."
+    if any(int(summary.get(key) or 0) > 0 for key in ["registrations", "registration_selections", "event_draws", "teams", "games", "podium"]):
+        return False, summary, "This tournament has existing operational/history records. Archive it instead of deleting."
+    return True, summary, None
+
+
+def archive_tournament(supabase, tournament_id: str) -> None:
+    supabase.table("tournaments").update({"status": "ARCHIVED"}).eq("id", str(tournament_id)).execute()
+
+
+def unarchive_tournament(supabase, tournament_id: str) -> None:
+    supabase.table("tournaments").update({"status": "DRAFT"}).eq("id", str(tournament_id)).execute()
+
+
+def delete_unused_draft_tournament(supabase, tournament: dict[str, Any]) -> None:
+    tournament_id = str((tournament or {}).get("id") or "").strip()
+    if not tournament_id:
+        raise ValueError("Tournament id is required.")
+
+    can_delete, _, reason = tournament_can_be_deleted(supabase, tournament)
+    if not can_delete:
+        raise ValueError(reason or "Tournament cannot be deleted.")
+
+    (
+        supabase.table("tournament_registration_settings")
+        .delete()
+        .eq("tournament_id", tournament_id)
+        .execute()
+    )
+    (
+        supabase.table("tournament_event_options")
+        .delete()
+        .eq("tournament_id", tournament_id)
+        .execute()
+    )
+    (
+        supabase.table("tournament_registration_days")
+        .delete()
+        .eq("tournament_id", tournament_id)
+        .execute()
+    )
+    supabase.table("tournaments").delete().eq("id", tournament_id).execute()
 
 
 def get_tournament_record(supabase, tournament_id: str) -> dict[str, Any] | None:
@@ -501,6 +576,8 @@ def get_public_tournament_bundle(
     tournament = get_tournament_record(supabase, str(tournament_id))
     if not tournament or str(tournament.get("club_id")) != str(club_id):
         return None, None, [], []
+    if str(tournament.get("status") or "").upper() == "ARCHIVED":
+        return None, None, [], []
 
     days = list_registration_days(supabase, str(tournament_id))
     event_options = list_event_options(supabase, str(tournament_id))
@@ -517,6 +594,8 @@ def list_open_public_tournaments(supabase, club_id: str) -> list[dict[str, Any]]
         if not tournament:
             continue
         if str(tournament.get("club_id")) != str(club_id):
+            continue
+        if str(tournament.get("status") or "").upper() == "ARCHIVED":
             continue
         out.append({"tournament": tournament, "settings": settings})
     out.sort(key=lambda row: str(row.get("tournament", {}).get("created_at") or ""), reverse=True)

--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -714,15 +714,21 @@ def render(ctx):
             st.caption(detail)
         st.stop()
 
-    tournaments = list_existing_tournaments(supabase, str(club_id))
+    st.subheader("Select Tournament")
+    show_archived = st.checkbox("Show archived", value=False, key="tournament_manager_show_archived")
+    st.caption("Archived tournaments are hidden from default selectors and public registration.")
+    tournaments = list_existing_tournaments(supabase, str(club_id), include_archived=show_archived)
     if not tournaments:
-        st.info("Create a tournament shell on the Tournaments page first.")
+        st.info("Create a tournament shell on the Tournaments page first, or enable Show archived.")
         st.stop()
 
-    st.subheader("Select Tournament")
     st.caption("Choose which tournament shell to manage before editing metadata, days, events, and divisions.")
     requested_id = _safe_text(st.query_params.get("tournament_id"))
-    labels = [f"{row.get('name')} ({row.get('status')})" for row in tournaments]
+    labels = []
+    for row in tournaments:
+        status = _safe_text(row.get('status') or 'DRAFT')
+        status_label = 'ARCHIVED' if status.upper() == 'ARCHIVED' else status
+        labels.append(f"{row.get('name')} ({status_label})")
     default_index = 0
     if requested_id:
         for idx, row in enumerate(tournaments):

--- a/jupr_app/ui/pages/tournament_registration.py
+++ b/jupr_app/ui/pages/tournament_registration.py
@@ -146,6 +146,8 @@ def render(ctx):
     )
 
     if not tournament:
+        if qp_tournament_id or qp_slug:
+            st.warning("This tournament is unavailable for public registration.")
         tournament, settings, days, event_options = _show_tournament_picker(ctx, supabase)
         if not tournament:
             st.stop()

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -30,18 +30,23 @@ from jupr_app.domain.tournaments import (
 )
 from jupr_app.domain.tournament_podium import award_tournament_trophies_from_podium, upsert_tournament_podium
 from jupr_app.domain.tournament_registration_repo import (
+    archive_tournament,
     build_public_urls,
     build_registration_state,
+    delete_unused_draft_tournament,
     get_registration_settings,
     list_event_options as list_registration_event_options,
+    list_existing_tournaments,
     list_registration_days,
     registration_feature_available,
+    tournament_can_be_deleted,
+    unarchive_tournament,
     upsert_registration_settings,
 )
 from jupr_app.ui.layout import page_shell
 
 LEGACY_DEFAULT_TEAM_COUNT = 4
-TOURNAMENT_STATUS_OPTIONS = ["DRAFT", "REGISTRATION", "REGISTRATION_OPEN", "REGISTRATION_CLOSED"]
+TOURNAMENT_STATUS_OPTIONS = ["DRAFT", "REGISTRATION", "REGISTRATION_OPEN", "REGISTRATION_CLOSED", "ARCHIVED"]
 TOURNAMENT_LOCALE_OPTIONS = ["en", "es", "bilingual"]
 IMPORT_SOURCE_OPTIONS = ["REGISTRATION", "MANUAL", "BULK_UPLOAD"]
 
@@ -344,21 +349,22 @@ def render(ctx):
 
     st.divider()
 
-    tournaments_resp = (
-        supabase.table("tournaments")
-        .select("*")
-        .eq("club_id", str(club_id))
-        .order("created_at", desc=True)
-        .execute()
-    )
-    tournaments = tournaments_resp.data or []
+    st.subheader("Tournament List")
+    show_archived = st.checkbox("Show archived", value=False, key="tournaments_show_archived")
+    st.caption("Archived tournaments are hidden from default selectors and public registration.")
+
+    tournaments = list_existing_tournaments(supabase, str(club_id), include_archived=show_archived)
 
     if not tournaments:
-        st.info("No tournaments created yet.")
+        st.info("No tournaments available for this filter.")
         st.stop()
 
     preselected = _safe_text(st.query_params.get("tournament_id"))
-    tournament_labels = [f"{row['name']} ({row['status']})" for row in tournaments]
+    tournament_labels = []
+    for row in tournaments:
+        status = _safe_text(row.get("status") or "DRAFT")
+        status_label = "ARCHIVED" if status.upper() == "ARCHIVED" else status
+        tournament_labels.append(f"{row['name']} ({status_label})")
     default_index = 0
     if preselected:
         for idx, row in enumerate(tournaments):
@@ -398,6 +404,37 @@ def render(ctx):
         st.info("This tournament has no saved start/end dates yet. Add dates in Tournament Manager to auto-generate the default day schedule.")
     if st.button("Open Tournament Manager", key=f"open_tournament_manager_{tournament_id}"):
         _go_to_tournament_manager(tournament_id)
+
+    st.markdown("#### Admin Actions")
+    st.caption("Delete Draft is only available for empty draft shells with no registrations, draws, teams, games, or podium.")
+    action_cols = st.columns(2)
+    if _safe_text(tournament.get("status")).upper() == "ARCHIVED":
+        action_cols[0].caption("Unarchive restores this tournament as DRAFT; you can change status afterward if needed.")
+        if action_cols[0].button("Unarchive Tournament", key=f"unarchive_tournament_{tournament_id}"):
+            unarchive_tournament(supabase, tournament_id)
+            st.success("Tournament unarchived and restored to DRAFT.")
+            st.rerun()
+    else:
+        if action_cols[0].button("Archive Tournament", key=f"archive_tournament_{tournament_id}"):
+            archive_tournament(supabase, tournament_id)
+            st.success("Tournament archived and hidden from default selectors and public registration.")
+            st.rerun()
+
+    can_delete, usage_summary, delete_reason = tournament_can_be_deleted(supabase, tournament)
+    if can_delete:
+        delete_confirm = action_cols[1].text_input("Type DELETE to confirm draft deletion", key=f"delete_draft_confirm_{tournament_id}")
+        if action_cols[1].button("Delete Draft", key=f"delete_draft_tournament_{tournament_id}"):
+            if delete_confirm != "DELETE":
+                st.error("Type DELETE exactly to confirm draft deletion.")
+            else:
+                delete_unused_draft_tournament(supabase, tournament)
+                st.success("Draft tournament shell deleted.")
+                st.query_params.pop("tournament_id", None)
+                st.rerun()
+    else:
+        usage_bits = [f"{label}: {usage_summary.get(key, 0)}" for key, label in [("registrations", "registrations"), ("registration_selections", "selections"), ("event_draws", "draws"), ("teams", "teams"), ("games", "games"), ("podium", "podium")]]
+        action_cols[1].warning(delete_reason or "This tournament has existing operational/history records. Archive it instead of deleting.")
+        action_cols[1].caption("Usage summary — " + ", ".join(usage_bits))
 
     draws = _list_draws(supabase, tournament_id)
     modern_mode = bool((registration_bridge or {}).get("events"))


### PR DESCRIPTION
### Motivation
- Prevent accidental destructive deletes while letting admins archive old tournaments that clutter selectors and unarchive them when needed.  
- Ensure public registration and admin selectors hide archived tournaments by default and never treat them as open.  
- Provide a safe, auditable hard-delete path only for truly unused draft shells and guide admins to archive otherwise.

### Description
- Added repository helpers in `jupr_app/domain/tournament_registration_repo.py`: `list_existing_tournaments(..., include_archived=False)`, `_count_table_rows`, `get_tournament_usage_summary`, `tournament_can_be_deleted`, `archive_tournament`, `unarchive_tournament`, and `delete_unused_draft_tournament`; archived tournaments are filtered out by default and public bundle/open-list functions now exclude archived tournaments.  
- Updated admin UI in `jupr_app/ui/pages/tournaments.py` to add a `Show archived` checkbox (default off), label archived rows as `(ARCHIVED)`, show `Archive Tournament` / `Unarchive Tournament` actions, and add a guarded `Delete Draft` flow that requires typing `DELETE` and only deletes empty draft shells (cleans `tournament_registration_settings`, `tournament_event_options`, `tournament_registration_days` then the `tournaments` row).  
- Updated `jupr_app/ui/pages/tournament_manager.py` to add the same `Show archived` toggle and archived labeling in its selector (default off).  
- Updated public registration page `jupr_app/ui/pages/tournament_registration.py` so direct query params pointing to archived tournaments show an unavailable warning and archived tournaments are not returned by the open-public picker.  
- Kept existing behavior for non-archived tournaments, added `ARCHIVED` to status options, and intentionally did not add any DB migrations or create any permanent delete path for non-draft tournaments.  
- Files changed: `jupr_app/domain/tournament_registration_repo.py`, `jupr_app/ui/pages/tournaments.py`, `jupr_app/ui/pages/tournament_manager.py`, `jupr_app/ui/pages/tournament_registration.py`.

### Testing
- Ran Python compile checks with `python -m py_compile jupr_app/domain/tournament_registration_repo.py jupr_app/ui/pages/tournaments.py jupr_app/ui/pages/tournament_manager.py jupr_app/ui/pages/tournament_registration.py` and it completed without syntax errors.  
- Verified (manual code inspection) that archived tournaments are filtered from `list_open_public_tournaments` and `get_public_tournament_bundle`, and that UI selectors call `list_existing_tournaments(..., include_archived=...)` so the `Show archived` toggles control visibility by default.
- No automated DB/migration tests were run since the change intentionally avoids schema changes.  

Assumptions: no DB migration allowed so prior status is not preserved on unarchive (unarchive restores `DRAFT`); commit applied on the current working branch in the environment where `rollback-feb8` was not present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e289b4bf748326ae69b171dfa4a36e)