### PR TITLE
Harden registration schema contract and align builder ↔ DB ↔ public flow

### DIFF
--- a/jupr_app/domain/tournament_registration_compiler.py
+++ b/jupr_app/domain/tournament_registration_compiler.py
@@ -564,6 +564,7 @@ def _apply_capacity(
         return entries, []
 
     issues: list[dict[str, Any]] = []
+    waitlist_enabled = bool(event.get("waitlist_enabled", True))
     confirmed_slots = 0
     ordered = sorted(entries, key=lambda row: row.get("sort_key") or datetime.min)
     out: list[dict[str, Any]] = []
@@ -575,13 +576,14 @@ def _apply_capacity(
         confirmed_slots += 1
         if confirmed_slots > int(capacity):
             entry = dict(entry)
-            entry["status"] = "WAITLIST"
+            entry["status"] = "WAITLIST" if waitlist_enabled else "REVIEW"
+            overflow_status = "waitlist" if waitlist_enabled else "manual review"
             issues.append(
                 _issue(
                     str(tournament_id),
                     "EVENT_AT_CAPACITY",
                     "warning",
-                    f"{event.get('label')} exceeded its configured capacity. Later entry moved to waitlist.",
+                    f"{event.get('label')} exceeded its configured capacity. Later entry moved to {overflow_status}.",
                     registration_id=(entry.get("source_registration_ids") or [None])[0],
                     event_option_id=str(event.get("id")),
                 )

--- a/jupr_app/domain/tournament_registration_repo.py
+++ b/jupr_app/domain/tournament_registration_repo.py
@@ -17,6 +17,46 @@ PARTNER_MODE_OPTIONS = ["NONE", "HAS_PARTNER", "NEEDS_PARTNER"]
 ADMIN_REGISTRATION_STATUS_OPTIONS = ["pending", "confirmed", "waitlist", "cancelled"]
 ADMIN_PAYMENT_STATUS_OPTIONS = ["unpaid", "paid", "refunded"]
 
+REGISTRATION_SCHEMA_CONTRACT_MIGRATIONS = [
+    "migrations/20261010_tournament_builder_refactor.sql",
+    "migrations/20261018_tournament_registration_schema_contract.sql",
+]
+
+REGISTRATION_SCHEMA_REQUIRED_COLUMNS: dict[str, tuple[str, ...]] = {
+    "tournament_registration_settings": (
+        "id",
+        "tournament_id",
+        "builder_draft_json",
+        "builder_draft_updated_at",
+    ),
+    "tournament_registration_days": (
+        "id",
+        "tournament_id",
+        "enabled",
+    ),
+    "tournament_event_options": (
+        "id",
+        "tournament_id",
+        "registration_day_id",
+        "event_family_label",
+        "division_name",
+        "event_format_default",
+        "scoring_default",
+        "event_format_override",
+        "scoring_override",
+        "skill_mode",
+        "age_mode",
+        "age_rules",
+        "waitlist_enabled",
+        "partner_board_enabled",
+        "status",
+        "enabled",
+    ),
+}
+
+PUBLIC_EVENT_STATUS_VISIBLE = {"open", "tentative", "confirmed", "closed"}
+PUBLIC_EVENT_STATUS_SELECTABLE = {"open", "tentative", "confirmed"}
+
 
 def _with_normalized_event_tags(row: dict[str, Any] | None) -> dict[str, Any] | None:
     if not row:
@@ -106,17 +146,51 @@ def _is_missing_column_error(exc: Exception, column_name: str, table_name: str) 
     )
 
 
+def _schema_contract_error_message(missing: list[str]) -> str:
+    missing_text = "; ".join(sorted(set(missing)))
+    migration_text = " then ".join(REGISTRATION_SCHEMA_CONTRACT_MIGRATIONS)
+    return (
+        "Tournament registration schema contract check failed. "
+        f"Missing required columns: {missing_text}. "
+        f"Run {migration_text}, then refresh the app."
+    )
+
+
+def assert_registration_schema_contract(supabase, *, required_tables: list[str] | None = None) -> None:
+    tables = required_tables or list(REGISTRATION_SCHEMA_REQUIRED_COLUMNS.keys())
+    failures: list[str] = []
+    for table_name in tables:
+        required_columns = REGISTRATION_SCHEMA_REQUIRED_COLUMNS.get(table_name, ())
+        if not required_columns:
+            continue
+        select_expr = ", ".join(required_columns)
+        try:
+            supabase.table(table_name).select(select_expr).limit(1).execute()
+        except Exception as exc:
+            failures.append(f"{table_name} ({select_expr}): {exc}")
+    if failures:
+        raise ValueError(_schema_contract_error_message(failures))
+
+
+def is_day_enabled(day: dict[str, Any]) -> bool:
+    return _coerce_bool((day or {}).get("enabled", True))
+
+
+def public_event_option_visibility(event: dict[str, Any]) -> str:
+    if not _coerce_bool((event or {}).get("enabled", True)):
+        return "hidden"
+    status = str((event or {}).get("status") or "draft").strip().lower()
+    if status in PUBLIC_EVENT_STATUS_SELECTABLE:
+        return "selectable"
+    if status in PUBLIC_EVENT_STATUS_VISIBLE:
+        return "visible_blocked"
+    return "hidden"
+
+
 def _insert_registration_days(supabase, days: list[dict[str, Any]]) -> None:
     if not days:
         return
-    try:
-        supabase.table("tournament_registration_days").insert(days).execute()
-        return
-    except Exception as exc:
-        if not _is_missing_column_error(exc, "enabled", "tournament_registration_days"):
-            raise
-    stripped_days = [{k: v for k, v in row.items() if k != "enabled"} for row in days]
-    supabase.table("tournament_registration_days").insert(stripped_days).execute()
+    supabase.table("tournament_registration_days").insert(days).execute()
 
 
 def registration_feature_available(supabase) -> tuple[bool, str | None]:
@@ -135,6 +209,11 @@ def registration_feature_available(supabase) -> tuple[bool, str | None]:
             failures.append(f"{table_name}: {exc}")
     if failures:
         return False, "Registration tables unavailable: " + " | ".join(failures)
+
+    try:
+        assert_registration_schema_contract(supabase)
+    except ValueError as exc:
+        return False, str(exc)
     return True, None
 
 
@@ -321,6 +400,7 @@ def save_builder_draft(
     divisions: list[dict[str, Any]],
     saved_step: str | None = None,
 ) -> dict[str, Any]:
+    assert_registration_schema_contract(supabase, required_tables=["tournament_registration_settings"])
     settings = get_registration_settings(supabase, str(tournament_id))
     payload = build_builder_draft_payload(
         days=days,
@@ -335,16 +415,11 @@ def save_builder_draft(
         "builder_draft_updated_at": _now_iso(),
         "updated_at": _now_iso(),
     }
-    try:
-        (
-            supabase.table("tournament_registration_settings")
-            .upsert(update_payload, on_conflict="tournament_id")
-            .execute()
-        )
-    except Exception as exc:
-        if _is_missing_column_error(exc, "builder_draft_json", "tournament_registration_settings"):
-            raise ValueError("Builder draft columns are missing. Run the latest migrations.") from exc
-        raise
+    (
+        supabase.table("tournament_registration_settings")
+        .upsert(update_payload, on_conflict="tournament_id")
+        .execute()
+    )
     return payload
 
 
@@ -431,6 +506,10 @@ def replace_registration_configuration(
     event_options: list[dict[str, Any]],
     allow_replace_with_registrations: bool = False,
 ) -> None:
+    assert_registration_schema_contract(
+        supabase,
+        required_tables=["tournament_registration_settings", "tournament_registration_days", "tournament_event_options"],
+    )
     registration_count = count_tournament_registrations(supabase, tournament_id)
     if registration_count and not allow_replace_with_registrations:
         raise ValueError(
@@ -618,6 +697,8 @@ def save_registration(supabase, *, tournament_id: str, payload: dict[str, Any]) 
         "updated_at": submitted_at,
     }
 
+    days = list_registration_days(supabase, str(tournament_id))
+    day_lookup = {str(row.get("id")): row for row in days if is_day_enabled(row)}
     event_lookup = {str(row.get("id")): row for row in list_event_options(supabase, str(tournament_id))}
 
     rows: list[dict[str, Any]] = []
@@ -629,6 +710,16 @@ def save_registration(supabase, *, tournament_id: str, payload: dict[str, Any]) 
         event = event_lookup.get(event_option_id)
         if not event:
             raise ValueError(f"Selected division {event_option_id} is no longer available.")
+        if str(event.get("registration_day_id") or "") not in day_lookup:
+            raise ValueError("Selected division is not on an enabled registration day.")
+
+        visibility = public_event_option_visibility(event)
+        if visibility != "selectable":
+            status_label = str(event.get("status") or "draft").lower()
+            division_label = str(event.get("division_name") or event.get("label") or event_option_id)
+            raise ValueError(
+                f"{division_label} is not open for public registration (status={status_label}, enabled={bool(event.get('enabled', True))})."
+            )
 
         partner_email = _normalize_email(selection.get("partner_email")) or None
         partner_payload = {

--- a/jupr_app/ui/pages/README.md
+++ b/jupr_app/ui/pages/README.md
@@ -22,7 +22,7 @@ This package contains rewritten versions of the four tournament-facing Streamlit
 - Added event defaults for format/scoring.
 - Added division-level scheduling so each division is assigned to exactly one day.
 - Added structured capture for age rules, auto age split thresholds, and split-age thresholds.
-- Keeps database output backward-compatible by flattening the builder back into the existing registration `event_options` payload shape.
+- Persists the builder output as the canonical registration contract (`days` + rich `event_options`) consumed by public registration.
 
 ### Tournaments
 - Creation is now a tournament shell flow instead of a bracket-first flow.

--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -724,7 +724,7 @@ def _seed_divisions(days_df: pd.DataFrame, event_templates_df: pd.DataFrame, eve
                 "price_usd": row.get("price_usd"),
                 "waitlist_enabled": bool(row.get("waitlist_enabled", True)),
                 "partner_board_enabled": bool(row.get("partner_board_enabled", row.get("public_partner_board", True))),
-                "status": _safe_text(row.get("status") or "draft"),
+                "status": _safe_text(row.get("status") or "draft").lower(),
                 "division_format": _safe_text(row.get("event_format_override") or ""),
                 "division_scoring": _safe_text(row.get("scoring_override") or ""),
                 "notes": _safe_text(age_rules.get("notes")),
@@ -871,6 +871,13 @@ def _build_payloads(
     event_templates_df: pd.DataFrame,
     divisions_df: pd.DataFrame,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """
+    Canonical persisted registration contract (consumed by public registration):
+    - days: id/tournament_id/sort_order/label/event_date/enabled
+    - event options: day assignment, family/division labels, skill+age labels and modes,
+      format/scoring defaults and overrides, capacity, partner/waitlist controls,
+      and publication semantics via status + enabled.
+    """
     days_df = _ensure_editor_columns(days_df, DAYS_EDITOR_COLUMNS)
     event_templates_df = _ensure_editor_columns(event_templates_df, EVENT_TEMPLATE_COLUMNS)
     divisions_df = _ensure_editor_columns(divisions_df, DIVISION_EDITOR_COLUMNS)
@@ -917,6 +924,7 @@ def _build_payloads(
                 "event_type": participant_type,
                 "gender_restriction": _safe_text(template.get("gender_restriction") or "ANY"),
                 "skill_label": _safe_text(row.get("skill_label") or "Open"),
+                "skill_mode": "OPEN" if _safe_text(row.get("skill_label") or "Open").lower() == "open" else "SKILL_BRACKET",
                 "age_label": _safe_text(row.get("age_label") or "All Ages"),
                 "partner_required": participant_type != "SINGLES",
                 "capacity_teams": _coerce_int(row.get("capacity_teams")),
@@ -932,7 +940,7 @@ def _build_payloads(
                 "age_rules": _encode_age_rules(row),
                 "waitlist_enabled": bool(row.get("waitlist_enabled", template.get("default_waitlist", True))),
                 "partner_board_enabled": bool(row.get("partner_board_enabled", template.get("default_partner_board", True))),
-                "status": _safe_text(row.get("status") or "draft"),
+                "status": _safe_text(row.get("status") or "draft").lower(),
                 "enabled": True,
             }
         )

--- a/jupr_app/ui/pages/tournament_registration.py
+++ b/jupr_app/ui/pages/tournament_registration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+import json
 import uuid
 
 import streamlit as st
@@ -10,7 +11,9 @@ from jupr_app.domain.tournament_registration_repo import (
     build_registration_state,
     build_public_urls,
     get_public_tournament_bundle,
+    is_day_enabled,
     list_open_public_tournaments,
+    public_event_option_visibility,
     registration_feature_available,
     registration_is_open,
     save_registration,
@@ -70,8 +73,11 @@ def _show_tournament_picker(ctx, supabase) -> tuple[dict[str, Any] | None, dict[
 
 def _group_events(days: list[dict[str, Any]], event_options: list[dict[str, Any]]) -> dict[str, dict[str, list[dict[str, Any]]]]:
     grouped: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    day_ids = {str(day.get("id")) for day in days}
     for event in event_options:
         day_id = str(event.get("registration_day_id"))
+        if day_id not in day_ids:
+            continue
         family = _safe_text(event.get("event_family_label") or event.get("label") or "Event")
         grouped.setdefault(day_id, {}).setdefault(family, []).append(event)
     return grouped
@@ -125,7 +131,21 @@ def _division_help(event: dict[str, Any]) -> str:
     elif age_mode == "FIXED_AGE_BRACKET":
         details.append(_safe_text(event.get("age_label")))
     if age_rules:
-        details.append("Age rule details available")
+        try:
+            parsed_age_rules = json.loads(age_rules)
+        except Exception:
+            parsed_age_rules = {}
+        min_teams = parsed_age_rules.get("min_teams_per_age_group")
+        split_threshold = parsed_age_rules.get("split_age_threshold")
+        notes = _safe_text(parsed_age_rules.get("notes"))
+        if age_mode == "AUTO_AGE_SPLIT" and min_teams not in (None, ""):
+            details.append(f"Auto-split minimum: {min_teams} teams/group")
+        if age_mode == "SPLIT_AGE" and split_threshold not in (None, ""):
+            details.append(f"Split-age threshold: {split_threshold}+")
+        if notes:
+            details.append(notes)
+        if not any([min_teams not in (None, ""), split_threshold not in (None, ""), notes]):
+            details.append("Age rule details available")
     return " • ".join(part for part in details if part)
 
 
@@ -198,11 +218,21 @@ def render(ctx):
         st.warning(message or "Registration is not open.")
         st.stop()
 
-    if not days or not event_options:
+    days = [row for row in days if is_day_enabled(row)]
+    selectable_event_options = [row for row in event_options if public_event_option_visibility(row) == "selectable"]
+    blocked_visible_options = [row for row in event_options if public_event_option_visibility(row) == "visible_blocked"]
+
+    if not days or not selectable_event_options:
         st.warning("This tournament does not have a registration form configured yet.")
         st.stop()
 
-    grouped_events = _group_events(days, event_options)
+    grouped_events = _group_events(days, selectable_event_options)
+    blocked_by_family: dict[tuple[str, str], list[str]] = {}
+    for event in blocked_visible_options:
+        day_id = str(event.get("registration_day_id"))
+        family = _safe_text(event.get("event_family_label") or event.get("label") or "Event")
+        division_name = _safe_text(event.get("division_name") or event.get("label") or "Division")
+        blocked_by_family.setdefault((day_id, family), []).append(division_name)
 
     with st.form(f"registration_form_{tournament.get('id')}"):
         st.markdown("### 1. Player information")
@@ -254,6 +284,9 @@ def render(ctx):
                 )
                 selected_event = option_lookup[selected_label]
                 if not selected_event:
+                    blocked_names = blocked_by_family.get((day_id, family), [])
+                    if blocked_names:
+                        st.caption("Closed divisions: " + ", ".join(sorted(blocked_names)))
                     continue
 
                 help_text = _division_help(selected_event)

--- a/migrations/20261018_tournament_registration_schema_contract.sql
+++ b/migrations/20261018_tournament_registration_schema_contract.sql
@@ -1,0 +1,65 @@
+-- Tournament registration schema contract hardening (builder-era model)
+-- Apply after: migrations/20261010_tournament_builder_refactor.sql
+
+alter table if exists tournament_registration_settings
+  add column if not exists builder_draft_json jsonb,
+  add column if not exists builder_draft_updated_at timestamptz;
+
+alter table if exists tournament_registration_days
+  add column if not exists enabled boolean not null default true;
+
+update tournament_registration_days
+set enabled = true
+where enabled is null;
+
+alter table if exists tournament_event_options
+  add column if not exists event_family_label text,
+  add column if not exists division_name text,
+  add column if not exists event_format_default text,
+  add column if not exists scoring_default text,
+  add column if not exists event_format_override text,
+  add column if not exists scoring_override text,
+  add column if not exists skill_mode text,
+  add column if not exists age_mode text,
+  add column if not exists age_rules text,
+  add column if not exists waitlist_enabled boolean not null default true,
+  add column if not exists partner_board_enabled boolean not null default true,
+  add column if not exists status text,
+  add column if not exists enabled boolean not null default true;
+
+update tournament_event_options
+set
+  waitlist_enabled = coalesce(waitlist_enabled, true),
+  partner_board_enabled = coalesce(partner_board_enabled, coalesce(public_partner_board, true)),
+  enabled = coalesce(enabled, true),
+  status = coalesce(nullif(lower(trim(status)), ''), 'draft'),
+  division_name = coalesce(nullif(division_name, ''), nullif(label, '')),
+  event_family_label = coalesce(nullif(event_family_label, ''), nullif(label, '')),
+  event_format_default = coalesce(nullif(event_format_default, ''), 'ROUND_ROBIN_PLUS_PLAYOFF'),
+  scoring_default = coalesce(nullif(scoring_default, ''), 'GAME_TO_15'),
+  age_mode = coalesce(nullif(age_mode, ''), 'ALL_AGES'),
+  skill_mode = coalesce(nullif(skill_mode, ''), case when lower(coalesce(skill_label, 'open')) = 'open' then 'OPEN' else 'SKILL_BRACKET' end)
+where true;
+
+-- Optional rollback (destructive: removes builder-era columns)
+-- alter table if exists tournament_event_options
+--   drop column if exists event_family_label,
+--   drop column if exists division_name,
+--   drop column if exists event_format_default,
+--   drop column if exists scoring_default,
+--   drop column if exists event_format_override,
+--   drop column if exists scoring_override,
+--   drop column if exists skill_mode,
+--   drop column if exists age_mode,
+--   drop column if exists age_rules,
+--   drop column if exists waitlist_enabled,
+--   drop column if exists partner_board_enabled,
+--   drop column if exists status,
+--   drop column if exists enabled;
+--
+-- alter table if exists tournament_registration_days
+--   drop column if exists enabled;
+--
+-- alter table if exists tournament_registration_settings
+--   drop column if exists builder_draft_json,
+--   drop column if exists builder_draft_updated_at;


### PR DESCRIPTION
### Motivation
- Fix production schema drift by making the persisted registration schema explicitly match the Tournament Manager builder model so public registration always works against a known contract. 
- Do not use compatibility band-aids (e.g. stripping unsupported columns); instead fail loudly and provide actionable migration instructions when schema is out-of-date.

### Description
- New idempotent migration `migrations/20261018_tournament_registration_schema_contract.sql` adds/backfills builder-era columns and settings and ensures `tournament_registration_days.enabled`; rollback SQL is included as commented lines in the file. The migration adds/ensures at minimum: `event_family_label`, `division_name`, `event_format_default`, `scoring_default`, `event_format_override`, `scoring_override`, `skill_mode`, `age_mode`, `age_rules`, `waitlist_enabled`, `partner_board_enabled`, `status`, `enabled`, plus `builder_draft_json` and `builder_draft_updated_at` on `tournament_registration_settings`.
- Added an explicit schema contract and validation helper in `jupr_app/domain/tournament_registration_repo.py` (`REGISTRATION_SCHEMA_REQUIRED_COLUMNS`, `assert_registration_schema_contract(...)`) and wired it into feature preflight and builder/write paths so missing-columns errors become a clear, actionable message that names the migrations to run.
- Removed the prior compatibility fallback that stripped `enabled` on day inserts; writes are now strict and require the migration to be applied first.
- Enforced public visibility semantics and enabled-day rules: new helpers `public_event_option_visibility(...)` and `is_day_enabled(...)` are used so public registration only presents enabled days and only allows selection of divisions with status semantics (`open`, `tentative`, `confirmed` are selectable; `closed` is visible-but-blocked; `draft`/unknown are hidden). `save_registration` now validates selections are on enabled days and are selectable.
- Updated Tournament Manager `_build_payloads(...)` to explicitly persist the canonical event-option contract (documented in the function docstring) and to include `skill_mode` and normalized/lowercase `status`. The public UI now parses `age_rules` to show richer messaging. The registration compiler capacity logic now respects `waitlist_enabled` (overflow → `WAITLIST` when enabled, otherwise `REVIEW`).
- Operators should run migrations in order: first `migrations/20261010_tournament_builder_refactor.sql` (if not already applied), then `migrations/20261018_tournament_registration_schema_contract.sql` and then reload the app.

### Testing
- Compiled the modified modules with: `python -m compileall jupr_app/domain/tournament_registration_repo.py jupr_app/domain/tournament_registration_compiler.py jupr_app/ui/pages/tournament_manager.py jupr_app/ui/pages/tournament_registration.py` and compilation succeeded. 
- No automated unit tests were added; migration SQL file `migrations/20261018_tournament_registration_schema_contract.sql` was created and is idempotent with commented rollback statements.
- Manual/operational checks to run after deploying the migration: open Tournament Manager, save Days/Divisions, open public registration and confirm only enabled days are shown and only `open`/`tentative`/`confirmed` divisions are selectable while `closed` divisions are shown as informational (not selectable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f0562c5c832692c6cdf1f7fb6793)