### PR TITLE
Implement guarded publish/edit behavior for Tournament Setup

### DIFF
--- a/jupr_app/domain/tournament_registration_repo.py
+++ b/jupr_app/domain/tournament_registration_repo.py
@@ -479,6 +479,252 @@ def count_tournament_registrations(supabase, tournament_id: str) -> int:
         return len(rows)
 
 
+def list_registration_usage_by_event_option(supabase, tournament_id: str) -> dict[str, dict[str, int]]:
+    tournament_id = str(tournament_id)
+    usage: dict[str, dict[str, int]] = {}
+
+    selection_rows = _safe_data(
+        supabase.table("tournament_registration_selections")
+        .select("event_option_id")
+        .eq("tournament_id", tournament_id)
+        .execute()
+    )
+    for row in selection_rows:
+        event_option_id = str(row.get("event_option_id") or "").strip()
+        if not event_option_id:
+            continue
+        bucket = usage.setdefault(event_option_id, {"registrations": 0, "event_draws": 0, "teams": 0, "games": 0})
+        bucket["registrations"] += 1
+
+    for table_name, key in [
+        ("tournament_event_draws", "event_draws"),
+        ("tournament_teams", "teams"),
+        ("tournament_games", "games"),
+    ]:
+        try:
+            rows = _safe_data(
+                supabase.table(table_name)
+                .select("event_option_id")
+                .eq("tournament_id", tournament_id)
+                .execute()
+            )
+        except Exception:
+            rows = []
+        for row in rows:
+            event_option_id = str(row.get("event_option_id") or "").strip()
+            if not event_option_id:
+                continue
+            bucket = usage.setdefault(event_option_id, {"registrations": 0, "event_draws": 0, "teams": 0, "games": 0})
+            bucket[key] += 1
+
+    return usage
+
+
+def list_registration_usage_by_day(supabase, tournament_id: str) -> dict[str, dict[str, int]]:
+    tournament_id = str(tournament_id)
+    usage: dict[str, dict[str, int]] = {}
+
+    selection_rows = _safe_data(
+        supabase.table("tournament_registration_selections")
+        .select("registration_day_id")
+        .eq("tournament_id", tournament_id)
+        .execute()
+    )
+    for row in selection_rows:
+        day_id = str(row.get("registration_day_id") or "").strip()
+        if not day_id:
+            continue
+        bucket = usage.setdefault(day_id, {"registrations": 0, "event_draws": 0, "teams": 0, "games": 0})
+        bucket["registrations"] += 1
+
+    for table_name, key in [
+        ("tournament_event_draws", "event_draws"),
+        ("tournament_teams", "teams"),
+        ("tournament_games", "games"),
+    ]:
+        try:
+            rows = _safe_data(
+                supabase.table(table_name)
+                .select("registration_day_id")
+                .eq("tournament_id", tournament_id)
+                .execute()
+            )
+        except Exception:
+            rows = []
+        for row in rows:
+            day_id = str(row.get("registration_day_id") or "").strip()
+            if not day_id:
+                continue
+            bucket = usage.setdefault(day_id, {"registrations": 0, "event_draws": 0, "teams": 0, "games": 0})
+            bucket[key] += 1
+
+    return usage
+
+
+def _entity_usage_total(usage: dict[str, int] | None) -> int:
+    if not usage:
+        return 0
+    return int(usage.get("registrations", 0) or 0) + int(usage.get("event_draws", 0) or 0) + int(usage.get("teams", 0) or 0) + int(usage.get("games", 0) or 0)
+
+
+def _event_identity_key(event: dict[str, Any]) -> tuple[str, ...]:
+    return (
+        str(event.get("event_family_label") or "").strip().lower(),
+        str(event.get("division_name") or event.get("label") or "").strip().lower(),
+        str(event.get("event_type") or "").strip().upper(),
+        str(event.get("gender_restriction") or "").strip().upper(),
+        str(event.get("skill_label") or "").strip().lower(),
+        str(event.get("age_label") or "").strip().lower(),
+    )
+
+
+def analyze_registration_publish_impact(
+    supabase,
+    *,
+    tournament_id: str,
+    days: list[dict[str, Any]],
+    event_options: list[dict[str, Any]],
+) -> dict[str, Any]:
+    tournament_id = str(tournament_id)
+    published_days = list_registration_days(supabase, tournament_id)
+    published_events = list_event_options(supabase, tournament_id)
+    usage_by_event = list_registration_usage_by_event_option(supabase, tournament_id)
+    usage_by_day = list_registration_usage_by_day(supabase, tournament_id)
+
+    published_days_by_id = {str(row.get("id")): row for row in published_days if str(row.get("id") or "").strip()}
+    published_events_by_id = {str(row.get("id")): row for row in published_events if str(row.get("id") or "").strip()}
+    published_event_ids_by_identity = {_event_identity_key(row): str(row.get("id")) for row in published_events if str(row.get("id") or "").strip()}
+
+    draft_days: list[dict[str, Any]] = []
+    draft_day_ids: set[str] = set()
+    for row in days or []:
+        row_id = str(row.get("id") or "").strip()
+        if not row_id:
+            row = {**row, "id": _uid("day")}
+            row_id = str(row.get("id"))
+        draft_day_ids.add(row_id)
+        draft_days.append({**row, "id": row_id})
+
+    draft_events: list[dict[str, Any]] = []
+    draft_event_ids: set[str] = set()
+    for row in event_options or []:
+        row_id = str(row.get("id") or "").strip()
+        if not row_id:
+            fallback_id = published_event_ids_by_identity.get(_event_identity_key(row))
+            row_id = fallback_id or _uid("event")
+            row = {**row, "id": row_id}
+        draft_event_ids.add(row_id)
+        draft_events.append({**row, "id": row_id})
+
+    creates: list[str] = []
+    updates: list[str] = []
+    soft_closes: list[str] = []
+    deletes: list[str] = []
+    warnings: list[str] = []
+    blocked: list[str] = []
+
+    for day in draft_days:
+        day_id = str(day.get("id"))
+        existing = published_days_by_id.get(day_id)
+        if existing is None:
+            creates.append(f"Day '{day.get('label') or day_id}' will be created.")
+            continue
+        updates.append(f"Day '{existing.get('label') or day_id}' will be updated.")
+        usage = usage_by_day.get(day_id, {})
+        if _entity_usage_total(usage) and str(existing.get("label") or "") != str(day.get("label") or ""):
+            warnings.append(f"Populated day '{existing.get('label') or day_id}' is being relabeled.")
+
+    for event in draft_events:
+        event_id = str(event.get("id"))
+        existing = published_events_by_id.get(event_id)
+        label = str(event.get("division_name") or event.get("label") or event_id)
+        if existing is None:
+            creates.append(f"Division '{label}' will be created.")
+            continue
+        updates.append(f"Division '{str(existing.get('division_name') or existing.get('label') or event_id)}' will be updated.")
+        usage = usage_by_event.get(event_id, {})
+        occupied = int(usage.get("registrations", 0) or 0)
+        has_usage = _entity_usage_total(usage) > 0
+
+        existing_day_id = str(existing.get("registration_day_id") or "")
+        draft_day_id = str(event.get("registration_day_id") or "")
+        if has_usage and existing_day_id != draft_day_id:
+            blocked.append(f"Cannot move populated division '{label}' to a different day.")
+        if has_usage and str(existing.get("event_type") or "") != str(event.get("event_type") or ""):
+            blocked.append(f"Cannot change participant type for populated division '{label}'.")
+        if has_usage and str(existing.get("gender_restriction") or "") != str(event.get("gender_restriction") or ""):
+            blocked.append(f"Cannot change gender restriction for populated division '{label}'.")
+
+        rule_columns = ["skill_label", "skill_mode", "age_label", "age_mode", "age_rules"]
+        if has_usage and any(str(existing.get(column) or "") != str(event.get(column) or "") for column in rule_columns):
+            blocked.append(f"Cannot change skill/age rules for populated division '{label}' in ways that could invalidate registrants.")
+
+        existing_capacity = existing.get("capacity_teams")
+        next_capacity = event.get("capacity_teams")
+        try:
+            if existing_capacity is not None and next_capacity is not None:
+                old_cap = int(existing_capacity)
+                new_cap = int(next_capacity)
+                if new_cap < old_cap:
+                    if new_cap < occupied:
+                        blocked.append(f"Cannot reduce capacity for '{label}' below occupied teams ({occupied}).")
+                    else:
+                        warnings.append(f"Capacity for '{label}' is being reduced from {old_cap} to {new_cap} with {occupied} occupied.")
+        except Exception:
+            pass
+
+        if has_usage and str(existing.get("division_name") or existing.get("label") or "") != label:
+            warnings.append(f"Populated division '{existing.get('division_name') or existing.get('label') or event_id}' is being relabeled.")
+
+        if str(existing.get("enabled", True)).lower() in {"true", "1"} and not _coerce_bool(event.get("enabled", True)):
+            warnings.append(f"Division '{label}' will be hidden from future registration.")
+
+    for existing_event in published_events:
+        event_id = str(existing_event.get("id") or "")
+        if not event_id or event_id in draft_event_ids:
+            continue
+        usage = usage_by_event.get(event_id, {})
+        event_label = str(existing_event.get("division_name") or existing_event.get("label") or event_id)
+        if _entity_usage_total(usage):
+            soft_closes.append(f"Division '{event_label}' is omitted from draft and will be archived/closed (history preserved).")
+            warnings.append(f"Division '{event_label}' has usage and cannot be destructively deleted; it will be soft-closed.")
+        else:
+            deletes.append(f"Division '{event_label}' is empty and will be deleted.")
+
+    for existing_day in published_days:
+        day_id = str(existing_day.get("id") or "")
+        if not day_id or day_id in draft_day_ids:
+            continue
+        usage = usage_by_day.get(day_id, {})
+        day_label = str(existing_day.get("label") or day_id)
+        if _entity_usage_total(usage):
+            soft_closes.append(f"Day '{day_label}' is omitted from draft and will be disabled (history preserved).")
+            warnings.append(f"Day '{day_label}' has usage and cannot be destructively deleted; it will be soft-closed.")
+        else:
+            deletes.append(f"Day '{day_label}' is empty and will be deleted.")
+
+    return {
+        "summary": {
+            "creates": len(creates),
+            "updates": len(updates),
+            "soft_closes": len(soft_closes),
+            "deletes": len(deletes),
+            "warnings": len(warnings),
+            "blocked": len(blocked),
+        },
+        "creates": creates,
+        "updates": updates,
+        "soft_closes": soft_closes,
+        "deletes": deletes,
+        "warnings": warnings,
+        "blocked": blocked,
+        "draft_days": draft_days,
+        "draft_event_options": draft_events,
+        "published_days": published_days,
+        "published_event_options": published_events,
+    }
+
+
 def _legacy_day_aliases(days: list[dict[str, Any]]) -> dict[str, str]:
     aliases: dict[str, str] = {}
     for idx, day in enumerate(days, start=1):
@@ -582,6 +828,98 @@ def replace_registration_configuration(
             )
     except Exception as exc:
         raise ValueError(f"Failed to replace registration configuration for tournament {tournament_id}: {exc}") from exc
+
+
+def publish_registration_configuration(
+    supabase,
+    *,
+    tournament_id: str,
+    days: list[dict[str, Any]],
+    event_options: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """
+    Publish rules summary:
+    - If tournament has zero registrations, publish can use full replace for simplicity.
+    - If tournament has registrations, publish uses a guarded diff:
+      preserve stable IDs, block destructive mutations to populated rows,
+      and convert removed populated rows into soft-closed/disabled records.
+    - Public registration continues to consume published day/event rows only.
+    """
+    registration_count = count_tournament_registrations(supabase, tournament_id)
+    if registration_count == 0:
+        replace_registration_configuration(
+            supabase,
+            tournament_id=tournament_id,
+            days=days,
+            event_options=event_options,
+            allow_replace_with_registrations=False,
+        )
+        return {"mode": "replace", "blocked": [], "warnings": []}
+
+    impact = analyze_registration_publish_impact(
+        supabase,
+        tournament_id=tournament_id,
+        days=days,
+        event_options=event_options,
+    )
+    if impact["blocked"]:
+        raise ValueError("Publish blocked due to destructive changes: " + " | ".join(impact["blocked"]))
+
+    published_days = impact["published_days"]
+    published_events = impact["published_event_options"]
+    draft_days = impact["draft_days"]
+    draft_events = impact["draft_event_options"]
+    draft_day_ids = {str(row.get("id")) for row in draft_days}
+    draft_event_ids = {str(row.get("id")) for row in draft_events}
+    usage_by_day = list_registration_usage_by_day(supabase, tournament_id)
+    usage_by_event = list_registration_usage_by_event_option(supabase, tournament_id)
+
+    day_upserts = list(draft_days)
+    event_upserts = list(draft_events)
+    day_delete_ids: list[str] = []
+    event_delete_ids: list[str] = []
+
+    for row in published_events:
+        row_id = str(row.get("id") or "")
+        if not row_id or row_id in draft_event_ids:
+            continue
+        if _entity_usage_total(usage_by_event.get(row_id)):
+            event_upserts.append(
+                {
+                    **row,
+                    "enabled": False,
+                    "status": "closed",
+                    "updated_at": _now_iso(),
+                }
+            )
+        else:
+            event_delete_ids.append(row_id)
+
+    for row in published_days:
+        row_id = str(row.get("id") or "")
+        if not row_id or row_id in draft_day_ids:
+            continue
+        if _entity_usage_total(usage_by_day.get(row_id)):
+            day_upserts.append(
+                {
+                    **row,
+                    "enabled": False,
+                    "updated_at": _now_iso(),
+                }
+            )
+        else:
+            day_delete_ids.append(row_id)
+
+    if day_upserts:
+        supabase.table("tournament_registration_days").upsert(day_upserts).execute()
+    if event_upserts:
+        supabase.table("tournament_event_options").upsert(event_upserts).execute()
+    if event_delete_ids:
+        supabase.table("tournament_event_options").delete().eq("tournament_id", str(tournament_id)).in_("id", event_delete_ids).execute()
+    if day_delete_ids:
+        supabase.table("tournament_registration_days").delete().eq("tournament_id", str(tournament_id)).in_("id", day_delete_ids).execute()
+
+    return {"mode": "guarded", "blocked": impact["blocked"], "warnings": impact["warnings"], "summary": impact["summary"]}
 
 
 def list_registrations(supabase, tournament_id: str) -> list[dict[str, Any]]:

--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -11,6 +11,7 @@ import streamlit as st
 from jupr_app.domain.event_tags import derive_default_date_tags, normalize_event_tags
 from jupr_app.domain.tournament_registration_repo import (
     REGISTRATION_STATUS_OPTIONS,
+    analyze_registration_publish_impact,
     build_public_urls,
     count_tournament_registrations,
     get_builder_draft,
@@ -19,8 +20,8 @@ from jupr_app.domain.tournament_registration_repo import (
     list_event_options,
     list_existing_tournaments,
     list_registration_days,
+    publish_registration_configuration,
     registration_feature_available,
-    replace_registration_configuration,
     save_builder_draft,
     upsert_registration_settings,
 )
@@ -1414,15 +1415,9 @@ def render(ctx):
         and inferred_end_date is not None
     )
 
-    structure_locked = bool(registration_count)
-    if structure_locked:
-        st.warning(
-            "This tournament already has registrations. Structural draft edits are locked."
-        )
-    else:
-        st.info(
-            "Recommended setup order: 1) save tournament info and dates, 2) review days, 3) define events and defaults, 4) review generated divisions, 5) publish links."
-        )
+    st.info(
+        "Recommended setup order: 1) save tournament info and dates, 2) review days, 3) define events and defaults, 4) review generated divisions, 5) publish links."
+    )
 
     metrics = st.columns(4)
     metrics[0].metric("Registration status", _safe_text(settings.get("registration_status") or "draft"))
@@ -1556,7 +1551,7 @@ def render(ctx):
                         "partner_board_enabled": True,
                     },
                 )
-                if dates_changed and not structure_locked:
+                if dates_changed:
                     synced_days, synced_events = _sync_days_with_date_range(
                         tournament_id,
                         start_date,
@@ -1564,19 +1559,23 @@ def render(ctx):
                         days,
                         event_options,
                     )
-                    replace_registration_configuration(
-                        supabase,
-                        tournament_id=tournament_id,
-                        days=synced_days,
-                        event_options=synced_events,
-                    )
+                    try:
+                        publish_registration_configuration(
+                            supabase,
+                            tournament_id=tournament_id,
+                            days=synced_days,
+                            event_options=synced_events,
+                        )
+                    except ValueError as exc:
+                        st.error(str(exc))
+                        st.stop()
 
                 _clear_tournament_manager_state(tournament_id)
                 st.session_state[f"tm_refresh_{tournament_id}"] = True
 
                 st.success(
                     "Tournament info and days synchronized."
-                    if dates_changed and not structure_locked
+                    if dates_changed
                     else "Tournament info saved."
                 )
                 st.rerun()
@@ -1653,14 +1652,12 @@ def render(ctx):
         st.caption("Days are created from the tournament date range. Relabel them to match how you actually talk about the schedule, such as 'Mixed Doubles Day' or 'Championship Sunday'.")
         if not canonical_has_range and not inferred_has_range:
             st.warning("No tournament date range is saved yet. You can add days manually, or save dates in Tournament Info to auto-generate days.")
-        if structure_locked:
-            st.caption("Days are view-only because registrations already exist.")
         days_df = st.data_editor(
             st.session_state[days_seed_key],
             hide_index=True,
             num_rows="dynamic",
             key=f"tm_days_editor_{tournament_id}",
-            disabled=structure_locked,
+            disabled=False,
             column_config={
                 "event_date": st.column_config.TextColumn("Date (YYYY-MM-DD)"),
                 "label": st.column_config.TextColumn("Day label"),
@@ -1670,7 +1667,7 @@ def render(ctx):
         )
         days_df = _ensure_editor_columns(days_df, DAYS_EDITOR_COLUMNS)
         st.session_state[days_seed_key] = days_df.copy()
-        if st.button("Regenerate days from tournament dates", disabled=structure_locked):
+        if st.button("Regenerate days from tournament dates"):
             generated = _df_with_hidden_ids(
                 [{"id": _uid("day"), **row} for row in _date_rows(regenerate_start_date, regenerate_end_date)],
                 "id",
@@ -1681,7 +1678,7 @@ def render(ctx):
             else:
                 st.session_state[days_seed_key] = generated
             st.rerun()
-        if st.button("Save Days Draft", disabled=structure_locked, key=f"tm_save_days_draft_{tournament_id}"):
+        if st.button("Save Days Draft", key=f"tm_save_days_draft_{tournament_id}"):
             saved_payload = save_builder_draft(
                 supabase,
                 tournament_id=tournament_id,
@@ -1711,17 +1708,15 @@ def render(ctx):
     with tabs[2]:
         st.subheader("Events")
         st.caption("Define persistent event-family defaults in this step. Use Generate Divisions for one-off batch runs.")
-        if structure_locked:
-            st.caption("Events are view-only because registrations already exist.")
         events_df = _ensure_editor_columns(st.session_state[events_seed_key], EVENT_TEMPLATE_COLUMNS)
         st.session_state[events_seed_key] = events_df.copy()
 
         action_col1, action_col2 = st.columns([1, 1])
-        if action_col1.button("Create Event", type="primary", disabled=structure_locked):
+        if action_col1.button("Create Event", type="primary"):
             st.session_state[event_form_mode_key] = "create"
             st.session_state[event_edit_id_key] = None
             st.rerun()
-        if action_col2.button("Load standard events", disabled=structure_locked):
+        if action_col2.button("Load standard events"):
             if not events_df.empty and not st.session_state.get(load_templates_confirm_key):
                 st.session_state[load_templates_confirm_key] = True
                 st.warning("Existing events found. Click again to append missing standard templates.")
@@ -1747,7 +1742,7 @@ def render(ctx):
                 mode=event_mode,
                 defaults=defaults,
                 submit_label="Save Event" if event_mode == "edit" else "Add Event",
-                disabled=structure_locked,
+                disabled=False,
             )
             if canceled:
                 st.session_state[event_form_mode_key] = None
@@ -1796,11 +1791,11 @@ def render(ctx):
                 name = _safe_text(row.get("event_family") or "Unnamed Event")
                 row_cols = st.columns([4, 1, 1, 1.2])
                 row_cols[0].markdown(f"**{name}** · {_safe_text(row.get('participant_type'))} · {_safe_text(row.get('gender_restriction'))}")
-                if row_cols[1].button("Edit", key=f"tm_evt_edit_{tournament_id}_{event_id}", disabled=structure_locked):
+                if row_cols[1].button("Edit", key=f"tm_evt_edit_{tournament_id}_{event_id}"):
                     st.session_state[event_form_mode_key] = "edit"
                     st.session_state[event_edit_id_key] = str(event_id)
                     st.rerun()
-                if row_cols[2].button("Delete", key=f"tm_evt_del_{tournament_id}_{event_id}", disabled=structure_locked):
+                if row_cols[2].button("Delete", key=f"tm_evt_del_{tournament_id}_{event_id}"):
                     has_dependent_divisions = not divisions_snapshot[
                         divisions_snapshot["event_family"].apply(lambda value: _safe_text(value).lower() == name.lower())
                     ].empty
@@ -1810,7 +1805,7 @@ def render(ctx):
                         st.session_state[events_seed_key] = _delete_event_family_row(events_df, str(event_id))
                         st.success(f"Deleted event '{name}'.")
                         st.rerun()
-                if row_cols[3].button("Generate Divisions", key=f"tm_evt_gen_{tournament_id}_{event_id}", disabled=structure_locked):
+                if row_cols[3].button("Generate Divisions", key=f"tm_evt_gen_{tournament_id}_{event_id}"):
                     st.session_state[generate_event_id_key] = str(event_id)
                     st.rerun()
         generate_event_id = st.session_state.get(generate_event_id_key)
@@ -1821,7 +1816,7 @@ def render(ctx):
                 form_key=f"tm_generate_form_{tournament_id}_{generate_event_id}",
                 event_defaults=generator_defaults,
                 day_label_options=ordered_day_labels,
-                disabled=structure_locked,
+                disabled=False,
             )
             if canceled:
                 st.session_state[generate_event_id_key] = None
@@ -1863,7 +1858,7 @@ def render(ctx):
         if _safe_text(st.session_state.get(generation_result_key)):
             st.success(_safe_text(st.session_state.get(generation_result_key)))
             st.session_state[generation_result_key] = ""
-        if st.button("Save Events Draft", disabled=structure_locked, key=f"tm_save_events_draft_{tournament_id}"):
+        if st.button("Save Events Draft", key=f"tm_save_events_draft_{tournament_id}"):
             saved_payload = save_builder_draft(
                 supabase,
                 tournament_id=tournament_id,
@@ -1896,9 +1891,7 @@ def render(ctx):
     with tabs[3]:
         st.subheader("Divisions")
         st.caption("Review, edit, and remove generated divisions. Manual one-off additions are optional.")
-        if structure_locked:
-            st.caption("Divisions are view-only because registrations already exist.")
-        create_disabled = structure_locked or not event_family_options or not day_label_options
+        create_disabled = not event_family_options or not day_label_options
         if st.button("Create Division", type="primary", disabled=create_disabled):
             st.session_state[division_form_mode_key] = "create"
             st.session_state[division_edit_id_key] = None
@@ -1922,7 +1915,7 @@ def render(ctx):
                 event_family_options=event_family_options,
                 day_label_options=day_label_options,
                 submit_label="Save Division" if division_mode == "edit" else "Add Division",
-                disabled=structure_locked,
+                disabled=False,
             )
             if canceled:
                 st.session_state[division_form_mode_key] = None
@@ -2005,11 +1998,11 @@ def render(ctx):
                             price_value = row.get("price_usd")
                             row_cols[5].markdown(f"${float(price_value):.2f}" if _coerce_float(price_value) is not None else "—")
                             action_cols = row_cols[6].columns([1, 1], gap="small")
-                            if action_cols[0].button("✏️ Edit", key=f"tm_div_edit_{tournament_id}_{division_id}", disabled=structure_locked):
+                            if action_cols[0].button("✏️ Edit", key=f"tm_div_edit_{tournament_id}_{division_id}"):
                                 st.session_state[division_form_mode_key] = "edit"
                                 st.session_state[division_edit_id_key] = str(division_id)
                                 st.rerun()
-                            if action_cols[1].button("🗑️ Delete", key=f"tm_div_del_{tournament_id}_{division_id}", disabled=structure_locked):
+                            if action_cols[1].button("🗑️ Delete", key=f"tm_div_del_{tournament_id}_{division_id}"):
                                 st.session_state[divisions_seed_key] = _delete_division_row(divisions_df, str(division_id))
                                 st.success(f"Deleted division '{division_name}'.")
                                 st.rerun()
@@ -2025,7 +2018,7 @@ def render(ctx):
                             st.divider()
         for mode, help_text in AGE_MODE_HELP.items():
             st.caption(f"**{mode.replace('_', ' ').title()}** — {help_text}")
-        if st.button("Save Divisions Draft", disabled=structure_locked, key=f"tm_save_divisions_draft_{tournament_id}"):
+        if st.button("Save Divisions Draft", key=f"tm_save_divisions_draft_{tournament_id}"):
             saved_payload = save_builder_draft(
                 supabase,
                 tournament_id=tournament_id,
@@ -2065,20 +2058,62 @@ def render(ctx):
                 st.warning(error)
 
         days_payload, event_payload = _build_payloads(tournament_id, days_df, events_df, divisions_df)
-        if st.button("Save builder changes", type="primary", disabled=structure_locked):
+        publish_impact = analyze_registration_publish_impact(
+            supabase,
+            tournament_id=tournament_id,
+            days=days_payload,
+            event_options=event_payload,
+        ) if days_payload and event_payload else None
+        if publish_impact:
+            summary = publish_impact.get("summary", {})
+            metric_cols = st.columns(6)
+            metric_cols[0].metric("Creates", int(summary.get("creates", 0)))
+            metric_cols[1].metric("Updates", int(summary.get("updates", 0)))
+            metric_cols[2].metric("Soft closes", int(summary.get("soft_closes", 0)))
+            metric_cols[3].metric("Deletes", int(summary.get("deletes", 0)))
+            metric_cols[4].metric("Warnings", int(summary.get("warnings", 0)))
+            metric_cols[5].metric("Blocked", int(summary.get("blocked", 0)))
+
+            for section_title, rows in [
+                ("Safe creates", publish_impact.get("creates", [])),
+                ("Safe updates", publish_impact.get("updates", [])),
+                ("Safe close/archive actions", publish_impact.get("soft_closes", [])),
+                ("Safe hard deletes (unused only)", publish_impact.get("deletes", [])),
+            ]:
+                if rows:
+                    st.markdown(f"##### {section_title}")
+                    for row in rows:
+                        st.caption(f"• {row}")
+            if publish_impact.get("warnings"):
+                st.markdown("##### Warnings")
+                for row in publish_impact.get("warnings", []):
+                    st.warning(row)
+            if publish_impact.get("blocked"):
+                st.markdown("##### Blocked destructive changes")
+                for row in publish_impact.get("blocked", []):
+                    st.error(row)
+
+        has_blocked_changes = bool(publish_impact and publish_impact.get("blocked"))
+        if st.button("Save builder changes", type="primary", disabled=has_blocked_changes):
             if validation_errors:
                 st.error("Resolve the builder warnings before saving.")
             elif not days_payload:
                 st.error("Enable at least one tournament day.")
             elif not event_payload:
                 st.error("Create at least one division before saving.")
+            elif has_blocked_changes:
+                st.error("Publish is blocked until destructive changes are resolved.")
             else:
-                replace_registration_configuration(
-                    supabase,
-                    tournament_id=tournament_id,
-                    days=days_payload,
-                    event_options=event_payload,
-                )
+                try:
+                    publish_registration_configuration(
+                        supabase,
+                        tournament_id=tournament_id,
+                        days=days_payload,
+                        event_options=event_payload,
+                    )
+                except ValueError as exc:
+                    st.error(str(exc))
+                    st.stop()
                 saved_payload = save_builder_draft(
                     supabase,
                     tournament_id=tournament_id,
@@ -2093,4 +2128,3 @@ def render(ctx):
                 st.rerun()
 
         st.info("Registration review, issue triage, and workbook exports now live on 📋 Tournament Operations.")
-


### PR DESCRIPTION
### Motivation
- Replace the existing blanket structure lock that prevented all Tournament Setup edits when any registrations existed with a finer-grained publish analysis so admins can safely edit and republish published tournaments.
- Allow safe non-destructive edits (labels, capacity increases, new days/divisions, etc.) while preventing or converting destructive changes that would break existing registrations.
- Preserve row identity and history for published days/divisions so public registration and downstream modules continue to read a stable published contract.

### Description
- Added repository helpers in `jupr_app/domain/tournament_registration_repo.py`: `list_registration_usage_by_event_option`, `list_registration_usage_by_day`, `analyze_registration_publish_impact`, and `publish_registration_configuration` to perform draft-vs-published diff analysis and apply guarded publishes with soft-close semantics instead of destructive replace for populated tournaments.
- Implemented guarded publish rules that preserve stable IDs when logical entities remain the same, warn for risky but allowed edits (e.g. modest capacity reductions, relabels), block destructive edits (e.g. deleting populated divisions/days, moving populated divisions between days, changing participant/gender/type or rules that would invalidate registrants, reducing capacity below occupied), and convert removed populated items into soft-closed/disabled rows rather than hard deletes.
- Reworked Tournament Setup UI in `jupr_app/ui/pages/tournament_manager.py` to remove the blanket `structure_locked` freeze, keep draft-save workflows intact, show a publish impact summary on the `Publish & QA` tab (counts, safe creates/updates, soft-closes, deletes, warnings, blocked items), and call `publish_registration_configuration` instead of the destructive `replace_registration_configuration` for published tournaments (preserving the replace-path when zero registrations exist).
- Files changed: `jupr_app/domain/tournament_registration_repo.py` and `jupr_app/ui/pages/tournament_manager.py`, and code comments summarizing the final publish rules were added near the `publish_registration_configuration` implementation.
- Deferred/notes: deleting an event-family is inferred from removal of its child divisions (there is no separate persisted family entity to gate independently), and identity fallback for draft events without IDs uses a conservative fingerprint so very unusual bulk-renames may be treated as create+close instead of pure updates.

### Testing
- Ran byte-compile verification with `python -m py_compile jupr_app/domain/tournament_registration_repo.py jupr_app/ui/pages/tournament_manager.py`, which succeeded.
- No additional automated unit tests were added in this change; runtime behavior for UI flows should be validated in staging, and edge-case scenarios (bulk renames / unusual identity collisions) were documented and deferred for follow-up tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40fe024f88326a1c86ae19ce3b9ca)