### PR TITLE
Badge audit: add soft-match layer and context-drift reporting; scope actual rows to live badge universe

### DIFF
--- a/jupr_app/domain/gamification/badge_audit.py
+++ b/jupr_app/domain/gamification/badge_audit.py
@@ -6,8 +6,10 @@ from typing import Any, Iterable
 
 import pandas as pd
 
+from jupr_app.domain.gamification.badge_catalog import BADGE_DEFINITIONS
 from jupr_app.data.load import load_data
 from jupr_app.domain.gamification.badge_engine import compute_candidates_for_club
+from jupr_app.domain.gamification.badge_registry import is_badge_active, registry
 
 
 KEY_FIELDS = ("player_id", "badge_id", "context_id")
@@ -63,21 +65,32 @@ def build_badge_audit_report(
         badge_id=badge_id,
         context_id=context_id,
     )
+    comparable_badge_ids = _comparable_badge_ids(ctx, include_non_live=include_non_live)
+    if not include_non_live:
+        actual_rows = [row for row in actual_rows if str(row.get("badge_id")) in comparable_badge_ids]
 
-    expected_keys = {_row_key(row) for row in expected_rows}
+    expected_exact_keys = {_row_key(row) for row in expected_rows}
+    expected_soft_keys = {_soft_key(row) for row in expected_rows}
     actual_active_rows = [row for row in actual_rows if row.get("revoked_at") is None]
     revoked_rows = [row for row in actual_rows if row.get("revoked_at") is not None]
-    actual_active_keys = {_row_key(row) for row in actual_active_rows}
+    actual_active_exact_keys = {_row_key(row) for row in actual_active_rows}
+    actual_active_soft_keys = {_soft_key(row) for row in actual_active_rows}
     revoked_keys = {_row_key(row) for row in revoked_rows}
 
-    missing_keys = expected_keys - actual_active_keys
-    stale_keys = actual_active_keys - expected_keys
+    missing_exact_keys = expected_exact_keys - actual_active_exact_keys
+    stale_exact_keys = actual_active_exact_keys - expected_exact_keys
+    missing_soft_keys = expected_soft_keys - actual_active_soft_keys
+    stale_soft_keys = actual_active_soft_keys - expected_soft_keys
 
     duplicate_groups = detect_duplicate_player_badges_rows(actual_rows)
     duplicate_rows = [row for group in duplicate_groups for row in group.get("rows", [])]
 
-    missing_rows = [row for row in expected_rows if _row_key(row) in missing_keys]
-    stale_rows = [row for row in actual_active_rows if _row_key(row) in stale_keys]
+    missing_rows = [row for row in expected_rows if _row_key(row) in missing_exact_keys]
+    stale_rows = [row for row in actual_active_rows if _row_key(row) in stale_exact_keys]
+    context_drift_rows = build_context_drift_rows(expected_rows=expected_rows, actual_active_rows=actual_active_rows)
+    context_drift_exact_row_count = sum(
+        int(row.get("expected_rows", 0)) + int(row.get("actual_rows", 0)) for row in context_drift_rows
+    )
 
     detail_expected_rows = [project_detail_row(row) for row in expected_rows]
     detail_actual_active_rows = [project_detail_row(row) for row in actual_active_rows]
@@ -88,8 +101,14 @@ def build_badge_audit_report(
         actual_active_rows=actual_active_rows,
         missing_rows=missing_rows,
         stale_rows=stale_rows,
+        missing_soft_keys=missing_soft_keys,
+        stale_soft_keys=stale_soft_keys,
+        context_drift_rows=context_drift_rows,
         duplicate_groups=duplicate_groups,
     )
+
+    missing_soft_rows = [row for row in expected_rows if _soft_key(row) in missing_soft_keys]
+    stale_soft_rows = [row for row in actual_active_rows if _soft_key(row) in stale_soft_keys]
 
     return {
         "scope": {
@@ -106,28 +125,51 @@ def build_badge_audit_report(
         "schema_degraded": bool(getattr(ctx, "schema_degraded", False)),
         "schema_degraded_reason": getattr(ctx, "schema_degraded_reason", None),
         "counts": {
-            "expected_count": len(expected_keys),
-            "actual_active_count": len(actual_active_keys),
-            "missing_count": len(missing_keys),
-            "stale_count": len(stale_keys),
+            "expected_exact_count": len(expected_exact_keys),
+            "actual_active_exact_count": len(actual_active_exact_keys),
+            "missing_exact_count": len(missing_exact_keys),
+            "stale_exact_count": len(stale_exact_keys),
+            "expected_soft_count": len(expected_soft_keys),
+            "actual_active_soft_count": len(actual_active_soft_keys),
+            "missing_soft_count": len(missing_soft_keys),
+            "stale_soft_count": len(stale_soft_keys),
+            "context_drift_soft_key_count": len(context_drift_rows),
+            "context_drift_exact_row_count": context_drift_exact_row_count,
             "duplicate_count": len(duplicate_rows),
             "duplicate_group_count": len(duplicate_groups),
             "revoked_count": len(revoked_rows),
             "revoked_key_count": len(revoked_keys),
+            # Backward-compat aliases (explicitly mapped to exact semantics)
+            "expected_count": len(expected_exact_keys),
+            "actual_active_count": len(actual_active_exact_keys),
+            "missing_count": len(missing_exact_keys),
+            "stale_count": len(stale_exact_keys),
         },
         "per_badge_summary": per_badge,
         "missing_rows": [project_detail_row(row) for row in missing_rows],
         "stale_rows": [project_detail_row(row) for row in stale_rows],
+        "missing_soft_rows": [project_detail_row(row) for row in missing_soft_rows],
+        "stale_soft_rows": [project_detail_row(row) for row in stale_soft_rows],
+        "context_drift_rows": context_drift_rows,
         "duplicate_rows": [project_detail_row(row) for row in duplicate_rows],
         "duplicate_groups": duplicate_groups,
         "revoked_rows": detail_revoked_rows if include_revoked else [],
         "actual_active_rows": detail_actual_active_rows,
         "expected_rows": detail_expected_rows,
-        "expected_keys": sorted(expected_keys),
-        "actual_active_keys": sorted(actual_active_keys),
+        "expected_exact_keys": sorted(expected_exact_keys),
+        "actual_active_exact_keys": sorted(actual_active_exact_keys),
+        "expected_soft_keys": sorted(expected_soft_keys),
+        "actual_active_soft_keys": sorted(actual_active_soft_keys),
         "revoked_keys": sorted(revoked_keys),
-        "missing_keys": sorted(missing_keys),
-        "stale_keys": sorted(stale_keys),
+        "missing_exact_keys": sorted(missing_exact_keys),
+        "stale_exact_keys": sorted(stale_exact_keys),
+        "missing_soft_keys": sorted(missing_soft_keys),
+        "stale_soft_keys": sorted(stale_soft_keys),
+        # Backward-compat aliases (explicitly mapped to exact semantics)
+        "expected_keys": sorted(expected_exact_keys),
+        "actual_active_keys": sorted(actual_active_exact_keys),
+        "missing_keys": sorted(missing_exact_keys),
+        "stale_keys": sorted(stale_exact_keys),
     }
 
 
@@ -299,31 +341,54 @@ def summarize_per_badge(
     actual_active_rows: list[dict[str, Any]],
     missing_rows: list[dict[str, Any]],
     stale_rows: list[dict[str, Any]],
+    missing_soft_keys: set[tuple[int, str]],
+    stale_soft_keys: set[tuple[int, str]],
+    context_drift_rows: list[dict[str, Any]],
     duplicate_groups: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    expected_counts = Counter(str(row.get("badge_id")) for row in expected_rows)
-    active_counts = Counter(str(row.get("badge_id")) for row in actual_active_rows)
-    missing_counts = Counter(str(row.get("badge_id")) for row in missing_rows)
-    stale_counts = Counter(str(row.get("badge_id")) for row in stale_rows)
+    expected_exact_counts = Counter(str(row.get("badge_id")) for row in expected_rows)
+    active_exact_counts = Counter(str(row.get("badge_id")) for row in actual_active_rows)
+    missing_exact_counts = Counter(str(row.get("badge_id")) for row in missing_rows)
+    stale_exact_counts = Counter(str(row.get("badge_id")) for row in stale_rows)
+    expected_soft_counts = Counter(str(badge_id) for _, badge_id in {_soft_key(row) for row in expected_rows})
+    active_soft_counts = Counter(str(badge_id) for _, badge_id in {_soft_key(row) for row in actual_active_rows})
+    missing_soft_counts = Counter(str(badge_id) for _, badge_id in missing_soft_keys)
+    stale_soft_counts = Counter(str(badge_id) for _, badge_id in stale_soft_keys)
+    context_drift_counts = Counter(str(row.get("badge_id")) for row in context_drift_rows)
     duplicate_counts = Counter(
         str(group.get("badge_id")) for group in duplicate_groups for _ in range(int(group.get("row_count", 0)))
     )
 
     all_badges = sorted(
-        set(expected_counts.keys())
-        | set(active_counts.keys())
-        | set(missing_counts.keys())
-        | set(stale_counts.keys())
+        set(expected_exact_counts.keys())
+        | set(active_exact_counts.keys())
+        | set(missing_exact_counts.keys())
+        | set(stale_exact_counts.keys())
+        | set(expected_soft_counts.keys())
+        | set(active_soft_counts.keys())
+        | set(missing_soft_counts.keys())
+        | set(stale_soft_counts.keys())
+        | set(context_drift_counts.keys())
         | set(duplicate_counts.keys())
     )
     return [
         {
             "badge_id": badge,
-            "expected_count": int(expected_counts.get(badge, 0)),
-            "actual_active_count": int(active_counts.get(badge, 0)),
-            "missing_count": int(missing_counts.get(badge, 0)),
-            "stale_count": int(stale_counts.get(badge, 0)),
+            "expected_exact_count": int(expected_exact_counts.get(badge, 0)),
+            "actual_active_exact_count": int(active_exact_counts.get(badge, 0)),
+            "missing_exact_count": int(missing_exact_counts.get(badge, 0)),
+            "stale_exact_count": int(stale_exact_counts.get(badge, 0)),
+            "expected_soft_count": int(expected_soft_counts.get(badge, 0)),
+            "actual_active_soft_count": int(active_soft_counts.get(badge, 0)),
+            "missing_soft_count": int(missing_soft_counts.get(badge, 0)),
+            "stale_soft_count": int(stale_soft_counts.get(badge, 0)),
+            "context_drift_count": int(context_drift_counts.get(badge, 0)),
             "duplicate_count": int(duplicate_counts.get(badge, 0)),
+            # Backward-compat aliases (explicitly mapped to exact semantics)
+            "expected_count": int(expected_exact_counts.get(badge, 0)),
+            "actual_active_count": int(active_exact_counts.get(badge, 0)),
+            "missing_count": int(missing_exact_counts.get(badge, 0)),
+            "stale_count": int(stale_exact_counts.get(badge, 0)),
         }
         for badge in all_badges
     ]
@@ -335,3 +400,68 @@ def project_detail_row(row: dict[str, Any]) -> dict[str, Any]:
 
 def _row_key(row: dict[str, Any]) -> tuple[int, str, str]:
     return (int(row.get("player_id")), str(row.get("badge_id")), str(row.get("context_id")))
+
+
+def _soft_key(row: dict[str, Any]) -> tuple[int, str]:
+    return (int(row.get("player_id")), str(row.get("badge_id")))
+
+
+def _live_badge_ids_from_ctx(ctx: Any | None) -> set[str]:
+    default_state_map = {badge.badge_id: badge.state for badge in BADGE_DEFINITIONS}
+    if ctx is None:
+        state_map = default_state_map
+    else:
+        df_badges = getattr(ctx, "df_badges", None)
+        if df_badges is None or getattr(df_badges, "empty", True) or "badge_id" not in df_badges.columns:
+            state_map = default_state_map
+        elif "state" not in df_badges.columns:
+            state_map = {str(badge_id): "live" for badge_id in df_badges["badge_id"].dropna().astype(str).unique()}
+        else:
+            state_map = {
+                str(row.badge_id): str(getattr(row, "state", "") or "live")
+                for row in df_badges.itertuples(index=False)
+            }
+    return {badge_id for badge_id, state in state_map.items() if str(state).strip().lower() == "live"}
+
+
+def _comparable_badge_ids(ctx: Any | None, *, include_non_live: bool) -> set[str]:
+    if include_non_live:
+        return set()
+    live_ids = _live_badge_ids_from_ctx(ctx)
+    return {
+        str(spec.badge_id)
+        for spec in registry().values()
+        if str(spec.badge_id) in live_ids and is_badge_active(str(spec.badge_id), status="live", award_timing="live")
+    }
+
+
+def build_context_drift_rows(
+    *,
+    expected_rows: list[dict[str, Any]],
+    actual_active_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    expected_by_soft: dict[tuple[int, str], list[dict[str, Any]]] = defaultdict(list)
+    actual_by_soft: dict[tuple[int, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in expected_rows:
+        expected_by_soft[_soft_key(row)].append(row)
+    for row in actual_active_rows:
+        actual_by_soft[_soft_key(row)].append(row)
+
+    context_drift_rows: list[dict[str, Any]] = []
+    shared_soft_keys = set(expected_by_soft.keys()) & set(actual_by_soft.keys())
+    for soft_key in sorted(shared_soft_keys):
+        expected_context_ids = sorted({str(row.get("context_id")) for row in expected_by_soft[soft_key]})
+        actual_context_ids = sorted({str(row.get("context_id")) for row in actual_by_soft[soft_key]})
+        if expected_context_ids == actual_context_ids:
+            continue
+        context_drift_rows.append(
+            {
+                "player_id": int(soft_key[0]),
+                "badge_id": str(soft_key[1]),
+                "expected_context_ids": expected_context_ids,
+                "actual_context_ids": actual_context_ids,
+                "expected_rows": len(expected_by_soft[soft_key]),
+                "actual_rows": len(actual_by_soft[soft_key]),
+            }
+        )
+    return context_drift_rows

--- a/jupr_app/ui/pages/badge_audit.py
+++ b/jupr_app/ui/pages/badge_audit.py
@@ -118,13 +118,30 @@ def render(ctx):
         return
 
     counts = report.get("counts", {})
-    cols = st.columns(6)
-    cols[0].metric("Expected Active", int(counts.get("expected_count", 0)))
-    cols[1].metric("Actual Active", int(counts.get("actual_active_count", 0)))
-    cols[2].metric("Missing", int(counts.get("missing_count", 0)))
-    cols[3].metric("Stale", int(counts.get("stale_count", 0)))
-    cols[4].metric("Duplicates", int(counts.get("duplicate_count", 0)))
-    cols[5].metric("Revoked", int(counts.get("revoked_count", 0)))
+    st.caption(
+        "Exact = strict player_id + badge_id + context_id. "
+        "Soft = player_id + badge_id only. "
+        "Context Drift = same player+badge exists on both sides but context_ids differ."
+    )
+    st.markdown("**Exact Match**")
+    exact_cols = st.columns(4)
+    exact_cols[0].metric("Expected Exact", int(counts.get("expected_exact_count", 0)))
+    exact_cols[1].metric("Actual Exact", int(counts.get("actual_active_exact_count", 0)))
+    exact_cols[2].metric("Missing Exact", int(counts.get("missing_exact_count", 0)))
+    exact_cols[3].metric("Stale Exact", int(counts.get("stale_exact_count", 0)))
+
+    st.markdown("**Soft Match**")
+    soft_cols = st.columns(5)
+    soft_cols[0].metric("Expected Soft", int(counts.get("expected_soft_count", 0)))
+    soft_cols[1].metric("Actual Soft", int(counts.get("actual_active_soft_count", 0)))
+    soft_cols[2].metric("Missing Soft", int(counts.get("missing_soft_count", 0)))
+    soft_cols[3].metric("Stale Soft", int(counts.get("stale_soft_count", 0)))
+    soft_cols[4].metric("Context Drift", int(counts.get("context_drift_soft_key_count", 0)))
+
+    diag_cols = st.columns(3)
+    diag_cols[0].metric("Context Drift Rows", int(counts.get("context_drift_exact_row_count", 0)))
+    diag_cols[1].metric("Duplicates", int(counts.get("duplicate_count", 0)))
+    diag_cols[2].metric("Revoked", int(counts.get("revoked_count", 0)))
 
     if report.get("schema_degraded"):
         st.warning(report.get("schema_degraded_reason") or "Schema degraded; badge details may be limited.")
@@ -132,13 +149,15 @@ def render(ctx):
     st.subheader("Per-badge Summary")
     st.dataframe(pd.DataFrame(report.get("per_badge_summary", [])), use_container_width=True, hide_index=True)
 
-    tab_missing, tab_stale, tab_duplicates, tab_revoked, tab_active, tab_expected = st.tabs(
-        ["Missing", "Stale", "Duplicates", "Revoked", "Actual Active", "Expected"]
+    tab_missing, tab_stale, tab_context_drift, tab_duplicates, tab_revoked, tab_active, tab_expected = st.tabs(
+        ["Missing Exact", "Stale Exact", "Context Drift", "Duplicates", "Revoked", "Actual Active", "Expected"]
     )
     with tab_missing:
         st.dataframe(pd.DataFrame(report.get("missing_rows", [])), use_container_width=True, hide_index=True)
     with tab_stale:
         st.dataframe(pd.DataFrame(report.get("stale_rows", [])), use_container_width=True, hide_index=True)
+    with tab_context_drift:
+        st.dataframe(pd.DataFrame(report.get("context_drift_rows", [])), use_container_width=True, hide_index=True)
     with tab_duplicates:
         st.dataframe(pd.DataFrame(report.get("duplicate_rows", [])), use_container_width=True, hide_index=True)
         if report.get("duplicate_groups"):

--- a/tests/test_badge_audit.py
+++ b/tests/test_badge_audit.py
@@ -52,29 +52,42 @@ def _ctx() -> SimpleNamespace:
     )
 
 
-def test_badge_audit_detects_stale_legacy_row(monkeypatch):
+def test_badge_audit_soft_match_context_drift(monkeypatch):
     storage = {
         "player_badges": [
             {
                 "id": "pb1",
                 "club_id": "club",
-                "player_id": 10,
+                "player_id": 7,
                 "badge_id": "high_roller",
-                "context_id": "match123:high_roller",
+                "context_id": "old_match_rule_context",
                 "revoked_at": None,
             }
         ]
     }
+    candidate = BadgeCandidate(
+        badge_id="high_roller",
+        player_id=7,
+        club_id="club",
+        context_type="overall",
+        context_id="lifetime_wins_100",
+        match_id=None,
+        value_json={"wins": 120},
+    )
 
     monkeypatch.setattr(
         "jupr_app.domain.gamification.badge_audit.compute_candidates_for_club",
-        lambda **kwargs: [],
+        lambda **kwargs: [candidate],
     )
 
     report = build_badge_audit_report(FakeSupabase(storage), club_id="club", ctx=_ctx())
-    assert report["counts"]["stale_count"] == 1
+    assert report["counts"]["missing_exact_count"] == 1
+    assert report["counts"]["stale_exact_count"] == 1
+    assert report["counts"]["missing_soft_count"] == 0
+    assert report["counts"]["stale_soft_count"] == 0
+    assert report["counts"]["context_drift_soft_key_count"] == 1
     assert report["per_badge_summary"][0]["badge_id"] == "high_roller"
-    assert report["per_badge_summary"][0]["stale_count"] == 1
+    assert report["per_badge_summary"][0]["context_drift_count"] == 1
 
 
 def test_badge_audit_detects_missing_row(monkeypatch):
@@ -93,9 +106,34 @@ def test_badge_audit_detects_missing_row(monkeypatch):
     )
 
     report = build_badge_audit_report(FakeSupabase({"player_badges": []}), club_id="club", ctx=_ctx())
-    assert report["counts"]["missing_count"] == 1
+    assert report["counts"]["missing_exact_count"] == 1
+    assert report["counts"]["missing_soft_count"] == 1
     assert report["per_badge_summary"][0]["badge_id"] == "high_roller"
-    assert report["per_badge_summary"][0]["missing_count"] == 1
+    assert report["per_badge_summary"][0]["missing_exact_count"] == 1
+    assert report["per_badge_summary"][0]["missing_soft_count"] == 1
+
+
+def test_badge_audit_detects_true_stale_on_both_layers(monkeypatch):
+    storage = {
+        "player_badges": [
+            {
+                "id": "pb1",
+                "club_id": "club",
+                "player_id": 9,
+                "badge_id": "high_roller",
+                "context_id": "legacy_context",
+                "revoked_at": None,
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        "jupr_app.domain.gamification.badge_audit.compute_candidates_for_club",
+        lambda **kwargs: [],
+    )
+
+    report = build_badge_audit_report(FakeSupabase(storage), club_id="club", ctx=_ctx())
+    assert report["counts"]["stale_exact_count"] == 1
+    assert report["counts"]["stale_soft_count"] == 1
 
 
 def test_badge_audit_detects_duplicates_and_revoked_not_active(monkeypatch):
@@ -105,7 +143,7 @@ def test_badge_audit_detects_duplicates_and_revoked_not_active(monkeypatch):
                 "id": "a1",
                 "club_id": "club",
                 "player_id": 1,
-                "badge_id": "participant",
+                "badge_id": "high_roller",
                 "context_id": "overall",
                 "revoked_at": None,
             },
@@ -113,7 +151,7 @@ def test_badge_audit_detects_duplicates_and_revoked_not_active(monkeypatch):
                 "id": "a2",
                 "club_id": "club",
                 "player_id": 1,
-                "badge_id": "participant",
+                "badge_id": "high_roller",
                 "context_id": "overall",
                 "revoked_at": "2026-01-01T00:00:00Z",
             },
@@ -127,7 +165,7 @@ def test_badge_audit_detects_duplicates_and_revoked_not_active(monkeypatch):
     report = build_badge_audit_report(FakeSupabase(storage), club_id="club", ctx=_ctx(), include_revoked=True)
     assert report["counts"]["duplicate_count"] == 2
     assert report["counts"]["revoked_count"] == 1
-    assert report["counts"]["actual_active_count"] == 1
+    assert report["counts"]["actual_active_exact_count"] == 1
 
 
 def test_badge_audit_include_non_live_passthrough(monkeypatch):
@@ -154,3 +192,43 @@ def test_badge_audit_include_non_live_passthrough(monkeypatch):
         include_non_live=True,
     )
     assert seen["allow_non_live"] is True
+
+
+def test_badge_audit_filters_non_live_actual_rows_by_default(monkeypatch):
+    storage = {
+        "player_badges": [
+            {
+                "id": "l1",
+                "club_id": "club",
+                "player_id": 1,
+                "badge_id": "high_roller",
+                "context_id": "overall",
+                "revoked_at": None,
+            },
+            {
+                "id": "n1",
+                "club_id": "club",
+                "player_id": 1,
+                "badge_id": "manual_only",
+                "context_id": "admin_manual",
+                "revoked_at": None,
+            },
+        ]
+    }
+    monkeypatch.setattr(
+        "jupr_app.domain.gamification.badge_audit.compute_candidates_for_club",
+        lambda **kwargs: [],
+    )
+    ctx = _ctx()
+    ctx.df_badges = pd.DataFrame(
+        [
+            {"badge_id": "high_roller", "state": "live"},
+            {"badge_id": "manual_only", "state": "inactive"},
+        ]
+    )
+
+    report_live_only = build_badge_audit_report(FakeSupabase(storage), club_id="club", ctx=ctx, include_non_live=False)
+    assert report_live_only["counts"]["actual_active_exact_count"] == 1
+
+    report_with_non_live = build_badge_audit_report(FakeSupabase(storage), club_id="club", ctx=ctx, include_non_live=True)
+    assert report_with_non_live["counts"]["actual_active_exact_count"] == 2


### PR DESCRIPTION
### Motivation
- The existing audit used only the strict key `(player_id, badge_id, context_id)` which inflated “missing”/“stale” counts when legacy `context_id` formats or non-live/manual badges exist.  
- Operators need a diagnostic layer that ignores context-id churn so they can tell true ownership loss from legacy/context drift.  
- Actual rows were being compared against live engine candidates without filtering to the same badge universe, producing misleading results by default.  

### Description
- Compute two audit layers in `jupr_app/domain/gamification/badge_audit.py`: an exact key (`player_id,badge_id,context_id`) and a soft key (`player_id,badge_id`), returning explicit key sets and counts for both (`*_exact_*` and `*_soft_*`).  
- Add context-drift detection (`build_context_drift_rows`) that emits `context_drift_rows`, `context_drift_soft_key_count`, and `context_drift_exact_row_count` describing player/badge pairs whose expected vs actual `context_id` sets differ.  
- Filter `actual` rows to the same comparable badge universe by default (when `include_non_live=False`) using badge metadata/registry (`_comparable_badge_ids`); `include_non_live=True` preserves full passthrough.  
- Expand per-badge summary to include exact/soft counts and `context_drift_count`, and keep backward-compatible aliases (`expected_count`, `missing_count`, etc.) mapped to exact semantics.  
- Update the UI `jupr_app/ui/pages/badge_audit.py` to show separate Exact and Soft metric groups, a caption explaining semantics, a new "Context Drift" tab, and renamed detail tabs to make metrics unambiguous.  
- Files changed: `jupr_app/domain/gamification/badge_audit.py`, `jupr_app/ui/pages/badge_audit.py`, and tests in `tests/test_badge_audit.py` (tests extended to cover soft-match/context-drift, true missing/stale, non-live filtering, duplicates/revoked).  

### Testing
- Added/updated `tests/test_badge_audit.py` to assert soft-match prevents false missing when only `context_id` changed, true missing/stale behavior, non-live filtering, and duplicate detection.  
- Ran the badge audit test suite with `pytest -q tests/test_badge_audit.py` and all tests passed (`6 passed`).  
- Repair semantics were intentionally not changed and existing recompute/repair paths remain exact-key scoped (no automated repair behavior modified by this patch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e656c4f6a08326a0b2b93804cbe5d4)