### PR TITLE
Sanitize NaN values in tournament registration publish flow

### DIFF
--- a/jupr_app/domain/tournament_registration_repo.py
+++ b/jupr_app/domain/tournament_registration_repo.py
@@ -586,6 +586,8 @@ def analyze_registration_publish_impact(
     event_options: list[dict[str, Any]],
 ) -> dict[str, Any]:
     tournament_id = str(tournament_id)
+    days = _json_safe_value(list(days or []))
+    event_options = _json_safe_value(list(event_options or []))
     published_days = list_registration_days(supabase, tournament_id)
     published_events = list_event_options(supabase, tournament_id)
     usage_by_event = list_registration_usage_by_event_option(supabase, tournament_id)
@@ -752,6 +754,8 @@ def replace_registration_configuration(
     event_options: list[dict[str, Any]],
     allow_replace_with_registrations: bool = False,
 ) -> None:
+    days = _json_safe_value(list(days or []))
+    event_options = _json_safe_value(list(event_options or []))
     assert_registration_schema_contract(
         supabase,
         required_tables=["tournament_registration_settings", "tournament_registration_days", "tournament_event_options"],
@@ -845,6 +849,8 @@ def publish_registration_configuration(
       and convert removed populated rows into soft-closed/disabled records.
     - Public registration continues to consume published day/event rows only.
     """
+    days = _json_safe_value(list(days or []))
+    event_options = _json_safe_value(list(event_options or []))
     registration_count = count_tournament_registrations(supabase, tournament_id)
     if registration_count == 0:
         replace_registration_configuration(

--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import uuid
 from datetime import date, datetime, timedelta
 from typing import Any
@@ -280,21 +281,31 @@ def _coerce_bool(value: Any, default: bool = False) -> bool:
 
 
 def _coerce_int(value: Any) -> int | None:
+    if pd.isna(value):
+        return None
     text = _safe_text(value)
     if not text:
         return None
     try:
-        return int(float(text))
+        number = float(text)
+        if not math.isfinite(number):
+            return None
+        return int(number)
     except Exception:
         return None
 
 
 def _coerce_float(value: Any) -> float | None:
+    if pd.isna(value):
+        return None
     text = _safe_text(value)
     if not text:
         return None
     try:
-        return float(text)
+        number = float(text)
+        if not math.isfinite(number):
+            return None
+        return number
     except Exception:
         return None
 


### PR DESCRIPTION
### Motivation
- Publishing tournament registration data sometimes crashed with `ValueError: Out of range float values are not JSON compliant: nan` when blank numeric cells from Streamlit/pandas editors became `nan` and were sent to PostgREST/Supabase. 
- The intent is to prevent `nan`/`inf`/`-inf`/pandas-missing values from ever reaching JSON payloads and to make blank numeric builder cells safely become `None`.

### Description
- Added defensive JSON sanitization by normalizing `days` and `event_options` with `_json_safe_value(list(...))` at the start of `analyze_registration_publish_impact(...)`, `replace_registration_configuration(...)`, and `publish_registration_configuration(...)` so non-JSON-safe floats are converted to `None` before any DB/diff logic. 
- Hardened UI numeric coercion by updating `_coerce_int(...)` and `_coerce_float(...)` to return `None` for `pd.isna(...)` and for non-finite values using `math.isfinite(...)`, and added `import math` to support those checks. 
- Confirmed affected numeric fields that could leak `nan`: `capacity_teams`, `price_usd`, `min_teams_per_age_group`, and `split_age_threshold` which are used when building division and age-rule payloads. 
- Files changed: `jupr_app/domain/tournament_registration_repo.py` and `jupr_app/ui/pages/tournament_manager.py`; the fix prevents NaN-like values from propagating and explains the root cause that blank/pandas-editor numeric cells turned into `nan` which earlier code allowed through to Supabase JSON encoding.

### Testing
- Ran `python -m compileall jupr_app/domain/tournament_registration_repo.py jupr_app/ui/pages/tournament_manager.py` and the files compiled successfully. 
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4146c0dbc8326804952bea420131e)