### PR TITLE
Make live badge awards reliable with queue fallback and live-safe loading

### DIFF
--- a/docs/badges_engine.md
+++ b/docs/badges_engine.md
@@ -118,13 +118,22 @@ If you have direct Postgres access, apply migrations in order with:
 DATABASE_URL="postgres://USER:PASSWORD@HOST:5432/dbname" make db-migrate
 ```
 
-## Incremental badge evaluation
+## Incremental badge evaluation (queue + inline fallback)
 When matches are ingested or edited, the app enqueues badge evaluation work instead of evaluating
 the full match history on every page view:
 - `badge_eval_queue` stores pending evaluation events (match recorded/updated, player IDs, context).
 - `player_badge_facts` stores incremental counters used by evaluators (future worker use).
+- The write path attempts a short worker drain immediately.
+- If queueing or queue processing fails, the app runs an **inline live fallback** (`run_live_badge_awards`)
+  so official non-popup match writes still award live badges.
 
-Current implementation only enqueues events; a worker will dequeue and process them separately.
+Live fallback only evaluates badges that are:
+- `status="live"`
+- `award_timing="live"`
+- relevant to the triggering event (`match_recorded` or `match_updated`)
+
+This fallback still persists via `upsert_player_badges`, so uniqueness/idempotency continues to be
+enforced by `(club_id, player_id, badge_id, context_id)`.
 
 ### Running the worker locally
 ```bash

--- a/jupr_app/data/schema_preflight.py
+++ b/jupr_app/data/schema_preflight.py
@@ -33,9 +33,25 @@ logger = logging.getLogger(__name__)
 
 
 def ensure_badge_schema_preflight(supabase: Any) -> bool:
+    return ensure_badge_schema_preflight_strict(supabase)
+
+
+def ensure_badge_schema_preflight_live(supabase: Any) -> bool:
     if _should_skip_preflight():
         return True
-    missing_columns = _find_missing_player_badges_columns(supabase)
+    missing_columns = _find_missing_player_badges_columns(supabase, include_revoked=False)
+    if missing_columns:
+        message_parts = [MIGRATION_HINT + "."]
+        missing_all = ", ".join(sorted(missing_columns))
+        message_parts.append(f"Missing player_badges columns: {missing_all}.")
+        raise RuntimeError(" ".join(message_parts))
+    return True
+
+
+def ensure_badge_schema_preflight_strict(supabase: Any) -> bool:
+    if _should_skip_preflight():
+        return True
+    missing_columns = _find_missing_player_badges_columns(supabase, include_revoked=True)
     missing_tables = _find_missing_tables(supabase, REQUIRED_BADGE_TABLES)
     missing_optional_tables = _find_missing_tables(supabase, OPTIONAL_BADGE_TABLES)
     if missing_columns or missing_tables:
@@ -55,9 +71,12 @@ def ensure_badge_schema_preflight(supabase: Any) -> bool:
     return True
 
 
-def _find_missing_player_badges_columns(supabase: Any) -> set[str]:
+def _find_missing_player_badges_columns(supabase: Any, *, include_revoked: bool) -> set[str]:
     missing = set()
-    for column in sorted(REQUIRED_PLAYER_BADGES_COLUMNS | REQUIRED_REVOKED_COLUMNS):
+    columns = set(REQUIRED_PLAYER_BADGES_COLUMNS)
+    if include_revoked:
+        columns |= REQUIRED_REVOKED_COLUMNS
+    for column in sorted(columns):
         if not _probe_column(supabase, "player_badges", column):
             missing.add(column)
     return missing

--- a/jupr_app/domain/bulk_match_editor.py
+++ b/jupr_app/domain/bulk_match_editor.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Set, Tuple
 import json
+import logging
 
 import pandas as pd
 
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
 from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
+from jupr_app.domain.gamification.live_awards import run_live_badge_awards
+
+logger = logging.getLogger(__name__)
 
 def compute_recompute_scope(patches: List[Dict[str, Any]]) -> Dict[str, bool]:
     """
@@ -138,6 +142,7 @@ def apply_bulk_match_edits(
 
     affected_leagues: Set[str] = set()
     affected_players: Set[int] = set()
+    badge_eligible_players: Set[int] = set()
 
     # For audit
     audit_before: List[Dict[str, Any]] = []
@@ -166,7 +171,11 @@ def apply_bulk_match_edits(
             v = before.get(col)
             if v is not None and not (isinstance(v, float) and pd.isna(v)):
                 try:
-                    affected_players.add(int(v))
+                    pid = int(v)
+                    affected_players.add(pid)
+                    is_popup = bool(before.get("is_popup", False)) or str(before.get("match_type") or "") == "PopUp"
+                    if not is_popup:
+                        badge_eligible_players.add(pid)
                 except Exception:
                     pass
 
@@ -260,18 +269,40 @@ def apply_bulk_match_edits(
         # don't fail admin operation if recompute fails
         warnings.append("Unable to recompute last_game_at for players automatically. (Non-fatal)")
 
-    if updated_ids and supabase is not None:
+    badge_summary: Dict[str, Any] = {"mode": "skipped", "awarded_count": 0, "candidate_count": 0, "badge_ids": []}
+    if updated_ids and supabase is not None and badge_eligible_players:
         for match_id in updated_ids:
-            queued = enqueue_badge_eval(
+            enqueue_result = enqueue_badge_eval(
                 supabase,
                 club_id=str(club_id),
                 event_type="match_updated",
-                player_ids=sorted(affected_players),
+                player_ids=sorted(badge_eligible_players),
                 match_id=str(match_id),
                 payload={"updated_ids": updated_ids[:50]},
             )
-            if queued:
-                process_badge_eval_queue(supabase, max_jobs=1, time_budget_seconds=2)
+            should_fallback = not bool(enqueue_result.get("queued"))
+            worker_result = None
+            if not should_fallback:
+                try:
+                    worker_result = process_badge_eval_queue(supabase, max_jobs=1, time_budget_seconds=2)
+                    badge_summary = {"mode": "queue", **worker_result}
+                    should_fallback = bool(worker_result.get("errored")) or (
+                        int(worker_result.get("processed") or 0) == 0 and int(worker_result.get("errored") or 0) > 0
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    should_fallback = True
+                    logger.warning("Badge queue worker failed during bulk match edit: %s", exc)
+            if should_fallback:
+                try:
+                    badge_summary = run_live_badge_awards(
+                        supabase,
+                        club_id=str(club_id),
+                        player_ids=sorted(badge_eligible_players),
+                        event_type="match_updated",
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Inline live badge fallback failed during bulk edit: %s", exc)
+                    badge_summary = {"mode": "inline_error", "error": str(exc)}
 
     return {
         "updated_count": len(updated_ids),
@@ -279,4 +310,5 @@ def apply_bulk_match_edits(
         "affected_leagues": sorted(affected_leagues),
         "recompute_scope": recompute_scope,
         "warnings": warnings,
+        "badge_summary": badge_summary,
     }

--- a/jupr_app/domain/gamification/badge_queue.py
+++ b/jupr_app/domain/gamification/badge_queue.py
@@ -22,9 +22,9 @@ def enqueue_badge_eval(
     context_id: str | None = None,
     match_id: str | None = None,
     payload: dict[str, Any] | None = None,
-) -> bool:
+) -> dict[str, Any]:
     if supabase is None or not club_id or not event_type:
-        return False
+        return {"queued": False, "reason": "invalid_input"}
     payload_json = dict(payload or {})
     row = {
         "club_id": str(club_id),
@@ -52,17 +52,17 @@ def enqueue_badge_eval(
                 code,
                 message,
             )
-            return False
+            return {"queued": False, "reason": "missing_table"}
         logger.warning(
             "Failed to enqueue badge evaluation (code=%s message=%s). Skipping badge enqueue.",
             code,
             message,
         )
-        return False
+        return {"queued": False, "reason": "api_error"}
     except Exception as exc:  # noqa: BLE001 - badge enqueue should never crash uploads
         logger.warning("Unexpected error while enqueueing badge evaluation: %s", exc)
-        return False
-    return True
+        return {"queued": False, "reason": "unexpected_error"}
+    return {"queued": True, "reason": "ok"}
 
 
 def dequeue_badge_eval(supabase: Any) -> dict[str, Any] | None:

--- a/jupr_app/domain/gamification/badge_worker.py
+++ b/jupr_app/domain/gamification/badge_worker.py
@@ -8,12 +8,13 @@ from typing import Any, Callable
 
 import httpx
 import pandas as pd
+from postgrest.exceptions import APIError
 
-from jupr_app.data.load import load_data
 from jupr_app.domain.gamification.badge_catalog import BADGE_DEFINITIONS
 from jupr_app.domain.gamification.badge_engine import compute_candidates_for_player
 from jupr_app.domain.gamification.badges_repo import upsert_player_badges
 from jupr_app.domain.gamification.badge_queue import ack_badge_eval, dequeue_badge_eval
+from jupr_app.domain.player_activity import add_activity_columns
 
 
 def process_badge_eval_queue(
@@ -204,7 +205,7 @@ def _resolve_context(ctx: Any | None, supabase: Any, club_id: str, match_limit: 
         id_to_name,
         schema_degraded,
         schema_degraded_reason,
-    ) = load_data(supabase, club_id, match_limit=match_limit)
+    ) = load_live_badge_data(supabase, club_id, match_limit=match_limit)
     return SimpleNamespace(
         supabase=supabase,
         club_id=club_id,
@@ -222,6 +223,126 @@ def _resolve_context(ctx: Any | None, supabase: Any, club_id: str, match_limit: 
         schema_degraded=schema_degraded,
         schema_degraded_reason=schema_degraded_reason,
     )
+
+
+def load_live_badge_data(supabase: Any, club_id: str, *, match_limit: int = 5000) -> tuple[Any, ...]:
+    club_id = str(club_id)
+    schema_degraded = False
+    schema_degraded_reason = None
+
+    p_resp = supabase.table("players").select("*").eq("club_id", club_id).execute()
+    df_players_all = add_activity_columns(pd.DataFrame(p_resp.data or []))
+    if not df_players_all.empty and "inactive_at" in df_players_all.columns:
+        df_players_active = df_players_all[df_players_all["inactive_at"].isna()].copy()
+    elif not df_players_all.empty and "active" in df_players_all.columns:
+        df_players_active = df_players_all[df_players_all["active"] == True].copy()
+    else:
+        df_players_active = df_players_all.copy()
+
+    l_resp = (
+        supabase.table("league_ratings")
+        .select("id,player_id,league_name,rating,starting_rating,wins,losses,matches_played,is_active")
+        .eq("club_id", club_id)
+        .execute()
+    )
+    df_leagues = pd.DataFrame(l_resp.data or [])
+
+    m_resp = (
+        supabase.table("matches")
+        .select("*")
+        .eq("club_id", club_id)
+        .order("id", desc=True)
+        .limit(int(match_limit))
+        .execute()
+    )
+    df_matches = pd.DataFrame(m_resp.data or [])
+
+    meta_resp = supabase.table("leagues_metadata").select("*").eq("club_id", club_id).execute()
+    df_meta = pd.DataFrame(meta_resp.data or [])
+
+    df_badges = _fetch_badges(supabase)
+    df_player_badges, schema_degraded, schema_degraded_reason = _fetch_player_badges_live(supabase, club_id)
+
+    if not df_players_all.empty and "id" in df_players_all.columns and "name" in df_players_all.columns:
+        ids = pd.to_numeric(df_players_all["id"], errors="coerce").dropna().astype(int)
+        names = df_players_all.loc[ids.index, "name"].astype(str)
+        id_to_name = dict(zip(ids, names))
+        name_to_id = dict(zip(names, ids))
+    else:
+        id_to_name, name_to_id = {}, {}
+
+    return (
+        df_players_all,
+        df_players_active,
+        df_leagues,
+        df_matches,
+        df_meta,
+        df_badges,
+        df_player_badges,
+        name_to_id,
+        id_to_name,
+        schema_degraded,
+        schema_degraded_reason,
+    )
+
+
+def _fetch_badges(supabase: Any) -> pd.DataFrame:
+    try:
+        resp = supabase.table("badges").select(
+            "badge_id,name,prestige,category,is_stackable,is_active,rarity,"
+            "tier,icon_key,scope,state,eval_triggers,created_at"
+        ).execute()
+    except APIError:
+        resp = supabase.table("badges").select(
+            "badge_id,name,prestige,category,is_stackable,is_active,rarity,"
+            "tier,icon_key,scope,created_at"
+        ).execute()
+    df_badges = pd.DataFrame(resp.data or [])
+    if not df_badges.empty:
+        if "state" not in df_badges.columns:
+            df_badges["state"] = "live"
+        if "eval_triggers" not in df_badges.columns:
+            df_badges["eval_triggers"] = [["match_recorded", "match_updated"]] * len(df_badges)
+    return df_badges
+
+
+def _fetch_player_badges_live(supabase: Any, club_id: str) -> tuple[pd.DataFrame, bool, str | None]:
+    base_cols = [
+        "id",
+        "club_id",
+        "player_id",
+        "badge_id",
+        "earned_at",
+        "context_type",
+        "context_id",
+        "match_id",
+        "value_num",
+        "value_json",
+    ]
+    optional_cols = ["awarded_by", "rule_version", "eval_run_id", "revoked_at", "revoked_by", "revoke_reason"]
+    schema_degraded = False
+    schema_degraded_reason = None
+    try:
+        resp = (
+            supabase.table("player_badges")
+            .select(",".join(base_cols + optional_cols))
+            .eq("club_id", club_id)
+            .execute()
+        )
+    except APIError:
+        schema_degraded = True
+        schema_degraded_reason = "player_badges optional provenance/revocation columns missing"
+        resp = (
+            supabase.table("player_badges")
+            .select(",".join(base_cols))
+            .eq("club_id", club_id)
+            .execute()
+        )
+    df = pd.DataFrame(resp.data or [])
+    for col in optional_cols:
+        if col not in df.columns:
+            df[col] = None
+    return df, schema_degraded, schema_degraded_reason
 
 
 def _badge_ids_for_trigger(ctx: Any, event_type: str) -> set[str]:

--- a/jupr_app/domain/gamification/live_awards.py
+++ b/jupr_app/domain/gamification/live_awards.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any
+
+from jupr_app.domain.gamification.badge_engine import compute_candidates_for_player
+from jupr_app.domain.gamification.badges_repo import upsert_player_badges
+from jupr_app.domain.gamification.badge_worker import _badge_ids_for_trigger, _resolve_context
+
+
+def run_live_badge_awards(
+    supabase: Any,
+    *,
+    club_id: str,
+    player_ids: list[int] | set[int],
+    event_type: str,
+    ctx: Any | None = None,
+    match_limit: int = 5000,
+) -> dict[str, Any]:
+    normalized_player_ids = sorted({int(pid) for pid in (player_ids or [])})
+    if not normalized_player_ids:
+        return {"awarded_count": 0, "candidate_count": 0, "badge_ids": [], "mode": "inline"}
+
+    context = _resolve_context(ctx, supabase, str(club_id), match_limit)
+    eligible_badge_ids = sorted(_badge_ids_for_trigger(context, event_type))
+    if not eligible_badge_ids:
+        return {"awarded_count": 0, "candidate_count": 0, "badge_ids": [], "mode": "inline"}
+
+    candidates = []
+    for pid in normalized_player_ids:
+        player_candidates = compute_candidates_for_player(
+            str(club_id),
+            int(pid),
+            ctx=context,
+            status="live",
+            award_timing="live",
+        )
+        candidates.extend([c for c in player_candidates if str(c.badge_id) in set(eligible_badge_ids)])
+
+    created = upsert_player_badges(
+        supabase,
+        str(club_id),
+        candidates,
+        awarded_by="engine",
+    )
+    return {
+        "awarded_count": len(created),
+        "candidate_count": len(candidates),
+        "badge_ids": eligible_badge_ids,
+        "mode": "inline",
+    }

--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import logging
 from typing import Any, Callable
 
 from jupr_app.domain.ratings import calculate_hybrid_elo
@@ -13,6 +14,10 @@ from jupr_app.domain.player_activity import (
 )
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
 from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
+from jupr_app.domain.gamification.live_awards import run_live_badge_awards
+
+
+logger = logging.getLogger(__name__)
 
 
 def process_matches(
@@ -278,6 +283,7 @@ def process_matches(
     # -------------------------
     # Write match rows
     # -------------------------
+    badge_summary: dict[str, Any] = {"mode": "skipped", "awarded_count": 0, "candidate_count": 0, "badge_ids": []}
     if db_matches:
         CHUNK_M = 300
         for i in range(0, len(db_matches), CHUNK_M):
@@ -304,15 +310,41 @@ def process_matches(
                 )
 
         if supabase is not None and has_non_popup_match:
-            queued = enqueue_badge_eval(
+            enqueue_result = enqueue_badge_eval(
                 supabase,
                 club_id=str(club_id),
                 event_type="match_recorded",
                 player_ids=sorted(affected_players),
                 payload={"match_count": len(db_matches), "matches": match_payloads[:10]},
             )
-            if queued:
-                process_badge_eval_queue(supabase, max_jobs=1, time_budget_seconds=2)
+            worker_result = None
+            should_fallback = not bool(enqueue_result.get("queued"))
+            if not should_fallback:
+                try:
+                    worker_result = process_badge_eval_queue(supabase, max_jobs=1, time_budget_seconds=2)
+                    should_fallback = bool(worker_result.get("errored")) or (
+                        int(worker_result.get("processed") or 0) == 0 and int(worker_result.get("errored") or 0) > 0
+                    )
+                    badge_summary = {"mode": "queue", **worker_result}
+                except Exception as exc:  # noqa: BLE001
+                    should_fallback = True
+                    logger.warning("Badge queue worker failed during match processing: %s", exc)
+            else:
+                logger.warning(
+                    "Badge queue enqueue unavailable during match processing; falling back inline. reason=%s",
+                    enqueue_result.get("reason"),
+                )
+            if should_fallback:
+                try:
+                    badge_summary = run_live_badge_awards(
+                        supabase,
+                        club_id=str(club_id),
+                        player_ids=sorted(affected_players),
+                        event_type="match_recorded",
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Inline live badge fallback failed after match processing: %s", exc)
+                    badge_summary = {"mode": "inline_error", "error": str(exc)}
 
     # -------------------------
     # Update overall player rows
@@ -399,4 +431,5 @@ def process_matches(
         "inserted": len(db_matches),
         "skipped_incomplete": int(skipped_incomplete),
         "skipped_empty": int(skipped_empty),
+        "badge_summary": badge_summary,
     }

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -297,7 +297,7 @@ def main():
                 and "id" in df_players_all.columns
             ):
                 player_ids = df_players_all["id"].dropna().astype(int).tolist()
-            queued = enqueue_badge_eval(
+            enqueue_result = enqueue_badge_eval(
                 supabase,
                 club_id=CLUB_ID,
                 event_type="match_recorded",
@@ -305,7 +305,7 @@ def main():
                 match_id=f"initial_load:{CLUB_ID}",
                 payload={"initial_load": True},
             )
-            if queued:
+            if enqueue_result.get("queued"):
                 process_badge_eval_queue(supabase, max_jobs=2, time_budget_seconds=2)
 
         # -------------------------

--- a/tests/test_badge_worker.py
+++ b/tests/test_badge_worker.py
@@ -208,13 +208,15 @@ def test_worker_error_marks_queue(monkeypatch):
 def test_enqueue_badge_eval_missing_table_is_ignored():
     storage = {"raise_missing_table": True}
     supabase = FakeSupabase(storage)
-    enqueue_badge_eval(
+    status = enqueue_badge_eval(
         supabase,
         club_id="club",
         event_type="match_recorded",
         player_ids=[1],
         match_id="m1",
     )
+    assert status["queued"] is False
+    assert status["reason"] == "missing_table"
     assert storage.get(BADGE_QUEUE_TABLE) is None
 
 

--- a/tests/test_match_processing_badges.py
+++ b/tests/test_match_processing_badges.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+from postgrest.exceptions import APIError
+
+from jupr_app.domain.bulk_match_editor import apply_bulk_match_edits
+from jupr_app.domain.gamification.live_awards import run_live_badge_awards
+from jupr_app.domain.match_processing import process_matches
+
+
+class _Query:
+    def __init__(self, sb, table):
+        self.sb = sb
+        self.table = table
+        self._op = "select"
+        self._payload = None
+        self._filters = []
+        self._order = None
+        self._limit = None
+        self._select = "*"
+
+    def select(self, cols):
+        self._op = "select"
+        self._select = cols
+        return self
+
+    def insert(self, payload):
+        self._op = "insert"
+        self._payload = payload
+        return self
+
+    def upsert(self, payload, on_conflict=None):
+        self._op = "upsert"
+        self._payload = payload
+        self._on_conflict = on_conflict
+        return self
+
+    def update(self, payload):
+        self._op = "update"
+        self._payload = payload
+        return self
+
+    def eq(self, col, val):
+        self._filters.append(("eq", col, val))
+        return self
+
+    def in_(self, col, vals):
+        self._filters.append(("in", col, set(vals)))
+        return self
+
+    def order(self, col, desc=False):
+        self._order = (col, desc)
+        return self
+
+    def limit(self, n):
+        self._limit = int(n)
+        return self
+
+    def execute(self):
+        return self.sb.execute(self)
+
+
+class _Supabase:
+    def __init__(self, *, queue_missing=False, missing_optional_pb=False):
+        self.queue_missing = queue_missing
+        self.missing_optional_pb = missing_optional_pb
+        self.tables = {
+            "matches": [],
+            "players": [],
+            "league_ratings": [],
+            "leagues_metadata": [],
+            "badges": [
+                {"badge_id": "participant", "state": "live", "eval_triggers": ["match_recorded", "match_updated"]},
+                {"badge_id": "first_win", "state": "live", "eval_triggers": ["match_recorded", "match_updated"]},
+            ],
+            "player_badges": [],
+        }
+
+    def table(self, name):
+        return _Query(self, name)
+
+    def execute(self, q: _Query):
+        if q.table == "badge_eval_queue" and self.queue_missing:
+            raise APIError({"code": "PGRST205", "message": "missing"})
+
+        rows = self.tables.setdefault(q.table, [])
+        data = list(rows)
+        for op, col, val in q._filters:
+            if op == "eq":
+                data = [r for r in data if str(r.get(col)) == str(val)]
+            elif op == "in":
+                data = [r for r in data if r.get(col) in val]
+
+        if q._order:
+            col, desc = q._order
+            data = sorted(data, key=lambda r: r.get(col), reverse=desc)
+        if q._limit is not None:
+            data = data[: q._limit]
+
+        if q._op == "select":
+            if (
+                q.table == "player_badges"
+                and self.missing_optional_pb
+                and "awarded_by" in q._select
+            ):
+                raise APIError({"code": "42703", "message": "column player_badges.awarded_by does not exist"})
+            return SimpleNamespace(data=data)
+
+        if q._op == "insert":
+            payload = q._payload if isinstance(q._payload, list) else [q._payload]
+            for row in payload:
+                row = dict(row)
+                row.setdefault("id", len(rows) + 1)
+                rows.append(row)
+            return SimpleNamespace(data=payload)
+
+        if q._op == "update":
+            for row in data:
+                row.update(q._payload)
+            return SimpleNamespace(data=data)
+
+        if q._op == "upsert":
+            payload = q._payload if isinstance(q._payload, list) else [q._payload]
+            keys = [k.strip() for k in (q._on_conflict or "").split(",") if k.strip()]
+            for row in payload:
+                row = dict(row)
+                existing = None
+                if keys:
+                    for cur in rows:
+                        if all(str(cur.get(k)) == str(row.get(k)) for k in keys):
+                            existing = cur
+                            break
+                if existing:
+                    existing.update(row)
+                else:
+                    row.setdefault("id", len(rows) + 1)
+                    rows.append(row)
+            return SimpleNamespace(data=payload)
+
+        return SimpleNamespace(data=[])
+
+
+def _players_df():
+    return pd.DataFrame(
+        [
+            {"id": 1, "name": "A", "rating": 1200, "wins": 0, "losses": 0, "matches_played": 0},
+            {"id": 2, "name": "B", "rating": 1200, "wins": 0, "losses": 0, "matches_played": 0},
+            {"id": 3, "name": "C", "rating": 1200, "wins": 0, "losses": 0, "matches_played": 0},
+            {"id": 4, "name": "D", "rating": 1200, "wins": 0, "losses": 0, "matches_played": 0},
+        ]
+    )
+
+
+def test_match_insert_awards_inline_when_queue_table_missing():
+    sb = _Supabase(queue_missing=True)
+    result = process_matches(
+        [{"league": "Main", "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "s1": 11, "s2": 5}],
+        supabase=sb,
+        club_id="club",
+        name_to_id={},
+        df_players_all=_players_df(),
+        df_leagues=pd.DataFrame(),
+        df_meta=pd.DataFrame(),
+    )
+    badge_ids = {row["badge_id"] for row in sb.tables["player_badges"]}
+    assert result["badge_summary"]["mode"] == "inline"
+    assert "participant" in badge_ids
+    assert "first_win" in badge_ids
+
+
+def test_live_awards_work_when_recompute_columns_missing():
+    sb = _Supabase(queue_missing=True, missing_optional_pb=True)
+    sb.tables["matches"] = [
+        {"id": 1, "club_id": "club", "league": "Main", "date": "2024-01-01T00:00:00Z", "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 4}
+    ]
+    sb.tables["players"] = _players_df().to_dict("records")
+
+    summary = run_live_badge_awards(sb, club_id="club", player_ids=[1], event_type="match_recorded")
+    assert summary["mode"] == "inline"
+    assert summary["awarded_count"] >= 1
+
+
+def test_live_awards_are_idempotent_via_upsert_key():
+    sb = _Supabase(missing_optional_pb=True)
+    sb.tables["matches"] = [
+        {"id": 1, "club_id": "club", "league": "Main", "date": "2024-01-01T00:00:00Z", "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 4}
+    ]
+    sb.tables["players"] = _players_df().to_dict("records")
+
+    run_live_badge_awards(sb, club_id="club", player_ids=[1], event_type="match_recorded")
+    run_live_badge_awards(sb, club_id="club", player_ids=[1], event_type="match_recorded")
+    keys = {(r["club_id"], r["player_id"], r["badge_id"], r["context_id"]) for r in sb.tables["player_badges"]}
+    assert len(keys) == len(sb.tables["player_badges"])
+
+
+def test_bulk_edit_uses_inline_fallback_without_breaking():
+    sb = _Supabase(queue_missing=True, missing_optional_pb=True)
+    sb.tables["players"] = _players_df().to_dict("records")
+    sb.tables["matches"] = [
+        {"id": 10, "club_id": "club", "league": "Main", "date": "2024-01-01T00:00:00Z", "week_tag": None, "match_type": "League", "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 5}
+    ]
+    result = apply_bulk_match_edits(sb, "club", [{"id": 10, "notes": "edited"}], actor="admin")
+    assert result["updated_count"] == 1
+    assert result["badge_summary"]["mode"] == "inline"
+
+
+def test_popup_matches_do_not_trigger_live_awards():
+    sb = _Supabase(queue_missing=True)
+    result = process_matches(
+        [{"league": "Main", "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "s1": 11, "s2": 5, "match_type": "PopUp", "is_popup": True}],
+        supabase=sb,
+        club_id="club",
+        name_to_id={},
+        df_players_all=_players_df(),
+        df_leagues=pd.DataFrame(),
+        df_meta=pd.DataFrame(),
+    )
+    assert result["badge_summary"]["mode"] == "skipped"
+    assert sb.tables["player_badges"] == []

--- a/tests/test_schema_preflight.py
+++ b/tests/test_schema_preflight.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import pytest
 from postgrest.exceptions import APIError
 
-from jupr_app.data.schema_preflight import ensure_badge_schema_preflight
+from jupr_app.data.schema_preflight import (
+    ensure_badge_schema_preflight,
+    ensure_badge_schema_preflight_live,
+)
 
 
 class _FakeResponse:
@@ -77,3 +80,13 @@ def test_preflight_raises_when_columns_missing(monkeypatch):
     assert "migrations/20260625_badge_recompute_runs.sql" in str(excinfo.value)
     assert "migrations/20260630_player_badges_revocation.sql" in str(excinfo.value)
     assert "badge_eval_runs" in str(excinfo.value)
+
+
+def test_live_preflight_does_not_require_recompute_schema(monkeypatch):
+    monkeypatch.delenv("JUPR_SKIP_BADGE_SCHEMA_PREFLIGHT", raising=False)
+    supabase = _FakeSupabase(
+        {
+            "player_badges": {"awarded_by", "rule_version", "eval_run_id"},
+        }
+    )
+    assert ensure_badge_schema_preflight_live(supabase) is True


### PR DESCRIPTION
### Motivation
- Live badge awards were failing silently when `badge_eval_queue` or recompute-only schema (e.g., `badge_eval_runs`, provenance/revocation columns) was missing or drifted. 
- The write paths (`match_recorded` / `match_updated`) relied on enqueue → worker → strict schema and had no robust inline fallback, causing production matches to miss live awards. 

### Description
- Added an inline live-award helper `run_live_badge_awards` in `jupr_app/domain/gamification/live_awards.py` that evaluates only `status="live"` / `award_timing="live"` badges, filters by trigger, and persists via `upsert_player_badges` while returning a structured summary. 
- Updated write flows in `process_matches` and `apply_bulk_match_edits` to: try `enqueue_badge_eval`, attempt a short `process_badge_eval_queue` drain, and run the inline fallback when enqueue/worker is unavailable or errored, while preserving popup-exclusion logic and returning a `badge_summary`. 
- Made `enqueue_badge_eval` return structured status (`{"queued": bool, "reason": ...}`) instead of silently no-op so callers can decide to fallback; improved logging for enqueue/worker failures. 
- Decoupled live evaluation from recompute-only schema by adding `load_live_badge_data` in `badge_worker` that loads only the live-eval essentials and tolerates missing optional `player_badges` provenance/revocation columns. 
- Split schema preflight into strict vs live checks via `ensure_badge_schema_preflight_strict` (default `ensure_badge_schema_preflight`) and `ensure_badge_schema_preflight_live` so live awards do not require recompute-only migrations. 
- Updated docs (`docs/badges_engine.md`) and added tests (`tests/test_match_processing_badges.py`) covering queue-missing fallback, degraded schema tolerance, idempotency, bulk-edit fallback, and popup exclusion. 

### Testing
- Ran the focused test suite: `pytest -q tests/test_badge_worker.py tests/test_schema_preflight.py tests/test_match_processing_badges.py`. 
- Result: all tests passed (`16 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53991d3f88326b5e1e3bdcbdf5650)