### PR TITLE
Fix event edit/create crash caused by list-valued generator fields

### DIFF
--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -501,7 +501,9 @@ def _add_event_family_row(events_df: pd.DataFrame, payload: dict[str, Any]) -> p
     out = _ensure_editor_columns(events_df, EVENT_TEMPLATE_COLUMNS).copy()
     row_id = _uid("evt")
     for column in EVENT_TEMPLATE_COLUMNS:
-        out.loc[row_id, column] = payload.get(column)
+        if column not in out.columns:
+            out[column] = None
+        out.at[row_id, column] = payload.get(column)
     return _ensure_editor_columns(out, EVENT_TEMPLATE_COLUMNS)
 
 
@@ -510,7 +512,9 @@ def _update_event_family_row(events_df: pd.DataFrame, event_id: str, payload: di
     if str(event_id) not in {str(idx) for idx in out.index.tolist()}:
         return out
     for column in EVENT_TEMPLATE_COLUMNS:
-        out.loc[event_id, column] = payload.get(column)
+        if column not in out.columns:
+            out[column] = None
+        out.at[event_id, column] = payload.get(column)
     return _ensure_editor_columns(out, EVENT_TEMPLATE_COLUMNS)
 
 


### PR DESCRIPTION
### Motivation
- Event payloads can include list-valued generator fields (e.g., `generator_selected_days`, `generator_selected_skill_levels`, `generator_age_labels`) which caused `ValueError: Must have equal len keys and value when setting with an iterable` during event create/edit flows when assigned with per-column `.loc` semantics.

### Description
- Replace per-cell `.loc[...]` writes with scalar `.at[...]` in `_add_event_family_row` and `_update_event_family_row` to ensure single-cell scalar assignment.
- Ensure columns exist before assignment by creating the column with `None` if missing in both helpers.
- Preserve list-valued generator fields as Python lists in the DataFrame working state and do not stringify those fields.
- Changes are localized to `jupr_app/ui/pages/tournament_manager.py` in the event-family add/update helpers.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/tournament_manager.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2af2d6ff08326b0cd88a6b17dda8c)