### PR TITLE
Fix Trophy Room crash when player_badges already contains badge metadata

### DIFF
--- a/jupr_app/domain/gamification/profile.py
+++ b/jupr_app/domain/gamification/profile.py
@@ -96,13 +96,40 @@ def build_gamification_summary(
         assert "rarity" in badge_defs.columns or rarity_fallback
     active_badges = badge_defs[badge_defs["is_active"] != False].copy()
 
-    pb = pb[pb.get("player_id") == int(player_id)].copy() if not pb.empty else pd.DataFrame()
+    def _series_or_default(df: pd.DataFrame, col: str, default: Any) -> pd.Series:
+        if col in df.columns:
+            return df[col]
+        fallback_col = f"{col}_def"
+        if fallback_col in df.columns:
+            return df[fallback_col]
+        return pd.Series([default] * len(df), index=df.index)
+
+    if not pb.empty:
+        pb_player_id = pd.to_numeric(pb.get("player_id"), errors="coerce")
+        pb = pb.loc[pb_player_id.notna()].copy()
+        if not pb.empty:
+            pb_player_id = pb_player_id.loc[pb.index].astype(int)
+            pb = pb.loc[pb_player_id == int(player_id)].copy()
+
     if pb.empty or active_badges.empty:
         unlocked = []
     else:
-        merged = pb.merge(active_badges, on="badge_id", how="left")
+        merged = pb.merge(active_badges, on="badge_id", how="left", suffixes=("", "_def"))
         merged["earned_at_dt"] = pd.to_datetime(merged.get("earned_at", None), utc=True, errors="coerce")
-        merged["prestige"] = pd.to_numeric(merged.get("prestige", 0), errors="coerce").fillna(0)
+        merged["prestige"] = pd.to_numeric(
+            _series_or_default(merged, "prestige", 0), errors="coerce"
+        ).fillna(0)
+        merged["name"] = _series_or_default(merged, "name", None)
+        merged["category"] = _series_or_default(merged, "category", "")
+        merged["rarity"] = _series_or_default(merged, "rarity", None)
+        merged["requirements"] = _series_or_default(merged, "requirements", "Requirements TBD")
+        merged["is_stackable"] = _series_or_default(merged, "is_stackable", False)
+        merged["icon_key"] = _series_or_default(merged, "icon_key", None)
+        merged["tier"] = _series_or_default(merged, "tier", None)
+        merged["scope"] = _series_or_default(merged, "scope", None)
+        merged["badge_scope"] = _series_or_default(merged, "badge_scope", None)
+        merged["badge_status"] = _series_or_default(merged, "badge_status", "live")
+        merged["badge_award_timing"] = _series_or_default(merged, "badge_award_timing", "live")
 
         unlocked = []
         for badge_id, group in merged.groupby("badge_id"):

--- a/tests/test_gamification_profile_story.py
+++ b/tests/test_gamification_profile_story.py
@@ -271,3 +271,133 @@ def test_story_cards_dedupe_by_type_and_context():
     stories = compute_story_cards(ctx, facts, awards)
     keys = [(s["story_type"], s["context_id"]) for s in stories]
     assert len(keys) == len(set(keys))
+
+
+def test_profile_summary_supports_raw_player_badges():
+    df_badges = pd.DataFrame(
+        [
+            {
+                "badge_id": "participant_grace",
+                "name": "Grace",
+                "prestige": 10,
+                "category": "Participation",
+                "rarity": "common",
+            }
+        ]
+    )
+    df_player_badges = pd.DataFrame(
+        [
+            {
+                "player_id": 42,
+                "badge_id": "participant_grace",
+                "earned_at": "2024-02-01T00:00:00Z",
+            }
+        ]
+    )
+
+    summary = build_gamification_summary(42, df_badges, df_player_badges)
+
+    assert summary["collected_unique_count"] == 1
+    assert summary["prestige_total"] == 10
+    assert summary["unlocked_badges"][0]["name"] == "Grace"
+
+
+def test_profile_summary_supports_enriched_player_badges():
+    df_badges = pd.DataFrame(
+        [
+            {
+                "badge_id": "participant_grace",
+                "name": "Grace",
+                "prestige": 10,
+                "category": "Participation",
+                "rarity": "common",
+            }
+        ]
+    )
+    df_player_badges = pd.DataFrame(
+        [
+            {
+                "player_id": "42",
+                "badge_id": "participant_grace",
+                "earned_at": "2024-02-01T00:00:00Z",
+                "name": "Grace (enriched)",
+                "prestige": 15,
+                "category": "Participation",
+                "rarity": "rare",
+                "requirements": "Play one match",
+                "is_stackable": False,
+            }
+        ]
+    )
+
+    summary = build_gamification_summary(42, df_badges, df_player_badges)
+
+    assert summary["collected_unique_count"] == 1
+    assert summary["prestige_total"] == 15
+    assert summary["unlocked_badges"][0]["name"] == "Grace (enriched)"
+    assert summary["unlocked_badges"][0]["rarity"] == "rare"
+
+
+def test_profile_summary_handles_def_suffix_without_crash():
+    df_badges = pd.DataFrame(
+        [
+            {
+                "badge_id": "participant_grace",
+                "name": "Grace",
+                "prestige": 10,
+                "category": "Participation",
+                "rarity": "common",
+            }
+        ]
+    )
+    df_player_badges = pd.DataFrame(
+        [
+            {
+                "player_id": "42",
+                "badge_id": "participant_grace",
+                "earned_at": "2024-02-01T00:00:00Z",
+                "prestige_def": 99,
+                "name_def": "Grace def",
+            },
+            {
+                "player_id": "not-a-number",
+                "badge_id": "participant_grace",
+                "earned_at": "2024-02-02T00:00:00Z",
+            },
+        ]
+    )
+
+    summary = build_gamification_summary(42, df_badges, df_player_badges)
+
+    assert summary["collected_unique_count"] == 1
+    assert summary["prestige_total"] == 10
+    assert summary["unlocked_badges"][0]["name"] == "Grace"
+
+
+def test_profile_summary_single_participant_badge_is_unlocked():
+    df_badges = pd.DataFrame(
+        [
+            {
+                "badge_id": "participant_grace",
+                "name": "Grace",
+                "prestige": 10,
+                "category": "Participation",
+                "rarity": "common",
+            }
+        ]
+    )
+    df_player_badges = pd.DataFrame(
+        [
+            {
+                "player_id": 7.0,
+                "badge_id": "participant_grace",
+                "earned_at": "2024-02-01T00:00:00Z",
+            }
+        ]
+    )
+
+    summary = build_gamification_summary(7, df_badges, df_player_badges)
+
+    assert len(summary["unlocked_badges"]) == 1
+    assert summary["collected_unique_count"] == 1
+    assert summary["prestige_total"] > 0


### PR DESCRIPTION
### Motivation
- A merge of `player_badges` and badge definitions could yield suffixed columns (`prestige` vs `prestige_def`), and `merged.get("prestige", 0)` sometimes returned a scalar `int`, causing `.fillna()` to raise `AttributeError`; the Trophy Room path needed to handle both raw and already-enriched `player_badges` without crashing.

### Description
- Add a helper ` _series_or_default(df, col, default)` that returns an unsuffixed column, then a `_def` fallback, or a row-aligned `pd.Series` of defaults so downstream calls like `.fillna()` always operate on a `Series` rather than a scalar.
- Merge `pb` and `active_badges` with explicit `suffixes=("", "_def")` to avoid ambiguous columns and then resolve merged fields (`prestige`, `name`, `category`, `rarity`, `requirements`, `is_stackable`, `icon_key`, `tier`, `scope`, `badge_scope`, `badge_status`, `badge_award_timing`) via the resolver before computing summaries.
- Normalize and validate player filtering by coercing `player_id` with `pd.to_numeric(..., errors="coerce")`, dropping non-numeric IDs, casting to `int`, and then filtering by `player_id` to keep the filter robust.
- Add tests in `tests/test_gamification_profile_story.py` to cover raw `player_badges`, enriched `player_badges`, `_def`-suffix fallback cases, and a single-participant badge unlocked path.

### Testing
- Ran `pytest -q tests/test_gamification_profile_story.py` and the new/updated tests passed (8 passed).
- Ran `pytest -q tests/test_player_trophy_room.py` to verify related trophy-room behavior and it passed (8 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5470e74808326b4588b7f2a6f8e51)