### PR TITLE
Add Club Social roster confirmation flow and social tab refresh fixes

### DIFF
--- a/jupr_app/domain/live_social.py
+++ b/jupr_app/domain/live_social.py
@@ -236,6 +236,8 @@ def resolve_or_create_club_person(
     display_name: str,
     event_date: str,
     club_id: str | None = None,
+    explicit_linked_player_id: int | None = None,
+    allow_name_auto_link: bool = True,
 ) -> tuple[dict, bool, bool]:
     """Returns (club_person_row, created_new, matched_competitive_player)."""
     supabase = ctx.supabase
@@ -245,8 +247,12 @@ def resolve_or_create_club_person(
     if not normalized:
         raise ValueError("Participant display name is required.")
 
-    player_map = _normalized_name_to_player_id(getattr(ctx, "name_to_id", {}))
-    linked_player_id = player_map.get(normalized)
+    linked_player_id = None
+    if explicit_linked_player_id is not None:
+        linked_player_id = int(explicit_linked_player_id)
+    elif allow_name_auto_link:
+        player_map = _normalized_name_to_player_id(getattr(ctx, "name_to_id", {}))
+        linked_player_id = player_map.get(normalized)
 
     if linked_player_id is not None:
         linked_rows = (
@@ -500,11 +506,20 @@ def save_social_live_event(
     try:
         for participant in participants:
             display_name = str(participant.get("name") or participant.get("id") or "")
+            explicit_player_id = participant.get("player_id")
+            match_status = str(participant.get("match_status") or "").strip().lower()
+            auto_link_enabled = match_status not in {"new_social", "new social person"}
             club_person, created_new, matched_player = resolve_or_create_club_person(
                 ctx,
                 display_name=display_name,
                 event_date=event_date,
                 club_id=club_id,
+                explicit_linked_player_id=(
+                    int(explicit_player_id)
+                    if explicit_player_id is not None and str(explicit_player_id).strip() != ""
+                    else None
+                ),
+                allow_name_auto_link=auto_link_enabled,
             )
             created_people_count += int(bool(created_new))
             linked_existing_players_count += int(bool(matched_player))
@@ -552,6 +567,7 @@ def save_social_live_event(
             "event_date": event_date,
             "status": status,
             "submission_mode": normalized_submission_mode,
+            "submitted_by": submitted_by,
             "submitted_by_name": submitted_by,
             "moderated_at": moderated_at,
             "moderated_by": moderated_by,
@@ -621,6 +637,7 @@ def save_social_live_event(
             "event_id": event_id,
             "status": status,
             "submission_mode": normalized_submission_mode,
+            "submitted_by": submitted_by,
             "submitted_by_name": submitted_by,
             "saved_rounds": _saved_rounds(event),
             "participant_count": len(participant_rows),

--- a/jupr_app/ui/live/shared.py
+++ b/jupr_app/ui/live/shared.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import difflib
 import re
 from typing import Callable
 
@@ -66,6 +67,7 @@ class LivePageConfig:
     allow_tournament: bool = False
     show_official_context: bool = False
     persistent_save_label: str | None = None
+    requires_roster_resolution: bool = False
 
 
 def _default_state(config: LivePageConfig) -> dict:
@@ -82,6 +84,11 @@ def _default_state(config: LivePageConfig) -> dict:
         "official_week_tag": "Week 1",
         "last_saved_rounds": [],
         "editing_substitution_id": None,
+        "parsed_roster_lines": [],
+        "roster_candidates": [],
+        "confirmed_roster_rows": [],
+        "roster_confirmed": False,
+        "resolved_roster_ids": {},
     }
 
 
@@ -229,6 +236,130 @@ def _merge_participant_text(participant_text: str, selected_names: list[str]) ->
     existing_lines = _participant_lines(participant_text)
     merged_lines = _dedupe_names(existing_lines + list(selected_names or []))
     return "\n".join(merged_lines)
+
+
+def _normalized_person_key(value: object) -> str:
+    return normalize_name(value).casefold()
+
+
+def _best_fuzzy_score(target: str, candidate: str) -> float:
+    if not target or not candidate:
+        return 0.0
+    return float(difflib.SequenceMatcher(None, target, candidate).ratio())
+
+
+def _build_roster_candidate_rows(
+    participant_names: list[str],
+    player_name_to_id: dict[str, int],
+    *,
+    suggestion_cap: int = 5,
+) -> list[dict]:
+    normalized_to_names: dict[str, list[str]] = {}
+    for player_name in player_name_to_id.keys():
+        key = _normalized_person_key(player_name)
+        if not key:
+            continue
+        normalized_to_names.setdefault(key, []).append(str(player_name))
+    normalized_keys = list(normalized_to_names.keys())
+
+    rows: list[dict] = []
+    for pasted_name in participant_names:
+        normalized_pasted = _normalized_person_key(pasted_name)
+        exact_names = normalized_to_names.get(normalized_pasted, [])
+        candidate_names: list[str] = []
+        if exact_names:
+            candidate_names.extend(exact_names)
+        else:
+            close_keys = difflib.get_close_matches(
+                normalized_pasted,
+                normalized_keys,
+                n=max(1, int(suggestion_cap)),
+                cutoff=0.65,
+            )
+            for key in close_keys:
+                for match_name in normalized_to_names.get(key, []):
+                    if match_name not in candidate_names:
+                        candidate_names.append(match_name)
+        candidate_names = candidate_names[: max(1, int(suggestion_cap))]
+        top_score = 0.0
+        if candidate_names:
+            top_score = max(
+                _best_fuzzy_score(normalized_pasted, _normalized_person_key(name))
+                for name in candidate_names
+            )
+        if exact_names:
+            status = "exact match"
+        elif candidate_names:
+            status = "suggested match"
+        else:
+            status = "new social person"
+
+        new_social_token = f"new::{normalized_pasted or pasted_name}"
+        options: list[dict[str, str | int | None]] = [
+            {"token": f"player::{int(player_name_to_id[name])}", "label": str(name)}
+            for name in candidate_names
+        ]
+        options.append(
+            {
+                "token": new_social_token,
+                "label": f"Use as new social player: {normalize_name(pasted_name)}",
+            }
+        )
+        default_token = new_social_token
+        if exact_names:
+            default_token = f"player::{int(player_name_to_id[exact_names[0]])}"
+        elif candidate_names and top_score >= 0.86:
+            default_token = f"player::{int(player_name_to_id[candidate_names[0]])}"
+        rows.append(
+            {
+                "original": str(pasted_name),
+                "normalized": normalize_name(pasted_name),
+                "status": status,
+                "default_token": default_token,
+                "options": options,
+            }
+        )
+    return rows
+
+
+def _resolved_participants_from_confirmation(
+    confirmed_rows: list[dict],
+    player_name_to_id: dict[str, int],
+) -> tuple[list[str], dict[str, int], list[dict]]:
+    id_to_name = {int(pid): str(name) for name, pid in player_name_to_id.items()}
+    names: list[str] = []
+    resolved_ids: dict[str, int] = {}
+    resolved_rows: list[dict] = []
+    for row in confirmed_rows:
+        selected_token = str(row.get("selection") or "")
+        original = normalize_name(row.get("original"))
+        if selected_token.startswith("player::"):
+            player_id = int(selected_token.split("::", 1)[1])
+            canonical = normalize_name(id_to_name.get(player_id, original))
+            if canonical:
+                names.append(canonical)
+                resolved_ids[canonical] = int(player_id)
+                resolved_rows.append(
+                    {
+                        "name": canonical,
+                        "player_id": int(player_id),
+                        "source_name": original,
+                        "match_status": "matched_existing",
+                    }
+                )
+            continue
+        social_name = original
+        if social_name:
+            names.append(social_name)
+            resolved_rows.append(
+                {
+                    "name": social_name,
+                    "player_id": None,
+                    "source_name": original,
+                    "match_status": "new_social",
+                }
+            )
+    return names, resolved_ids, resolved_rows
 
 def _team_entry_lines(value: str) -> list[dict[str, str]]:
     entries: list[dict[str, str]] = []
@@ -433,6 +564,20 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
     if config.show_official_context:
         official_context, can_create = _official_context_ui(ctx, state)
     participant_names = _participant_lines(state["participant_text"])
+    roster_requires_resolution = bool(config.requires_roster_resolution) and state["type_label"] in {
+        "Round Robin",
+        "League / Ladder",
+    }
+    player_options, player_name_to_id = _player_directory(ctx)
+    if roster_requires_resolution:
+        if state.get("parsed_roster_lines") != participant_names:
+            state["parsed_roster_lines"] = list(participant_names)
+            state["roster_candidates"] = _build_roster_candidate_rows(
+                participant_names,
+                player_name_to_id,
+            )
+            state["confirmed_roster_rows"] = []
+            state["roster_confirmed"] = False
     team_entries: list[dict[str, str]] = []
     team_parse_error: str | None = None
     if state["type_label"] == "Tournament":
@@ -455,30 +600,124 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
             f"You entered {len(participant_names)} name(s); count is set to {int(state['participant_count'])}."
         )
         can_create = False
+    if roster_requires_resolution and participant_names:
+        roster_candidates = list(state.get("roster_candidates") or [])
+        st.markdown("#### Review roster matches")
+        st.caption(
+            "Confirm each pasted name once. Exact or suggested matches use canonical current-player names; "
+            "or choose the explicit new social player option."
+        )
+        with st.form(f"{config.state_key}_roster_resolution_form"):
+            confirmed_rows: list[dict] = []
+            for idx, row in enumerate(roster_candidates):
+                status_col, selector_col = st.columns([1.3, 3.7])
+                status_col.caption(f"**{row.get('original', '')}**")
+                status_col.caption(f"Status: {row.get('status', 'new social person')}")
+                options = list(row.get("options") or [])
+                labels = [str(opt.get("label") or "") for opt in options]
+                tokens = [str(opt.get("token") or "") for opt in options]
+                default_token = str(row.get("default_token") or "")
+                default_index = tokens.index(default_token) if default_token in tokens else max(len(tokens) - 1, 0)
+                selected_label = selector_col.selectbox(
+                    f"Match choice {idx + 1}",
+                    options=labels,
+                    index=default_index,
+                    key=f"{config.state_key}_roster_choice_{idx}",
+                    label_visibility="collapsed",
+                )
+                selected_token = tokens[labels.index(selected_label)] if selected_label in labels else default_token
+                confirmed_rows.append(
+                    {
+                        "original": str(row.get("original") or ""),
+                        "selection": selected_token,
+                        "status": str(row.get("status") or ""),
+                    }
+                )
+            confirmed = st.form_submit_button("Confirm roster", type="primary")
+        if confirmed:
+            canonical_names, resolved_ids, resolved_rows = _resolved_participants_from_confirmation(
+                confirmed_rows,
+                player_name_to_id,
+            )
+            if len(canonical_names) != int(state["participant_count"]):
+                st.error(
+                    f"Confirmed roster has {len(canonical_names)} entries; expected {int(state['participant_count'])}."
+                )
+            else:
+                state["confirmed_roster_rows"] = resolved_rows
+                state["roster_confirmed"] = True
+                state["participant_text"] = "\n".join(canonical_names)
+                state["resolved_roster_ids"] = resolved_ids
+                st.success("Roster confirmed. You can now create the event.")
+                st.rerun()
+        if state.get("roster_confirmed"):
+            confirmed_rows = list(state.get("confirmed_roster_rows") or [])
+            matched_rows = [row for row in confirmed_rows if row.get("player_id") is not None]
+            new_rows = [row for row in confirmed_rows if row.get("player_id") is None]
+            st.caption(
+                f"Confirmed roster: {len(matched_rows)} matched existing players, {len(new_rows)} new social players."
+            )
+            if matched_rows:
+                st.caption("Matched: " + ", ".join(str(row.get("name") or "") for row in matched_rows))
+            if new_rows:
+                st.caption("New social: " + ", ".join(str(row.get("name") or "") for row in new_rows))
+
     action_cols = st.columns([1, 1, 3])
+    create_disabled = not can_create or (roster_requires_resolution and not bool(state.get("roster_confirmed")))
     if action_cols[0].button(
         "Create event",
         type="primary",
-        disabled=not can_create,
+        disabled=create_disabled,
         key=f"{config.state_key}_create_btn",
     ):
         try:
+            create_participant_names = list(participant_names)
+            create_resolved_ids: dict[str, int] | None = None
+            confirmed_roster_rows = list(state.get("confirmed_roster_rows") or [])
+            if roster_requires_resolution and confirmed_roster_rows:
+                create_participant_names, create_resolved_ids, resolved_rows = _resolved_participants_from_confirmation(
+                    [
+                        {
+                            "original": row.get("source_name") or row.get("name"),
+                            "selection": (
+                                f"player::{int(row.get('player_id'))}"
+                                if row.get("player_id") is not None
+                                else f"new::{_normalized_person_key(row.get('name'))}"
+                            ),
+                        }
+                        for row in confirmed_roster_rows
+                    ],
+                    player_name_to_id,
+                )
             if state["type_label"] == "Round Robin":
                 resolved_ids = None
                 if _is_official(config):
                     resolved_ids, missing = _resolved_ids_for_official(
-                        participant_names, getattr(ctx, "name_to_id", {})
+                        create_participant_names, getattr(ctx, "name_to_id", {})
                     )
                     if missing:
                         raise ValueError(
                             "Official mode could not resolve: " + ", ".join(missing)
                         )
+                elif create_resolved_ids:
+                    resolved_ids = dict(create_resolved_ids)
                 state["event"] = create_round_robin_event(
                     name=state["event_name"],
-                    participant_names=participant_names,
+                    participant_names=create_participant_names,
                     resolved_ids=resolved_ids,
                     official_context=official_context,
                 )
+                if roster_requires_resolution and confirmed_roster_rows:
+                    participant_by_name = {
+                        str(p.get("name") or ""): p for p in (state["event"].get("participants") or [])
+                    }
+                    for row in confirmed_roster_rows:
+                        participant = participant_by_name.get(str(row.get("name") or ""))
+                        if not participant:
+                            continue
+                        participant["social_resolution"] = dict(row)
+                        participant["match_status"] = str(row.get("match_status") or "")
+                        participant["source_name"] = str(row.get("source_name") or "")
             elif state["type_label"] == "Tournament":
                 if _is_official(config):
                     resolved_team_entries: list[dict[str, str | int]] = []
@@ -528,20 +767,33 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
                 resolved_ids = None
                 if _is_official(config):
                     resolved_ids, missing = _resolved_ids_for_official(
-                        participant_names, getattr(ctx, "name_to_id", {})
+                        create_participant_names, getattr(ctx, "name_to_id", {})
                     )
                     if missing:
                         raise ValueError(
                             "Official mode could not resolve: " + ", ".join(missing)
                         )
+                elif create_resolved_ids:
+                    resolved_ids = dict(create_resolved_ids)
                 state["event"] = create_league_event(
                     name=state["event_name"],
-                    participant_names=participant_names,
+                    participant_names=create_participant_names,
                     total_rounds=int(state["league_rounds"]),
                     resolved_ids=resolved_ids,
                     court_sizes=exact_sizes,
                     official_context=official_context,
                 )
+                if roster_requires_resolution and confirmed_roster_rows:
+                    participant_by_name = {
+                        str(p.get("name") or ""): p for p in (state["event"].get("participants") or [])
+                    }
+                    for row in confirmed_roster_rows:
+                        participant = participant_by_name.get(str(row.get("name") or ""))
+                        if not participant:
+                            continue
+                        participant["social_resolution"] = dict(row)
+                        participant["match_status"] = str(row.get("match_status") or "")
+                        participant["source_name"] = str(row.get("source_name") or "")
             state["last_saved_rounds"] = []
             st.success("Event created.")
             st.rerun()

--- a/jupr_app/ui/pages/jupr_live.py
+++ b/jupr_app/ui/pages/jupr_live.py
@@ -39,6 +39,7 @@ CLUB_SOCIAL_CONFIG = LivePageConfig(
     allow_tournament=False,
     show_official_context=False,
     persistent_save_label="Submit club social results",
+    requires_roster_resolution=True,
 )
 
 MODE_OPTIONS = ("Quick Session", "Club Social")
@@ -106,9 +107,23 @@ def _save_social(ctx, state: dict, event: dict) -> bool:
     state["last_saved_rounds"] = list(result.get("saved_rounds") or [])
     event["saved_rounds"] = list(result.get("saved_rounds") or [])
     st.session_state["force_data_refresh"] = True
+    try:
+        from jupr_app.ui.pages.players import (
+            fetch_player_social_event_history,
+            fetch_player_social_participation,
+        )
+
+        fetch_player_social_event_history.clear()
+        fetch_player_social_participation.clear()
+    except Exception:
+        pass
+    status = str(result.get("status") or "")
+    if status == "saved":
+        title = "Club Social results saved"
+    else:
+        title = "Club Social results submitted and awaiting approval"
     st.success(
-        "Club Social results submitted "
-        f"({result['match_count']} matches, {result['participant_count']} participants, status: {result['status']})."
+        f"{title} ({result['participant_count']} participants, {result['match_count']} matches, final status: {status})."
     )
     return True
 

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -351,7 +351,7 @@ def fetch_player_social_event_history(_supabase, club_id: str, pid: int, limit: 
     try:
         events_resp = (
             _supabase.table("live_events")
-            .select("id,name,event_type,event_date,submitted_by,status,result_mode,summary_json")
+            .select("id,name,event_type,event_date,submitted_by,submitted_by_name,status,result_mode,summary_json")
             .eq("club_id", str(club_id))
             .eq("result_mode", "social_unrated")
             .eq("status", "saved")
@@ -434,7 +434,7 @@ def fetch_player_social_event_history(_supabase, club_id: str, pid: int, limit: 
                 "Wins": 0,
                 "Losses": 0,
                 "Diff": 0,
-                "Submitted By": str(event_row.get("submitted_by") or "").strip(),
+                "Submitted By": str(event_row.get("submitted_by") or event_row.get("submitted_by_name") or "").strip(),
             }
         )
 


### PR DESCRIPTION
### Motivation
- Club Social needs an explicit paste→resolve→confirm roster UX so pasted names do not silently create competitive `players` rows and matched players reliably link to their Social tab. 
- Event creation for Club Social should be blocked until the roster is confirmed so canonical display names and explicit `player_id` linkage can be preserved on save. 
- After a Club Social save, player Social views must reflect results immediately without relying solely on eventual cache expiry.

### Description
- Added a narrow flag `requires_roster_resolution` to `LivePageConfig` and enabled it for the Club Social config so the new roster confirmation UI runs only for Club Social (`jupr_app/ui/live/shared.py` and `jupr_app/ui/pages/jupr_live.py`).
- Implemented paste parsing + candidate matching using existing normalization helpers and `difflib` fuzzy matching (no new dependencies) with per-line selectboxes and an explicit `Use as new social player: <name>` option; default picks prefer exact matches then high-confidence fuzzy matches (`jupr_app/ui/live/shared.py`).
- On confirmation the flow canonicalizes names, builds a confirmed roster carrying `player_id` where matched and `match_status` for new social-only people, disables Create Event until confirmation, and annotates event participant rows with `social_resolution` metadata to preserve deterministic linkage (`jupr_app/ui/live/shared.py`).
- In `jupr_app/domain/live_social.py` `resolve_or_create_club_person` now accepts an `explicit_linked_player_id` and an `allow_name_auto_link` flag so explicit confirmations are honored and automatic name-based linking can be disabled for rows marked new social; the save path preserves explicit matches and writes both `submitted_by` and `submitted_by_name` for consistency.
- Improved submit feedback and targeted cache invalidation: after successful Club Social save the UI shows either `Club Social results saved` (admin path / `saved`) or `Club Social results submitted and awaiting approval` (public / `pending`) including participant and match counts, and the code clears `fetch_player_social_event_history` and `fetch_player_social_participation` caches to ensure player Social pages refresh immediately (`jupr_app/ui/pages/jupr_live.py`, `jupr_app/ui/pages/players.py`).
- Adjusted the player Social reader to prefer `submitted_by` but fall back to `submitted_by_name` so the Recent Social Events table displays submitter reliably (`jupr_app/ui/pages/players.py`).

### Testing
- Ran `python -m py_compile jupr_app/ui/live/shared.py jupr_app/ui/pages/jupr_live.py jupr_app/domain/live_social.py jupr_app/ui/pages/players.py` and compilation succeeded with no syntax errors. 
- Verified targeted cache-clear calls are invoked in the save flow (unit/runtime behavior to be validated in integration/manual QA). 
- No new external packages were introduced and official JUPR Live Admin workflows were left unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28f8f076c8326834a50af6e69f4eb)