### PR TITLE
Add admin Badge Audit page and scoped recompute safety rails

### DIFF
--- a/jupr_app/domain/gamification/badge_audit.py
+++ b/jupr_app/domain/gamification/badge_audit.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from types import SimpleNamespace
+from typing import Any, Iterable
+
+import pandas as pd
+
+from jupr_app.data.load import load_data
+from jupr_app.domain.gamification.badge_engine import compute_candidates_for_club
+
+
+KEY_FIELDS = ("player_id", "badge_id", "context_id")
+DETAIL_FIELDS = [
+    "id",
+    "club_id",
+    "player_id",
+    "badge_id",
+    "context_id",
+    "context_type",
+    "match_id",
+    "value_json",
+    "earned_at",
+    "revoked_at",
+    "awarded_by",
+    "rule_version",
+    "eval_run_id",
+]
+
+
+def build_badge_audit_report(
+    supabase: Any,
+    *,
+    club_id: str,
+    ctx: Any | None = None,
+    league_id: str | None = None,
+    player_id: int | None = None,
+    badge_id: str | None = None,
+    context_id: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    include_non_live: bool = False,
+    include_revoked: bool = False,
+    match_limit: int = 5000,
+) -> dict[str, Any]:
+    if ctx is None:
+        ctx = _load_ctx(supabase, club_id, match_limit)
+
+    scoped_ctx = _apply_match_filters(ctx, since=since, until=until)
+    expected_rows = _build_expected_rows(
+        club_id=club_id,
+        ctx=scoped_ctx,
+        league_id=league_id,
+        player_id=player_id,
+        badge_id=badge_id,
+        context_id=context_id,
+        include_non_live=include_non_live,
+    )
+    actual_rows = fetch_scoped_player_badges_rows(
+        supabase,
+        club_id=club_id,
+        player_id=player_id,
+        badge_id=badge_id,
+        context_id=context_id,
+    )
+
+    expected_keys = {_row_key(row) for row in expected_rows}
+    actual_active_rows = [row for row in actual_rows if row.get("revoked_at") is None]
+    revoked_rows = [row for row in actual_rows if row.get("revoked_at") is not None]
+    actual_active_keys = {_row_key(row) for row in actual_active_rows}
+    revoked_keys = {_row_key(row) for row in revoked_rows}
+
+    missing_keys = expected_keys - actual_active_keys
+    stale_keys = actual_active_keys - expected_keys
+
+    duplicate_groups = detect_duplicate_player_badges_rows(actual_rows)
+    duplicate_rows = [row for group in duplicate_groups for row in group.get("rows", [])]
+
+    missing_rows = [row for row in expected_rows if _row_key(row) in missing_keys]
+    stale_rows = [row for row in actual_active_rows if _row_key(row) in stale_keys]
+
+    detail_expected_rows = [project_detail_row(row) for row in expected_rows]
+    detail_actual_active_rows = [project_detail_row(row) for row in actual_active_rows]
+    detail_revoked_rows = [project_detail_row(row) for row in revoked_rows]
+
+    per_badge = summarize_per_badge(
+        expected_rows=expected_rows,
+        actual_active_rows=actual_active_rows,
+        missing_rows=missing_rows,
+        stale_rows=stale_rows,
+        duplicate_groups=duplicate_groups,
+    )
+
+    return {
+        "scope": {
+            "club_id": str(club_id),
+            "league_id": league_id,
+            "player_id": player_id,
+            "badge_id": badge_id,
+            "context_id": context_id,
+            "since": since,
+            "until": until,
+            "include_non_live": bool(include_non_live),
+            "include_revoked": bool(include_revoked),
+        },
+        "schema_degraded": bool(getattr(ctx, "schema_degraded", False)),
+        "schema_degraded_reason": getattr(ctx, "schema_degraded_reason", None),
+        "counts": {
+            "expected_count": len(expected_keys),
+            "actual_active_count": len(actual_active_keys),
+            "missing_count": len(missing_keys),
+            "stale_count": len(stale_keys),
+            "duplicate_count": len(duplicate_rows),
+            "duplicate_group_count": len(duplicate_groups),
+            "revoked_count": len(revoked_rows),
+            "revoked_key_count": len(revoked_keys),
+        },
+        "per_badge_summary": per_badge,
+        "missing_rows": [project_detail_row(row) for row in missing_rows],
+        "stale_rows": [project_detail_row(row) for row in stale_rows],
+        "duplicate_rows": [project_detail_row(row) for row in duplicate_rows],
+        "duplicate_groups": duplicate_groups,
+        "revoked_rows": detail_revoked_rows if include_revoked else [],
+        "actual_active_rows": detail_actual_active_rows,
+        "expected_rows": detail_expected_rows,
+        "expected_keys": sorted(expected_keys),
+        "actual_active_keys": sorted(actual_active_keys),
+        "revoked_keys": sorted(revoked_keys),
+        "missing_keys": sorted(missing_keys),
+        "stale_keys": sorted(stale_keys),
+    }
+
+
+def _load_ctx(supabase: Any, club_id: str, match_limit: int) -> Any:
+    (
+        df_players_all,
+        df_players_active,
+        df_leagues,
+        df_matches,
+        df_meta,
+        df_badges,
+        df_player_badges,
+        name_to_id,
+        id_to_name,
+        schema_degraded,
+        schema_degraded_reason,
+    ) = load_data(supabase, club_id, match_limit=match_limit)
+
+    return SimpleNamespace(
+        supabase=supabase,
+        club_id=club_id,
+        df_players_all=df_players_all,
+        df_players_active=df_players_active,
+        df_leagues=df_leagues,
+        df_meta=df_meta,
+        df_badges=df_badges,
+        df_matches=df_matches,
+        df_player_badges=df_player_badges,
+        name_to_id=name_to_id,
+        id_to_name=id_to_name,
+        public_mode=False,
+        admin_logged_in=True,
+        schema_degraded=schema_degraded,
+        schema_degraded_reason=schema_degraded_reason,
+    )
+
+
+def _apply_match_filters(ctx: Any, *, since: str | None, until: str | None) -> Any:
+    if not since and not until:
+        return ctx
+    df_matches = getattr(ctx, "df_matches", None)
+    if df_matches is None or df_matches.empty:
+        return ctx
+
+    df = df_matches.copy()
+    df["date_dt"] = pd.to_datetime(df.get("date"), utc=True, errors="coerce")
+    if since:
+        since_dt = pd.to_datetime(since, utc=True, errors="coerce")
+        df = df[df["date_dt"] >= since_dt]
+    if until:
+        until_dt = pd.to_datetime(until, utc=True, errors="coerce")
+        df = df[df["date_dt"] <= until_dt]
+
+    attrs = dict(vars(ctx)) if hasattr(ctx, "__dict__") else {}
+    attrs["df_matches"] = df.drop(columns=["date_dt"], errors="ignore")
+    return SimpleNamespace(**attrs)
+
+
+def _build_expected_rows(
+    *,
+    club_id: str,
+    ctx: Any,
+    league_id: str | None,
+    player_id: int | None,
+    badge_id: str | None,
+    context_id: str | None,
+    include_non_live: bool,
+) -> list[dict[str, Any]]:
+    candidates = compute_candidates_for_club(
+        club_id=club_id,
+        league_id=league_id,
+        ctx=ctx,
+        allow_non_live=include_non_live,
+    )
+    rows: list[dict[str, Any]] = []
+    for candidate in candidates:
+        row = {
+            "player_id": int(candidate.player_id),
+            "badge_id": str(candidate.badge_id),
+            "context_id": str(candidate.context_id),
+            "context_type": candidate.context_type,
+            "match_id": candidate.match_id,
+            "value_json": candidate.value_json,
+            "earned_at": None,
+            "revoked_at": None,
+            "awarded_by": "engine_expected",
+            "rule_version": None,
+            "eval_run_id": None,
+        }
+        if player_id is not None and int(row["player_id"]) != int(player_id):
+            continue
+        if badge_id is not None and str(row["badge_id"]) != str(badge_id):
+            continue
+        if context_id is not None and str(row["context_id"]) != str(context_id):
+            continue
+        rows.append(row)
+
+    deduped: dict[tuple[int, str, str], dict[str, Any]] = {}
+    for row in rows:
+        deduped[_row_key(row)] = row
+    return list(deduped.values())
+
+
+def fetch_scoped_player_badges_rows(
+    supabase: Any,
+    *,
+    club_id: str,
+    player_id: int | None = None,
+    badge_id: str | None = None,
+    context_id: str | None = None,
+) -> list[dict[str, Any]]:
+    query = (
+        supabase.table("player_badges")
+        .select(
+            "id,club_id,player_id,badge_id,context_id,context_type,match_id,value_json,"
+            "earned_at,revoked_at,awarded_by,rule_version,eval_run_id"
+        )
+        .eq("club_id", str(club_id))
+    )
+    if player_id is not None:
+        query = query.eq("player_id", int(player_id))
+    if badge_id is not None:
+        query = query.eq("badge_id", str(badge_id))
+    if context_id is not None:
+        query = query.eq("context_id", str(context_id))
+
+    resp = query.execute()
+    rows = []
+    for row in resp.data or []:
+        cleaned = dict(row)
+        cleaned["player_id"] = int(cleaned.get("player_id"))
+        cleaned["badge_id"] = str(cleaned.get("badge_id"))
+        cleaned["context_id"] = str(cleaned.get("context_id"))
+        rows.append(cleaned)
+    return rows
+
+
+def detect_duplicate_player_badges_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, int, str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        key = (
+            str(row.get("club_id") or ""),
+            int(row.get("player_id")),
+            str(row.get("badge_id")),
+            str(row.get("context_id")),
+        )
+        grouped[key].append(row)
+
+    duplicates: list[dict[str, Any]] = []
+    for key, key_rows in grouped.items():
+        if len(key_rows) <= 1:
+            continue
+        duplicates.append(
+            {
+                "club_id": key[0],
+                "player_id": key[1],
+                "badge_id": key[2],
+                "context_id": key[3],
+                "row_count": len(key_rows),
+                "rows": [project_detail_row(row) for row in key_rows],
+            }
+        )
+    return duplicates
+
+
+def summarize_per_badge(
+    *,
+    expected_rows: list[dict[str, Any]],
+    actual_active_rows: list[dict[str, Any]],
+    missing_rows: list[dict[str, Any]],
+    stale_rows: list[dict[str, Any]],
+    duplicate_groups: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    expected_counts = Counter(str(row.get("badge_id")) for row in expected_rows)
+    active_counts = Counter(str(row.get("badge_id")) for row in actual_active_rows)
+    missing_counts = Counter(str(row.get("badge_id")) for row in missing_rows)
+    stale_counts = Counter(str(row.get("badge_id")) for row in stale_rows)
+    duplicate_counts = Counter(
+        str(group.get("badge_id")) for group in duplicate_groups for _ in range(int(group.get("row_count", 0)))
+    )
+
+    all_badges = sorted(
+        set(expected_counts.keys())
+        | set(active_counts.keys())
+        | set(missing_counts.keys())
+        | set(stale_counts.keys())
+        | set(duplicate_counts.keys())
+    )
+    return [
+        {
+            "badge_id": badge,
+            "expected_count": int(expected_counts.get(badge, 0)),
+            "actual_active_count": int(active_counts.get(badge, 0)),
+            "missing_count": int(missing_counts.get(badge, 0)),
+            "stale_count": int(stale_counts.get(badge, 0)),
+            "duplicate_count": int(duplicate_counts.get(badge, 0)),
+        }
+        for badge in all_badges
+    ]
+
+
+def project_detail_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {field: row.get(field) for field in DETAIL_FIELDS}
+
+
+def _row_key(row: dict[str, Any]) -> tuple[int, str, str]:
+    return (int(row.get("player_id")), str(row.get("badge_id")), str(row.get("context_id")))

--- a/jupr_app/domain/gamification/recompute.py
+++ b/jupr_app/domain/gamification/recompute.py
@@ -32,13 +32,14 @@ def run_badge_recompute(
     allow_strict_global: bool = False,
     match_limit: int = 5000,
     ctx: Any | None = None,
+    include_non_live: bool = False,
 ) -> dict[str, Any]:
     if mode not in {"dry-run", "append-only", "strict"}:
         raise ValueError(f"Unsupported mode: {mode}")
 
     if mode == "strict" and not allow_strict_global:
-        if not any([badge_id, player_id, context_id]):
-            raise ValueError("Strict mode requires badge_id, player_id, or context_id unless allow_strict_global is set.")
+        if not _has_scope_filter(league_id=league_id, badge_id=badge_id, player_id=player_id, context_id=context_id):
+            raise ValueError("Strict mode requires badge_id, player_id, context_id, or league_id unless allow_strict_global is set.")
 
     scope = _build_scope(
         club_id=club_id,
@@ -63,6 +64,7 @@ def run_badge_recompute(
                 club_id=club_id,
                 league_id=league_id,
                 ctx=ctx,
+                allow_non_live=include_non_live,
             )
         )
         computed = _filter_candidates(
@@ -83,19 +85,23 @@ def run_badge_recompute(
         computed_keys = {(c.player_id, str(c.badge_id), str(c.context_id)) for c in computed}
 
         rule_version = rule_version or _compute_rule_version()
+        active_existing_keys = {row["key"] for row in existing_rows if row.get("revoked_at") is None}
+        missing_keys = computed_keys - active_existing_keys
+        stale_keys = active_existing_keys - computed_keys
+
         summary: dict[str, Any] = {
             "mode": mode,
             "scope": scope,
             "computed_count": len(computed_keys),
             "existing_count": len(existing_keys),
             "rule_version": rule_version,
+            "missing_count_candidate_scope": len(missing_keys),
+            "stale_count_candidate_scope": len(stale_keys),
         }
 
         if mode == "dry-run":
-            summary["new_awards_count"] = len(computed_keys - existing_keys)
-            summary["revoked_count"] = len(
-                [row for row in existing_rows if row["key"] not in computed_keys and row.get("revoked_at") is None]
-            )
+            summary["new_awards_count"] = len(missing_keys)
+            summary["revoked_count"] = len(stale_keys)
             _update_eval_run(supabase, eval_run_id, status="completed", finished_at=_now_iso(), summary=summary)
             return summary
 
@@ -313,3 +319,13 @@ def _update_eval_run(
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _has_scope_filter(
+    *,
+    league_id: str | None,
+    badge_id: str | None,
+    player_id: int | None,
+    context_id: str | None,
+) -> bool:
+    return any([league_id, badge_id, player_id, context_id])

--- a/jupr_app/ui/page_registry.py
+++ b/jupr_app/ui/page_registry.py
@@ -20,6 +20,7 @@ PAGE_DEFINITIONS: tuple[PageDefinition, ...] = (
     PageDefinition("players", "🔍 Player Search", public=True),
     PageDefinition("badge_codex", "📼 Badge Codex", public=True),
     PageDefinition("badge_debug", "🧪 Badge Debug", admin_only=True),
+    PageDefinition("badge_audit", "🧾 Badge Audit", admin_only=True),
     PageDefinition("challenge_ladder", "🪜 Challenge Ladder", public=True),
     PageDefinition("faqs", "❓ FAQs", public=True),
     PageDefinition("league_manager", "🏟️ League Manager", admin_only=True),

--- a/jupr_app/ui/pages/badge_audit.py
+++ b/jupr_app/ui/pages/badge_audit.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import streamlit as st
+
+from jupr_app.domain.gamification.badge_audit import build_badge_audit_report
+from jupr_app.domain.gamification.recompute import run_badge_recompute
+from jupr_app.ui.layout import page_shell
+
+
+def render(ctx):
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell("🧾 Badge Audit", "Audit and repair badge awards against the current engine.", mode_label=mode_label)
+
+    if not bool(getattr(ctx, "admin_logged_in", False)):
+        st.error("Admin login required.")
+        st.stop()
+
+    club_id = str(ctx.club_id)
+    defaults = {
+        "badge_id": "",
+        "player_id": "",
+        "league_id": "",
+        "context_id": "",
+        "since": "",
+        "until": "",
+        "include_non_live": False,
+        "include_revoked": False,
+    }
+    st.session_state.setdefault("badge_audit_filters", defaults)
+
+    with st.form("badge_audit_filters"):
+        st.caption(f"Club: {club_id}")
+        col1, col2, col3 = st.columns(3)
+
+        badge_options = [""] + _badge_options(ctx)
+        with col1:
+            badge_id = st.selectbox(
+                "Badge ID",
+                options=badge_options,
+                index=_safe_index(badge_options, st.session_state["badge_audit_filters"].get("badge_id", "")),
+                format_func=lambda v: "All" if not v else v,
+            )
+            player_options = [""] + _player_options(ctx)
+            saved_player = st.session_state["badge_audit_filters"].get("player_id", "")
+            saved_player_value = int(saved_player) if str(saved_player).strip().isdigit() else ""
+            player_id = st.selectbox(
+                "Player ID",
+                options=player_options,
+                index=_safe_index(player_options, saved_player_value),
+                format_func=lambda v: "All" if v == "" else str(v),
+            )
+
+        with col2:
+            league_id = st.selectbox(
+                "League ID",
+                options=[""] + _league_options(ctx),
+                index=_safe_index([""] + _league_options(ctx), st.session_state["badge_audit_filters"].get("league_id", "")),
+                format_func=lambda v: "All" if not v else v,
+            )
+            context_id = st.text_input("Context ID", value=st.session_state["badge_audit_filters"].get("context_id", ""))
+
+        with col3:
+            since = st.text_input("Since (optional)", value=st.session_state["badge_audit_filters"].get("since", ""))
+            until = st.text_input("Until (optional)", value=st.session_state["badge_audit_filters"].get("until", ""))
+
+        include_non_live = st.checkbox(
+            "Include non-live badges?",
+            value=bool(st.session_state["badge_audit_filters"].get("include_non_live", False)),
+        )
+        include_revoked = st.checkbox(
+            "Include revoked rows in detail?",
+            value=bool(st.session_state["badge_audit_filters"].get("include_revoked", False)),
+        )
+
+        run_audit = st.form_submit_button("Run Audit", type="primary")
+
+    if run_audit:
+        filters = {
+            "badge_id": badge_id or None,
+            "player_id": int(player_id) if str(player_id).strip() else None,
+            "league_id": league_id or None,
+            "context_id": context_id.strip() or None,
+            "since": since.strip() or None,
+            "until": until.strip() or None,
+            "include_non_live": bool(include_non_live),
+            "include_revoked": bool(include_revoked),
+        }
+        st.session_state["badge_audit_filters"] = {
+            "badge_id": badge_id,
+            "player_id": str(player_id),
+            "league_id": league_id,
+            "context_id": context_id,
+            "since": since,
+            "until": until,
+            "include_non_live": include_non_live,
+            "include_revoked": include_revoked,
+        }
+        with st.spinner("Running badge audit..."):
+            report = build_badge_audit_report(
+                ctx.supabase,
+                club_id=club_id,
+                ctx=ctx,
+                **filters,
+            )
+        st.session_state["badge_audit_report"] = report
+
+    report = st.session_state.get("badge_audit_report")
+    if not report:
+        st.info("Run an audit to view summary, details, and repair actions.")
+        return
+
+    counts = report.get("counts", {})
+    cols = st.columns(6)
+    cols[0].metric("Expected Active", int(counts.get("expected_count", 0)))
+    cols[1].metric("Actual Active", int(counts.get("actual_active_count", 0)))
+    cols[2].metric("Missing", int(counts.get("missing_count", 0)))
+    cols[3].metric("Stale", int(counts.get("stale_count", 0)))
+    cols[4].metric("Duplicates", int(counts.get("duplicate_count", 0)))
+    cols[5].metric("Revoked", int(counts.get("revoked_count", 0)))
+
+    if report.get("schema_degraded"):
+        st.warning(report.get("schema_degraded_reason") or "Schema degraded; badge details may be limited.")
+
+    st.subheader("Per-badge Summary")
+    st.dataframe(pd.DataFrame(report.get("per_badge_summary", [])), use_container_width=True, hide_index=True)
+
+    tab_missing, tab_stale, tab_duplicates, tab_revoked, tab_active, tab_expected = st.tabs(
+        ["Missing", "Stale", "Duplicates", "Revoked", "Actual Active", "Expected"]
+    )
+    with tab_missing:
+        st.dataframe(pd.DataFrame(report.get("missing_rows", [])), use_container_width=True, hide_index=True)
+    with tab_stale:
+        st.dataframe(pd.DataFrame(report.get("stale_rows", [])), use_container_width=True, hide_index=True)
+    with tab_duplicates:
+        st.dataframe(pd.DataFrame(report.get("duplicate_rows", [])), use_container_width=True, hide_index=True)
+        if report.get("duplicate_groups"):
+            st.caption("Duplicate groups")
+            st.json(report.get("duplicate_groups"))
+    with tab_revoked:
+        st.dataframe(pd.DataFrame(report.get("revoked_rows", [])), use_container_width=True, hide_index=True)
+    with tab_active:
+        st.dataframe(pd.DataFrame(report.get("actual_active_rows", [])), use_container_width=True, hide_index=True)
+    with tab_expected:
+        st.dataframe(pd.DataFrame(report.get("expected_rows", [])), use_container_width=True, hide_index=True)
+
+    st.subheader("Repair")
+    with st.form("badge_repair_form"):
+        mode = st.selectbox("Mode", ["dry-run", "append-only", "strict"], format_func=_format_mode)
+        created_by = st.text_input("Created by / operator note", value="")
+        allow_strict_global = st.checkbox("Allow strict global repair", value=False)
+        revoke_reason = st.text_input("Revoke reason", value="badge audit strict repair")
+
+        run_repair = st.form_submit_button("Run Repair", type="primary")
+
+    if run_repair:
+        scope = report.get("scope", {})
+        scope_for_run = {
+            "league_id": scope.get("league_id"),
+            "badge_id": scope.get("badge_id"),
+            "player_id": scope.get("player_id"),
+            "context_id": scope.get("context_id"),
+            "since": scope.get("since"),
+            "until": scope.get("until"),
+        }
+
+        strict_scope_present = any(scope_for_run.get(k) for k in ("league_id", "badge_id", "player_id", "context_id"))
+        if mode == "strict":
+            if not revoke_reason.strip():
+                st.error("Revoke reason is required for strict mode.")
+                st.stop()
+            if not strict_scope_present and not allow_strict_global:
+                st.error("Strict global repair is blocked unless you explicitly check 'Allow strict global repair'.")
+                st.stop()
+            if strict_scope_present and not scope.get("badge_id"):
+                st.warning("Strict repair on broad scopes can revoke many rows. Double-check your filters.")
+
+        with st.spinner("Running repair..."):
+            result = run_badge_recompute(
+                ctx.supabase,
+                club_id=club_id,
+                mode=mode,
+                league_id=scope_for_run["league_id"],
+                badge_id=scope_for_run["badge_id"],
+                player_id=scope_for_run["player_id"],
+                context_id=scope_for_run["context_id"],
+                since=scope_for_run["since"],
+                until=scope_for_run["until"],
+                include_non_live=bool(scope.get("include_non_live", False)),
+                created_by=created_by.strip() or None,
+                revoke_reason=revoke_reason.strip() or "badge audit strict repair",
+                allow_strict_global=bool(allow_strict_global),
+                ctx=ctx,
+            )
+        st.success("Repair completed.")
+        st.code(json.dumps(result, indent=2), language="json")
+        if mode in {"append-only", "strict"}:
+            st.session_state["force_data_refresh"] = True
+            st.rerun()
+
+
+def _badge_options(ctx) -> list[str]:
+    df_badges = getattr(ctx, "df_badges", pd.DataFrame())
+    if df_badges is None or df_badges.empty or "badge_id" not in df_badges.columns:
+        return []
+    return sorted(df_badges["badge_id"].dropna().astype(str).unique().tolist())
+
+
+def _league_options(ctx) -> list[str]:
+    df_meta = getattr(ctx, "df_meta", pd.DataFrame())
+    if df_meta is None or df_meta.empty or "league_name" not in df_meta.columns:
+        return []
+    return sorted(df_meta["league_name"].dropna().astype(str).unique().tolist())
+
+
+def _player_options(ctx) -> list[int]:
+    df_players = getattr(ctx, "df_players_all", pd.DataFrame())
+    if df_players is None or df_players.empty or "id" not in df_players.columns:
+        return []
+    return sorted(df_players["id"].dropna().astype(int).unique().tolist())
+
+
+def _safe_index(options: list, value):
+    try:
+        return options.index(value)
+    except Exception:
+        return 0
+
+
+def _format_mode(value: str) -> str:
+    mapping = {
+        "dry-run": "Dry run",
+        "append-only": "Append only",
+        "strict": "Strict",
+    }
+    return mapping.get(value, value)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -316,6 +316,7 @@ def main():
             admin_tools,
             badge_codex,
             badge_debug,
+            badge_audit,
             challenge_ladder,
             challenge_ladder_admin,
             faqs,
@@ -353,6 +354,7 @@ def main():
             "🔍 Player Search": players,
             "📼 Badge Codex": badge_codex,
             "🧪 Badge Debug": badge_debug,
+            "🧾 Badge Audit": badge_audit,
             "🪜 Challenge Ladder": challenge_ladder,
             "❓ FAQs": faqs,
             # Admin-only

--- a/tests/test_badge_audit.py
+++ b/tests/test_badge_audit.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+from jupr_app.domain.gamification.badge_audit import build_badge_audit_report
+from jupr_app.domain.gamification.badge_types import BadgeCandidate
+
+
+class FakeTable:
+    def __init__(self, storage, name):
+        self.storage = storage
+        self.name = name
+        self.filters = []
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, column, value):
+        self.filters.append(("eq", column, value))
+        return self
+
+    def execute(self):
+        data = list(self.storage.get(self.name, []))
+        for op, column, value in self.filters:
+            if op == "eq":
+                data = [row for row in data if str(row.get(column)) == str(value)]
+        return SimpleNamespace(data=data)
+
+
+class FakeSupabase:
+    def __init__(self, storage=None):
+        self.storage = storage if storage is not None else {}
+
+    def table(self, name):
+        return FakeTable(self.storage, name)
+
+
+def _ctx() -> SimpleNamespace:
+    return SimpleNamespace(
+        club_id="club",
+        df_matches=pd.DataFrame(),
+        df_players_all=pd.DataFrame(),
+        df_players_active=pd.DataFrame(),
+        df_leagues=pd.DataFrame(),
+        df_meta=pd.DataFrame(),
+        df_badges=pd.DataFrame([{"badge_id": "high_roller", "state": "live"}]),
+        df_player_badges=pd.DataFrame(),
+        schema_degraded=False,
+        schema_degraded_reason=None,
+    )
+
+
+def test_badge_audit_detects_stale_legacy_row(monkeypatch):
+    storage = {
+        "player_badges": [
+            {
+                "id": "pb1",
+                "club_id": "club",
+                "player_id": 10,
+                "badge_id": "high_roller",
+                "context_id": "match123:high_roller",
+                "revoked_at": None,
+            }
+        ]
+    }
+
+    monkeypatch.setattr(
+        "jupr_app.domain.gamification.badge_audit.compute_candidates_for_club",
+        lambda **kwargs: [],
+    )
+
+    report = build_badge_audit_report(FakeSupabase(storage), club_id="club", ctx=_ctx())
+    assert report["counts"]["stale_count"] == 1
+    assert report["per_badge_summary"][0]["badge_id"] == "high_roller"
+    assert report["per_badge_summary"][0]["stale_count"] == 1
+
+
+def test_badge_audit_detects_missing_row(monkeypatch):
+    candidate = BadgeCandidate(
+        badge_id="high_roller",
+        player_id=5,
+        club_id="club",
+        context_type="overall",
+        context_id="lifetime_wins_100",
+        match_id=None,
+        value_json={"wins": 120},
+    )
+    monkeypatch.setattr(
+        "jupr_app.domain.gamification.badge_audit.compute_candidates_for_club",
+        lambda **kwargs: [candidate],
+    )
+
+    report = build_badge_audit_report(FakeSupabase({"player_badges": []}), club_id="club", ctx=_ctx())
+    assert report["counts"]["missing_count"] == 1
+    assert report["per_badge_summary"][0]["badge_id"] == "high_roller"
+    assert report["per_badge_summary"][0]["missing_count"] == 1
+
+
+def test_badge_audit_detects_duplicates_and_revoked_not_active(monkeypatch):
+    storage = {
+        "player_badges": [
+            {
+                "id": "a1",
+                "club_id": "club",
+                "player_id": 1,
+                "badge_id": "participant",
+                "context_id": "overall",
+                "revoked_at": None,
+            },
+            {
+                "id": "a2",
+                "club_id": "club",
+                "player_id": 1,
+                "badge_id": "participant",
+                "context_id": "overall",
+                "revoked_at": "2026-01-01T00:00:00Z",
+            },
+        ]
+    }
+    monkeypatch.setattr(
+        "jupr_app.domain.gamification.badge_audit.compute_candidates_for_club",
+        lambda **kwargs: [],
+    )
+
+    report = build_badge_audit_report(FakeSupabase(storage), club_id="club", ctx=_ctx(), include_revoked=True)
+    assert report["counts"]["duplicate_count"] == 2
+    assert report["counts"]["revoked_count"] == 1
+    assert report["counts"]["actual_active_count"] == 1
+
+
+def test_badge_audit_include_non_live_passthrough(monkeypatch):
+    seen = {}
+
+    def _fake_compute(**kwargs):
+        seen["allow_non_live"] = kwargs.get("allow_non_live")
+        return []
+
+    monkeypatch.setattr("jupr_app.domain.gamification.badge_audit.compute_candidates_for_club", _fake_compute)
+
+    build_badge_audit_report(
+        FakeSupabase({"player_badges": []}),
+        club_id="club",
+        ctx=_ctx(),
+        include_non_live=False,
+    )
+    assert seen["allow_non_live"] is False
+
+    build_badge_audit_report(
+        FakeSupabase({"player_badges": []}),
+        club_id="club",
+        ctx=_ctx(),
+        include_non_live=True,
+    )
+    assert seen["allow_non_live"] is True

--- a/tests/test_badge_recompute.py
+++ b/tests/test_badge_recompute.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pandas as pd
+import pytest
 
 from jupr_app.domain.gamification.recompute import run_badge_recompute
 
@@ -201,3 +202,94 @@ def test_recompute_strict_revokes_missing():
     assert row.get("revoked_at")
     assert row.get("revoked_by") == "admin"
     assert row.get("revoke_reason") == "strict cleanup"
+
+
+def test_recompute_strict_global_blocked_without_scope():
+    supabase = FakeSupabase({})
+    with pytest.raises(ValueError, match="Strict mode requires"):
+        run_badge_recompute(
+            supabase,
+            club_id="club",
+            mode="strict",
+            ctx=_build_ctx(),
+            allow_strict_global=False,
+        )
+
+
+def test_recompute_append_only_does_not_revoke_stale_rows():
+    storage = {
+        "player_badges": [
+            {
+                "id": "legacy1",
+                "club_id": "club",
+                "player_id": 99,
+                "badge_id": "participant",
+                "context_id": "overall",
+                "revoked_at": None,
+            }
+        ]
+    }
+    supabase = FakeSupabase(storage)
+    run_badge_recompute(
+        supabase,
+        club_id="club",
+        mode="append-only",
+        ctx=_build_ctx(),
+        badge_id="participant",
+        allow_strict_global=True,
+    )
+    stale = next(row for row in storage["player_badges"] if row["id"] == "legacy1")
+    assert stale.get("revoked_at") is None
+
+
+def test_recompute_strict_scoped_to_badge_id_only():
+    storage = {
+        "player_badges": [
+            {
+                "id": "legacy-high",
+                "club_id": "club",
+                "player_id": 7,
+                "badge_id": "high_roller",
+                "context_id": "legacy",
+                "revoked_at": None,
+            },
+            {
+                "id": "keep-other",
+                "club_id": "club",
+                "player_id": 7,
+                "badge_id": "participant",
+                "context_id": "overall",
+                "revoked_at": None,
+            },
+        ]
+    }
+    supabase = FakeSupabase(storage)
+    ctx = SimpleNamespace(
+        supabase=None,
+        club_id="club",
+        df_matches=pd.DataFrame(),
+        df_players_all=pd.DataFrame(),
+        df_leagues=pd.DataFrame(),
+        df_meta=pd.DataFrame(),
+        df_badges=pd.DataFrame([
+            {"badge_id": "high_roller", "state": "live"},
+            {"badge_id": "participant", "state": "live"},
+        ]),
+        df_player_badges=pd.DataFrame(),
+        name_to_id={},
+        id_to_name={},
+        public_mode=False,
+        admin_logged_in=True,
+    )
+    run_badge_recompute(
+        supabase,
+        club_id="club",
+        mode="strict",
+        ctx=ctx,
+        badge_id="high_roller",
+        allow_strict_global=False,
+    )
+    legacy = next(row for row in storage["player_badges"] if row["id"] == "legacy-high")
+    untouched = next(row for row in storage["player_badges"] if row["id"] == "keep-other")
+    assert legacy.get("revoked_at") is not None
+    assert untouched.get("revoked_at") is None


### PR DESCRIPTION
### Motivation

- Provide an admin-only audit + repair workflow to detect legacy/stale/duplicate player_badges and reconcile them against the CURRENT badge engine rather than inventing alternate badge logic.
- Make repairs safe and scoped so operators can run dry-run/append-only/strict repairs without risking an accidental global destructive revocation. 

### Description

- Add a new domain audit module `jupr_app/domain/gamification/badge_audit.py` exposing `build_badge_audit_report(...)` which loads or reuses a `ctx`, computes expected candidates via the current engine, fetches scoped `player_badges` rows, and returns summary counts and row-level details (missing, stale, revoked, duplicates, per-badge rollups, and detail rows).
- Tighten `run_badge_recompute(...)` in `jupr_app/domain/gamification/recompute.py` by adding an `include_non_live` passthrough, returning `missing_count_candidate_scope` and `stale_count_candidate_scope`, and enforcing that `strict` mode requires a scope selector (`league_id`, `badge_id`, `player_id`, or `context_id`) unless `allow_strict_global=True`, while preserving `dry-run`/`append-only` semantics and ensuring revocations are scoped.
- Add an admin-only Streamlit page `jupr_app/ui/pages/badge_audit.py` (label: "🧾 Badge Audit") and wire it into `jupr_app/ui/page_registry.py` and `streamlit_app.py`; the page is form-first, shows summary and detail tabs (Missing, Stale, Duplicates, Revoked, Actual Active, Expected), and provides an explicit Repair form supporting Dry run, Append-only, and Strict with UI safety checks and explicit revoke-reason and allow-strict-global guard.
- Report duplicates robustly but do not perform destructive dedupe in this PR (audit-first); reuse `compute_candidates_for_club` and `upsert_player_badges` instead of reimplementing badge logic.

### Testing

- Ran unit tests: `pytest -q tests/test_badge_audit.py tests/test_badge_recompute.py tests/test_page_registry.py tests/test_imports.py` and all tests passed (14 passed).
- Verified compilation of new modules with `python -m compileall` and ran targeted smoke checks during development; UI wiring was exercised in test harnesses (no external browser screenshots taken).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e551583ba08326b8f4a18d45f83622)