### PR TITLE
Improve Divisions tab row layout and action button usability

### DIFF
--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -1874,46 +1874,34 @@ def render(ctx):
                 for day in sorted({ _safe_text(v) for v in family_df["assigned_day"].tolist() if _safe_text(v) }):
                     day_df = family_df[family_df["assigned_day"].apply(lambda value: _safe_text(value) == day)]
                     st.caption(f"Day: {day}")
-                    col_widths = [2.8, 1.0, 1.3, 0.9, 0.9, 0.9, 0.9, 1.2, 1.2, 1.8, 1.4]
-                    header_cols = st.columns(col_widths)
-                    headers = [
-                        "Division",
-                        "Skill",
-                        "Age Mode",
-                        "Age",
-                        "Status",
-                        "Capacity",
-                        "Price",
-                        "Format",
-                        "Scoring",
-                        "Notes",
-                        "Actions",
-                    ]
-                    for idx, header in enumerate(headers):
-                        header_cols[idx].markdown(f"**{header}**")
+                    st.caption("**Division | Skill | Age | Status | Capacity | Price**")
                     for division_id, row in day_df.iterrows():
                         division_name = _display_division_name(row)
-                        row_cols = st.columns(col_widths)
-                        row_cols[0].markdown(_display_optional(division_name))
+                        row_cols = st.columns([5.0, 1.0, 1.2, 1.0, 1.0, 1.0, 2.4])
+                        row_cols[0].markdown(f"**{_display_optional(division_name)}**")
                         row_cols[1].markdown(_display_optional(row.get("skill_label")))
-                        row_cols[2].markdown(_display_optional(row.get("age_mode")))
-                        row_cols[3].markdown(_display_optional(row.get("age_label")))
-                        row_cols[4].markdown(_display_optional(row.get("status")))
-                        row_cols[5].markdown(_display_optional(row.get("capacity_teams")))
+                        row_cols[2].markdown(_display_optional(row.get("age_label")))
+                        row_cols[3].markdown(_display_optional(row.get("status")))
+                        row_cols[4].markdown(_display_optional(row.get("capacity_teams")))
                         price_value = row.get("price_usd")
-                        row_cols[6].markdown(f"${float(price_value):.2f}" if _coerce_float(price_value) is not None else "—")
-                        row_cols[7].markdown(_display_optional(row.get("division_format")))
-                        row_cols[8].markdown(_display_optional(row.get("division_scoring")))
-                        row_cols[9].markdown(_truncate_text(row.get("notes")))
-                        action_cols = row_cols[10].columns([1, 1])
-                        if action_cols[0].button("Edit", key=f"tm_div_edit_{tournament_id}_{division_id}", disabled=structure_locked):
+                        row_cols[5].markdown(f"${float(price_value):.2f}" if _coerce_float(price_value) is not None else "—")
+                        action_cols = row_cols[6].columns([1, 1], gap="small")
+                        if action_cols[0].button("✏️ Edit", key=f"tm_div_edit_{tournament_id}_{division_id}", disabled=structure_locked):
                             st.session_state[division_form_mode_key] = "edit"
                             st.session_state[division_edit_id_key] = str(division_id)
                             st.rerun()
-                        if action_cols[1].button("Delete", key=f"tm_div_del_{tournament_id}_{division_id}", disabled=structure_locked):
+                        if action_cols[1].button("🗑️ Delete", key=f"tm_div_del_{tournament_id}_{division_id}", disabled=structure_locked):
                             st.session_state[divisions_seed_key] = _delete_division_row(divisions_df, str(division_id))
                             st.success(f"Deleted division '{division_name}'.")
                             st.rerun()
+                        secondary_parts = [
+                            f"Age Mode: {_display_optional(row.get('age_mode'))}",
+                            f"Format: {_display_optional(row.get('division_format'))}",
+                            f"Scoring: {_display_optional(row.get('division_scoring'))}",
+                            f"Notes: {_truncate_text(row.get('notes'))}",
+                        ]
+                        st.caption(" · ".join(secondary_parts))
+                        st.divider()
         for mode, help_text in AGE_MODE_HELP.items():
             st.caption(f"**{mode.replace('_', ' ').title()}** — {help_text}")
         if st.button("Save Divisions Draft", disabled=structure_locked, key=f"tm_save_divisions_draft_{tournament_id}"):


### PR DESCRIPTION
### Motivation
- The Divisions tab rendered Edit/Delete inside a very narrow nested Actions column causing labels to wrap and the row to look cluttered.
- The goal is to keep one row per division and grouping by event family/day while making the right-side action area usable and the row easier to scan.

### Description
- Replaced the dense 11-column header/row with a compact day-level heading and a two-tier per-division layout shown under `Existing Divisions` using a primary row and a secondary muted details line.
- Render the primary row with `st.columns([5.0, 1.0, 1.2, 1.0, 1.0, 1.0, 2.4])` so the last column is a dedicated, wider actions area and no longer nests tiny columns inside a tiny parent column.
- Kept Edit/Delete keys and behavior exactly the same (`tm_div_edit_{tournament_id}_{division_id}` and `tm_div_del_{tournament_id}_{division_id}`) and preserved `division_form_mode_key`, `division_edit_id_key`, delete success messaging, rerun flow, and `structure_locked` disabling.
- Added emoji labels for clarity (`✏️ Edit`, `🗑️ Delete`), a secondary caption line for `Age Mode`, `Format`, `Scoring`, and `Notes` using `_display_optional(...)` and `_truncate_text(...)`, and added `st.divider()` after each division for visual separation.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/tournament_manager.py` and it succeeded without errors.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ddcb48088326b2d9e0f91f0670e8)