### PR TITLE
Add badge-specific threshold diagnostics to Badge Debug (high_roller + participant thresholds)

### DIFF
--- a/jupr_app/domain/gamification/badge_debug.py
+++ b/jupr_app/domain/gamification/badge_debug.py
@@ -22,6 +22,7 @@ class BadgeDebugReport:
     matches_filtered: list[str] = field(default_factory=list)
     filter_audit_steps: list[MatchFilterAuditStep] = field(default_factory=list)
     candidates: list[dict[str, Any]] = field(default_factory=list)
+    diagnostics: dict[str, Any] = field(default_factory=dict)
     errors: list[str] = field(default_factory=list)
 
 
@@ -78,6 +79,12 @@ def build_badge_debug_report(
     except Exception:
         report.errors.append(traceback.format_exc())
 
+    report.diagnostics = _build_badge_diagnostics(
+        evaluation=evaluation,
+        badge_id=str(badge_id),
+        player_id=int(player_id),
+    )
+
     return report
 
 
@@ -112,3 +119,69 @@ def _derive_match_id(candidate: BadgeCandidate) -> str | None:
         if match_id:
             return str(match_id)
     return None
+
+
+def _build_badge_diagnostics(*, evaluation: Any, badge_id: str, player_id: int) -> dict[str, Any]:
+    badge_id = str(badge_id)
+    if badge_id == "high_roller":
+        return _high_roller_diagnostics(evaluation=evaluation, player_id=player_id)
+    if badge_id == "dedicated_participant_50":
+        return _participant_threshold_diagnostics(
+            evaluation=evaluation,
+            player_id=player_id,
+            badge_id=badge_id,
+            threshold=50,
+        )
+    if badge_id == "lifetime_participant_200":
+        return _participant_threshold_diagnostics(
+            evaluation=evaluation,
+            player_id=player_id,
+            badge_id=badge_id,
+            threshold=200,
+        )
+    return {}
+
+
+def _high_roller_diagnostics(*, evaluation: Any, player_id: int) -> dict[str, Any]:
+    facts = getattr(evaluation, "facts", pd.DataFrame())
+    if facts is None:
+        facts = pd.DataFrame()
+    player_facts = facts[facts["player_id"] == int(player_id)].copy() if "player_id" in facts.columns else pd.DataFrame()
+    player_wins = player_facts[player_facts["win"] == True].copy() if "win" in player_facts.columns else pd.DataFrame()
+    if "match_id" in player_wins.columns:
+        distinct_wins = int(player_wins["match_id"].dropna().nunique())
+    else:
+        distinct_wins = 0
+    threshold = 100
+    return {
+        "player_id": int(player_id),
+        "badge_id": "high_roller",
+        "filtered_player_match_rows": int(len(player_facts)),
+        "filtered_player_win_rows": int(len(player_wins)),
+        "filtered_player_distinct_win_match_ids": distinct_wins,
+        "threshold_required": threshold,
+        "qualifies_boolean": bool(distinct_wins >= threshold),
+    }
+
+
+def _participant_threshold_diagnostics(
+    *,
+    evaluation: Any,
+    player_id: int,
+    badge_id: str,
+    threshold: int,
+) -> dict[str, Any]:
+    counts = {}
+    ctx = getattr(evaluation, "ctx", None)
+    if ctx is not None:
+        from jupr_app.domain.gamification.participation import compute_lifetime_games
+
+        counts = compute_lifetime_games(ctx) or {}
+    player_games = int(counts.get(int(player_id), 0))
+    return {
+        "player_id": int(player_id),
+        "badge_id": str(badge_id),
+        "filtered_player_distinct_match_ids": player_games,
+        "threshold_required": int(threshold),
+        "qualifies_boolean": bool(player_games >= int(threshold)),
+    }

--- a/jupr_app/ui/pages/badge_debug.py
+++ b/jupr_app/ui/pages/badge_debug.py
@@ -119,6 +119,7 @@ def render(ctx):
     st.subheader("Candidate Rows")
     if not report.candidates:
         st.info("No candidates returned by evaluator.")
+        _render_no_candidate_diagnostics(report)
     else:
         candidate_df = pd.DataFrame(report.candidates)
         display_cols = [c for c in ["context_id", "match_id", "value_json"] if c in candidate_df.columns]
@@ -132,6 +133,12 @@ def render(ctx):
         for idx, row in candidate_df.iterrows():
             with st.expander(f"Candidate {idx + 1} • context_id={row.get('context_id')}"):
                 st.json(report.candidates[idx].get("value_json", {}))
+
+    st.subheader("Badge Diagnostics")
+    if report.diagnostics:
+        _render_badge_diagnostics(report)
+    else:
+        st.caption("No badge-specific diagnostics available for this badge yet.")
 
     st.subheader("Match Filtering Audit")
     if not report.filter_audit_steps:
@@ -196,3 +203,32 @@ def _render_id_list(ids: list[str], *, key: str, sample_size: int = 50) -> None:
     else:
         st.write(ids[:sample_size])
         st.caption(f"Showing first {sample_size} of {len(ids)} IDs.")
+
+
+def _render_no_candidate_diagnostics(report) -> None:
+    if len(report.candidates) > 0 or not report.diagnostics:
+        return
+    st.markdown("**Why no candidate?**")
+    _render_badge_diagnostics(report)
+
+
+def _render_badge_diagnostics(report) -> None:
+    diagnostics = dict(report.diagnostics or {})
+    badge_id = diagnostics.get("badge_id")
+    if badge_id == "high_roller":
+        distinct_wins = int(diagnostics.get("filtered_player_distinct_win_match_ids", 0))
+        threshold = int(diagnostics.get("threshold_required", 100))
+        qualifies = bool(diagnostics.get("qualifies_boolean", False))
+        st.write(f"Distinct qualifying wins: {distinct_wins}")
+        st.write(f"Threshold: {threshold}")
+        st.write(f"Qualifies: {'Yes' if qualifies else 'No'}")
+    elif badge_id in {"dedicated_participant_50", "lifetime_participant_200"}:
+        distinct_matches = int(diagnostics.get("filtered_player_distinct_match_ids", 0))
+        threshold = int(diagnostics.get("threshold_required", 0))
+        qualifies = bool(diagnostics.get("qualifies_boolean", False))
+        st.write(f"Distinct qualifying matches: {distinct_matches}")
+        st.write(f"Threshold: {threshold}")
+        st.write(f"Qualifies: {'Yes' if qualifies else 'No'}")
+
+    with st.expander("Diagnostics payload"):
+        st.json(diagnostics)

--- a/tests/test_badge_debug_report.py
+++ b/tests/test_badge_debug_report.py
@@ -1,6 +1,9 @@
 import pandas as pd
 
-from jupr_app.domain.gamification.badge_debug import build_badge_debug_report
+from jupr_app.domain.gamification.badge_debug import (
+    _build_badge_diagnostics,
+    build_badge_debug_report,
+)
 
 
 class DummyContext:
@@ -24,3 +27,57 @@ def test_build_badge_debug_report_smoke():
     assert report.club_id == "club-1"
     assert report.player_id == 1
     assert report.errors == []
+
+
+def test_high_roller_diagnostics_below_threshold():
+    facts = pd.DataFrame(
+        [{"player_id": 5, "match_id": f"m{i}", "win": True} for i in range(99)]
+    )
+    evaluation = type("Evaluation", (), {"facts": facts, "ctx": None})()
+
+    diagnostics = _build_badge_diagnostics(
+        evaluation=evaluation,
+        badge_id="high_roller",
+        player_id=5,
+    )
+
+    assert diagnostics["filtered_player_distinct_win_match_ids"] == 99
+    assert diagnostics["threshold_required"] == 100
+    assert diagnostics["qualifies_boolean"] is False
+
+
+def test_high_roller_diagnostics_at_threshold():
+    facts = pd.DataFrame(
+        [{"player_id": 8, "match_id": f"m{i}", "win": True} for i in range(100)]
+    )
+    evaluation = type("Evaluation", (), {"facts": facts, "ctx": None})()
+
+    diagnostics = _build_badge_diagnostics(
+        evaluation=evaluation,
+        badge_id="high_roller",
+        player_id=8,
+    )
+
+    assert diagnostics["filtered_player_distinct_win_match_ids"] == 100
+    assert diagnostics["qualifies_boolean"] is True
+
+
+def test_high_roller_diagnostics_counts_distinct_wins():
+    facts = pd.DataFrame(
+        [
+            {"player_id": 11, "match_id": "m1", "win": True},
+            {"player_id": 11, "match_id": "m1", "win": True},
+            {"player_id": 11, "match_id": "m2", "win": True},
+            {"player_id": 11, "match_id": "m3", "win": False},
+        ]
+    )
+    evaluation = type("Evaluation", (), {"facts": facts, "ctx": None})()
+
+    diagnostics = _build_badge_diagnostics(
+        evaluation=evaluation,
+        badge_id="high_roller",
+        player_id=11,
+    )
+
+    assert diagnostics["filtered_player_win_rows"] == 3
+    assert diagnostics["filtered_player_distinct_win_match_ids"] == 2


### PR DESCRIPTION
### Motivation
- Admins need a clear, player-specific explanation for why threshold-style badges (like `high_roller`) did or did not qualify, using the same evaluator/facts path already in use.

### Description
- Added a `diagnostics` payload to `BadgeDebugReport` and populate it from the existing evaluation context (uses `build_evaluation_context(...).facts`).
- Implemented badge-specific diagnostics helpers: `high_roller` returns `player_id`, `badge_id`, `filtered_player_match_rows`, `filtered_player_win_rows`, `filtered_player_distinct_win_match_ids`, `threshold_required` (100), and `qualifies_boolean`; threshold hooks added for `dedicated_participant_50` and `lifetime_participant_200`.
- Updated UI `badge_debug` page to show a new **Badge Diagnostics** section, a human-readable summary for `high_roller` (distinct wins, threshold, qualifies), and a **Why no candidate?** panel that displays diagnostics when `candidates_count == 0`.
- Files changed: `jupr_app/domain/gamification/badge_debug.py` (diagnostics payload + helpers), `jupr_app/ui/pages/badge_debug.py` (render diagnostics and "Why no candidate?"), and `tests/test_badge_debug_report.py` (new diagnostics unit tests).
- Diagnostics reuse the same filtered match / facts path used by evaluators and do not introduce a separate truth source.

### Testing
- Added focused unit tests for `high_roller` diagnostics: below threshold, at threshold, and distinct-win counting behavior (duplicates counted once).
- Ran: `pytest -q tests/test_badge_debug_report.py tests/test_high_roller_badge.py` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e660224a948326b8a76ab35c18ae64)