### PR TITLE
Fix Club Social submit persistence drift and explicit rated-roster resolution with provisional seeding

### DIFF
--- a/jupr_app/domain/live_social.py
+++ b/jupr_app/domain/live_social.py
@@ -63,6 +63,35 @@ def is_missing_social_tables_error(exc: Exception) -> bool:
     return has_missing_code and has_table_marker and mentions_social_table
 
 
+def submitted_by_name_from_row(row: dict) -> str:
+    return normalize_name((row or {}).get("submitted_by_name") or (row or {}).get("submitted_by"))
+
+
+def _upsert_live_event_row(supabase, payload: dict) -> None:
+    attempts = [dict(payload)]
+    if "submitted_by" in payload:
+        attempts.append({k: v for k, v in payload.items() if k != "submitted_by"})
+    if "submitted_by_name" in payload:
+        attempts.append({k: v for k, v in payload.items() if k != "submitted_by_name"})
+    last_exc: Exception | None = None
+    for attempt in attempts:
+        try:
+            supabase.table("live_events").upsert(
+                attempt,
+                on_conflict="club_id,source_event_uid",
+            ).execute()
+            return
+        except Exception as exc:
+            payload_text = _error_payload_text(exc)
+            if "submitted_by" in payload_text or "submitted_by_name" in payload_text or "schema cache" in payload_text:
+                last_exc = exc
+                continue
+            raise
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("Unable to upsert live_events row.")
+
+
 def normalize_person_name(value: object) -> str:
     return normalize_name(value).casefold()
 
@@ -575,10 +604,7 @@ def save_social_live_event(
             "summary_json": summary_json,
         }
 
-        supabase.table("live_events").upsert(
-            upsert_payload,
-            on_conflict="club_id,source_event_uid",
-        ).execute()
+        _upsert_live_event_row(supabase, upsert_payload)
 
         event_rows = (
             supabase.table("live_events")
@@ -666,22 +692,45 @@ def list_social_submissions_for_review(
     limit: int = 100,
 ) -> list[dict]:
     club_id = str(ctx.club_id)
-    rows = (
-        ctx.supabase.table("live_events")
-        .select(
-            "id,name,event_type,event_date,status,submitted_by_name,submission_mode,"
-            "summary_json,raw_event_json,created_at,updated_at,rejection_reason,moderated_at,moderated_by"
-        )
-        .eq("club_id", club_id)
-        .eq("result_mode", "social_unrated")
-        .eq("status", status)
-        .order("updated_at", desc=True)
-        .limit(int(limit))
-        .execute()
-        .data
-        or []
+    base_select = (
+        "id,name,event_type,event_date,status,submission_mode,"
+        "summary_json,raw_event_json,created_at,updated_at,rejection_reason,moderated_at,moderated_by"
     )
-    return [dict(row) for row in rows]
+    try:
+        rows = (
+            ctx.supabase.table("live_events")
+            .select(f"{base_select},submitted_by_name")
+            .eq("club_id", club_id)
+            .eq("result_mode", "social_unrated")
+            .eq("status", status)
+            .order("updated_at", desc=True)
+            .limit(int(limit))
+            .execute()
+            .data
+            or []
+        )
+    except Exception as exc:
+        payload = _error_payload_text(exc)
+        if "submitted_by_name" not in payload or "schema cache" not in payload:
+            raise
+        rows = (
+            ctx.supabase.table("live_events")
+            .select(f"{base_select},submitted_by")
+            .eq("club_id", club_id)
+            .eq("result_mode", "social_unrated")
+            .eq("status", status)
+            .order("updated_at", desc=True)
+            .limit(int(limit))
+            .execute()
+            .data
+            or []
+        )
+    normalized_rows = []
+    for row in rows:
+        payload = dict(row)
+        payload["submitted_by_name"] = submitted_by_name_from_row(payload)
+        normalized_rows.append(payload)
+    return normalized_rows
 
 
 def moderate_social_submission(

--- a/jupr_app/domain/live_social_submit.py
+++ b/jupr_app/domain/live_social_submit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import difflib
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -22,6 +23,7 @@ from jupr_app.domain.live_social import (
 from jupr_app.domain.player_ops import safe_add_player
 
 DEFAULT_PROVISIONAL_SEED_ELO = 1400.0
+STRONG_DUPLICATE_THRESHOLD = 0.94
 
 
 def _error_payload_text(exc: Exception) -> str:
@@ -160,10 +162,51 @@ def _ensure_rated_player_from_social(
     return created, True
 
 
+def _normalized_name(value: object) -> str:
+    return normalize_name(value).casefold()
+
+
+def _best_fuzzy_score(target: str, candidate: str) -> float:
+    if not target or not candidate:
+        return 0.0
+    return float(difflib.SequenceMatcher(None, target, candidate).ratio())
+
+
+def _find_strong_duplicate_candidates(ctx, *, display_name: str) -> list[dict]:
+    players_df = _players_frame(ctx)
+    if players_df.empty:
+        return []
+    target = _normalized_name(display_name)
+    if not target:
+        return []
+    scored: list[tuple[float, dict]] = []
+    for _, row in players_df.iterrows():
+        candidate_name = str(row.get("name") or "")
+        normalized_candidate = _normalized_name(candidate_name)
+        if not normalized_candidate:
+            continue
+        score = float(_best_fuzzy_score(target, normalized_candidate))
+        if score < STRONG_DUPLICATE_THRESHOLD:
+            continue
+        scored.append(
+            (
+                score,
+                {
+                    "id": int(row.get("id")),
+                    "name": candidate_name,
+                    "score": score,
+                },
+            )
+        )
+    scored.sort(key=lambda item: item[0], reverse=True)
+    return [item[1] for item in scored[:3]]
+
+
 def _upsert_live_event_row(supabase, payload: dict) -> None:
     attempts = [dict(payload)]
-    if "submitted_by_name" in payload and "submitted_by" in payload:
+    if "submitted_by" in payload:
         attempts.append({k: v for k, v in payload.items() if k != "submitted_by"})
+    if "submitted_by_name" in payload:
         attempts.append({k: v for k, v in payload.items() if k != "submitted_by_name"})
     last_exc: Exception | None = None
     for attempt in attempts:
@@ -225,8 +268,20 @@ def save_resolved_social_live_event(
             if (
                 explicit_player_id is None
                 and admin_logged_in
-                and match_status in {"new_social", "new social person", "create_rated", "create rated"}
+                and match_status in {"create_rated", "create rated"}
             ):
+                duplicate_candidates = _find_strong_duplicate_candidates(
+                    ctx,
+                    display_name=display_name,
+                )
+                if duplicate_candidates:
+                    top = duplicate_candidates[0]
+                    if _normalized_name(top.get("name")) != _normalized_name(display_name):
+                        raise ValueError(
+                            "Duplicate warning: "
+                            f"'{display_name}' is very close to existing rated player '{top.get('name')}'. "
+                            "Select the existing player in roster confirmation to continue."
+                        )
                 rated_player, created_rated = _ensure_rated_player_from_social(
                     ctx,
                     club_id=club_id,
@@ -298,7 +353,6 @@ def save_resolved_social_live_event(
             "status": status,
             "submission_mode": normalized_submission_mode,
             "submitted_by_name": submitted_by_name,
-            "submitted_by": submitted_by_name,
             "moderated_at": moderated_at,
             "moderated_by": moderated_by,
             "rejection_reason": None,

--- a/jupr_app/ui/live/shared.py
+++ b/jupr_app/ui/live/shared.py
@@ -292,24 +292,29 @@ def _build_roster_candidate_rows(
         elif candidate_names:
             status = "suggested match"
         else:
-            status = "new social person"
+            status = "create rated"
 
-        new_social_token = f"new::{normalized_pasted or pasted_name}"
+        create_rated_token = f"create_rated::{normalized_pasted or pasted_name}"
         options: list[dict[str, str | int | None]] = [
             {"token": f"player::{int(player_name_to_id[name])}", "label": str(name)}
             for name in candidate_names
         ]
         options.append(
             {
-                "token": new_social_token,
-                "label": f"Use as new social player: {normalize_name(pasted_name)}",
+                "token": create_rated_token,
+                "label": f"Create new rated player: {normalize_name(pasted_name)}",
             }
         )
-        default_token = new_social_token
+        default_token = create_rated_token
         if exact_names:
             default_token = f"player::{int(player_name_to_id[exact_names[0]])}"
         elif candidate_names and top_score >= 0.86:
             default_token = f"player::{int(player_name_to_id[candidate_names[0]])}"
+        duplicate_warning = ""
+        if (not exact_names) and candidate_names and top_score >= 0.9:
+            duplicate_warning = (
+                "Possible duplicate: this name is very close to an existing rated player."
+            )
         rows.append(
             {
                 "original": str(pasted_name),
@@ -317,6 +322,7 @@ def _build_roster_candidate_rows(
                 "status": status,
                 "default_token": default_token,
                 "options": options,
+                "duplicate_warning": duplicate_warning,
             }
         )
     return rows
@@ -345,6 +351,19 @@ def _resolved_participants_from_confirmation(
                         "player_id": int(player_id),
                         "source_name": original,
                         "match_status": "matched_existing",
+                    }
+                )
+            continue
+        if selected_token.startswith("create_rated::"):
+            create_name = original
+            if create_name:
+                names.append(create_name)
+                resolved_rows.append(
+                    {
+                        "name": create_name,
+                        "player_id": None,
+                        "source_name": original,
+                        "match_status": "create_rated",
                     }
                 )
             continue
@@ -605,14 +624,17 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
         st.markdown("#### Step 1: Review roster matches")
         st.caption(
             "Confirm each pasted name once. Exact or suggested matches use canonical current-player names; "
-            "or choose the explicit new social player option."
+            "or choose explicit rated-player creation."
         )
         with st.form(f"{config.state_key}_roster_resolution_form"):
             confirmed_rows: list[dict] = []
             for idx, row in enumerate(roster_candidates):
                 status_col, selector_col = st.columns([1.3, 3.7])
                 status_col.caption(f"**{row.get('original', '')}**")
-                status_col.caption(f"Status: {row.get('status', 'new social person')}")
+                status_col.caption(f"Status: {row.get('status', 'create rated')}")
+                duplicate_warning = str(row.get("duplicate_warning") or "").strip()
+                if duplicate_warning:
+                    status_col.warning(duplicate_warning)
                 options = list(row.get("options") or [])
                 labels = [str(opt.get("label") or "") for opt in options]
                 tokens = [str(opt.get("token") or "") for opt in options]
@@ -653,14 +675,20 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
         if state.get("roster_confirmed"):
             confirmed_rows = list(state.get("confirmed_roster_rows") or [])
             matched_rows = [row for row in confirmed_rows if row.get("player_id") is not None]
-            new_rows = [row for row in confirmed_rows if row.get("player_id") is None]
+            new_rows = [row for row in confirmed_rows if row.get("match_status") == "create_rated"]
+            social_only_rows = [
+                row for row in confirmed_rows if row.get("player_id") is None and row.get("match_status") != "create_rated"
+            ]
             st.caption(
-                f"Confirmed roster: {len(matched_rows)} matched existing players, {len(new_rows)} new social players."
+                f"Confirmed roster: {len(matched_rows)} matched existing rated players, "
+                f"{len(new_rows)} create-new rated players."
             )
             if matched_rows:
                 st.caption("Matched: " + ", ".join(str(row.get("name") or "") for row in matched_rows))
             if new_rows:
-                st.caption("New social: " + ", ".join(str(row.get("name") or "") for row in new_rows))
+                st.caption("Create rated: " + ", ".join(str(row.get("name") or "") for row in new_rows))
+            if social_only_rows:
+                st.caption("Social-only fallback: " + ", ".join(str(row.get("name") or "") for row in social_only_rows))
 
     action_cols = st.columns([1, 1, 3])
     if roster_requires_resolution:
@@ -684,7 +712,11 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
                             "selection": (
                                 f"player::{int(row.get('player_id'))}"
                                 if row.get("player_id") is not None
-                                else f"new::{_normalized_person_key(row.get('name'))}"
+                                else (
+                                    f"create_rated::{_normalized_person_key(row.get('name'))}"
+                                    if str(row.get("match_status") or "") == "create_rated"
+                                    else f"new::{_normalized_person_key(row.get('name'))}"
+                                )
                             ),
                         }
                         for row in confirmed_roster_rows

--- a/jupr_app/ui/pages/jupr_live.py
+++ b/jupr_app/ui/pages/jupr_live.py
@@ -120,9 +120,9 @@ def _save_social(ctx, state: dict, event: dict) -> bool:
         pass
     status = str(result.get("status") or "")
     if status == "saved":
-        title = "Club Social results saved (admin)"
+        title = "Club Social results saved"
     else:
-        title = "Club Social results submitted (public) — pending admin approval"
+        title = "Club Social results submitted and awaiting approval"
     created_rated = int(result.get("created_rated_players_count") or 0)
     created_names = [
         str(name).strip()
@@ -130,7 +130,8 @@ def _save_social(ctx, state: dict, event: dict) -> bool:
         if str(name).strip()
     ]
     detail = (
-        f"{title} ({result['participant_count']} participants, {result['match_count']} matches, final status: {status})."
+        f"{title} ({result['participant_count']} participants, "
+        f"{result['match_count']} matches, final status: {status})."
     )
     if created_rated > 0:
         created_suffix = ", ".join(created_names[:6])

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -346,19 +346,38 @@ def _social_skill_levels_from_summary(summary_json: object) -> list[str]:
     return skill_levels
 
 
+def _social_submitter_name(row: dict) -> str:
+    return str(row.get("submitted_by_name") or row.get("submitted_by") or "").strip()
+
+
 @st.cache_data(ttl=60)
 def fetch_player_social_event_history(_supabase, club_id: str, pid: int, limit: int = 100) -> pd.DataFrame:
     try:
-        events_resp = (
-            _supabase.table("live_events")
-            .select("id,name,event_type,event_date,submitted_by_name,status,result_mode,summary_json")
-            .eq("club_id", str(club_id))
-            .eq("result_mode", "social_unrated")
-            .eq("status", "saved")
-            .order("event_date", desc=True)
-            .limit(max(int(limit), 1))
-            .execute()
-        )
+        try:
+            events_resp = (
+                _supabase.table("live_events")
+                .select("id,name,event_type,event_date,submitted_by_name,status,result_mode,summary_json")
+                .eq("club_id", str(club_id))
+                .eq("result_mode", "social_unrated")
+                .eq("status", "saved")
+                .order("event_date", desc=True)
+                .limit(max(int(limit), 1))
+                .execute()
+            )
+        except Exception as exc:
+            text = str(exc).lower()
+            if "submitted_by_name" not in text and "schema cache" not in text:
+                raise
+            events_resp = (
+                _supabase.table("live_events")
+                .select("id,name,event_type,event_date,submitted_by,status,result_mode,summary_json")
+                .eq("club_id", str(club_id))
+                .eq("result_mode", "social_unrated")
+                .eq("status", "saved")
+                .order("event_date", desc=True)
+                .limit(max(int(limit), 1))
+                .execute()
+            )
     except Exception as exc:
         if is_missing_social_tables_error(exc):
             return pd.DataFrame([{"_missing_social_tables": True, "_social_message": SOCIAL_TABLES_INSTALL_MESSAGE}])
@@ -434,7 +453,7 @@ def fetch_player_social_event_history(_supabase, club_id: str, pid: int, limit: 
                 "Wins": 0,
                 "Losses": 0,
                 "Diff": 0,
-                "Submitted By": str(event_row.get("submitted_by_name") or "").strip(),
+                "Submitted By": _social_submitter_name(event_row),
             }
         )
 

--- a/migrations/20260417_live_events_submitted_by_name_canonical_rollback.sql
+++ b/migrations/20260417_live_events_submitted_by_name_canonical_rollback.sql
@@ -1,0 +1,7 @@
+-- Rollback for 20260417_live_events_submitted_by_name_canonical.sql
+-- Canonical field remains submitted_by_name in forward schema.
+-- This rollback removes transition helpers and canonical column.
+
+drop trigger if exists live_events_sync_submitted_by_name on public.live_events;
+drop function if exists public.live_events_sync_submitted_by_name();
+alter table if exists public.live_events drop column if exists submitted_by_name;

--- a/tests/test_live_social.py
+++ b/tests/test_live_social.py
@@ -17,6 +17,8 @@ from jupr_app.domain.live_social import (
     social_person_rollup_rows,
     social_round_robin_match_rows_from_event,
 )
+from jupr_app.domain.live_social_submit import save_resolved_social_live_event
+from jupr_app.ui.pages.players import fetch_player_social_event_history
 import pandas as pd
 
 
@@ -34,6 +36,8 @@ class _TableQuery:
         self._payload = None
 
     def select(self, _cols: str):
+        if any(col in str(_cols) for col in self.store.get("__missing_select_columns__", set())):
+            raise Exception(f"PGRST204: Could not find requested column in schema cache: {_cols}")
         self._op = "select"
         return self
 
@@ -116,12 +120,25 @@ class _TableQuery:
             inserted = []
             for row in payload:
                 record = dict(row)
-                record.setdefault("id", str(uuid4()))
+                if "id" not in record:
+                    if self.name == "players":
+                        existing_ids = [
+                            int(existing.get("id"))
+                            for existing in rows
+                            if str(existing.get("id") or "").isdigit()
+                        ]
+                        record["id"] = (max(existing_ids) + 1) if existing_ids else 1
+                    else:
+                        record["id"] = str(uuid4())
                 rows.append(record)
                 inserted.append(dict(record))
             return _Resp(inserted)
         if self._op == "upsert":
             payload, on_conflict = self._payload
+            missing_write_columns = self.store.get("__missing_write_columns__", set())
+            if any(col in payload for col in missing_write_columns):
+                col = next(col for col in missing_write_columns if col in payload)
+                raise Exception(f"PGRST204: Could not find the '{col}' column of '{self.name}' in the schema cache")
             keys = [k.strip() for k in on_conflict.split(",")]
             match = None
             for row in rows:
@@ -405,6 +422,182 @@ def test_social_save_does_not_write_public_matches_table():
         host_name="Host",
     )
     assert "matches" not in supabase.calls
+
+
+def test_resolved_social_save_handles_submitted_by_schema_drift():
+    supabase = _FakeSupabase()
+    supabase.store["__missing_write_columns__"] = {"submitted_by"}
+    ctx = _Ctx(supabase=supabase, club_id="club-1", name_to_id={})
+    result = save_resolved_social_live_event(
+        ctx,
+        _sample_event(),
+        target_club_id="club-1",
+        submission_mode="admin",
+        host_name="admin",
+    )
+    assert result["status"] == "saved"
+    assert len(supabase.store["live_events"]) == 1
+    assert supabase.store["live_events"][0]["submitted_by_name"] == "admin"
+
+
+def test_resolved_save_preserves_explicit_existing_player_linkage():
+    supabase = _FakeSupabase()
+    ctx = _Ctx(supabase=supabase, club_id="club-1", name_to_id={})
+    event = _sample_event()
+    event["participants"][0]["name"] = "Alias Name"
+    event["participants"][0]["player_id"] = 77
+    event["participants"][0]["match_status"] = "matched_existing"
+    save_resolved_social_live_event(
+        ctx,
+        event,
+        target_club_id="club-1",
+        submission_mode="admin",
+        host_name="admin",
+    )
+    saved = supabase.store["live_event_participants"]
+    linked_row = [row for row in saved if row["participant_key"] == "p-1"][0]
+    assert linked_row["linked_player_id"] == 77
+
+
+def test_resolved_save_creates_new_rated_player_and_links_participant():
+    supabase = _FakeSupabase()
+    supabase.store["players"] = [
+        {"id": 101, "club_id": "club-1", "name": "Alice", "rating": 1600.0, "starting_rating": 1600.0},
+        {"id": 102, "club_id": "club-1", "name": "Bob", "rating": 1200.0, "starting_rating": 1200.0},
+    ]
+    ctx = _Ctx(
+        supabase=supabase,
+        club_id="club-1",
+        name_to_id={},
+    )
+    ctx.admin_logged_in = True
+    ctx.df_players_all = pd.DataFrame(
+        [
+            {"id": 101, "name": "Alice", "rating": 1600.0},
+            {"id": 102, "name": "Bob", "rating": 1200.0},
+        ]
+    )
+    event = _sample_event()
+    event["participants"] = [
+        {"id": "p-1", "name": "Alice", "player_id": 101, "seed": 1, "match_status": "matched_existing"},
+        {"id": "p-2", "name": "Bob", "player_id": 102, "seed": 2, "match_status": "matched_existing"},
+        {"id": "p-3", "name": "New Rated", "player_id": None, "seed": 3, "match_status": "create_rated"},
+        {"id": "p-4", "name": "Drew", "player_id": None, "seed": 4, "match_status": "new_social"},
+    ]
+    result = save_resolved_social_live_event(
+        ctx,
+        event,
+        target_club_id="club-1",
+        submission_mode="admin",
+        host_name="admin",
+    )
+    assert result["created_rated_players_count"] == 1
+    created_players = [row for row in supabase.store["players"] if row["name"] == "New Rated"]
+    assert len(created_players) == 1
+    created = created_players[0]
+    assert created["rating"] == 1400.0
+    unchanged_alice = [row for row in supabase.store["players"] if row["id"] == 101][0]
+    unchanged_bob = [row for row in supabase.store["players"] if row["id"] == 102][0]
+    assert unchanged_alice["rating"] == 1600.0
+    assert unchanged_bob["rating"] == 1200.0
+    participants = supabase.store["live_event_participants"]
+    created_participant = [row for row in participants if row["participant_key"] == "p-3"][0]
+    assert created_participant["linked_player_id"] == created["id"]
+
+
+def test_resolved_save_falls_back_to_default_provisional_seed_without_other_rated_players():
+    supabase = _FakeSupabase()
+    supabase.store["players"] = []
+    ctx = _Ctx(supabase=supabase, club_id="club-1", name_to_id={})
+    ctx.admin_logged_in = True
+    ctx.df_players_all = pd.DataFrame()
+    event = _sample_event()
+    for participant in event["participants"]:
+        participant["player_id"] = None
+        participant["match_status"] = "create_rated"
+    save_resolved_social_live_event(
+        ctx,
+        event,
+        target_club_id="club-1",
+        submission_mode="admin",
+        host_name="admin",
+    )
+    created = [row for row in supabase.store["players"] if row["club_id"] == "club-1"]
+    assert all(float(row["rating"]) == 1400.0 for row in created)
+
+
+def test_resolved_save_detects_strong_duplicate_and_blocks_creation():
+    supabase = _FakeSupabase()
+    supabase.store["players"] = [
+        {"id": 55, "club_id": "club-1", "name": "Jon Snow", "rating": 1500.0, "starting_rating": 1500.0}
+    ]
+    ctx = _Ctx(supabase=supabase, club_id="club-1", name_to_id={})
+    ctx.admin_logged_in = True
+    ctx.df_players_all = pd.DataFrame([{"id": 55, "name": "Jon Snow", "rating": 1500.0}])
+    event = _sample_event()
+    event["participants"][0]["name"] = "John Snow"
+    event["participants"][0]["player_id"] = None
+    event["participants"][0]["match_status"] = "create_rated"
+    try:
+        save_resolved_social_live_event(
+            ctx,
+            event,
+            target_club_id="club-1",
+            submission_mode="admin",
+            host_name="admin",
+        )
+    except ValueError as exc:
+        assert "Duplicate warning" in str(exc)
+    else:
+        raise AssertionError("Expected duplicate warning ValueError")
+
+
+def test_social_history_falls_back_to_legacy_submitted_by_column():
+    fetch_player_social_event_history.clear()
+    supabase = _FakeSupabase()
+    supabase.store["__missing_select_columns__"] = {"submitted_by_name"}
+    supabase.store["live_events"] = [
+        {
+            "id": "evt-1",
+            "club_id": "club-1",
+            "name": "Social Night",
+            "event_type": "round_robin",
+            "event_date": "2026-03-29",
+            "submitted_by": "Legacy Host",
+            "status": "saved",
+            "result_mode": "social_unrated",
+            "summary_json": {},
+        }
+    ]
+    supabase.store["live_event_participants"] = [
+        {"id": "lep-1", "event_id": "evt-1", "club_person_id": "cp-1", "linked_player_id": 12}
+    ]
+    supabase.store["live_event_matches"] = []
+    df = fetch_player_social_event_history(supabase, "club-1", 12, limit=20)
+    assert len(df) == 1
+    assert df.iloc[0]["Submitted By"] == "Legacy Host"
+
+
+def test_resolved_save_status_admin_vs_public():
+    supabase = _FakeSupabase()
+    ctx = _Ctx(supabase=supabase, club_id="club-1", name_to_id={})
+    ctx.admin_logged_in = True
+    admin_result = save_resolved_social_live_event(
+        ctx,
+        _sample_event(),
+        target_club_id="club-1",
+        submission_mode="admin",
+        host_name="admin",
+    )
+    assert admin_result["status"] == "saved"
+    public_result = save_resolved_social_live_event(
+        ctx,
+        _sample_event(),
+        target_club_id="club-1",
+        submission_mode="public",
+        host_name="Host",
+    )
+    assert public_result["status"] == "pending"
 
 
 def test_approve_moves_pending_to_saved():


### PR DESCRIPTION
### Motivation
- Club Social submissions were crashing due to submitter-column/schema drift (missing `submitted_by` vs `submitted_by_name`) and needed a safe, backwards-compatible persistence path.
- Admins require an explicit roster-confirmation flow that prefers matching to existing rated players or deliberately creating new rated players (no silent rated-player creation).
- Newly-created rated players from Club Social need a provisional seed based on the roster, and post-submit Social views must reflect the new data immediately.

### Description
- Add robust upsert/read fallbacks for `live_events` so writes tolerate schema drift between `submitted_by` and `submitted_by_name` and reads normalize to a canonical `submitted_by_name` (helper `submitted_by_name_from_row` and `_upsert_live_event_row`).
- Extend roster confirmation behavior in the Live UI to present explicit options that prefer matching existing players or `Create new rated player: <name>`, include duplicate/high-confidence warnings, and preserve confirmed linkage through event creation (`_build_roster_candidate_rows`, `_resolved_participants_from_confirmation`, form flow changes in `jupr_app/ui/live/shared.py`).
- Restrict backend rated-player creation to explicit `create_rated` selections and enforce duplicate-risk protection using stdlib `difflib` fuzzy checks (helper `_find_strong_duplicate_candidates`); create new competitive `players` rows via `safe_add_player` with a provisional seed computed as the average Elo of other explicitly rated roster members (`_provisional_seed_elo`) in `jupr_app/domain/live_social_submit.py`.
- Preserve explicit player linkage by carrying `player_id`/match_status into `live_event_participants` rather than relying on later name matching; ensure social saves remain unrated and do not mutate existing ratings.
- Make `fetch_player_social_event_history` resilient to schema drift by falling back to `submitted_by` when `submitted_by_name` is unavailable and display a consistent submitter name in the Players UI (`jupr_app/ui/pages/players.py`).
- Update Club Social submit success copy and keep targeted cache invalidation for social profile helpers by clearing `fetch_player_social_event_history` and `fetch_player_social_participation` after save (`jupr_app/ui/pages/jupr_live.py`).
- Add a rollback SQL file for the canonical `submitted_by_name` migration under `migrations/20260417_live_events_submitted_by_name_canonical_rollback.sql`.

### Testing
- Ran `pytest -q tests/test_live_social.py` and all tests passed (26 passed).
- Added/updated tests in `tests/test_live_social.py` to cover: schema-drift submitter handling, explicit existing-player linkage preservation, explicit create-new-rated-player flow and linkage, provisional seeding behavior (including fallback), duplicate detection/blocking, social-history submitter fallback, and admin/public save status behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a16b3ab08326ae8b9b1a0228a48a)