### PR TITLE
Add player aggregate reconciliation diagnostics to Badge Debug

### DIFF
--- a/jupr_app/domain/gamification/badge_debug.py
+++ b/jupr_app/domain/gamification/badge_debug.py
@@ -10,6 +10,7 @@ from jupr_app.domain.gamification.badge_registry import registry
 from jupr_app.domain.gamification.badge_types import BadgeCandidate
 from jupr_app.domain.gamification.evaluators import build_evaluation_context
 from jupr_app.domain.match_filters import MatchFilterAudit, MatchFilterAuditStep, apply_match_filters_with_audit
+from jupr_app.domain.player_aggregate_audit import compute_player_aggregate_reconciliation
 
 
 @dataclass
@@ -83,6 +84,14 @@ def build_badge_debug_report(
         evaluation=evaluation,
         badge_id=str(badge_id),
         player_id=int(player_id),
+    )
+    report.diagnostics["player_aggregate_reconciliation"] = compute_player_aggregate_reconciliation(
+        ctx,
+        player_id=int(player_id),
+        club_id=str(club_id),
+        league_id=league_id,
+        filtered_matches=filtered_matches,
+        match_audit=match_audit,
     )
 
     return report

--- a/jupr_app/domain/player_aggregate_audit.py
+++ b/jupr_app/domain/player_aggregate_audit.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from jupr_app.domain.gamification.match_facts import build_player_match_facts
+from jupr_app.domain.match_filters import apply_match_filters_with_audit, normalize_player_id
+
+_PLAYER_SLOT_COLUMNS = ["t1_p1", "t1_p2", "t2_p1", "t2_p2"]
+
+
+def compute_player_aggregate_reconciliation(
+    ctx: Any,
+    *,
+    player_id: int,
+    club_id: str,
+    league_id: str | None = None,
+    filtered_matches: pd.DataFrame | None = None,
+    match_audit: Any | None = None,
+) -> dict[str, Any]:
+    pid = int(player_id)
+    club = str(club_id)
+
+    players_row = _lookup_player_row(getattr(ctx, "df_players_all", pd.DataFrame()), pid)
+
+    df_matches = getattr(ctx, "df_matches", pd.DataFrame())
+    player_raw = _filter_player_rows(df_matches, pid)
+
+    context_filters: dict[str, Any] = {"club_id": club, "exclude_popups": True}
+    if league_id:
+        context_filters["league_name"] = str(league_id).strip()
+
+    if filtered_matches is None or match_audit is None:
+        filtered_matches, match_audit = apply_match_filters_with_audit(player_raw, context_filters)
+    else:
+        filtered_matches = _filter_player_rows(filtered_matches, pid)
+
+    facts = build_player_match_facts(
+        ctx,
+        df_matches_override=filtered_matches,
+        club_id_override=club,
+    )
+    facts_player = facts[facts["player_id"] == pid].copy() if "player_id" in facts.columns else pd.DataFrame()
+    wins = facts_player[facts_player["win"] == True].copy() if "win" in facts_player.columns else pd.DataFrame()
+    losses = facts_player[facts_player["win"] == False].copy() if "win" in facts_player.columns else pd.DataFrame()
+
+    dup_rows = 0
+    if filtered_matches is not None and not filtered_matches.empty:
+        match_id_col = "id" if "id" in filtered_matches.columns else "match_id" if "match_id" in filtered_matches.columns else None
+        if match_id_col:
+            dup_rows = int(filtered_matches.duplicated(subset=[match_id_col], keep=False).sum())
+
+    diagnostics: dict[str, Any] = {
+        "player_id": pid,
+        "players_table_wins": int(players_row.get("wins", 0)),
+        "players_table_losses": int(players_row.get("losses", 0)),
+        "players_table_matches_played": int(players_row.get("matches_played", 0)),
+        "raw_player_match_rows": int(len(player_raw)),
+        "filtered_player_match_rows": int(len(filtered_matches.index) if isinstance(filtered_matches, pd.DataFrame) else 0),
+        "filtered_match_win_rows": int(len(wins)),
+        "filtered_match_loss_rows": int(len(losses)),
+        "filtered_match_distinct_match_ids": _distinct_count(facts_player, "match_id"),
+        "filtered_match_distinct_win_match_ids": _distinct_count(wins, "match_id"),
+        "filtered_match_distinct_loss_match_ids": _distinct_count(losses, "match_id"),
+        "excluded_match_count_by_filter_step": _step_removed_counts(match_audit),
+        "popup_match_count_for_player": _count_mask(player_raw, lambda d: d.get("match_type", "").fillna("").astype(str).str.upper() == "POPUP"),
+        "tournament_context_match_count_for_player": _count_mask(
+            player_raw,
+            lambda d: (
+                d.get("context_type", "").fillna("").astype(str).str.upper() == "TOURNAMENT"
+            )
+            | d.get("tournament_id", pd.Series(index=d.index)).notna()
+            | (d.get("match_type", "").fillna("").astype(str).str.upper() == "TOURNAMENT"),
+        ),
+        "invalid_or_void_match_count_for_player": _invalid_void_count(player_raw),
+        "invalid_or_missing_score_match_count_for_player": _score_invalid_count(player_raw),
+        "matches_missing_required_player_slots_for_facts": _missing_required_slots_count(filtered_matches),
+        "filtered_duplicate_match_rows_for_player": int(dup_rows),
+    }
+
+    diagnostics["wins_delta"] = diagnostics["players_table_wins"] - diagnostics["filtered_match_distinct_win_match_ids"]
+    diagnostics["losses_delta"] = diagnostics["players_table_losses"] - diagnostics["filtered_match_distinct_loss_match_ids"]
+    diagnostics["matches_delta"] = diagnostics["players_table_matches_played"] - diagnostics["filtered_match_distinct_match_ids"]
+    diagnostics["aggregate_out_of_sync_warning"] = bool(
+        diagnostics["wins_delta"] != 0 or diagnostics["losses_delta"] != 0 or diagnostics["matches_delta"] != 0
+    )
+
+    return diagnostics
+
+
+def _lookup_player_row(df_players: pd.DataFrame | None, player_id: int) -> dict[str, int]:
+    defaults = {"wins": 0, "losses": 0, "matches_played": 0}
+    if df_players is None or df_players.empty or "id" not in df_players.columns:
+        return defaults
+    hit = df_players[df_players["id"].astype(int) == int(player_id)]
+    if hit.empty:
+        return defaults
+    row = hit.iloc[0]
+    return {
+        "wins": int(pd.to_numeric(row.get("wins", 0), errors="coerce") or 0),
+        "losses": int(pd.to_numeric(row.get("losses", 0), errors="coerce") or 0),
+        "matches_played": int(pd.to_numeric(row.get("matches_played", 0), errors="coerce") or 0),
+    }
+
+
+def _filter_player_rows(df_matches: pd.DataFrame | None, player_id: int) -> pd.DataFrame:
+    if df_matches is None or df_matches.empty:
+        return pd.DataFrame()
+    df = df_matches.copy()
+    mask = pd.Series(False, index=df.index)
+    for col in [c for c in _PLAYER_SLOT_COLUMNS if c in df.columns]:
+        mask = mask | df[col].map(lambda value: normalize_player_id(value) == int(player_id))
+    return df[mask].copy()
+
+
+def _distinct_count(df: pd.DataFrame, col: str) -> int:
+    if df is None or df.empty or col not in df.columns:
+        return 0
+    return int(df[col].dropna().nunique())
+
+
+def _step_removed_counts(audit: Any | None) -> dict[str, int]:
+    if audit is None:
+        return {}
+    steps = getattr(audit, "steps", []) or []
+    return {str(step.step_name): int(len(step.removed_match_ids or [])) for step in steps}
+
+
+def _count_mask(df: pd.DataFrame, mask_builder) -> int:
+    if df is None or df.empty:
+        return 0
+    try:
+        mask = mask_builder(df)
+        return int(mask.fillna(False).astype(bool).sum())
+    except Exception:
+        return 0
+
+
+def _invalid_void_count(df: pd.DataFrame) -> int:
+    if df is None or df.empty:
+        return 0
+    mask = pd.Series(False, index=df.index)
+    for col in ["is_valid", "is_void", "voided", "is_voided", "invalid", "is_invalid", "deleted", "is_deleted"]:
+        if col not in df.columns:
+            continue
+        if col == "is_valid":
+            mask = mask | (~df[col].fillna(True).astype(bool))
+        else:
+            mask = mask | df[col].fillna(False).astype(bool)
+    return int(mask.sum())
+
+
+def _score_invalid_count(df: pd.DataFrame) -> int:
+    if df is None or df.empty:
+        return 0
+    if "score_t1" not in df.columns or "score_t2" not in df.columns:
+        return 0
+    s1 = pd.to_numeric(df["score_t1"], errors="coerce").fillna(0).astype(int)
+    s2 = pd.to_numeric(df["score_t2"], errors="coerce").fillna(0).astype(int)
+    return int(((s1 + s2) <= 0).sum())
+
+
+def _missing_required_slots_count(df: pd.DataFrame | None) -> int:
+    if df is None or df.empty:
+        return 0
+    if "t1_p1" not in df.columns or "t2_p1" not in df.columns:
+        return 0
+    p1 = df["t1_p1"].map(normalize_player_id)
+    p3 = df["t2_p1"].map(normalize_player_id)
+    return int((p1.isna() | p3.isna()).sum())

--- a/jupr_app/ui/pages/badge_debug.py
+++ b/jupr_app/ui/pages/badge_debug.py
@@ -222,6 +222,7 @@ def _render_badge_diagnostics(report) -> None:
         st.write(f"Distinct qualifying wins: {distinct_wins}")
         st.write(f"Threshold: {threshold}")
         st.write(f"Qualifies: {'Yes' if qualifies else 'No'}")
+        st.caption("High Roller uses canonical filtered match history, not the OVERALL player aggregate row.")
     elif badge_id in {"dedicated_participant_50", "lifetime_participant_200"}:
         distinct_matches = int(diagnostics.get("filtered_player_distinct_match_ids", 0))
         threshold = int(diagnostics.get("threshold_required", 0))
@@ -229,6 +230,55 @@ def _render_badge_diagnostics(report) -> None:
         st.write(f"Distinct qualifying matches: {distinct_matches}")
         st.write(f"Threshold: {threshold}")
         st.write(f"Qualifies: {'Yes' if qualifies else 'No'}")
+
+
+    reconciliation = diagnostics.get("player_aggregate_reconciliation")
+    if isinstance(reconciliation, dict) and reconciliation:
+        st.markdown("### Player Aggregate Reconciliation")
+        col_a, col_b, col_c = st.columns(3)
+        with col_a:
+            st.markdown("**Leaderboard / players row**")
+            st.write(f"wins: {int(reconciliation.get('players_table_wins', 0))}")
+            st.write(f"losses: {int(reconciliation.get('players_table_losses', 0))}")
+            st.write(f"matches_played: {int(reconciliation.get('players_table_matches_played', 0))}")
+        with col_b:
+            st.markdown("**Canonical filtered match history**")
+            st.write(f"distinct matches: {int(reconciliation.get('filtered_match_distinct_match_ids', 0))}")
+            st.write(f"distinct wins: {int(reconciliation.get('filtered_match_distinct_win_match_ids', 0))}")
+            st.write(f"distinct losses: {int(reconciliation.get('filtered_match_distinct_loss_match_ids', 0))}")
+        with col_c:
+            st.markdown("**Difference (players - canonical)**")
+            st.write(f"wins delta: {int(reconciliation.get('wins_delta', 0))}")
+            st.write(f"losses delta: {int(reconciliation.get('losses_delta', 0))}")
+            st.write(f"matches delta: {int(reconciliation.get('matches_delta', 0))}")
+
+        aux_rows = {
+            "raw_player_match_rows": int(reconciliation.get("raw_player_match_rows", 0)),
+            "filtered_player_match_rows": int(reconciliation.get("filtered_player_match_rows", 0)),
+            "filtered_match_win_rows": int(reconciliation.get("filtered_match_win_rows", 0)),
+            "filtered_match_loss_rows": int(reconciliation.get("filtered_match_loss_rows", 0)),
+            "popup_match_count_for_player": int(reconciliation.get("popup_match_count_for_player", 0)),
+            "tournament_context_match_count_for_player": int(reconciliation.get("tournament_context_match_count_for_player", 0)),
+            "invalid_or_void_match_count_for_player": int(reconciliation.get("invalid_or_void_match_count_for_player", 0)),
+            "invalid_or_missing_score_match_count_for_player": int(reconciliation.get("invalid_or_missing_score_match_count_for_player", 0)),
+            "matches_missing_required_player_slots_for_facts": int(reconciliation.get("matches_missing_required_player_slots_for_facts", 0)),
+            "filtered_duplicate_match_rows_for_player": int(reconciliation.get("filtered_duplicate_match_rows_for_player", 0)),
+        }
+        st.dataframe(
+            pd.DataFrame([aux_rows]).T.rename(columns={0: "count"}),
+            use_container_width=True,
+        )
+
+        by_step = reconciliation.get("excluded_match_count_by_filter_step", {})
+        if by_step:
+            st.markdown("**Excluded by filter step**")
+            step_df = pd.DataFrame(
+                [{"step": str(k), "removed": int(v)} for k, v in by_step.items()]
+            )
+            st.dataframe(step_df, use_container_width=True, hide_index=True)
+
+        if bool(reconciliation.get("aggregate_out_of_sync_warning", False)):
+            st.warning("players aggregate appears out of sync with canonical match history")
 
     with st.expander("Diagnostics payload"):
         st.json(diagnostics)

--- a/tests/test_player_aggregate_audit.py
+++ b/tests/test_player_aggregate_audit.py
@@ -1,0 +1,168 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from jupr_app.domain.player_aggregate_audit import compute_player_aggregate_reconciliation
+
+
+def _ctx(df_players: pd.DataFrame, df_matches: pd.DataFrame):
+    return SimpleNamespace(df_players_all=df_players, df_matches=df_matches, club_id="club")
+
+
+def test_reconciliation_detects_players_aggregate_larger_than_canonical_wins():
+    ctx = _ctx(
+        pd.DataFrame([{"id": 1, "wins": 112, "losses": 46, "matches_played": 158}]),
+        pd.DataFrame(
+            [
+                {
+                    "id": "m1",
+                    "club_id": "club",
+                    "date": "2024-01-01",
+                    "score_t1": 11,
+                    "score_t2": 5,
+                    "t1_p1": 1,
+                    "t2_p1": 2,
+                    "match_type": "League",
+                    "is_valid": True,
+                    "context_type": "LEAGUE",
+                    "tournament_id": None,
+                },
+                {
+                    "id": "m2",
+                    "club_id": "club",
+                    "date": "2024-01-02",
+                    "score_t1": 11,
+                    "score_t2": 9,
+                    "t1_p1": 1,
+                    "t2_p1": 3,
+                    "match_type": "League",
+                    "is_valid": True,
+                    "context_type": "LEAGUE",
+                    "tournament_id": None,
+                },
+                {
+                    "id": "m3",
+                    "club_id": "club",
+                    "date": "2024-01-03",
+                    "score_t1": 11,
+                    "score_t2": 7,
+                    "t1_p1": 1,
+                    "t2_p1": 4,
+                    "match_type": "PopUp",
+                    "is_valid": True,
+                    "context_type": "LEAGUE",
+                    "tournament_id": None,
+                },
+            ]
+        ),
+    )
+
+    result = compute_player_aggregate_reconciliation(ctx, player_id=1, club_id="club")
+
+    assert result["players_table_wins"] == 112
+    assert result["filtered_match_distinct_win_match_ids"] == 2
+    assert result["wins_delta"] == 110
+    assert result["popup_match_count_for_player"] == 1
+    assert result["aggregate_out_of_sync_warning"] is True
+
+
+def test_reconciliation_exact_alignment_case():
+    ctx = _ctx(
+        pd.DataFrame([{"id": 7, "wins": 1, "losses": 1, "matches_played": 2}]),
+        pd.DataFrame(
+            [
+                {
+                    "id": "m1",
+                    "club_id": "club",
+                    "date": "2024-01-01",
+                    "score_t1": 11,
+                    "score_t2": 9,
+                    "t1_p1": 7,
+                    "t2_p1": 2,
+                    "match_type": "League",
+                    "is_valid": True,
+                    "context_type": "LEAGUE",
+                    "tournament_id": None,
+                },
+                {
+                    "id": "m2",
+                    "club_id": "club",
+                    "date": "2024-01-02",
+                    "score_t1": 7,
+                    "score_t2": 11,
+                    "t1_p1": 7,
+                    "t2_p1": 3,
+                    "match_type": "League",
+                    "is_valid": True,
+                    "context_type": "LEAGUE",
+                    "tournament_id": None,
+                },
+            ]
+        ),
+    )
+
+    result = compute_player_aggregate_reconciliation(ctx, player_id=7, club_id="club")
+
+    assert result["wins_delta"] == 0
+    assert result["losses_delta"] == 0
+    assert result["matches_delta"] == 0
+    assert result["aggregate_out_of_sync_warning"] is False
+
+
+def test_reconciliation_uses_distinct_win_match_ids_for_high_roller_semantics():
+    ctx = _ctx(
+        pd.DataFrame([{"id": 11, "wins": 2, "losses": 1, "matches_played": 3}]),
+        pd.DataFrame(
+            [
+                {
+                    "id": "m1",
+                    "club_id": "club",
+                    "date": "2024-01-01",
+                    "score_t1": 11,
+                    "score_t2": 8,
+                    "t1_p1": 11,
+                    "t1_p2": 99,
+                    "t2_p1": 2,
+                    "t2_p2": 3,
+                    "match_type": "League",
+                    "is_valid": True,
+                    "context_type": "LEAGUE",
+                    "tournament_id": None,
+                },
+                {
+                    "id": "m1",
+                    "club_id": "club",
+                    "date": "2024-01-01",
+                    "score_t1": 11,
+                    "score_t2": 8,
+                    "t1_p1": 11,
+                    "t1_p2": 99,
+                    "t2_p1": 2,
+                    "t2_p2": 3,
+                    "match_type": "League",
+                    "is_valid": True,
+                    "context_type": "LEAGUE",
+                    "tournament_id": None,
+                },
+                {
+                    "id": "m2",
+                    "club_id": "club",
+                    "date": "2024-01-02",
+                    "score_t1": 5,
+                    "score_t2": 11,
+                    "t1_p1": 11,
+                    "t2_p1": 4,
+                    "match_type": "League",
+                    "is_valid": True,
+                    "context_type": "LEAGUE",
+                    "tournament_id": None,
+                },
+            ]
+        ),
+    )
+
+    result = compute_player_aggregate_reconciliation(ctx, player_id=11, club_id="club")
+
+    assert result["filtered_match_win_rows"] == 2
+    assert result["filtered_match_distinct_win_match_ids"] == 1
+    assert result["filtered_duplicate_match_rows_for_player"] == 2


### PR DESCRIPTION
### Motivation
- Investigate and make visible the mismatch between OVERALL leaderboard aggregates and badge evaluators that use canonical filtered match history.  
- Provide an admin-facing reconciliation so operators can quickly see whether `players` rows are stale or whether matches were excluded by filters (popups, tournaments, invalid/no-score, duplicates).  
- Keep this change diagnostic-only (do not modify leaderboard aggregates) so root causes can be proven before any automatic correction.

### Description
- Added `compute_player_aggregate_reconciliation` (`jupr_app/domain/player_aggregate_audit.py`) which compares a selected player’s `players` table aggregates (`wins`, `losses`, `matches_played`) to canonical filtered match-derived counts (distinct matches, distinct win/loss match_ids), per-filter-step exclusion counts, and additional signals (popup count, tournament-context count, invalid/void/no-score counts, missing player slots, duplicate rows) and emits deltas plus an `aggregate_out_of_sync_warning` flag.  
- Wired the reconciliation into the badge debug report (`jupr_app/domain/gamification/badge_debug.py`) so it appears at `diagnostics.player_aggregate_reconciliation` for a run.  
- Extended the Badge Debug UI (`jupr_app/ui/pages/badge_debug.py`) with a **Player Aggregate Reconciliation** section that displays: leaderboard/players row metrics, canonical filtered distinct matches/wins/losses, delta metrics, auxiliary counts, excluded-by-filter-step table, and an out-of-sync warning; also preserved the High Roller outputs (distinct qualifying wins, threshold, qualifies) and added a caption clarifying that High Roller uses canonical filtered match history, not the OVERALL `players` aggregate row.  
- Where the numbers come from: the OVERALL leaderboard reads `wins/losses/matches_played` directly from `ctx.df_players_all` (the `players` rows) used by `jupr_app/ui/pages/leaderboards.py`, while High Roller is computed from canonical `facts` built by `build_player_match_facts` (which applies `apply_match_filters` with `exclude_popups`, tournament/invalid/score/slot checks) and counts distinct winning `match_id`s in `jupr_app/domain/gamification/evaluators.py`.

### Testing
- Added focused unit tests in `tests/test_player_aggregate_audit.py` covering: aggregate > canonical mismatch, exact-alignment case, and distinct-win counting with duplicate-match rows; these were added alongside existing badge debug tests.  
- Ran `pytest -q tests/test_player_aggregate_audit.py tests/test_badge_debug_report.py` and the suite passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6627ff27c83269fbc7716bb0b99a3)