### PR TITLE
Fix leaderboard badge map crash when prestige column is missing

### DIFF
--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -316,6 +316,17 @@ def _fetch_leaderboard_badges(ctx, player_ids):
     return badges_flat
 
 
+def _series_from_columns(
+    df: pd.DataFrame,
+    candidates: list[str],
+    default=None,
+) -> pd.Series:
+    for col in candidates:
+        if col in df.columns:
+            return df[col]
+    return pd.Series([default] * len(df), index=df.index)
+
+
 def _build_badge_map(badges_df: pd.DataFrame) -> dict[int, list[LeaderboardBadge]]:
     if badges_df is None or badges_df.empty:
         return {}
@@ -324,11 +335,27 @@ def _build_badge_map(badges_df: pd.DataFrame) -> dict[int, list[LeaderboardBadge
     if "badge_id" not in badge_rows.columns or "player_id" not in badge_rows.columns:
         return {}
 
-    earned_col = "earned_at" if "earned_at" in badge_rows.columns else "created_at"
     badge_rows["earned_at_dt"] = pd.to_datetime(
-        badge_rows.get(earned_col, None), utc=True, errors="coerce"
+        _series_from_columns(badge_rows, ["earned_at", "created_at"], default=None),
+        utc=True,
+        errors="coerce",
     )
-    badge_rows["prestige"] = pd.to_numeric(badge_rows.get("prestige", 0), errors="coerce").fillna(0)
+    badge_rows["prestige"] = pd.to_numeric(
+        _series_from_columns(
+            badge_rows,
+            ["prestige", "prestige_def", "badges.prestige"],
+            default=0,
+        ),
+        errors="coerce",
+    ).fillna(0)
+    badge_rows["name"] = _series_from_columns(badge_rows, ["name", "badges.name"], default="Badge")
+    badge_rows["category"] = _series_from_columns(
+        badge_rows, ["category", "badges.category"], default=""
+    )
+    badge_rows["icon_key"] = _series_from_columns(
+        badge_rows, ["icon_key", "badges.icon_key"], default=""
+    )
+    badge_rows["rarity"] = _series_from_columns(badge_rows, ["rarity", "badges.rarity"], default="")
 
     badge_rows = badge_rows.sort_values(
         ["player_id", "badge_id", "earned_at_dt"], ascending=[True, True, False]

--- a/tests/test_badge_render_data_paths.py
+++ b/tests/test_badge_render_data_paths.py
@@ -165,6 +165,73 @@ def test_leaderboard_badge_map_includes_single_badge_players_and_dedupes_duplica
     assert len(badge_map[102]) == 1
 
 
+def test_leaderboard_badge_map_missing_prestige_defaults_to_zero_without_crashing():
+    merged = pd.DataFrame(
+        [
+            {"player_id": 301, "badge_id": "participant", "name": "Participant", "earned_at": "2026-02-08T00:00:00Z"},
+        ]
+    )
+
+    badge_map = _build_badge_map(merged)
+    assert 301 in badge_map
+    assert len(badge_map[301]) == 1
+    assert badge_map[301][0].prestige == 0
+
+
+def test_leaderboard_badge_map_uses_normal_prestige_column_when_present():
+    merged = pd.DataFrame(
+        [
+            {"player_id": 302, "badge_id": "participant", "name": "Participant", "prestige": 5, "earned_at": "2026-02-08T00:00:00Z"},
+            {"player_id": 302, "badge_id": "giant_slayer", "name": "Giant Slayer", "prestige": 75, "earned_at": "2026-02-09T00:00:00Z"},
+        ]
+    )
+
+    badge_map = _build_badge_map(merged)
+    assert [badge.badge_id for badge in badge_map[302]] == ["giant_slayer", "participant"]
+    assert [badge.prestige for badge in badge_map[302]] == [75, 5]
+
+
+def test_leaderboard_badge_map_uses_suffix_style_prestige_column_when_available():
+    merged = pd.DataFrame(
+        [
+            {
+                "player_id": 303,
+                "badge_id": "participant",
+                "badges.name": "Participant",
+                "prestige_def": 11,
+                "created_at": "2026-02-08T00:00:00Z",
+            },
+            {
+                "player_id": 303,
+                "badge_id": "giant_slayer",
+                "badges.name": "Giant Slayer",
+                "prestige_def": 99,
+                "created_at": "2026-02-09T00:00:00Z",
+            },
+        ]
+    )
+
+    badge_map = _build_badge_map(merged)
+    assert [badge.badge_id for badge in badge_map[303]] == ["giant_slayer", "participant"]
+    assert [badge.prestige for badge in badge_map[303]] == [99, 11]
+    assert [badge.name for badge in badge_map[303]] == ["Giant Slayer", "Participant"]
+
+
+def test_leaderboard_badge_map_builds_from_minimal_row_shape():
+    merged = pd.DataFrame(
+        [
+            {"player_id": 304, "badge_id": "participant", "name": "Participant"},
+        ]
+    )
+
+    badge_map = _build_badge_map(merged)
+    assert 304 in badge_map
+    assert len(badge_map[304]) == 1
+    assert badge_map[304][0].badge_id == "participant"
+    assert badge_map[304][0].name == "Participant"
+    assert badge_map[304][0].prestige == 0
+
+
 def test_player_profile_summary_unlocked_badges_from_selected_player_rows():
     class _PlayerCtx:
         df_player_badges = pd.DataFrame(


### PR DESCRIPTION
### Motivation
- `_build_badge_map()` crashed when `badge_rows.get("prestige", 0)` returned a scalar `0` because scalars do not support `.fillna()`, causing leaderboard rendering failures when `prestige` is missing.
- The change must ensure the leaderboard never crashes if `prestige` (or similar merged/suffixed columns) is absent and preserve existing dedupe/sort fallback logic.

### Description
- Add a helper `def _series_from_columns(df, candidates, default=None) -> pd.Series:` in `jupr_app/ui/pages/leaderboards.py` that returns the first existing column as a `Series` or a `Series` full of the `default` value so a scalar is never returned.
- Use the helper in `_build_badge_map()` to extract `earned_at` (`["earned_at","created_at"]`), `prestige` (`["prestige","prestige_def","badges.prestige"]`), and optional text fields (`name`, `category`, `icon_key`, `rarity`) so suffix/merge variants are handled.
- Replace the fragile `pd.to_numeric(badge_rows.get("prestige", 0), ...).fillna(0)` pattern with a Series-based path that always allows `.fillna(0)` safely; keep dedupe by `(player_id, badge_id)` (most recent `earned_at_dt`) and sorting by `prestige` desc, `earned_at_dt` desc, `badge_id` asc.
- Changes made in `jupr_app/ui/pages/leaderboards.py` and tests added to `tests/test_badge_render_data_paths.py` to cover the requested scenarios.

### Testing
- Ran `pytest -q tests/test_badge_render_data_paths.py` and all tests passed with output `12 passed`.
- Added tests verify: (1) missing `prestige` defaults to `0` without crashing, (2) normal `prestige` column behavior is preserved, (3) suffix-style/alternate prestige columns (`prestige_def` / `badges.prestige`) are supported, and (4) minimal rows with `player_id`, `badge_id`, `name` still build a badge map.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e549dadd30832695ca2689bf89b42c)