### PR TITLE
Sanitize builder draft payload before JSON upsert

### DIFF
--- a/jupr_app/domain/tournament_registration_repo.py
+++ b/jupr_app/domain/tournament_registration_repo.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any
+import math
 import re
 import uuid
 
@@ -63,6 +64,37 @@ def _coerce_bool(value: Any) -> bool:
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _is_nan_like(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, float):
+        return math.isnan(value)
+
+    value_type = type(value)
+    type_name = value_type.__name__
+    type_module = value_type.__module__
+    if type_module.startswith("pandas") and type_name in {"NAType", "NaTType"}:
+        return True
+    if type_module.startswith("pandas") and str(value) == "NaT":
+        return True
+
+    return False
+
+
+def _json_safe_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _json_safe_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_value(item) for item in value]
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if _is_nan_like(value):
+        return None
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    return value
 
 
 def _is_missing_column_error(exc: Exception, column_name: str, table_name: str) -> bool:
@@ -261,7 +293,7 @@ def build_builder_draft_payload(
     divisions: list[dict[str, Any]],
     saved_step: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    payload = {
         "version": 1,
         "saved_at": _now_iso(),
         "saved_step": str(saved_step or "").strip() or None,
@@ -269,6 +301,7 @@ def build_builder_draft_payload(
         "event_families": list(event_families or []),
         "divisions": list(divisions or []),
     }
+    return _json_safe_value(payload)
 
 
 def get_builder_draft(supabase, tournament_id: str) -> dict[str, Any] | None:


### PR DESCRIPTION
### Motivation
- Saving builder drafts was failing with `ValueError: Out of range float values are not JSON compliant: nan` because pandas-derived draft data could contain `float('nan')`, pandas `NA`/`NaT`, or non-finite floats that `httpx` cannot JSON-encode.
- The fix centralizes JSON-safety normalization in the repository layer so the `builder_draft_json` stored in the DB is always JSON-encodable without changing the payload schema or UI behavior.

### Description
- Added imports for `math` and `date` to support numeric and date handling. 
- Implemented `_is_nan_like(value: Any) -> bool` to detect `float('nan')` and common pandas missing markers (`NAType`, `NaTType`, and `NaT` string). 
- Implemented `_json_safe_value(value: Any) -> Any` that recursively walks dicts/lists/tuples and: converts non-finite floats (`nan`, `inf`, `-inf`) and pandas missing values to `None`, converts `datetime`/`date` objects to ISO strings, and leaves valid primitives intact. 
- Applied the sanitizer in `build_builder_draft_payload(...)` so the returned payload is normalized before being assigned to `builder_draft_json`, preserving keys `saved_at`, `saved_step`, `days`, `event_families`, and `divisions`.

### Testing
- Compiled the modified module with `python -m compileall jupr_app/domain/tournament_registration_repo.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e8b689ac8326b667cc472147f653)