### PR TITLE
Allow admins to open Badge Debug without BADGE_DEBUG/JUPR_ADMIN

### DIFF
--- a/jupr_app/ui/pages/badge_debug.py
+++ b/jupr_app/ui/pages/badge_debug.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 
 import pandas as pd
 import streamlit as st
@@ -9,10 +8,6 @@ import streamlit as st
 from jupr_app.domain.gamification.badge_debug import build_badge_debug_report
 from jupr_app.domain.match_filters import apply_match_filters_with_audit
 from jupr_app.ui.layout import page_shell
-
-
-def _is_badge_debug_enabled() -> bool:
-    return os.getenv("BADGE_DEBUG") == "1" or os.getenv("JUPR_ADMIN") == "1"
 
 
 @st.cache_data(show_spinner=False)
@@ -27,10 +22,6 @@ def render(ctx):
 
     if not bool(getattr(ctx, "admin_logged_in", False)):
         st.error("Admin login required.")
-        st.stop()
-
-    if not _is_badge_debug_enabled():
-        st.info("Badge Debug is disabled. Set BADGE_DEBUG=1 (or JUPR_ADMIN=1) to enable this view.")
         st.stop()
 
     df_players = getattr(ctx, "df_players_all", pd.DataFrame())


### PR DESCRIPTION
### Motivation
- Admins could reach the Badge Debug page but were blocked by a deployment env var gate (`BADGE_DEBUG`/`JUPR_ADMIN`); the goal is to make `admin_logged_in` sufficient for core page access.

### Description
- Removed the `_is_badge_debug_enabled()` helper and the `os` import, and deleted the env-var gating so `jupr_app/ui/pages/badge_debug.py` only requires `admin_logged_in` to render the page.

### Testing
- Ran `python -m compileall jupr_app/ui/pages/badge_debug.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65c2fb918832682b8e45433eac0ec)