### PR TITLE
Extend Match Log to include and manage Club Social matches

### DIFF
--- a/jupr_app/domain/live_social.py
+++ b/jupr_app/domain/live_social.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Iterable
 from uuid import uuid4
 
 import pandas as pd
@@ -765,3 +766,225 @@ def moderate_social_submission(
     if not rows:
         raise RuntimeError("Unable to moderate social submission for this club.")
     return dict(rows[0])
+
+
+def list_social_match_log_rows(
+    supabase,
+    *,
+    club_id: str,
+    limit: int = 1000,
+) -> pd.DataFrame:
+    club_id = str(club_id)
+    event_rows = (
+        supabase.table("live_events")
+        .select("id,name,event_date,status,submission_mode")
+        .eq("club_id", club_id)
+        .eq("result_mode", "social_unrated")
+        .order("event_date", desc=True)
+        .limit(max(int(limit), 1))
+        .execute()
+        .data
+        or []
+    )
+    if not event_rows:
+        return pd.DataFrame()
+
+    event_map = {str(row["id"]): dict(row) for row in event_rows if row.get("id")}
+    event_ids = list(event_map.keys())
+    if not event_ids:
+        return pd.DataFrame()
+
+    participant_rows = (
+        supabase.table("live_event_participants")
+        .select("id,event_id,club_person_id,participant_key")
+        .in_("event_id", event_ids)
+        .execute()
+        .data
+        or []
+    )
+    participant_to_person_id: dict[str, str] = {}
+    club_person_ids: set[str] = set()
+    for row in participant_rows:
+        participant_id = row.get("id")
+        person_id = row.get("club_person_id")
+        if participant_id is None or person_id is None:
+            continue
+        participant_to_person_id[str(participant_id)] = str(person_id)
+        club_person_ids.add(str(person_id))
+
+    person_name_map: dict[str, str] = {}
+    if club_person_ids:
+        people_rows = (
+            supabase.table("club_people")
+            .select("id,display_name")
+            .in_("id", list(club_person_ids))
+            .execute()
+            .data
+            or []
+        )
+        person_name_map = {
+            str(row["id"]): normalize_name(row.get("display_name"))
+            for row in people_rows
+            if row.get("id") is not None
+        }
+
+    match_rows = (
+        supabase.table("live_event_matches")
+        .select(
+            "id,event_id,match_key,played_on,round_number,court_number,mini_round_number,"
+            "status,submission_mode,"
+            "t1_p1_participant_id,t1_p2_participant_id,t2_p1_participant_id,t2_p2_participant_id,"
+            "score_t1,score_t2"
+        )
+        .in_("event_id", event_ids)
+        .order("played_on", desc=True)
+        .limit(max(int(limit), 1))
+        .execute()
+        .data
+        or []
+    )
+
+    def _participant_name(participant_id: object) -> str:
+        if participant_id is None:
+            return ""
+        person_id = participant_to_person_id.get(str(participant_id))
+        if person_id is None:
+            return ""
+        return person_name_map.get(person_id, "")
+
+    rows: list[dict] = []
+    for row in match_rows:
+        event_id = str(row.get("event_id") or "")
+        event = event_map.get(event_id, {})
+        rows.append(
+            {
+                "source_type": "social",
+                "source_label": "Club Social (Unrated)",
+                "id": row.get("id"),
+                "social_match_id": row.get("id"),
+                "event_id": event_id,
+                "event_name": normalize_name(event.get("name")),
+                "date": row.get("played_on") or event.get("event_date"),
+                "played_on": row.get("played_on") or event.get("event_date"),
+                "round_number": row.get("round_number"),
+                "court_number": row.get("court_number"),
+                "mini_round_number": row.get("mini_round_number"),
+                "status": row.get("status") or event.get("status"),
+                "submission_mode": row.get("submission_mode") or event.get("submission_mode"),
+                "match_key": row.get("match_key"),
+                "t1_p1": _participant_name(row.get("t1_p1_participant_id")),
+                "t1_p2": _participant_name(row.get("t1_p2_participant_id")),
+                "t2_p1": _participant_name(row.get("t2_p1_participant_id")),
+                "t2_p2": _participant_name(row.get("t2_p2_participant_id")),
+                "score_t1": row.get("score_t1"),
+                "score_t2": row.get("score_t2"),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def update_social_match_row(
+    supabase,
+    *,
+    club_id: str,
+    social_match_id: str,
+    patch: dict,
+) -> dict:
+    club_id = str(club_id)
+    social_match_id = str(social_match_id)
+    match_rows = (
+        supabase.table("live_event_matches")
+        .select("id,event_id")
+        .eq("id", social_match_id)
+        .limit(1)
+        .execute()
+        .data
+        or []
+    )
+    if not match_rows:
+        raise RuntimeError("Social match not found.")
+    event_id = str(match_rows[0].get("event_id") or "")
+    if not event_id:
+        raise RuntimeError("Social match is missing event linkage.")
+
+    event_rows = (
+        supabase.table("live_events")
+        .select("id")
+        .eq("id", event_id)
+        .eq("club_id", club_id)
+        .limit(1)
+        .execute()
+        .data
+        or []
+    )
+    if not event_rows:
+        raise RuntimeError("Social match does not belong to this club.")
+
+    allowed_match_fields = {
+        "played_on",
+        "score_t1",
+        "score_t2",
+        "round_number",
+        "court_number",
+        "mini_round_number",
+    }
+    match_payload = {k: v for k, v in (patch or {}).items() if k in allowed_match_fields}
+    if match_payload:
+        supabase.table("live_event_matches").update(match_payload).eq("id", social_match_id).execute()
+
+    event_name = (patch or {}).get("event_name")
+    if event_name is not None:
+        supabase.table("live_events").update({"name": normalize_name(event_name)}).eq("id", event_id).eq(
+            "club_id", club_id
+        ).execute()
+
+    return {
+        "social_match_id": social_match_id,
+        "event_id": event_id,
+        "updated_match_fields": sorted(match_payload.keys()),
+        "updated_event_name": event_name is not None,
+    }
+
+
+def delete_social_matches(
+    supabase,
+    *,
+    club_id: str,
+    social_match_ids: Iterable[str],
+) -> int:
+    club_id = str(club_id)
+    ids = [str(v) for v in (social_match_ids or []) if str(v).strip()]
+    if not ids:
+        return 0
+
+    rows = (
+        supabase.table("live_event_matches")
+        .select("id,event_id")
+        .in_("id", ids)
+        .execute()
+        .data
+        or []
+    )
+    if not rows:
+        return 0
+
+    event_ids = [str(r.get("event_id")) for r in rows if r.get("event_id")]
+    allowed_events = set()
+    if event_ids:
+        allowed_rows = (
+            supabase.table("live_events")
+            .select("id")
+            .eq("club_id", club_id)
+            .in_("id", event_ids)
+            .execute()
+            .data
+            or []
+        )
+        allowed_events = {str(r["id"]) for r in allowed_rows if r.get("id")}
+
+    allowed_ids = [str(r["id"]) for r in rows if str(r.get("event_id")) in allowed_events]
+    if not allowed_ids:
+        return 0
+
+    supabase.table("live_event_matches").delete().in_("id", allowed_ids).execute()
+    return len(allowed_ids)

--- a/jupr_app/ui/pages/match_log.py
+++ b/jupr_app/ui/pages/match_log.py
@@ -3,6 +3,12 @@ import pandas as pd
 
 from jupr_app.domain.dupes import canonical_dup_key
 from jupr_app.domain.bulk_match_editor import apply_bulk_match_edits, compute_recompute_scope
+from jupr_app.domain.live_social import (
+    SocialTablesNotInstalledError,
+    delete_social_matches,
+    list_social_match_log_rows,
+    update_social_match_row,
+)
 from jupr_app.domain.player_activity import recompute_last_game_at_for_players
 from jupr_app.ui.layout import page_shell
 from jupr_app.domain.replay_history import replay_history
@@ -23,6 +29,31 @@ def render(ctx):
         st.stop()
 
     df = df_matches.copy()
+    df["source_type"] = "rated"
+    df["source_label"] = "Rated"
+
+    st.markdown("### Match Sources")
+    source_mode = st.radio(
+        "Choose what to show",
+        ["Rated only", "Include Club Social"],
+        horizontal=True,
+        key="match_log_source_mode",
+    )
+    include_social = source_mode == "Include Club Social"
+
+    social_df = pd.DataFrame()
+    social_error = None
+    if include_social:
+        try:
+            social_df = list_social_match_log_rows(
+                ctx.supabase,
+                club_id=str(ctx.club_id),
+                limit=5000,
+            )
+        except SocialTablesNotInstalledError as exc:
+            social_error = str(exc)
+        except Exception as exc:
+            social_error = f"Unable to load Club Social rows: {exc}"
 
     # Basic filters
     c1, c2, c3 = st.columns([2, 2, 2])
@@ -42,6 +73,158 @@ def render(ctx):
         df = df[df["id"].astype(int) == int(id_filter)].copy()
 
     df = df.head(int(limit_rows)).copy()
+
+    if include_social and social_error:
+        st.warning(social_error)
+
+    if include_social and social_df is not None and not social_df.empty:
+        social_df = social_df.head(int(limit_rows)).copy()
+        combined_df = pd.concat([df, social_df], ignore_index=True, sort=False)
+    else:
+        combined_df = df.copy()
+
+    st.subheader("📋 Match Log Rows")
+    show_cols = [
+        c
+        for c in [
+            "source_label",
+            "id",
+            "event_name",
+            "date",
+            "played_on",
+            "league",
+            "week_tag",
+            "match_type",
+            "match_key",
+            "round_number",
+            "court_number",
+            "mini_round_number",
+            "status",
+            "submission_mode",
+            "t1_p1",
+            "t1_p2",
+            "t2_p1",
+            "t2_p2",
+            "score_t1",
+            "score_t2",
+        ]
+        if c in combined_df.columns
+    ]
+    if not combined_df.empty:
+        st.dataframe(combined_df[show_cols], use_container_width=True, hide_index=True)
+    else:
+        st.info("No rows for current filter/settings.")
+
+    if include_social and social_df is not None and not social_df.empty:
+        st.divider()
+        st.subheader("🎾 Club Social Editor")
+        st.caption(
+            "Edit/delete unrated Club Social rows here. This updates only live_event_matches (and optionally live_events name)."
+        )
+
+        social_view = social_df.copy()
+        social_view.insert(0, "Update", False)
+        social_view.insert(1, "Delete", False)
+
+        edit_cols = [
+            c
+            for c in [
+                "Update",
+                "Delete",
+                "source_label",
+                "social_match_id",
+                "event_id",
+                "event_name",
+                "played_on",
+                "round_number",
+                "court_number",
+                "mini_round_number",
+                "score_t1",
+                "score_t2",
+                "status",
+                "submission_mode",
+                "match_key",
+                "t1_p1",
+                "t1_p2",
+                "t2_p1",
+                "t2_p2",
+            ]
+            if c in social_view.columns
+        ]
+
+        edited_social = st.data_editor(
+            social_view[edit_cols],
+            hide_index=True,
+            use_container_width=True,
+            key="social_match_editor",
+            column_config={
+                "Update": st.column_config.CheckboxColumn(default=False),
+                "Delete": st.column_config.CheckboxColumn(default=False),
+                "played_on": st.column_config.DateColumn("played_on"),
+                "event_name": st.column_config.TextColumn("event_name"),
+            },
+            disabled=["source_label", "social_match_id", "event_id", "status", "submission_mode", "match_key", "t1_p1", "t1_p2", "t2_p1", "t2_p2"],
+        )
+
+        def _as_date_text(value):
+            if pd.isna(value):
+                return None
+            ts = pd.to_datetime(value, errors="coerce")
+            if pd.isna(ts):
+                return None
+            return ts.date().isoformat()
+
+        original_by_id = social_df.set_index("social_match_id", drop=False)
+        update_rows = edited_social[edited_social["Update"] == True] if "Update" in edited_social.columns else pd.DataFrame()
+        delete_rows = edited_social[edited_social["Delete"] == True] if "Delete" in edited_social.columns else pd.DataFrame()
+
+        c_save, c_delete = st.columns([1, 1])
+        with c_save:
+            if st.button("Save selected social edits", type="primary", key="social_save_btn"):
+                updated_count = 0
+                for _, row in update_rows.iterrows():
+                    sid = str(row.get("social_match_id") or "").strip()
+                    if not sid or sid not in original_by_id.index:
+                        continue
+                    before = original_by_id.loc[sid]
+                    patch = {}
+                    for fld in ("score_t1", "score_t2", "round_number", "court_number", "mini_round_number"):
+                        old_v = None if pd.isna(before.get(fld)) else int(before.get(fld))
+                        new_v = None if pd.isna(row.get(fld)) else int(row.get(fld))
+                        if new_v != old_v:
+                            patch[fld] = new_v
+                    old_played = _as_date_text(before.get("played_on"))
+                    new_played = _as_date_text(row.get("played_on"))
+                    if new_played != old_played and new_played is not None:
+                        patch["played_on"] = new_played
+                    old_name = str(before.get("event_name") or "").strip()
+                    new_name = str(row.get("event_name") or "").strip()
+                    if new_name != old_name:
+                        patch["event_name"] = new_name
+                    if patch:
+                        update_social_match_row(
+                            ctx.supabase,
+                            club_id=str(ctx.club_id),
+                            social_match_id=sid,
+                            patch=patch,
+                        )
+                        updated_count += 1
+                if updated_count:
+                    st.success(f"Updated {updated_count} Club Social match row(s).")
+                    st.rerun()
+                st.info("No social row edits detected.")
+        with c_delete:
+            if st.button("Delete selected social rows", key="social_delete_btn"):
+                delete_ids = delete_rows["social_match_id"].dropna().astype(str).tolist() if not delete_rows.empty else []
+                deleted = delete_social_matches(
+                    ctx.supabase,
+                    club_id=str(ctx.club_id),
+                    social_match_ids=delete_ids,
+                )
+                if deleted:
+                    st.success(f"Deleted {deleted} Club Social match row(s).")
+                    st.rerun()
+                st.info("No social rows deleted.")
 
     st.divider()
 


### PR DESCRIPTION
### Motivation
- Allow admins to view, edit, and delete Club Social matches (stored in `live_events` / `live_event_participants` / `live_event_matches`) from the existing Match Log without routing those rows through rated match logic or triggering rating/replay side effects.
- Keep existing rated match workflows unchanged while making social rows clearly identifiable and manageable from the same page.

### Description
- Added domain helpers in `jupr_app/domain/live_social.py`: `list_social_match_log_rows(...)` to load club-scoped social match rows with event and player context, `update_social_match_row(...)` to safely update allowed social fields and optionally `live_events.name`, and `delete_social_matches(...)` to delete only `live_event_matches` rows that belong to the club.
- Updated `jupr_app/ui/pages/match_log.py` to add a top-level source toggle (`Rated only` / `Include Club Social`), to render combined match-log rows with clear `source_label` for each row, and to surface a dedicated Club Social Editor that supports per-row update and delete actions for social rows.
- Social edits are limited to `played_on`, `score_t1`, `score_t2`, `round_number`, `court_number`, `mini_round_number`, and optional `event_name`, and are routed through the new social-safe updater; social deletes only remove `live_event_matches` rows owned by the current club and do not touch rated `matches` or replay/rating subsystems.
- Added error handling for missing social tables (`SocialTablesNotInstalledError`) and resolved player display names via `live_event_participants.club_person_id -> club_people.display_name` for readable rows.

### Testing
- Compiled modified modules successfully with `python -m py_compile jupr_app/ui/pages/match_log.py jupr_app/domain/live_social.py` (no syntax errors).
- No automated unit tests were added; manual UI validation expected in the app to confirm interactive edit/delete behavior in admin mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2ac6b98008326a1cfb39a1241e7f0)