### PR TITLE
Regroup Divisions tab by schedule day first

### DIFF
--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -1902,21 +1902,30 @@ def render(ctx):
                 if _safe_text(template_row.get("event_family"))
             }
             st.markdown("##### Existing Divisions")
-            for family in sorted({ _safe_text(v) for v in divisions_df["event_family"].tolist() if _safe_text(v) }):
-                family_df = divisions_df[divisions_df["event_family"].apply(lambda value: _safe_text(value) == family)]
-                st.markdown(f"**{family}**")
-                family_day_labels = { _safe_text(v) for v in family_df["assigned_day"].tolist() if _safe_text(v) }
-                ordered_family_days = [day for day in ordered_day_labels if day in family_day_labels]
-                remaining_days = list(
-                    dict.fromkeys(
-                        _safe_text(value)
-                        for value in family_df["assigned_day"].tolist()
-                        if _safe_text(value) and _safe_text(value) not in ordered_family_days
-                    )
+            divisions_day_labels = {
+                _safe_text(value) for value in divisions_df["assigned_day"].tolist() if _safe_text(value)
+            }
+            ordered_division_days = [day for day in ordered_day_labels if day in divisions_day_labels]
+            remaining_days = list(
+                dict.fromkeys(
+                    _safe_text(value)
+                    for value in divisions_df["assigned_day"].tolist()
+                    if _safe_text(value) and _safe_text(value) not in ordered_division_days
                 )
-                for day_index, day in enumerate(ordered_family_days + remaining_days):
-                    day_df = family_df[family_df["assigned_day"].apply(lambda value: _safe_text(value) == day)]
-                    with st.expander(day, expanded=(day_index == 0)):
+            )
+            for day_index, day in enumerate(ordered_division_days + remaining_days):
+                day_df = divisions_df[divisions_df["assigned_day"].apply(lambda value: _safe_text(value) == day)]
+                if day_df.empty:
+                    continue
+                with st.expander(day, expanded=(day_index == 0)):
+                    day_families = sorted({
+                        _safe_text(value) for value in day_df["event_family"].tolist() if _safe_text(value)
+                    })
+                    for family in day_families:
+                        family_df = day_df[day_df["event_family"].apply(lambda value: _safe_text(value) == family)]
+                        if family_df.empty:
+                            continue
+                        st.markdown(f"**{family}**")
                         header_cols = st.columns([5.0, 1.0, 1.2, 1.0, 1.0, 1.0, 2.4])
                         header_cols[0].markdown("**Division**")
                         header_cols[1].markdown("**Skill**")
@@ -1925,7 +1934,7 @@ def render(ctx):
                         header_cols[4].markdown("**Capacity**")
                         header_cols[5].markdown("**Price**")
                         header_cols[6].markdown("**Actions**")
-                        for division_id, row in day_df.iterrows():
+                        for division_id, row in family_df.iterrows():
                             division_name = _display_division_name(row)
                             row_cols = st.columns([5.0, 1.0, 1.2, 1.0, 1.0, 1.0, 2.4])
                             row_cols[0].markdown(f"**{_display_optional(division_name)}**")


### PR DESCRIPTION
### Motivation
- Make the Divisions tab easier to scan by grouping divisions under the actual tournament schedule day rather than by event family. 
- Preserve existing UX and behavior (collapsible days, edit/delete flows, and format/scoring fallback) while changing only the rendering order.

### Description
- Reworked `Existing Divisions` rendering in `jupr_app/ui/pages/tournament_manager.py` so the outer loop is by day (top-level `st.expander`) and the inner loop lists event families that have divisions on that day. 
- Use `ordered_day_labels` (derived from `days_df`) to preserve true tournament day order and append any remaining division-assigned days afterward. 
- Keep the family block layout intact including the aligned header row (`Division`, `Skill`, `Age`, `Status`, `Capacity`, `Price`, `Actions`) shown once per family and the existing secondary details line with format/scoring fallback logic. 
- Preserve all existing button keys and behaviors such as `tm_div_edit_{tournament_id}_{division_id}`, `tm_div_del_{tournament_id}_{division_id}`, `division_form_mode_key`, `division_edit_id_key`, delete messaging, and `st.rerun()` usage.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/tournament_manager.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e74eef888326972e716ecf3bd545)