### PR TITLE
Normalize player_badges and add Supabase fallback to fix badge rendering

### DIFF
--- a/jupr_app/ui/badge_data.py
+++ b/jupr_app/ui/badge_data.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def normalize_player_ids(player_ids: list[object] | tuple[object, ...] | set[object]) -> list[int]:
+    if not player_ids:
+        return []
+    ids_series = pd.to_numeric(pd.Series(list(player_ids)), errors="coerce").dropna()
+    if ids_series.empty:
+        return []
+    return ids_series.astype(int).tolist()
+
+
+def normalize_player_badges_frame(pb_df: pd.DataFrame | None) -> pd.DataFrame:
+    if pb_df is None or pb_df.empty:
+        return pd.DataFrame()
+    if "player_id" not in pb_df.columns:
+        return pd.DataFrame()
+
+    normalized = pb_df.copy()
+    normalized["player_id"] = pd.to_numeric(normalized["player_id"], errors="coerce")
+    normalized = normalized.dropna(subset=["player_id"]).copy()
+    if normalized.empty:
+        return pd.DataFrame(columns=pb_df.columns)
+    normalized["player_id"] = normalized["player_id"].astype(int)
+
+    if "badge_id" in normalized.columns:
+        normalized["badge_id"] = normalized["badge_id"].fillna("").astype(str).str.strip()
+    if "club_id" in normalized.columns:
+        normalized["club_id"] = normalized["club_id"].fillna("").astype(str).str.strip()
+    return normalized
+

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -10,6 +10,7 @@ from jupr_app.ui.url import qp_get
 from jupr_app.ui.public_links import build_public_url, public_link_button
 from jupr_app.ui.layout import page_shell
 from jupr_app.ui.theme_clean import callout
+from jupr_app.ui.badge_data import normalize_player_badges_frame, normalize_player_ids
 from jupr_app.ui.pages.players import badge_icon
 
 
@@ -194,7 +195,8 @@ def select_leaderboard_players(
 
 
 def _fetch_leaderboard_badges(ctx, player_ids):
-    if not player_ids:
+    normalized_player_ids = normalize_player_ids(player_ids)
+    if not normalized_player_ids:
         return pd.DataFrame()
 
     pb_df = getattr(ctx, "df_player_badges", None)
@@ -206,20 +208,28 @@ def _fetch_leaderboard_badges(ctx, player_ids):
         and not pb_df.empty
         and not badges_df.empty
     ):
-        pb_copy = pb_df.copy()
+        pb_copy = normalize_player_badges_frame(pb_df)
         if "club_id" in pb_copy.columns:
-            pb_copy = pb_copy[pb_copy["club_id"].astype(str) == str(ctx.club_id)]
-        pb_copy = pb_copy[pb_copy["player_id"].isin(player_ids)]
+            pb_copy = pb_copy[pb_copy["club_id"] == str(ctx.club_id).strip()]
+        pb_copy = pb_copy[pb_copy["player_id"].isin(normalized_player_ids)]
         if pb_copy.empty:
-            return pd.DataFrame()
-        merged = pb_copy.merge(badges_df, on="badge_id", how="left")
-        for col in ("name", "category", "icon_key", "rarity"):
-            if col in merged.columns:
-                merged[col] = merged[col].fillna("").astype(str).str.replace(r"<[^>]+>", "", regex=True)
-        sort_cols = [col for col in ("player_id", "earned_at", "badge_id") if col in merged.columns]
-        if sort_cols:
-            merged = merged.sort_values(sort_cols, ascending=[True] * len(sort_cols)).reset_index(drop=True)
-        return merged
+            logger.info(
+                "Leaderboard badges: ctx.df_player_badges had 0 rows for requested players=%s club_id=%s; using fallback query.",
+                normalized_player_ids,
+                str(ctx.club_id).strip(),
+            )
+        else:
+            badges_defs = badges_df.copy()
+            if "badge_id" in badges_defs.columns:
+                badges_defs["badge_id"] = badges_defs["badge_id"].fillna("").astype(str).str.strip()
+            merged = pb_copy.merge(badges_defs, on="badge_id", how="left")
+            for col in ("name", "category", "icon_key", "rarity"):
+                if col in merged.columns:
+                    merged[col] = merged[col].fillna("").astype(str).str.replace(r"<[^>]+>", "", regex=True)
+            sort_cols = [col for col in ("player_id", "earned_at", "badge_id") if col in merged.columns]
+            if sort_cols:
+                merged = merged.sort_values(sort_cols, ascending=[True] * len(sort_cols)).reset_index(drop=True)
+            return merged
 
     try:
         resp = (
@@ -229,7 +239,7 @@ def _fetch_leaderboard_badges(ctx, player_ids):
                 "badges:badges(badge_id,name,prestige,category,icon_key,rarity)"
             )
             .eq("club_id", str(ctx.club_id))
-            .in_("player_id", player_ids)
+            .in_("player_id", normalized_player_ids)
             .execute()
         )
     except Exception:
@@ -241,6 +251,9 @@ def _fetch_leaderboard_badges(ctx, player_ids):
         return pd.DataFrame()
 
     badges_flat = pd.json_normalize(data, sep=".")
+    badges_flat = normalize_player_badges_frame(badges_flat)
+    if "badge_id" in badges_flat.columns and "badges.badge_id" in badges_flat.columns:
+        badges_flat = badges_flat.drop(columns=["badge_id"])
     column_map = {
         "badges.badge_id": "badge_id",
         "badges.name": "name",
@@ -250,12 +263,20 @@ def _fetch_leaderboard_badges(ctx, player_ids):
         "badges.rarity": "rarity",
     }
     badges_flat = badges_flat.rename(columns=column_map)
+    if "badge_id" in badges_flat.columns:
+        badges_flat["badge_id"] = badges_flat["badge_id"].fillna("").astype(str).str.strip()
     for col in ("name", "category", "icon_key", "rarity"):
         if col in badges_flat.columns:
             badges_flat[col] = badges_flat[col].fillna("").astype(str).str.replace(r"<[^>]+>", "", regex=True)
     sort_cols = [col for col in ("player_id", "earned_at", "badge_id") if col in badges_flat.columns]
     if sort_cols:
         badges_flat = badges_flat.sort_values(sort_cols, ascending=[True] * len(sort_cols)).reset_index(drop=True)
+    logger.info(
+        "Leaderboard badges fallback query returned %s rows for players=%s club_id=%s.",
+        len(badges_flat),
+        normalized_player_ids,
+        str(ctx.club_id).strip(),
+    )
     return badges_flat
 
 

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -12,6 +12,7 @@ from streamlit.components.v1 import html as st_html
 
 from jupr_app.domain.gamification.badge_copy import build_badge_copy_plain
 from jupr_app.ui.components.badge_cards import render_inline_badge_text
+from jupr_app.ui.badge_data import normalize_player_badges_frame
 from jupr_app.ui.helpers import (
     qp_get,
     display_requirement_text,
@@ -201,6 +202,56 @@ BADGE_ICONS = {
 
 def badge_icon(badge_id: str, category: str | None = None) -> str:
     return BADGE_ICONS.get(str(badge_id), "🏆")
+
+
+def resolve_player_badges_for_profile(ctx, _supabase, club_id: str, pid: int) -> pd.DataFrame:
+    shared_badges = getattr(ctx, "df_player_badges", None)
+    normalized_shared = normalize_player_badges_frame(shared_badges)
+    if not normalized_shared.empty:
+        if "club_id" in normalized_shared.columns:
+            normalized_shared = normalized_shared[
+                normalized_shared["club_id"] == str(club_id).strip()
+            ].copy()
+        selected_rows = normalized_shared[normalized_shared["player_id"] == int(pid)].copy()
+        if not selected_rows.empty:
+            return selected_rows
+        logger.info(
+            "Player badges: shared ctx.df_player_badges yielded 0 rows for player_id=%s club_id=%s; using direct player query.",
+            int(pid),
+            str(club_id).strip(),
+        )
+
+    try:
+        fetched = fetch_player_badges(_supabase, club_id, pid)
+    except Exception:
+        logger.exception("Failed to fetch badges for player view")
+        return pd.DataFrame()
+
+    normalized_fetched = normalize_player_badges_frame(fetched)
+    if normalized_fetched.empty:
+        return pd.DataFrame()
+    return normalized_fetched[normalized_fetched["player_id"] == int(pid)].copy()
+
+
+def select_featured_cuts(unlocked_badges: list[dict], limit: int = 3) -> list[dict]:
+    prestige_sorted = sorted(
+        unlocked_badges,
+        key=lambda b: (
+            int(b.get("prestige", 0) or 0),
+            pd.to_datetime(b.get("last_earned_at"), utc=True, errors="coerce"),
+        ),
+        reverse=True,
+    )
+    non_participant = [b for b in prestige_sorted if b.get("badge_id") != "participant"]
+    if len(non_participant) >= limit:
+        return non_participant[:limit]
+
+    featured = non_participant[:]
+    remaining_slots = limit - len(featured)
+    if remaining_slots > 0:
+        participant_badges = [b for b in prestige_sorted if b.get("badge_id") == "participant"]
+        featured.extend(participant_badges[:remaining_slots])
+    return featured
 
 
 def _season_sort_key(league_name: str) -> tuple[int, int] | None:
@@ -1339,13 +1390,7 @@ def render(ctx):
         if badge_defs is None or (isinstance(badge_defs, pd.DataFrame) and badge_defs.empty):
             badge_defs = fetch_badge_definitions(_supabase)
 
-        player_badges = getattr(ctx, "df_player_badges", None)
-        if player_badges is None or (isinstance(player_badges, pd.DataFrame) and player_badges.empty):
-            try:
-                player_badges = fetch_player_badges(_supabase, club_id, pid)
-            except Exception:
-                logger.exception("Failed to fetch badges for player view")
-                player_badges = pd.DataFrame()
+        player_badges = resolve_player_badges_for_profile(ctx, _supabase, club_id, pid)
 
         summary = build_gamification_summary(pid, badge_defs, player_badges)
         prestige_total = summary.get("prestige_total", 0)
@@ -1537,25 +1582,7 @@ def render(ctx):
             badge_caption("No badges available yet.", label="badges.empty")
         else:
             badge_markdown("#### Featured Cuts", label="badges.featured.header")
-            prestige_sorted = sorted(
-                unlocked_badges,
-                key=lambda b: (
-                    int(b.get("prestige", 0) or 0),
-                    pd.to_datetime(b.get("last_earned_at"), utc=True, errors="coerce"),
-                ),
-                reverse=True,
-            )
-            non_participant = [b for b in prestige_sorted if b.get("badge_id") != "participant"]
-            if len(non_participant) >= 3:
-                featured = non_participant[:3]
-            else:
-                featured = non_participant[:]
-                remaining_slots = 3 - len(featured)
-                if remaining_slots > 0:
-                    participant_badges = [
-                        b for b in prestige_sorted if b.get("badge_id") == "participant"
-                    ]
-                    featured.extend(participant_badges[:remaining_slots])
+            featured = select_featured_cuts(unlocked_badges, limit=3)
             if not featured:
                 badge_caption(
                     "The trophy room is quiet—new reels arrive after the next run.",

--- a/tests/test_badge_render_data_paths.py
+++ b/tests/test_badge_render_data_paths.py
@@ -1,0 +1,126 @@
+import pandas as pd
+
+from jupr_app.domain.gamification.profile import build_gamification_summary
+from jupr_app.ui.badge_data import normalize_player_badges_frame
+from jupr_app.ui.pages.leaderboards import _fetch_leaderboard_badges
+from jupr_app.ui.pages.players import get_player_trophy_case, resolve_player_badges_for_profile, select_featured_cuts
+
+
+class _SupabaseQueryStub:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def select(self, _value):
+        return self
+
+    def eq(self, _column, _value):
+        return self
+
+    def in_(self, _column, _value):
+        return self
+
+    def execute(self):
+        class _Resp:
+            data = self.payload
+
+        return _Resp()
+
+
+class _SupabaseStub:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def table(self, _name):
+        return _SupabaseQueryStub(self.payload)
+
+
+class _Ctx:
+    def __init__(self, df_player_badges, df_badges, supabase, club_id="club-1"):
+        self.df_player_badges = df_player_badges
+        self.df_badges = df_badges
+        self.supabase = supabase
+        self.club_id = club_id
+
+
+def _badge_defs():
+    return pd.DataFrame(
+        [
+            {"badge_id": "participant", "name": "Participant", "prestige": 5, "is_active": True, "category": "Participation"},
+            {"badge_id": "giant_slayer", "name": "Giant Slayer", "prestige": 75, "is_active": True, "category": "Rivalries"},
+        ]
+    )
+
+
+def test_leaderboard_badges_handles_string_player_id_from_ctx():
+    ctx = _Ctx(
+        df_player_badges=pd.DataFrame(
+            [{"club_id": "club-1", "player_id": "12", "badge_id": "participant", "earned_at": "2026-02-08T00:00:00Z"}]
+        ),
+        df_badges=_badge_defs(),
+        supabase=_SupabaseStub(payload=[]),
+    )
+
+    out = _fetch_leaderboard_badges(ctx, ["12"])
+    assert len(out) == 1
+    assert int(out.iloc[0]["player_id"]) == 12
+    assert out.iloc[0]["name"] == "Participant"
+
+
+def test_leaderboard_badges_falls_back_when_ctx_misses_visible_players():
+    fallback_payload = [
+        {
+            "player_id": 22,
+            "badge_id": "participant",
+            "earned_at": "2026-02-08T00:00:00Z",
+            "badges": {"badge_id": "participant", "name": "Participant", "prestige": 5, "category": "Participation"},
+        }
+    ]
+    ctx = _Ctx(
+        df_player_badges=pd.DataFrame(
+            [{"club_id": "club-1", "player_id": 99, "badge_id": "participant", "earned_at": "2026-02-08T00:00:00Z"}]
+        ),
+        df_badges=_badge_defs(),
+        supabase=_SupabaseStub(payload=fallback_payload),
+    )
+
+    out = _fetch_leaderboard_badges(ctx, [22])
+    assert len(out) == 1
+    assert int(out.iloc[0]["player_id"]) == 22
+    assert out.iloc[0]["badge_id"] == "participant"
+
+
+def test_player_profile_summary_unlocked_badges_from_selected_player_rows():
+    class _PlayerCtx:
+        df_player_badges = pd.DataFrame(
+            [
+                {"club_id": "club-1", "player_id": "7", "badge_id": "participant", "earned_at": "2026-02-08T00:00:00Z"},
+                {"club_id": "club-1", "player_id": "8", "badge_id": "giant_slayer", "earned_at": "2026-02-09T00:00:00Z"},
+            ]
+        )
+
+    resolved = resolve_player_badges_for_profile(_PlayerCtx(), _SupabaseStub([]), "club-1", 7)
+    summary = build_gamification_summary(7, _badge_defs(), resolved)
+    assert summary["collected_unique_count"] == 1
+    assert summary["unlocked_badges"][0]["badge_id"] == "participant"
+
+
+def test_trophy_case_can_be_empty_while_badge_collection_is_nonzero():
+    player_badges = pd.DataFrame(
+        [{"club_id": "club-1", "player_id": "7", "badge_id": "participant", "earned_at": "2026-02-08T00:00:00Z"}]
+    )
+    normalized = normalize_player_badges_frame(player_badges)
+    summary = build_gamification_summary(7, _badge_defs(), normalized)
+    trophy_case = get_player_trophy_case(normalized, 7, completed_league_ids=set())
+    assert summary["collected_unique_count"] == 1
+    assert trophy_case.empty
+
+
+def test_grace_like_single_participant_populates_collection_and_featured():
+    player_badges = pd.DataFrame(
+        [{"club_id": "club-1", "player_id": "101", "badge_id": "participant", "earned_at": "2026-02-08T00:00:00Z"}]
+    )
+    summary = build_gamification_summary(101, _badge_defs(), normalize_player_badges_frame(player_badges))
+    featured = select_featured_cuts(summary["unlocked_badges"], limit=3)
+    assert summary["collected_unique_count"] == 1
+    assert len(featured) == 1
+    assert featured[0]["badge_id"] == "participant"


### PR DESCRIPTION
### Motivation
- The UI could show 0 badges while the DB had `player_badges` rows because shared `ctx.df_player_badges` was filtered without robust dtype/format normalization. 
- `player_id` and `badge_id` values can arrive as strings or ints, causing `isin(...)` and equality checks to silently drop valid rows. 
- A lightweight, surgical fix was needed to normalize badge data centrally and to fall back to a direct query when the shared frame is non-empty but misses the requested player(s).

### Description
- Added `jupr_app/ui/badge_data.py` with `normalize_player_ids` and `normalize_player_badges_frame` to coerce `player_id` to int and strip `badge_id` / `club_id` before filtering. 
- Updated `_fetch_leaderboard_badges` to use normalized visible player IDs and a normalized `ctx.df_player_badges`, and to fall back to a Supabase query for requested players when the shared frame yields 0 rows; preserved merge-to-badges behavior and added info-level logging. 
- Introduced `resolve_player_badges_for_profile` in `players.py` which normalizes and filters shared `df_player_badges` for the selected player and falls back to `fetch_player_badges(...)` when needed, ensuring `build_gamification_summary` receives the selected player’s rows. 
- Added `select_featured_cuts` helper and focused tests in `tests/test_badge_render_data_paths.py` to cover dtype drift, fallback behavior, profile summary correctness, trophy-vs-collection semantics, and a Grace-like single-Participant case.

### Testing
- Ran `pytest -q tests/test_badge_render_data_paths.py tests/test_player_activity.py tests/test_badge_aggregation.py` (subset of the test suite relevant to badges and players). 
- All tests passed: 13 passed in the final run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54547c1008326a5ce6336a886a19e)