### PR TITLE
Harden _ensure_editor_columns to avoid pandas iterable-assignment crash

### DIFF
--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -315,10 +315,11 @@ def _ensure_editor_columns(df: pd.DataFrame | None, columns: list[str]) -> pd.Da
     if not isinstance(df, pd.DataFrame):
         return pd.DataFrame(columns=columns)
     out = df.copy()
+    out = out.loc[:, ~pd.Index(out.columns).duplicated(keep="last")]
     for column in columns:
         if column not in out.columns:
             out[column] = pd.Series([None] * len(out), index=out.index)
-    return out[columns]
+    return out.loc[:, columns]
 
 
 def _df_with_hidden_ids(rows: list[dict[str, Any]], id_key: str, ordered_columns: list[str]) -> pd.DataFrame:


### PR DESCRIPTION
### Motivation
- Saving event-family rows can write list-valued fields and pandas may treat assignment as iterable-to-multiple-target when the dataframe contains duplicate editor column names, raising `ValueError: Must have equal len keys and value when setting with an iterable`.
- Apply a small, surgical fix restricted to the event-family editor path to remove duplicate column names before any cell-wise assignments are made.

### Description
- In `jupr_app/ui/pages/tournament_manager.py` updated `_ensure_editor_columns(...)` to drop duplicated columns with `out = out.loc[:, ~pd.Index(out.columns).duplicated(keep="last")]` before adding missing editor columns.
- Kept the existing behavior of adding missing columns as `pd.Series([None] * len(out), index=out.index)` when absent.
- Return the ordered editor columns using `out.loc[:, columns]` to avoid ambiguous indexing shapes.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/tournament_manager.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d066968c8326b054381df8c847e6)