### PR TITLE
Enforce division skill-band eligibility in tournament registration

### DIFF
--- a/jupr_app/domain/tournament_registration_compiler.py
+++ b/jupr_app/domain/tournament_registration_compiler.py
@@ -4,12 +4,171 @@ from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime
 from typing import Any
+import math
+import re
 import uuid
 
 
 DoublesTypes = {"GENDER_DOUBLES", "MIXED_DOUBLES", "DOUBLES", "MIXED"}
 
 
+
+
+def _coerce_skill(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def _parse_skill_anchor(skill_label: str) -> float | None:
+    text = str(skill_label or "").strip()
+    if not text:
+        return None
+    match = re.search(r"(\d+(?:\.\d+)?)", text)
+    if not match:
+        return None
+    try:
+        anchor = float(match.group(1))
+    except Exception:
+        return None
+    return round(math.floor(anchor * 2.0) / 2.0, 2)
+
+
+def _next_half_step(value: float) -> float:
+    return round(value + 0.5, 2)
+
+
+def _skill_band_for_label(skill_label: Any) -> tuple[float, float] | None:
+    floor = _parse_skill_anchor(str(skill_label or ""))
+    if floor is None:
+        return None
+    return floor, _next_half_step(floor)
+
+
+def _rating_in_band(rating: float | None, floor: float, ceiling_exclusive: float) -> bool:
+    return rating is not None and rating >= floor and rating < ceiling_exclusive
+
+
+def _rating_above_band(rating: float | None, ceiling_exclusive: float) -> bool:
+    return rating is not None and rating >= ceiling_exclusive
+
+
+def _recommended_anchor_for_rating(rating: float | None) -> float | None:
+    if rating is None:
+        return None
+    return round(math.floor(rating * 2.0) / 2.0, 1)
+
+
+def _format_skill(value: float | None) -> str:
+    if value is None:
+        return ""
+    return f"{value:.2f}".rstrip("0").rstrip(".")
+
+
+def _effective_singles_skill(player: dict[str, Any]) -> float | None:
+    singles = _coerce_skill(player.get("singles_skill"))
+    if singles is not None:
+        return singles
+    return _coerce_skill(player.get("doubles_skill"))
+
+
+def _effective_doubles_skill(player: dict[str, Any]) -> float | None:
+    doubles = _coerce_skill(player.get("doubles_skill"))
+    if doubles is not None:
+        return doubles
+    return _coerce_skill(player.get("singles_skill"))
+
+
+def _validate_singles_selection_against_skill(event: dict[str, Any], player: dict[str, Any]) -> tuple[bool, str | None]:
+    band = _skill_band_for_label(event.get("skill_label"))
+    if not band:
+        return True, None
+
+    floor, ceiling = band
+    rating = _effective_singles_skill(player)
+    if rating is None:
+        return False, "This division requires a rating to verify eligibility. Please enter your rating."
+    if _rating_in_band(rating, floor, ceiling):
+        return True, None
+    if _rating_above_band(rating, ceiling):
+        recommended = _recommended_anchor_for_rating(rating)
+        return False, (
+            f"Your rating is {_format_skill(rating)}, so you are not eligible for {_format_skill(floor)}. "
+            f"Please register for a {_format_skill(recommended)} division."
+        )
+    return False, f"Your rating is {_format_skill(rating)}, so you are not eligible for {_format_skill(floor)}."
+
+
+def _validate_doubles_selection_against_skill(
+    event: dict[str, Any],
+    player: dict[str, Any],
+    partner: dict[str, Any] | None,
+    *,
+    allow_missing_partner_for_preview: bool = False,
+) -> tuple[bool, str | None]:
+    band = _skill_band_for_label(event.get("skill_label"))
+    if not band:
+        return True, None
+
+    floor, ceiling = band
+    player_rating = _effective_doubles_skill(player)
+    partner_rating = _effective_doubles_skill(partner or {}) if partner else None
+
+    if player_rating is None:
+        return False, "This division requires a rating to verify eligibility. Please enter your rating."
+
+    if partner is None and allow_missing_partner_for_preview:
+        if _rating_in_band(player_rating, floor, ceiling):
+            return True, None
+        if _rating_above_band(player_rating, ceiling):
+            recommended = _recommended_anchor_for_rating(player_rating)
+            return False, (
+                f"Your rating is {_format_skill(player_rating)}, so you are not eligible for {_format_skill(floor)}. "
+                f"Please register for a {_format_skill(recommended)} division."
+            )
+        return False, f"Your rating is {_format_skill(player_rating)}, so you are not eligible for {_format_skill(floor)}."
+
+    if partner_rating is None:
+        return False, "This division requires a rating to verify eligibility. Please enter your rating."
+
+    ratings = [player_rating, partner_rating]
+    if any(_rating_above_band(value, ceiling) for value in ratings):
+        highest = max(ratings)
+        recommended = _recommended_anchor_for_rating(highest)
+        return False, (
+            f"Your team is not eligible for {_format_skill(floor)} because one player is rated above that division. "
+            f"Please register for a {_format_skill(recommended)} division."
+        )
+
+    if not any(_rating_in_band(value, floor, ceiling) for value in ratings):
+        return False, f"Your team is not eligible for {_format_skill(floor)} because neither player is in the {_format_skill(floor)} skill band."
+
+    return True, None
+
+
+def validate_selection_against_skill(
+    *,
+    event: dict[str, Any],
+    selection: dict[str, Any],
+    player: dict[str, Any],
+    partner: dict[str, Any] | None = None,
+    allow_missing_partner_for_preview: bool = False,
+) -> tuple[bool, str | None]:
+    if _is_doubles_event(event):
+        partner_mode = str(selection.get("partner_mode") or "NONE").upper()
+        resolved_partner = partner
+        if partner_mode == "NEEDS_PARTNER" and allow_missing_partner_for_preview:
+            resolved_partner = None
+        return _validate_doubles_selection_against_skill(
+            event,
+            player,
+            resolved_partner,
+            allow_missing_partner_for_preview=allow_missing_partner_for_preview,
+        )
+    return _validate_singles_selection_against_skill(event, player)
 def _uid(prefix: str) -> str:
     return f"{prefix}_{uuid.uuid4().hex[:12]}"
 

--- a/jupr_app/domain/tournament_registration_repo.py
+++ b/jupr_app/domain/tournament_registration_repo.py
@@ -7,7 +7,7 @@ import uuid
 
 from jupr_app.domain.event_tags import derive_default_date_tags, normalize_event_tags
 
-from .tournament_registration_compiler import compile_tournament_registration_state
+from .tournament_registration_compiler import compile_tournament_registration_state, validate_selection_against_skill
 
 REGISTRATION_STATUS_OPTIONS = ["draft", "open", "closed"]
 EVENT_TYPE_OPTIONS = ["SINGLES", "GENDER_DOUBLES", "MIXED_DOUBLES"]
@@ -447,11 +447,18 @@ def list_registration_selections(supabase, tournament_id: str) -> list[dict[str,
 
 
 def _get_existing_registration_by_email(supabase, tournament_id: str, email: str) -> dict[str, Any] | None:
+    return _get_registration_by_email(supabase, tournament_id, email)
+
+
+def _get_registration_by_email(supabase, tournament_id: str, email: str) -> dict[str, Any] | None:
+    clean_email = _normalize_email(email)
+    if not clean_email:
+        return None
     resp = (
         supabase.table("tournament_registrations")
         .select("*")
         .eq("tournament_id", str(tournament_id))
-        .eq("email", _normalize_email(email))
+        .eq("email", clean_email)
         .limit(1)
         .execute()
     )
@@ -497,6 +504,68 @@ def save_registration(supabase, *, tournament_id: str, payload: dict[str, Any]) 
         "updated_at": submitted_at,
     }
 
+    event_lookup = {str(row.get("id")): row for row in list_event_options(supabase, str(tournament_id))}
+
+    rows: list[dict[str, Any]] = []
+    for index, selection in enumerate(payload.get("selections") or []):
+        if not selection.get("event_option_id"):
+            continue
+
+        event_option_id = str(selection.get("event_option_id"))
+        event = event_lookup.get(event_option_id)
+        if not event:
+            raise ValueError(f"Selected division {event_option_id} is no longer available.")
+
+        partner_email = _normalize_email(selection.get("partner_email")) or None
+        partner_payload = {
+            "display_name": str(selection.get("partner_name") or "").strip() or None,
+            "email": partner_email,
+            "doubles_skill": selection.get("partner_skill"),
+            "singles_skill": selection.get("partner_skill"),
+            "age": selection.get("partner_age"),
+        }
+        if partner_payload.get("doubles_skill") in (None, "") and partner_email:
+            partner_registration = _get_registration_by_email(supabase, tournament_id, partner_email)
+            if partner_registration:
+                partner_payload["doubles_skill"] = partner_registration.get("doubles_skill")
+                partner_payload["singles_skill"] = partner_registration.get("singles_skill")
+        partner_mode = str(selection.get("partner_mode") or "NONE").upper()
+        partner_for_validation = None
+        if partner_mode == "HAS_PARTNER":
+            partner_for_validation = partner_payload
+
+        eligible, message = validate_selection_against_skill(
+            event=event,
+            selection=selection,
+            player=reg_row,
+            partner=partner_for_validation,
+            allow_missing_partner_for_preview=False,
+        )
+        if not eligible:
+            division_label = str(event.get("division_name") or event.get("label") or event_option_id)
+            raise ValueError(f"{division_label}: {message or 'Skill eligibility requirements were not met.'}")
+
+        rows.append(
+            {
+                "id": str(selection.get("id") or _uid("sel")),
+                "tournament_id": str(tournament_id),
+                "registration_id": registration_id,
+                "registration_day_id": str(selection.get("registration_day_id")),
+                "event_option_id": event_option_id,
+                "partner_mode": partner_mode,
+                "partner_name": str(selection.get("partner_name") or "").strip() or None,
+                "partner_email": partner_email,
+                "partner_phone": str(selection.get("partner_phone") or "").strip() or None,
+                "partner_dupr_id": str(selection.get("partner_dupr_id") or "").strip() or None,
+                "partner_skill": selection.get("partner_skill"),
+                "partner_age": selection.get("partner_age"),
+                "partner_note": str(selection.get("partner_note") or "").strip() or None,
+                "show_on_partner_board": _coerce_bool(selection.get("show_on_partner_board", False)),
+                "sort_order": index,
+                "created_at": submitted_at,
+            }
+        )
+
     (
         supabase.table("tournament_registrations")
         .upsert(reg_row, on_conflict="id")
@@ -509,31 +578,6 @@ def save_registration(supabase, *, tournament_id: str, payload: dict[str, Any]) 
         .eq("registration_id", registration_id)
         .execute()
     )
-
-    rows: list[dict[str, Any]] = []
-    for index, selection in enumerate(payload.get("selections") or []):
-        if not selection.get("event_option_id"):
-            continue
-        rows.append(
-            {
-                "id": str(selection.get("id") or _uid("sel")),
-                "tournament_id": str(tournament_id),
-                "registration_id": registration_id,
-                "registration_day_id": str(selection.get("registration_day_id")),
-                "event_option_id": str(selection.get("event_option_id")),
-                "partner_mode": str(selection.get("partner_mode") or "NONE").upper(),
-                "partner_name": str(selection.get("partner_name") or "").strip() or None,
-                "partner_email": _normalize_email(selection.get("partner_email")) or None,
-                "partner_phone": str(selection.get("partner_phone") or "").strip() or None,
-                "partner_dupr_id": str(selection.get("partner_dupr_id") or "").strip() or None,
-                "partner_skill": selection.get("partner_skill"),
-                "partner_age": selection.get("partner_age"),
-                "partner_note": str(selection.get("partner_note") or "").strip() or None,
-                "show_on_partner_board": _coerce_bool(selection.get("show_on_partner_board", False)),
-                "sort_order": index,
-                "created_at": submitted_at,
-            }
-        )
 
     if rows:
         (

--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -820,6 +820,7 @@ def _render_division_form(
             )
             division_name = st.text_input("Division name", value=_safe_text(defaults.get("division_name")), disabled=disabled)
             skill_label = st.text_input("Skill label", value=_safe_text(defaults.get("skill_label") or "Open"), disabled=disabled)
+            st.caption("Skill labels are enforced as half-step bands (example: 3.5 means 3.5 to <4.0). Doubles teams play to the higher-rated player: at least one player must be in-band and no player may be above the band.")
             age_mode = st.selectbox(
                 "Age mode",
                 AGE_MODES,

--- a/jupr_app/ui/pages/tournament_registration.py
+++ b/jupr_app/ui/pages/tournament_registration.py
@@ -5,6 +5,7 @@ import uuid
 
 import streamlit as st
 
+from jupr_app.domain.tournament_registration_compiler import validate_selection_against_skill
 from jupr_app.domain.tournament_registration_repo import (
     build_registration_state,
     build_public_urls,
@@ -76,7 +77,7 @@ def _group_events(days: list[dict[str, Any]], event_options: list[dict[str, Any]
     return grouped
 
 
-def _division_choice_label(event: dict[str, Any]) -> str:
+def _division_choice_label(event: dict[str, Any], *, eligible: bool = True) -> str:
     name = _safe_text(event.get("division_name") or event.get("label") or "Division")
     parts: list[str] = []
     skill = _safe_text(event.get("skill_label"))
@@ -88,8 +89,21 @@ def _division_choice_label(event: dict[str, Any]) -> str:
         parts.append(age)
     if price not in (None, "", "None"):
         parts.append(f"${price}")
-    return f"{name} — {' • '.join(parts)}" if parts else name
+    label = f"{name} — {' • '.join(parts)}" if parts else name
+    return label if eligible else f"{label} ⛔ Not eligible based on current rating"
 
+
+
+
+def _preview_division_eligibility(event: dict[str, Any], player: dict[str, Any]) -> tuple[bool, str | None]:
+    preview_selection = {"partner_mode": "NEEDS_PARTNER" if bool(event.get("partner_required")) else "NONE"}
+    return validate_selection_against_skill(
+        event=event,
+        selection=preview_selection,
+        player=player,
+        partner=None,
+        allow_missing_partner_for_preview=True,
+    )
 
 def _division_help(event: dict[str, Any]) -> str:
     details: list[str] = []
@@ -208,6 +222,11 @@ def render(ctx):
         gender = st.selectbox("Gender", ["", "Female", "Male", "Other", "Prefer not to say"])
         notes = st.text_area("Notes for tournament staff", height=90)
 
+        player_profile = {
+            "doubles_skill": _coerce_float(doubles_skill),
+            "singles_skill": _coerce_float(singles_skill),
+        }
+
         st.markdown("### 2. Choose your divisions")
         st.caption("Work day by day. You can skip any event family you are not playing.")
         selections: list[dict[str, Any]] = []
@@ -221,10 +240,13 @@ def render(ctx):
                 st.markdown(f"**{family}**")
                 option_lookup = {"— Not playing this event —": None}
                 ordered_labels = ["— Not playing this event —"]
+                eligibility_lookup: dict[str, tuple[bool, str | None]] = {}
                 for event in options:
-                    label = _division_choice_label(event)
+                    eligible, reason = _preview_division_eligibility(event, player_profile)
+                    label = _division_choice_label(event, eligible=eligible)
                     option_lookup[label] = event
                     ordered_labels.append(label)
+                    eligibility_lookup[str(event.get("id"))] = (eligible, reason)
                 selected_label = st.selectbox(
                     f"Choose your division for {family}",
                     ordered_labels,
@@ -237,6 +259,12 @@ def render(ctx):
                 help_text = _division_help(selected_event)
                 if help_text:
                     st.caption(help_text)
+
+                current_eligible, current_reason = eligibility_lookup.get(str(selected_event.get("id")), (True, None))
+                if not current_eligible:
+                    st.warning(current_reason or "Not eligible based on current rating.")
+                elif bool(selected_event.get("partner_required")):
+                    st.caption("For doubles, final eligibility is validated at submit time using both players' ratings when a partner is named.")
 
                 selection_row: dict[str, Any] = {
                     "id": _uid("sel"),
@@ -298,6 +326,33 @@ def render(ctx):
                 if not _safe_text(selection.get("partner_name")) and not _safe_text(selection.get("partner_email")):
                     st.error("For doubles events with a named partner, enter at least the partner name or partner email.")
                     st.stop()
+
+        event_lookup = {str(row.get("id")): row for row in event_options}
+        submit_player = {
+            "doubles_skill": _coerce_float(doubles_skill),
+            "singles_skill": _coerce_float(singles_skill),
+        }
+        for selection in selections:
+            event = event_lookup.get(str(selection.get("event_option_id") or ""))
+            if not event:
+                continue
+            partner = None
+            if _safe_text(selection.get("partner_mode")).upper() == "HAS_PARTNER":
+                partner = {
+                    "doubles_skill": selection.get("partner_skill"),
+                    "singles_skill": selection.get("partner_skill"),
+                }
+            eligible, reason = validate_selection_against_skill(
+                event=event,
+                selection=selection,
+                player=submit_player,
+                partner=partner,
+                allow_missing_partner_for_preview=False,
+            )
+            if not eligible:
+                division_label = _safe_text(event.get("division_name") or event.get("label") or event.get("id"))
+                st.error(f"{division_label}: {reason or 'Skill eligibility requirements were not met.'}")
+                st.stop()
 
         try:
             state_before_submit = build_registration_state(supabase, tournament, settings, days, event_options)


### PR DESCRIPTION
### Motivation
- Division `skill_label` values must do more than display — they must actively control who can register so players and teams only enter valid half-step bands.
- The existing flow validated display but did not reliably block invalid submissions or apply the doubles hybrid rule; this patch enforces rules at submit/save time and improves picker UX.
- Need consistent parsing of admin-entered labels (e.g., `3.5`) into half-step bands and clear, actionable messages when a rating disqualifies a selection.

### Description
- Added reusable skill-band helpers and validators to `jupr_app/domain/tournament_registration_compiler.py`, including `_parse_skill_anchor`, `_next_half_step`, `_coerce_skill`, `_skill_band_for_label`, `_rating_in_band`, `_rating_above_band`, `_effective_singles_skill`, `_effective_doubles_skill`, `_validate_singles_selection_against_skill`, `_validate_doubles_selection_against_skill`, and exported `validate_selection_against_skill` to centralize the business rules.
- Enforced hard submit/save-time validation in `jupr_app/domain/tournament_registration_repo.py::save_registration` by validating each `selection` with `validate_selection_against_skill` before writing registration/selections and raising a `ValueError` with clear copy when invalid; added partner-email lookup to use stored partner ratings when `partner_skill` is omitted.
- Improved public registration UX in `jupr_app/ui/pages/tournament_registration.py` by previewing eligibility for each division in the picker (marking unavailable divisions and showing inline reason), and by performing client-side pre-submit validation (final enforcement still occurs server-side on save).
- Added admin guidance text to `jupr_app/ui/pages/tournament_manager.py` near the `skill_label` field explaining half-step band semantics and the doubles higher-rated-player rule; kept `skill_label` shape unchanged for backward compatibility.
- Files changed: `jupr_app/domain/tournament_registration_compiler.py`, `jupr_app/domain/tournament_registration_repo.py`, `jupr_app/ui/pages/tournament_registration.py`, and `jupr_app/ui/pages/tournament_manager.py`.

### Testing
- Compiled modified modules with `python -m py_compile jupr_app/domain/tournament_registration_compiler.py jupr_app/domain/tournament_registration_repo.py jupr_app/ui/pages/tournament_registration.py jupr_app/ui/pages/tournament_manager.py` and the compile completed successfully.
- Verified the UI now marks ineligible divisions in the picker and that `save_registration` validation code path raises `ValueError` for invalid selections (behavior exercised during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e297cb077c8326874c52a08d9a551d)