### PR TITLE
Fix Club Social submitted-by schema drift and finalize roster confirmation flow

### DIFF
--- a/jupr_app/domain/live_social.py
+++ b/jupr_app/domain/live_social.py
@@ -554,7 +554,7 @@ def save_social_live_event(
         )
         normalized_submission_mode = str(submission_mode or "").strip().lower() or "public"
         status = _status_for_submission_mode(normalized_submission_mode)
-        submitted_by = normalize_name(host_name) or ("admin" if status == "saved" else "guest")
+        submitted_by_name = normalize_name(host_name) or ("admin" if status == "saved" else "guest")
         moderated_at = datetime.now(timezone.utc).isoformat() if status == "saved" else None
         moderated_by = _moderated_by(ctx) if status == "saved" else None
 
@@ -567,8 +567,7 @@ def save_social_live_event(
             "event_date": event_date,
             "status": status,
             "submission_mode": normalized_submission_mode,
-            "submitted_by": submitted_by,
-            "submitted_by_name": submitted_by,
+            "submitted_by_name": submitted_by_name,
             "moderated_at": moderated_at,
             "moderated_by": moderated_by,
             "rejection_reason": None,
@@ -637,8 +636,7 @@ def save_social_live_event(
             "event_id": event_id,
             "status": status,
             "submission_mode": normalized_submission_mode,
-            "submitted_by": submitted_by,
-            "submitted_by_name": submitted_by,
+            "submitted_by_name": submitted_by_name,
             "saved_rounds": _saved_rounds(event),
             "participant_count": len(participant_rows),
             "match_count": len(match_rows),

--- a/jupr_app/ui/live/shared.py
+++ b/jupr_app/ui/live/shared.py
@@ -602,7 +602,7 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
         can_create = False
     if roster_requires_resolution and participant_names:
         roster_candidates = list(state.get("roster_candidates") or [])
-        st.markdown("#### Review roster matches")
+        st.markdown("#### Step 1: Review roster matches")
         st.caption(
             "Confirm each pasted name once. Exact or suggested matches use canonical current-player names; "
             "or choose the explicit new social player option."
@@ -648,7 +648,7 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
                 state["roster_confirmed"] = True
                 state["participant_text"] = "\n".join(canonical_names)
                 state["resolved_roster_ids"] = resolved_ids
-                st.success("Roster confirmed. You can now create the event.")
+                st.success("Step 2 complete: roster confirmed. You can now create the event.")
                 st.rerun()
         if state.get("roster_confirmed"):
             confirmed_rows = list(state.get("confirmed_roster_rows") or [])
@@ -663,6 +663,8 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
                 st.caption("New social: " + ", ".join(str(row.get("name") or "") for row in new_rows))
 
     action_cols = st.columns([1, 1, 3])
+    if roster_requires_resolution:
+        st.caption("Step 3: Create event → enter scores → submit Club Social results.")
     create_disabled = not can_create or (roster_requires_resolution and not bool(state.get("roster_confirmed")))
     if action_cols[0].button(
         "Create event",

--- a/jupr_app/ui/pages/jupr_live.py
+++ b/jupr_app/ui/pages/jupr_live.py
@@ -119,9 +119,9 @@ def _save_social(ctx, state: dict, event: dict) -> bool:
         pass
     status = str(result.get("status") or "")
     if status == "saved":
-        title = "Club Social results saved"
+        title = "Club Social results saved (admin)"
     else:
-        title = "Club Social results submitted and awaiting approval"
+        title = "Club Social results submitted (public) — pending admin approval"
     st.success(
         f"{title} ({result['participant_count']} participants, {result['match_count']} matches, final status: {status})."
     )

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -351,7 +351,7 @@ def fetch_player_social_event_history(_supabase, club_id: str, pid: int, limit: 
     try:
         events_resp = (
             _supabase.table("live_events")
-            .select("id,name,event_type,event_date,submitted_by,submitted_by_name,status,result_mode,summary_json")
+            .select("id,name,event_type,event_date,submitted_by_name,status,result_mode,summary_json")
             .eq("club_id", str(club_id))
             .eq("result_mode", "social_unrated")
             .eq("status", "saved")
@@ -434,7 +434,7 @@ def fetch_player_social_event_history(_supabase, club_id: str, pid: int, limit: 
                 "Wins": 0,
                 "Losses": 0,
                 "Diff": 0,
-                "Submitted By": str(event_row.get("submitted_by") or event_row.get("submitted_by_name") or "").strip(),
+                "Submitted By": str(event_row.get("submitted_by_name") or "").strip(),
             }
         )
 

--- a/migrations/20260417_live_events_submitted_by_name_canonical.sql
+++ b/migrations/20260417_live_events_submitted_by_name_canonical.sql
@@ -1,0 +1,60 @@
+-- Canonical submitter field for Club Social is live_events.submitted_by_name.
+-- Forward migration:
+--   1) Ensure submitted_by_name exists.
+--   2) Backfill from legacy submitted_by when present.
+--   3) Keep submitted_by_name synchronized when legacy submitted_by is written during transition.
+
+alter table if exists public.live_events
+    add column if not exists submitted_by_name text null;
+
+-- Backfill canonical column from legacy column where available.
+do $$
+begin
+    if exists (
+        select 1
+        from information_schema.columns
+        where table_schema = 'public'
+          and table_name = 'live_events'
+          and column_name = 'submitted_by'
+    ) then
+        execute $sql$
+            update public.live_events
+               set submitted_by_name = coalesce(nullif(submitted_by_name, ''), submitted_by)
+             where coalesce(nullif(submitted_by_name, ''), '') = ''
+               and coalesce(nullif(submitted_by, ''), '') <> ''
+        $sql$;
+    end if;
+end;
+$$;
+
+-- Transition trigger: if some clients still write submitted_by, mirror it into canonical submitted_by_name.
+create or replace function public.live_events_sync_submitted_by_name()
+returns trigger
+language plpgsql
+as $$
+begin
+    if new.submitted_by_name is null or btrim(new.submitted_by_name) = '' then
+        if exists (
+            select 1
+            from information_schema.columns
+            where table_schema = 'public'
+              and table_name = 'live_events'
+              and column_name = 'submitted_by'
+        ) then
+            execute 'select ($1).submitted_by' into new.submitted_by_name using new;
+        end if;
+    end if;
+    return new;
+end;
+$$;
+
+drop trigger if exists live_events_sync_submitted_by_name on public.live_events;
+create trigger live_events_sync_submitted_by_name
+before insert or update on public.live_events
+for each row
+execute function public.live_events_sync_submitted_by_name();
+
+-- Rollback SQL:
+--   drop trigger if exists live_events_sync_submitted_by_name on public.live_events;
+--   drop function if exists public.live_events_sync_submitted_by_name();
+--   alter table if exists public.live_events drop column if exists submitted_by_name;


### PR DESCRIPTION
### Motivation
- Stop Club Social saves from crashing with PostgREST error `PGRST204` by removing mixed writes to a missing `submitted_by` column and standardizing to a single canonical field. 
- Ensure player Social history reads and displays the correct submitter value so Social tabs show the right data after saves. 
- Provide a clear confirmable roster flow for Club Social and make newly-submitted socials visible immediately without waiting on stale cache expiry.

### Description
- Standardized persistence and return values to use the canonical column `live_events.submitted_by_name` only by removing writes to the legacy `submitted_by` field in `save_social_live_event` (file: `jupr_app/domain/live_social.py`).
- Updated player social history query and display to select and render `submitted_by_name` consistently (file: `jupr_app/ui/pages/players.py`).
- Added a migration `migrations/20260417_live_events_submitted_by_name_canonical.sql` that ensures `submitted_by_name` exists, backfills it from `submitted_by` when present, and installs a transition trigger to mirror legacy `submitted_by` writes into the canonical column; rollback SQL is included in the migration file comments. The canonical column going forward is `live_events.submitted_by_name`.
- Kept targeted cache invalidation after Club Social save by clearing the cached helpers `fetch_player_social_event_history` and `fetch_player_social_participation` so the Player → Social view updates immediately (file: `jupr_app/ui/pages/jupr_live.py`).
- Finalized roster confirmation UX messaging and flow (Step 1/2/3 labels and confirm-before-create gating) while preserving the existing behavior of matching existing players and creating social-only people for unmatched names (file: `jupr_app/ui/live/shared.py`).
- Clarified post-submit success messages to explicitly distinguish admin (`saved`) vs public (`pending`) submissions (file: `jupr_app/ui/pages/jupr_live.py`).

### Testing
- Compiled the modified modules with `python -m compileall jupr_app/domain/live_social.py jupr_app/ui/pages/jupr_live.py jupr_app/ui/pages/players.py jupr_app/ui/live/shared.py` and the compilation succeeded. 
- No automated DB migration runtime tests were run in this environment; the migration SQL and explicit rollback SQL are provided in `migrations/20260417_live_events_submitted_by_name_canonical.sql` for application in CI / staging before production rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e291d1b5308326aa7ed8494a66f16b)