### PR TITLE
Render divisions as single-row entries with inline Edit/Delete actions

### DIFF
--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -784,6 +784,20 @@ def _display_division_name(row: pd.Series) -> str:
     return f"{family} {suffix}".strip() or family
 
 
+def _display_optional(value: Any, fallback: str = "—") -> str:
+    text = _safe_text(value)
+    return text if text else fallback
+
+
+def _truncate_text(value: Any, max_len: int = 40) -> str:
+    text = _safe_text(value)
+    if not text:
+        return "—"
+    if len(text) <= max_len:
+        return text
+    return f"{text[: max_len - 1].rstrip()}…"
+
+
 def _validate_builder(days_df: pd.DataFrame, event_templates_df: pd.DataFrame, divisions_df: pd.DataFrame) -> list[str]:
     days_df = _ensure_editor_columns(days_df, DAYS_EDITOR_COLUMNS)
     event_templates_df = _ensure_editor_columns(event_templates_df, EVENT_TEMPLATE_COLUMNS)
@@ -1860,41 +1874,43 @@ def render(ctx):
                 for day in sorted({ _safe_text(v) for v in family_df["assigned_day"].tolist() if _safe_text(v) }):
                     day_df = family_df[family_df["assigned_day"].apply(lambda value: _safe_text(value) == day)]
                     st.caption(f"Day: {day}")
-                    display = day_df[[
-                        "division_name",
-                        "skill_label",
-                        "age_mode",
-                        "age_label",
-                        "status",
-                        "capacity_teams",
-                        "price_usd",
-                        "division_format",
-                        "division_scoring",
-                        "notes",
-                    ]].rename(
-                        columns={
-                            "division_name": "Division",
-                            "skill_label": "Skill",
-                            "age_mode": "Age Mode",
-                            "age_label": "Age",
-                            "status": "Status",
-                            "capacity_teams": "Capacity",
-                            "price_usd": "Price USD",
-                            "division_format": "Format Override",
-                            "division_scoring": "Scoring Override",
-                            "notes": "Notes",
-                        }
-                    )
-                    st.dataframe(display, hide_index=True, use_container_width=True)
+                    col_widths = [2.8, 1.0, 1.3, 0.9, 0.9, 0.9, 0.9, 1.2, 1.2, 1.8, 1.4]
+                    header_cols = st.columns(col_widths)
+                    headers = [
+                        "Division",
+                        "Skill",
+                        "Age Mode",
+                        "Age",
+                        "Status",
+                        "Capacity",
+                        "Price",
+                        "Format",
+                        "Scoring",
+                        "Notes",
+                        "Actions",
+                    ]
+                    for idx, header in enumerate(headers):
+                        header_cols[idx].markdown(f"**{header}**")
                     for division_id, row in day_df.iterrows():
                         division_name = _display_division_name(row)
-                        row_cols = st.columns([4, 1, 1])
-                        row_cols[0].markdown(f"- {division_name}")
-                        if row_cols[1].button("Edit", key=f"tm_div_edit_{tournament_id}_{division_id}", disabled=structure_locked):
+                        row_cols = st.columns(col_widths)
+                        row_cols[0].markdown(_display_optional(division_name))
+                        row_cols[1].markdown(_display_optional(row.get("skill_label")))
+                        row_cols[2].markdown(_display_optional(row.get("age_mode")))
+                        row_cols[3].markdown(_display_optional(row.get("age_label")))
+                        row_cols[4].markdown(_display_optional(row.get("status")))
+                        row_cols[5].markdown(_display_optional(row.get("capacity_teams")))
+                        price_value = row.get("price_usd")
+                        row_cols[6].markdown(f"${float(price_value):.2f}" if _coerce_float(price_value) is not None else "—")
+                        row_cols[7].markdown(_display_optional(row.get("division_format")))
+                        row_cols[8].markdown(_display_optional(row.get("division_scoring")))
+                        row_cols[9].markdown(_truncate_text(row.get("notes")))
+                        action_cols = row_cols[10].columns([1, 1])
+                        if action_cols[0].button("Edit", key=f"tm_div_edit_{tournament_id}_{division_id}", disabled=structure_locked):
                             st.session_state[division_form_mode_key] = "edit"
                             st.session_state[division_edit_id_key] = str(division_id)
                             st.rerun()
-                        if row_cols[2].button("Delete", key=f"tm_div_del_{tournament_id}_{division_id}", disabled=structure_locked):
+                        if action_cols[1].button("Delete", key=f"tm_div_del_{tournament_id}_{division_id}", disabled=structure_locked):
                             st.session_state[divisions_seed_key] = _delete_division_row(divisions_df, str(division_id))
                             st.success(f"Deleted division '{division_name}'.")
                             st.rerun()


### PR DESCRIPTION
### Motivation
- Remove the redundant double-render of divisions where a `st.dataframe(...)` table is shown and each division is then listed again with actions. 
- Present each division exactly once in a compact, row-based layout while keeping grouping by event family and assigned day.
- Preserve existing session-state behavior and disablement rules so UI actions continue to work unchanged.

### Description
- Replaced the two-pass rendering in the Divisions tab (`st.dataframe(...)` + separate per-row actions loop) with a single row renderer built from `st.columns(...)` grouped by event family and assigned day in `jupr_app/ui/pages/tournament_manager.py`.
- Added small helpers ` _display_optional(value, fallback="—")` and `_truncate_text(value, max_len=40)` adjacent to `_display_division_name` for safe blank fallbacks and notes truncation.
- Rendered a header row with columns `Division | Skill | Age Mode | Age | Status | Capacity | Price | Format | Scoring | Notes | Actions` and then one row per division using the same session-state keys for actions (`tm_div_edit_{tournament_id}_{division_id}`, `tm_div_del_{tournament_id}_{division_id}`, `division_form_mode_key`, `division_edit_id_key`).
- Kept delete success message, `st.rerun()` behavior, and `structure_locked` disabling intact, and formatted `price_usd` with a safe fallback.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/tournament_manager.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3dcafde408326b1dcdc7f6139fb46)