### PR TITLE
Fix leaderboard badges when ctx badge data is partially populated

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -199,6 +199,59 @@ def _fetch_leaderboard_badges(ctx, player_ids):
     if not normalized_player_ids:
         return pd.DataFrame()
 
+    def _fetch_badges_from_db(target_player_ids):
+        if not target_player_ids:
+            return pd.DataFrame()
+        try:
+            resp = (
+                ctx.supabase.table("player_badges")
+                .select(
+                    "player_id,badge_id,earned_at,"
+                    "badges:badges(badge_id,name,prestige,category,icon_key,rarity)"
+                )
+                .eq("club_id", str(ctx.club_id))
+                .in_("player_id", target_player_ids)
+                .execute()
+            )
+        except Exception:
+            logger.exception("Failed to fetch leaderboard badges")
+            return pd.DataFrame()
+
+        data = resp.data or []
+        if not data:
+            logger.info(
+                "Leaderboard badges fallback query returned 0 rows for players=%s club_id=%s.",
+                target_player_ids,
+                str(ctx.club_id).strip(),
+            )
+            return pd.DataFrame()
+
+        badges_flat = pd.json_normalize(data, sep=".")
+        badges_flat = normalize_player_badges_frame(badges_flat)
+        if "badge_id" in badges_flat.columns and "badges.badge_id" in badges_flat.columns:
+            badges_flat = badges_flat.drop(columns=["badge_id"])
+        column_map = {
+            "badges.badge_id": "badge_id",
+            "badges.name": "name",
+            "badges.prestige": "prestige",
+            "badges.category": "category",
+            "badges.icon_key": "icon_key",
+            "badges.rarity": "rarity",
+        }
+        badges_flat = badges_flat.rename(columns=column_map)
+        if "badge_id" in badges_flat.columns:
+            badges_flat["badge_id"] = badges_flat["badge_id"].fillna("").astype(str).str.strip()
+        for col in ("name", "category", "icon_key", "rarity"):
+            if col in badges_flat.columns:
+                badges_flat[col] = badges_flat[col].fillna("").astype(str).str.replace(r"<[^>]+>", "", regex=True)
+        logger.info(
+            "Leaderboard badges fallback query returned %s rows for players=%s club_id=%s.",
+            len(badges_flat),
+            target_player_ids,
+            str(ctx.club_id).strip(),
+        )
+        return badges_flat
+
     pb_df = getattr(ctx, "df_player_badges", None)
     badges_df = getattr(ctx, "df_badges", None)
 
@@ -212,71 +265,54 @@ def _fetch_leaderboard_badges(ctx, player_ids):
         if "club_id" in pb_copy.columns:
             pb_copy = pb_copy[pb_copy["club_id"] == str(ctx.club_id).strip()]
         pb_copy = pb_copy[pb_copy["player_id"].isin(normalized_player_ids)]
+        requested_ids = set(normalized_player_ids)
+        ctx_ids = set(pb_copy["player_id"].unique()) if "player_id" in pb_copy.columns else set()
+        missing_ids = sorted(requested_ids - ctx_ids)
+        logger.info(
+            "Leaderboard badges coverage check: requested_ids=%s ctx_ids=%s missing_ids=%s club_id=%s.",
+            sorted(requested_ids),
+            sorted(ctx_ids),
+            missing_ids,
+            str(ctx.club_id).strip(),
+        )
+
         if pb_copy.empty:
             logger.info(
                 "Leaderboard badges: ctx.df_player_badges had 0 rows for requested players=%s club_id=%s; using fallback query.",
                 normalized_player_ids,
                 str(ctx.club_id).strip(),
             )
+            merged = _fetch_badges_from_db(normalized_player_ids)
         else:
-            badges_defs = badges_df.copy()
-            if "badge_id" in badges_defs.columns:
-                badges_defs["badge_id"] = badges_defs["badge_id"].fillna("").astype(str).str.strip()
-            merged = pb_copy.merge(badges_defs, on="badge_id", how="left")
-            for col in ("name", "category", "icon_key", "rarity"):
-                if col in merged.columns:
-                    merged[col] = merged[col].fillna("").astype(str).str.replace(r"<[^>]+>", "", regex=True)
-            sort_cols = [col for col in ("player_id", "earned_at", "badge_id") if col in merged.columns]
-            if sort_cols:
-                merged = merged.sort_values(sort_cols, ascending=[True] * len(sort_cols)).reset_index(drop=True)
-            return merged
+            merged = pb_copy
+            if missing_ids:
+                fallback_missing = _fetch_badges_from_db(missing_ids)
+                if not fallback_missing.empty:
+                    merged = pd.concat([merged, fallback_missing], ignore_index=True, sort=False)
+                    dedupe_keys = [
+                        col
+                        for col in ("player_id", "badge_id", "earned_at", "context_id")
+                        if col in merged.columns
+                    ]
+                    if dedupe_keys:
+                        merged = merged.drop_duplicates(subset=dedupe_keys, keep="first")
 
-    try:
-        resp = (
-            ctx.supabase.table("player_badges")
-            .select(
-                "player_id,badge_id,earned_at,"
-                "badges:badges(badge_id,name,prestige,category,icon_key,rarity)"
-            )
-            .eq("club_id", str(ctx.club_id))
-            .in_("player_id", normalized_player_ids)
-            .execute()
-        )
-    except Exception:
-        logger.exception("Failed to fetch leaderboard badges")
-        return pd.DataFrame()
+        badges_defs = badges_df.copy()
+        if "badge_id" in badges_defs.columns:
+            badges_defs["badge_id"] = badges_defs["badge_id"].fillna("").astype(str).str.strip()
+        merged = merged.merge(badges_defs, on="badge_id", how="left")
+        for col in ("name", "category", "icon_key", "rarity"):
+            if col in merged.columns:
+                merged[col] = merged[col].fillna("").astype(str).str.replace(r"<[^>]+>", "", regex=True)
+        sort_cols = [col for col in ("player_id", "earned_at", "badge_id") if col in merged.columns]
+        if sort_cols:
+            merged = merged.sort_values(sort_cols, ascending=[True] * len(sort_cols)).reset_index(drop=True)
+        return merged
 
-    data = resp.data or []
-    if not data:
-        return pd.DataFrame()
-
-    badges_flat = pd.json_normalize(data, sep=".")
-    badges_flat = normalize_player_badges_frame(badges_flat)
-    if "badge_id" in badges_flat.columns and "badges.badge_id" in badges_flat.columns:
-        badges_flat = badges_flat.drop(columns=["badge_id"])
-    column_map = {
-        "badges.badge_id": "badge_id",
-        "badges.name": "name",
-        "badges.prestige": "prestige",
-        "badges.category": "category",
-        "badges.icon_key": "icon_key",
-        "badges.rarity": "rarity",
-    }
-    badges_flat = badges_flat.rename(columns=column_map)
-    if "badge_id" in badges_flat.columns:
-        badges_flat["badge_id"] = badges_flat["badge_id"].fillna("").astype(str).str.strip()
-    for col in ("name", "category", "icon_key", "rarity"):
-        if col in badges_flat.columns:
-            badges_flat[col] = badges_flat[col].fillna("").astype(str).str.replace(r"<[^>]+>", "", regex=True)
+    badges_flat = _fetch_badges_from_db(normalized_player_ids)
     sort_cols = [col for col in ("player_id", "earned_at", "badge_id") if col in badges_flat.columns]
     if sort_cols:
         badges_flat = badges_flat.sort_values(sort_cols, ascending=[True] * len(sort_cols)).reset_index(drop=True)
-    logger.info(
-        "Leaderboard badges fallback query returned %s rows for players=%s club_id=%s.",
-        len(badges_flat),
-        normalized_player_ids,
-        str(ctx.club_id).strip(),
-    )
     return badges_flat
 
 

--- a/tests/test_badge_render_data_paths.py
+++ b/tests/test_badge_render_data_paths.py
@@ -2,36 +2,46 @@ import pandas as pd
 
 from jupr_app.domain.gamification.profile import build_gamification_summary
 from jupr_app.ui.badge_data import normalize_player_badges_frame
-from jupr_app.ui.pages.leaderboards import _fetch_leaderboard_badges
+from jupr_app.ui.pages.leaderboards import _build_badge_map, _fetch_leaderboard_badges
 from jupr_app.ui.pages.players import get_player_trophy_case, resolve_player_badges_for_profile, select_featured_cuts
 
 
 class _SupabaseQueryStub:
-    def __init__(self, payload):
+    def __init__(self, payload, calls):
         self.payload = payload
+        self.calls = calls
+        self.filters = {}
 
     def select(self, _value):
         return self
 
-    def eq(self, _column, _value):
+    def eq(self, column, value):
+        self.filters[column] = value
         return self
 
-    def in_(self, _column, _value):
+    def in_(self, column, value):
+        self.filters[column] = list(value)
         return self
 
     def execute(self):
-        class _Resp:
+        self.calls.append(dict(self.filters))
+        in_players = self.filters.get("player_id")
+        if in_players is None:
             data = self.payload
+        else:
+            in_set = {int(v) for v in in_players}
+            data = [row for row in self.payload if int(row.get("player_id")) in in_set]
 
-        return _Resp()
+        return type("_Resp", (), {"data": data})()
 
 
 class _SupabaseStub:
     def __init__(self, payload):
         self.payload = payload
+        self.calls = []
 
     def table(self, _name):
-        return _SupabaseQueryStub(self.payload)
+        return _SupabaseQueryStub(self.payload, self.calls)
 
 
 class _Ctx:
@@ -87,6 +97,72 @@ def test_leaderboard_badges_falls_back_when_ctx_misses_visible_players():
     assert len(out) == 1
     assert int(out.iloc[0]["player_id"]) == 22
     assert out.iloc[0]["badge_id"] == "participant"
+
+
+def test_leaderboard_badges_complete_ctx_coverage_skips_fallback_query():
+    supabase = _SupabaseStub(payload=[])
+    ctx = _Ctx(
+        df_player_badges=pd.DataFrame(
+            [
+                {"club_id": "club-1", "player_id": 12, "badge_id": "participant", "earned_at": "2026-02-08T00:00:00Z"},
+                {"club_id": "club-1", "player_id": 22, "badge_id": "giant_slayer", "earned_at": "2026-02-09T00:00:00Z"},
+            ]
+        ),
+        df_badges=_badge_defs(),
+        supabase=supabase,
+    )
+
+    out = _fetch_leaderboard_badges(ctx, [12, 22])
+    assert set(out["player_id"].tolist()) == {12, 22}
+    assert supabase.calls == []
+
+
+def test_leaderboard_badges_partial_ctx_coverage_fetches_missing_only():
+    supabase = _SupabaseStub(
+        payload=[
+            {
+                "player_id": 22,
+                "badge_id": "participant",
+                "earned_at": "2026-02-08T00:00:00Z",
+                "badges": {"badge_id": "participant", "name": "Participant", "prestige": 5, "category": "Participation"},
+            },
+            {
+                "player_id": 33,
+                "badge_id": "giant_slayer",
+                "earned_at": "2026-02-08T00:00:00Z",
+                "badges": {"badge_id": "giant_slayer", "name": "Giant Slayer", "prestige": 75, "category": "Rivalries"},
+            },
+        ]
+    )
+    ctx = _Ctx(
+        df_player_badges=pd.DataFrame(
+            [{"club_id": "club-1", "player_id": 12, "badge_id": "participant", "earned_at": "2026-02-07T00:00:00Z"}]
+        ),
+        df_badges=_badge_defs(),
+        supabase=supabase,
+    )
+
+    out = _fetch_leaderboard_badges(ctx, [12, 22, 33])
+    assert set(out["player_id"].tolist()) == {12, 22, 33}
+    assert len(supabase.calls) == 1
+    assert set(supabase.calls[0]["player_id"]) == {22, 33}
+
+
+def test_leaderboard_badge_map_includes_single_badge_players_and_dedupes_duplicates():
+    merged = pd.DataFrame(
+        [
+            {"player_id": 101, "badge_id": "participant", "name": "Participant", "prestige": 5, "earned_at": "2026-02-08T00:00:00Z"},
+            {"player_id": 101, "badge_id": "participant", "name": "Participant", "prestige": 5, "earned_at": "2026-02-08T00:00:00Z"},
+            {"player_id": 102, "badge_id": "giant_slayer", "name": "Giant Slayer", "prestige": 75, "earned_at": "2026-02-09T00:00:00Z"},
+        ]
+    )
+
+    badge_map = _build_badge_map(merged)
+    assert 101 in badge_map
+    assert 102 in badge_map
+    assert len(badge_map[101]) == 1
+    assert badge_map[101][0].badge_id == "participant"
+    assert len(badge_map[102]) == 1
 
 
 def test_player_profile_summary_unlocked_badges_from_selected_player_rows():


### PR DESCRIPTION
### Motivation
- The leaderboard was only falling back to a direct DB query when `ctx.df_player_badges` returned zero rows overall, causing missing badge chips when `ctx` contained a partial subset of players (e.g., Joe/Ben present but Grace/Natasha/Dan/Don missing). 
- The change ensures all requested leaderboard players with badge rows are rendered by detecting and fetching any missing player IDs.

### Description
- Updated `_fetch_leaderboard_badges` to compute `requested_ids`, `ctx_ids`, and `missing_ids` after normalizing `ctx.df_player_badges`, and added logging for those sets. 
- Added a helper `_fetch_badges_from_db` that performs the Supabase query for a given list of player IDs, normalizes nested `badges:badges(...)` payloads, and preserves the prior flattening/cleanup behavior. 
- When `ctx` is partially covered, the code now queries only the `missing_ids`, concatenates the fallback rows with `ctx` rows, de-duplicates on `(player_id, badge_id, earned_at, context_id)` when available, then merges badge defs from `ctx.df_badges` and preserves existing sort order and limits. 
- Added/updated tests and enhanced Supabase test stubs to assert that fallback queries are scoped only to missing player IDs; files changed: `jupr_app/ui/pages/leaderboards.py` and `tests/test_badge_render_data_paths.py`.

### Testing
- Ran `pytest -q tests/test_badge_render_data_paths.py`, which passed (`8 passed`).
- New tests cover full-coverage `ctx.df_player_badges` (no fallback), partial-coverage (fetch missing IDs only), unioned results producing badges for all requested players, single-badge players (Grace-like case), and duplicate-row deduplication in the badge map.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e548a50aa4832693af9e6e2f143ebe)