### PR TITLE
Use controlled skill-band selector for tournament divisions

### DIFF
--- a/jupr_app/domain/tournament_registration_compiler.py
+++ b/jupr_app/domain/tournament_registration_compiler.py
@@ -5,11 +5,11 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Any
 import math
-import re
 import uuid
 
 
 DoublesTypes = {"GENDER_DOUBLES", "MIXED_DOUBLES", "DOUBLES", "MIXED"}
+CONTROLLED_SKILL_LABELS = {"3.0", "3.5", "4.0", "4.5", "5.0", "5.5"}
 
 
 
@@ -25,13 +25,12 @@ def _coerce_skill(value: Any) -> float | None:
 
 def _parse_skill_anchor(skill_label: str) -> float | None:
     text = str(skill_label or "").strip()
-    if not text:
+    if not text or text.lower() == "open":
         return None
-    match = re.search(r"(\d+(?:\.\d+)?)", text)
-    if not match:
+    if text not in CONTROLLED_SKILL_LABELS:
         return None
     try:
-        anchor = float(match.group(1))
+        anchor = float(text)
     except Exception:
         return None
     return round(math.floor(anchor * 2.0) / 2.0, 2)

--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -36,6 +36,7 @@ AGE_MODES = ["ALL_AGES", "FIXED_AGE_BRACKET", "AUTO_AGE_SPLIT", "SPLIT_AGE"]
 PARTICIPANT_TYPES = ["SINGLES", "GENDER_DOUBLES", "MIXED_DOUBLES"]
 GENDER_RESTRICTIONS = ["ANY", "MEN", "WOMEN", "MIXED"]
 DIVISION_STATUSES = ["draft", "open", "tentative", "confirmed", "closed"]
+SKILL_LABEL_OPTIONS = ["Open", "3.0", "3.5", "4.0", "4.5", "5.0", "5.5"]
 
 STANDARD_EVENT_TEMPLATES = [
     {
@@ -819,8 +820,16 @@ def _render_division_form(
                 disabled=disabled,
             )
             division_name = st.text_input("Division name", value=_safe_text(defaults.get("division_name")), disabled=disabled)
-            skill_label = st.text_input("Skill label", value=_safe_text(defaults.get("skill_label") or "Open"), disabled=disabled)
-            st.caption("Skill labels are enforced as half-step bands (example: 3.5 means 3.5 to <4.0). Doubles teams play to the higher-rated player: at least one player must be in-band and no player may be above the band.")
+            saved_skill_label = _safe_text(defaults.get("skill_label") or "Open")
+            skill_label = st.selectbox(
+                "Skill level",
+                SKILL_LABEL_OPTIONS,
+                index=SKILL_LABEL_OPTIONS.index(saved_skill_label) if saved_skill_label in SKILL_LABEL_OPTIONS else 0,
+                disabled=disabled,
+            )
+            st.caption(
+                "Skill level is a controlled division band. Open has no skill restriction. For rated divisions, doubles teams play to the higher-rated player: at least one player must be in-band and no player may be above the band."
+            )
             age_mode = st.selectbox(
                 "Age mode",
                 AGE_MODES,


### PR DESCRIPTION
### Motivation
- Make division skill levels a controlled choice to prevent arbitrary free-text values and ensure registration eligibility is enforced consistently.
- Preserve existing storage shape by continuing to use the `skill_label` field while providing a safe default and backwards-compatible behavior for legacy values.
- Apply the agreed hybrid doubles eligibility rule using a canonical set of allowed half-step anchors rather than parsing arbitrary typed labels.

### Description
- Added `SKILL_LABEL_OPTIONS = ["Open", "3.0", "3.5", "4.0", "4.5", "5.0", "5.5"]` and replaced the division form `st.text_input` with a `st.selectbox` labeled `Skill level` that preselects an existing saved value or falls back to `Open` when unknown.
- Kept saving to the same `skill_label` payload key and continued to store values as strings so no migration or field rename was introduced.
- Updated the help caption to: "Skill level is a controlled division band. Open has no skill restriction. For rated divisions, doubles teams play to the higher-rated player: at least one player must be in-band and no player may be above the band." to match the selector UX.
- Tightened registration parsing by introducing `CONTROLLED_SKILL_LABELS` and changing `_parse_skill_anchor` to accept only the controlled anchors (treating `Open` and any unknown/legacy label as unrestricted) so eligibility checks no longer rely on arbitrary typed values.

### Testing
- Ran Python syntax checks with `python -m py_compile jupr_app/ui/pages/tournament_manager.py jupr_app/domain/tournament_registration_compiler.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29b4cec908326ba9288493f58ea21)