### PR TITLE
Fix event family row assignment to handle list-valued fields

### DIFF
--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -499,7 +499,9 @@ def _event_family_name_exists(events_df: pd.DataFrame, event_family: str, exclud
 
 def _add_event_family_row(events_df: pd.DataFrame, payload: dict[str, Any]) -> pd.DataFrame:
     out = _ensure_editor_columns(events_df, EVENT_TEMPLATE_COLUMNS).copy()
-    out.loc[_uid("evt"), EVENT_TEMPLATE_COLUMNS] = [payload.get(column) for column in EVENT_TEMPLATE_COLUMNS]
+    row_id = _uid("evt")
+    for column in EVENT_TEMPLATE_COLUMNS:
+        out.loc[row_id, column] = payload.get(column)
     return _ensure_editor_columns(out, EVENT_TEMPLATE_COLUMNS)
 
 
@@ -507,7 +509,8 @@ def _update_event_family_row(events_df: pd.DataFrame, event_id: str, payload: di
     out = _ensure_editor_columns(events_df, EVENT_TEMPLATE_COLUMNS).copy()
     if str(event_id) not in {str(idx) for idx in out.index.tolist()}:
         return out
-    out.loc[event_id, EVENT_TEMPLATE_COLUMNS] = [payload.get(column) for column in EVENT_TEMPLATE_COLUMNS]
+    for column in EVENT_TEMPLATE_COLUMNS:
+        out.loc[event_id, column] = payload.get(column)
     return _ensure_editor_columns(out, EVENT_TEMPLATE_COLUMNS)
 
 


### PR DESCRIPTION
### Motivation
- Vectorized row assignment using `out.loc[... , EVENT_TEMPLATE_COLUMNS] = [...]` failed when some template columns contain Python list values (e.g. `generator_selected_days`, `generator_selected_skill_levels`, `generator_age_labels`) causing `ValueError: setting an array element with a sequence`.

### Description
- Replace vectorized row assignment in `_add_event_family_row` with per-column assignment using a generated `row_id` and a loop that sets `out.loc[row_id, column] = payload.get(column)`.
- Replace vectorized row assignment in `_update_event_family_row` with a per-column loop that first verifies the `event_id` exists and then sets each column individually, preserving list/object payload shapes.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/tournament_manager.py` which succeeded. 
- Verified the git diff contains only the targeted helper changes to `_add_event_family_row` and `_update_event_family_row` and no payload shape changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2adf634d88326b69c88987887ffbd)