### PR TITLE
Add Match Canonical Audit and Legacy Match Normalization Admin Flow

### DIFF
--- a/jupr_app/domain/match_canonical_audit.py
+++ b/jupr_app/domain/match_canonical_audit.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+import pandas as pd
+
+from jupr_app.domain.gamification.match_facts import build_player_match_facts
+from jupr_app.domain.match_filters import normalize_player_id, normalize_score
+
+PLAYER_SLOT_COLUMNS = ("t1_p1", "t1_p2", "t2_p1", "t2_p2")
+SNAPSHOT_COLUMNS = (
+    "t1_p1_r",
+    "t1_p1_r_end",
+    "t1_p2_r",
+    "t1_p2_r_end",
+    "t2_p1_r",
+    "t2_p1_r_end",
+    "t2_p2_r",
+    "t2_p2_r_end",
+)
+
+
+def build_match_canonical_audit(
+    ctx,
+    *,
+    club_id: str,
+    player_id: int | None = None,
+    league_id: str | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    scoped = _profile_visible_rows(
+        getattr(ctx, "df_matches", pd.DataFrame()),
+        club_id=str(club_id),
+        player_id=player_id,
+        league_id=league_id,
+        limit=limit,
+    )
+
+    canonical_facts = build_player_match_facts(
+        ctx,
+        df_matches_override=scoped,
+        club_id_override=str(club_id),
+    )
+    if player_id is not None and not canonical_facts.empty:
+        canonical_facts = canonical_facts[
+            pd.to_numeric(canonical_facts.get("player_id"), errors="coerce").fillna(-1).astype(int) == int(player_id)
+        ].copy()
+
+    profile_ids = _id_set(scoped)
+    canonical_ids = set(canonical_facts.get("match_id", pd.Series(dtype=str)).dropna().astype(str).tolist())
+
+    only_profile = sorted(profile_ids - canonical_ids, key=_sort_intish)
+    only_canonical = sorted(canonical_ids - profile_ids, key=_sort_intish)
+    shared = sorted(profile_ids & canonical_ids, key=_sort_intish)
+
+    excluded_rows = _build_excluded_diagnostics(scoped, only_profile, player_id=player_id, league_id=league_id)
+    reason_counts = Counter()
+    for row in excluded_rows:
+        for reason in row.get("exclusion_reasons", []):
+            reason_counts[reason] += 1
+
+    return {
+        "scope": {
+            "club_id": str(club_id),
+            "player_id": int(player_id) if player_id is not None else None,
+            "league_id": str(league_id).strip() if league_id else None,
+            "limit": int(limit) if limit else None,
+        },
+        "profile_visible_match_ids": sorted(profile_ids, key=_sort_intish),
+        "canonical_visible_match_ids": sorted(canonical_ids, key=_sort_intish),
+        "only_in_profile": only_profile,
+        "only_in_canonical": only_canonical,
+        "shared_ids": shared,
+        "excluded_only_in_profile": excluded_rows,
+        "exclusion_reasons_summary": [
+            {"reason": reason, "count": int(count)} for reason, count in sorted(reason_counts.items(), key=lambda kv: (-kv[1], kv[0]))
+        ],
+        "counts": {
+            "profile_visible": len(profile_ids),
+            "canonical_visible": len(canonical_ids),
+            "only_in_profile": len(only_profile),
+            "only_in_canonical": len(only_canonical),
+            "shared": len(shared),
+        },
+    }
+
+
+def _profile_visible_rows(
+    df_matches: pd.DataFrame | None,
+    *,
+    club_id: str,
+    player_id: int | None,
+    league_id: str | None,
+    limit: int | None,
+) -> pd.DataFrame:
+    if df_matches is None or df_matches.empty:
+        return pd.DataFrame()
+    df = df_matches.copy()
+    if "club_id" in df.columns:
+        df = df[df["club_id"].astype(str) == str(club_id)].copy()
+
+    if player_id is not None:
+        pid = int(player_id)
+        mask = pd.Series(False, index=df.index)
+        for col in [c for c in PLAYER_SLOT_COLUMNS if c in df.columns]:
+            mask = mask | df[col].map(lambda value: normalize_player_id(value) == pid)
+        df = df[mask].copy()
+
+    if league_id:
+        league_key = str(league_id).strip()
+        df["league"] = df.get("league", "").fillna("").astype(str).str.strip()
+        df = df[df["league"] == league_key].copy()
+
+    if "id" not in df.columns:
+        df["id"] = range(1, len(df) + 1)
+
+    df["date_dt"] = pd.to_datetime(df.get("date", None), utc=True, errors="coerce")
+    df = df.sort_values(["date_dt", "id"], ascending=[False, False]).reset_index(drop=True)
+    if limit:
+        df = df.head(int(limit)).copy()
+    df = df.dropna(subset=["date_dt"]).copy()
+
+    return df
+
+
+def _id_set(df: pd.DataFrame) -> set[str]:
+    if df is None or df.empty:
+        return set()
+    return set(df.get("id", pd.Series(dtype=object)).dropna().astype(str).tolist())
+
+
+def _sort_intish(value: str) -> tuple[int, str]:
+    raw = str(value)
+    try:
+        return (0, f"{int(raw):020d}")
+    except Exception:
+        return (1, raw)
+
+
+def _build_excluded_diagnostics(
+    scoped_rows: pd.DataFrame,
+    excluded_ids: list[str],
+    *,
+    player_id: int | None,
+    league_id: str | None,
+) -> list[dict[str, Any]]:
+    if scoped_rows is None or scoped_rows.empty or not excluded_ids:
+        return []
+
+    id_set = set(str(mid) for mid in excluded_ids)
+    subset = scoped_rows[scoped_rows["id"].astype(str).isin(id_set)].copy()
+    duplicate_ids = _duplicate_match_ids(subset)
+
+    rows: list[dict[str, Any]] = []
+    for _, row in subset.iterrows():
+        reasons = _classify_exclusion_reasons(row, player_id=player_id, league_id=league_id)
+        if str(row.get("id")) in duplicate_ids:
+            reasons.append("duplicate / superseded row")
+        reasons = sorted(set(reasons)) or ["unknown/unclassified"]
+
+        rows.append(
+            {
+                "match_id": _safe_int(row.get("id")),
+                "date": _safe_date(row.get("date")),
+                "league": _as_clean_str(row.get("league")),
+                "match_type": _as_clean_str(row.get("match_type")),
+                "context_type": _as_clean_str(row.get("context_type")),
+                "score_t1": normalize_score(row.get("score_t1")),
+                "score_t2": normalize_score(row.get("score_t2")),
+                "t1_p1": normalize_player_id(row.get("t1_p1")),
+                "t1_p2": normalize_player_id(row.get("t1_p2")),
+                "t2_p1": normalize_player_id(row.get("t2_p1")),
+                "t2_p2": normalize_player_id(row.get("t2_p2")),
+                "snapshot": {col: row.get(col) for col in SNAPSHOT_COLUMNS if col in subset.columns},
+                "exclusion_reasons": reasons,
+                "suggested_normalization_action": _suggested_action(reasons),
+            }
+        )
+
+    rows.sort(key=lambda r: (str(r.get("date") or ""), int(r.get("match_id") or 0)), reverse=True)
+    return rows
+
+
+def _classify_exclusion_reasons(row: pd.Series, *, player_id: int | None, league_id: str | None) -> list[str]:
+    reasons: list[str] = []
+
+    match_type = _as_clean_str(row.get("match_type"))
+    context_type = _as_clean_str(row.get("context_type"))
+    league = _as_clean_str(row.get("league"))
+
+    if match_type.lower() == "popup":
+        reasons.append("popup")
+
+    if context_type.upper() == "TOURNAMENT" or pd.notna(row.get("tournament_id")):
+        reasons.append("tournament context")
+
+    if match_type.upper() == "TOURNAMENT":
+        reasons.append("tournament match_type")
+
+    s1 = normalize_score(row.get("score_t1"))
+    s2 = normalize_score(row.get("score_t2"))
+    if (s1 + s2) <= 0:
+        reasons.append("invalid/zero score")
+
+    p1 = normalize_player_id(row.get("t1_p1"))
+    p3 = normalize_player_id(row.get("t2_p1"))
+    if not p1 or not p3:
+        reasons.append("missing required player slots")
+
+    if player_id is not None:
+        pid = int(player_id)
+        participants = {
+            normalize_player_id(row.get("t1_p1")),
+            normalize_player_id(row.get("t1_p2")),
+            normalize_player_id(row.get("t2_p1")),
+            normalize_player_id(row.get("t2_p2")),
+        }
+        if pid not in participants:
+            reasons.append("missing/legacy fields needed by canonical facts")
+
+    if league_id:
+        if not league or league != str(league_id).strip():
+            reasons.append("malformed league/context values")
+    elif not league:
+        reasons.append("missing/legacy fields needed by canonical facts")
+
+    return reasons
+
+
+def _duplicate_match_ids(df: pd.DataFrame) -> set[str]:
+    if df is None or df.empty:
+        return set()
+
+    keys: list[str] = []
+    for _, row in df.iterrows():
+        day = _safe_date(row.get("date"))
+        players = sorted([normalize_player_id(row.get(col)) or -1 for col in PLAYER_SLOT_COLUMNS])
+        score = (normalize_score(row.get("score_t1")), normalize_score(row.get("score_t2")))
+        keys.append(f"{day}|{players}|{score}")
+
+    key_series = pd.Series(keys)
+    dup_mask = key_series.duplicated(keep=False)
+    if not dup_mask.any():
+        return set()
+    dup_ids = df.loc[dup_mask, "id"].astype(str).tolist()
+    return set(dup_ids)
+
+
+def _suggested_action(reasons: list[str]) -> str:
+    reason_set = set(reasons)
+    if "invalid/zero score" in reason_set or "missing required player slots" in reason_set:
+        return "manual-review-needed"
+    if "tournament context" in reason_set or "tournament match_type" in reason_set:
+        return "review_tournament_markers_then_normalize_context_if_legacy"
+    if "popup" in reason_set:
+        return "confirm_popup_semantics_no_change_if_intentional"
+    if "malformed league/context values" in reason_set or "missing/legacy fields needed by canonical facts" in reason_set:
+        return "normalize_legacy_league_match_type_or_context_fields"
+    if "duplicate / superseded row" in reason_set:
+        return "mark_superseded_in_source_of_truth_or_keep_latest_only"
+    return "manual-review-needed"
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _safe_date(value: Any) -> str:
+    date_val = pd.to_datetime(value, utc=True, errors="coerce")
+    if pd.isna(date_val):
+        return ""
+    return date_val.strftime("%Y-%m-%d")
+
+
+def _as_clean_str(value: Any) -> str:
+    return str(value or "").strip()

--- a/jupr_app/domain/match_canonical_migration.py
+++ b/jupr_app/domain/match_canonical_migration.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from jupr_app.domain.match_canonical_audit import build_match_canonical_audit
+from jupr_app.domain.match_filters import normalize_player_id, normalize_score
+
+PLAYER_ALIASES: dict[str, tuple[str, ...]] = {
+    "t1_p1": ("team1_player1", "player1_id", "p1_id"),
+    "t1_p2": ("team1_player2", "player2_id", "p2_id"),
+    "t2_p1": ("team2_player1", "player3_id", "p3_id"),
+    "t2_p2": ("team2_player2", "player4_id", "p4_id"),
+}
+SCORE_ALIASES: dict[str, tuple[str, ...]] = {
+    "score_t1": ("team1_score", "score1", "score_a"),
+    "score_t2": ("team2_score", "score2", "score_b"),
+}
+
+
+def normalize_legacy_matches_for_canonical(
+    supabase,
+    *,
+    ctx,
+    club_id: str,
+    match_ids: list[int] | None = None,
+    player_id: int | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    audit = build_match_canonical_audit(
+        ctx,
+        club_id=str(club_id),
+        player_id=player_id,
+        limit=None,
+    )
+
+    excluded = audit.get("excluded_only_in_profile", [])
+    target_ids = {int(x) for x in (match_ids or [])}
+    if target_ids:
+        excluded = [row for row in excluded if int(row.get("match_id") or 0) in target_ids]
+
+    by_id = _rows_by_id(getattr(ctx, "df_matches", pd.DataFrame()))
+    proposals: list[dict[str, Any]] = []
+    manual_review: list[dict[str, Any]] = []
+
+    for diag in excluded:
+        mid = int(diag.get("match_id") or 0)
+        source_row = by_id.get(mid)
+        if source_row is None:
+            manual_review.append({"match_id": mid, "reason": "row_not_found_in_ctx_df_matches"})
+            continue
+
+        patch, reasons = _propose_patch(source_row)
+        if not patch:
+            manual_review.append({"match_id": mid, "reason": "no_safe_normalization", "exclusion_reasons": diag.get("exclusion_reasons", [])})
+            continue
+
+        proposals.append(
+            {
+                "match_id": mid,
+                "patch": patch,
+                "normalization_reasons": reasons,
+                "exclusion_reasons": diag.get("exclusion_reasons", []),
+            }
+        )
+
+    applied = []
+    if not dry_run:
+        for proposal in proposals:
+            mid = int(proposal["match_id"])
+            patch = dict(proposal["patch"])
+            (
+                supabase.table("matches")
+                .update(patch)
+                .eq("club_id", str(club_id))
+                .eq("id", mid)
+                .execute()
+            )
+            applied.append(mid)
+
+    return {
+        "dry_run": bool(dry_run),
+        "club_id": str(club_id),
+        "player_id": int(player_id) if player_id is not None else None,
+        "requested_match_ids": sorted(target_ids),
+        "candidate_count": len(excluded),
+        "proposed_update_count": len(proposals),
+        "applied_update_count": len(applied),
+        "applied_match_ids": applied,
+        "proposals": proposals,
+        "manual_review_needed": manual_review,
+    }
+
+
+def _rows_by_id(df_matches: pd.DataFrame | None) -> dict[int, dict[str, Any]]:
+    if df_matches is None or df_matches.empty or "id" not in df_matches.columns:
+        return {}
+    out: dict[int, dict[str, Any]] = {}
+    for _, row in df_matches.iterrows():
+        try:
+            mid = int(row.get("id"))
+        except Exception:
+            continue
+        out[mid] = row.to_dict()
+    return out
+
+
+def _propose_patch(row: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    patch: dict[str, Any] = {}
+    reasons: list[str] = []
+
+    for target, aliases in PLAYER_ALIASES.items():
+        canonical = normalize_player_id(row.get(target))
+        if canonical:
+            continue
+        alias_value = _first_normalized_player(row, aliases)
+        if alias_value:
+            patch[target] = int(alias_value)
+            reasons.append(f"filled_{target}_from_legacy_alias")
+
+    for target, aliases in SCORE_ALIASES.items():
+        canonical = normalize_score(row.get(target))
+        if canonical > 0:
+            continue
+        alias_score = _first_normalized_score(row, aliases)
+        if alias_score > 0:
+            patch[target] = int(alias_score)
+            reasons.append(f"filled_{target}_from_legacy_alias")
+
+    match_type = str(row.get("match_type") or "").strip()
+    normalized_match_type = _normalize_match_type(match_type)
+    if normalized_match_type and normalized_match_type != match_type:
+        patch["match_type"] = normalized_match_type
+        reasons.append("normalized_match_type")
+
+    context_type = str(row.get("context_type") or "").strip()
+    normalized_context_type = _normalize_context_type(context_type)
+    if normalized_context_type != context_type:
+        patch["context_type"] = normalized_context_type
+        reasons.append("normalized_context_type")
+
+    league = str(row.get("league") or "").strip()
+    if not league:
+        league_fallback = _infer_league(row)
+        if league_fallback:
+            patch["league"] = league_fallback
+            reasons.append("inferred_league")
+
+    if _is_legacy_tournament_mismatch(row):
+        patch.setdefault("context_type", "")
+        patch.setdefault("match_type", "League")
+        reasons.append("cleared_legacy_tournament_marker")
+
+    return patch, reasons
+
+
+def _first_normalized_player(row: dict[str, Any], aliases: tuple[str, ...]) -> int | None:
+    for alias in aliases:
+        pid = normalize_player_id(row.get(alias))
+        if pid:
+            return pid
+    return None
+
+
+def _first_normalized_score(row: dict[str, Any], aliases: tuple[str, ...]) -> int:
+    for alias in aliases:
+        score = normalize_score(row.get(alias))
+        if score > 0:
+            return score
+    return 0
+
+
+def _normalize_match_type(raw: str) -> str:
+    key = str(raw or "").strip().lower()
+    if not key:
+        return ""
+    if key in {"popup", "pop up", "pop-up"}:
+        return "PopUp"
+    if key in {"tournament", "tourny", "tourney"}:
+        return "Tournament"
+    if key in {"league", "league night", "regular", "ranked"}:
+        return "League"
+    return str(raw).strip()
+
+
+def _normalize_context_type(raw: str) -> str:
+    key = str(raw or "").strip().lower()
+    if not key:
+        return ""
+    if key in {"event", "popup", "pop up", "pop-up"}:
+        return "EVENT"
+    if key in {"tournament", "tourny", "tourney"}:
+        return "TOURNAMENT"
+    if key in {"league", "ladder"}:
+        return "LEAGUE"
+    return str(raw).strip()
+
+
+def _infer_league(row: dict[str, Any]) -> str:
+    for key in ("league_name", "league_id"):
+        val = str(row.get(key) or "").strip()
+        if val:
+            return val
+    context_type = str(row.get("context_type") or "").strip().upper()
+    context_id = str(row.get("context_id") or "").strip()
+    if context_type == "LEAGUE" and context_id:
+        return context_id.split(":")[0]
+    return ""
+
+
+def _is_legacy_tournament_mismatch(row: dict[str, Any]) -> bool:
+    tournament_id = row.get("tournament_id")
+    if tournament_id is not None and str(tournament_id).strip() != "":
+        return False
+
+    match_type = str(row.get("match_type") or "").strip().upper()
+    context_type = str(row.get("context_type") or "").strip().upper()
+    league = str(row.get("league") or "").strip()
+    score_ok = normalize_score(row.get("score_t1")) + normalize_score(row.get("score_t2")) > 0
+    players_ok = normalize_player_id(row.get("t1_p1")) and normalize_player_id(row.get("t2_p1"))
+
+    looks_tournament = match_type == "TOURNAMENT" or context_type == "TOURNAMENT"
+    return bool(looks_tournament and league and score_ok and players_ok)

--- a/jupr_app/ui/page_registry.py
+++ b/jupr_app/ui/page_registry.py
@@ -21,6 +21,7 @@ PAGE_DEFINITIONS: tuple[PageDefinition, ...] = (
     PageDefinition("badge_codex", "📼 Badge Codex", public=True),
     PageDefinition("badge_debug", "🧪 Badge Debug", admin_only=True),
     PageDefinition("badge_audit", "🧾 Badge Audit", admin_only=True),
+    PageDefinition("match_canonical_audit", "🧩 Match Canonical Audit", admin_only=True),
     PageDefinition("challenge_ladder", "🪜 Challenge Ladder", public=True),
     PageDefinition("faqs", "❓ FAQs", public=True),
     PageDefinition("league_manager", "🏟️ League Manager", admin_only=True),

--- a/jupr_app/ui/pages/match_canonical_audit.py
+++ b/jupr_app/ui/pages/match_canonical_audit.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import streamlit as st
+
+from jupr_app.domain.match_canonical_audit import build_match_canonical_audit
+from jupr_app.domain.match_canonical_migration import normalize_legacy_matches_for_canonical
+from jupr_app.ui.layout import page_shell
+
+AUDIT_STATE_KEY = "match_canonical_audit_report"
+
+
+def render(ctx):
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell(
+        "🧩 Match Canonical Audit",
+        "Compare profile-visible matches vs canonical facts visibility and normalize legacy rows safely.",
+        mode_label=mode_label,
+    )
+
+    if not bool(getattr(ctx, "admin_logged_in", False)):
+        st.error("Admin login required.")
+        st.stop()
+
+    club_id = str(ctx.club_id)
+    player_options = _player_options(ctx)
+    selected_player = st.selectbox(
+        "Player",
+        options=player_options,
+        format_func=lambda pid: f"{pid} — {ctx.id_to_name.get(int(pid), f'Player {pid}')}",
+    )
+
+    league_options = [""] + _league_options(ctx)
+    selected_league = st.selectbox(
+        "League (optional)",
+        options=league_options,
+        format_func=lambda value: "All leagues" if not value else value,
+    )
+
+    limit = st.number_input("Audit row limit", min_value=100, max_value=5000, value=1200, step=100)
+    if st.button("Run Audit", type="primary"):
+        with st.spinner("Building canonical visibility audit..."):
+            report = build_match_canonical_audit(
+                ctx,
+                club_id=club_id,
+                player_id=int(selected_player),
+                league_id=(selected_league or None),
+                limit=int(limit),
+            )
+        st.session_state[AUDIT_STATE_KEY] = report
+
+    report = st.session_state.get(AUDIT_STATE_KEY)
+    if not report:
+        st.info("Run the audit to compare profile-visible vs canonical-visible matches.")
+        return
+
+    counts = report.get("counts", {})
+    cols = st.columns(5)
+    cols[0].metric("Profile-visible", int(counts.get("profile_visible", 0)))
+    cols[1].metric("Canonical-visible", int(counts.get("canonical_visible", 0)))
+    cols[2].metric("Only in Profile", int(counts.get("only_in_profile", 0)))
+    cols[3].metric("Only in Canonical", int(counts.get("only_in_canonical", 0)))
+    cols[4].metric("Shared", int(counts.get("shared", 0)))
+
+    tab_only_profile, tab_only_canonical, tab_shared, tab_reasons = st.tabs(
+        ["Only in Profile", "Only in Canonical", "Shared", "Exclusion Reasons Summary"]
+    )
+    with tab_only_profile:
+        rows = report.get("excluded_only_in_profile", [])
+        st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+    with tab_only_canonical:
+        st.dataframe(
+            pd.DataFrame({"match_id": report.get("only_in_canonical", [])}),
+            use_container_width=True,
+            hide_index=True,
+        )
+    with tab_shared:
+        st.dataframe(
+            pd.DataFrame({"match_id": report.get("shared_ids", [])}),
+            use_container_width=True,
+            hide_index=True,
+        )
+    with tab_reasons:
+        st.dataframe(
+            pd.DataFrame(report.get("exclusion_reasons_summary", [])),
+            use_container_width=True,
+            hide_index=True,
+        )
+
+    st.subheader("Normalize Legacy Rows")
+    st.caption("Safe, explicit migration only. No auto-submit.")
+    col_dry, col_apply = st.columns(2)
+
+    if col_dry.button("Dry Run Normalize"):
+        with st.spinner("Generating normalization plan..."):
+            result = normalize_legacy_matches_for_canonical(
+                ctx.supabase,
+                ctx=ctx,
+                club_id=club_id,
+                player_id=int(selected_player),
+                dry_run=True,
+            )
+        st.code(json.dumps(result, indent=2), language="json")
+
+    if col_apply.button("Apply Normalize"):
+        with st.spinner("Applying normalization updates..."):
+            result = normalize_legacy_matches_for_canonical(
+                ctx.supabase,
+                ctx=ctx,
+                club_id=club_id,
+                player_id=int(selected_player),
+                dry_run=False,
+            )
+        st.success(f"Applied {int(result.get('applied_update_count', 0))} updates.")
+        st.code(json.dumps(result, indent=2), language="json")
+        st.session_state["force_data_refresh"] = True
+        st.rerun()
+
+    st.subheader("Next operator sequence")
+    st.markdown(
+        "\n".join(
+            [
+                "1. Run Match Canonical Audit for the player.",
+                "2. Inspect excluded legacy rows in **Only in Profile**.",
+                "3. Run **Dry Run Normalize**.",
+                "4. Run **Apply Normalize**.",
+                "5. Re-run Badge Debug (`high_roller`) for this player.",
+                "6. If canonical counts make sense, run aggregate repair and badge recompute.",
+            ]
+        )
+    )
+
+
+def _league_options(ctx) -> list[str]:
+    df_matches = getattr(ctx, "df_matches", pd.DataFrame())
+    if df_matches is None or df_matches.empty or "league" not in df_matches.columns:
+        return []
+    return sorted(df_matches["league"].dropna().astype(str).str.strip().replace("", pd.NA).dropna().unique().tolist())
+
+
+def _player_options(ctx) -> list[int]:
+    df_players = getattr(ctx, "df_players_all", pd.DataFrame())
+    if df_players is None or df_players.empty or "id" not in df_players.columns:
+        return []
+    return sorted(df_players["id"].dropna().astype(int).unique().tolist())

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -327,6 +327,7 @@ def main():
             league_printout,
             league_results,
             match_explorer,
+            match_canonical_audit,
             match_log,
             match_uploader,
             moneyball,
@@ -355,6 +356,7 @@ def main():
             "📼 Badge Codex": badge_codex,
             "🧪 Badge Debug": badge_debug,
             "🧾 Badge Audit": badge_audit,
+            "🧩 Match Canonical Audit": match_canonical_audit,
             "🪜 Challenge Ladder": challenge_ladder,
             "❓ FAQs": faqs,
             # Admin-only

--- a/tests/test_match_canonical_audit_and_migration.py
+++ b/tests/test_match_canonical_audit_and_migration.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from jupr_app.domain.match_canonical_audit import build_match_canonical_audit
+from jupr_app.domain.match_canonical_migration import normalize_legacy_matches_for_canonical
+
+
+@dataclass
+class Ctx:
+    club_id: str
+    df_matches: pd.DataFrame
+    df_players_all: pd.DataFrame
+
+
+class FakeExecute:
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeQuery:
+    def __init__(self, table_rows):
+        self.table_rows = table_rows
+        self._patch = {}
+        self._club_id = None
+        self._id = None
+
+    def update(self, patch):
+        self._patch = dict(patch)
+        return self
+
+    def eq(self, column, value):
+        if column == "club_id":
+            self._club_id = str(value)
+        if column == "id":
+            self._id = int(value)
+        return self
+
+    def execute(self):
+        for row in self.table_rows:
+            if str(row.get("club_id")) == self._club_id and int(row.get("id")) == self._id:
+                row.update(self._patch)
+        return FakeExecute([])
+
+
+class FakeSupabase:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def table(self, name):
+        assert name == "matches"
+        return FakeQuery(self.rows)
+
+
+def _ctx_from_rows(rows):
+    return Ctx(
+        club_id="club",
+        df_matches=pd.DataFrame(rows),
+        df_players_all=pd.DataFrame([{"id": 1, "rating": 1200.0}, {"id": 2, "rating": 1200.0}, {"id": 3, "rating": 1200.0}, {"id": 4, "rating": 1200.0}]),
+    )
+
+
+def test_audit_detects_profile_visible_but_not_canonical_with_reasons():
+    rows = [
+        {"id": 10, "club_id": "club", "date": "2026-01-01", "league": "L1", "match_type": "League", "score_t1": 11, "score_t2": 7, "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4},
+        {"id": 11, "club_id": "club", "date": "2026-01-02", "league": "L1", "match_type": "PopUp", "score_t1": 11, "score_t2": 8, "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4},
+        {"id": 12, "club_id": "club", "date": "2026-01-03", "league": "L1", "match_type": "League", "score_t1": 0, "score_t2": 0, "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4},
+        {"id": 13, "club_id": "club", "date": "2026-01-04", "league": "L1", "match_type": "Tournament", "score_t1": 11, "score_t2": 3, "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4},
+    ]
+    report = build_match_canonical_audit(_ctx_from_rows(rows), club_id="club", player_id=1)
+
+    assert report["shared_ids"] == ["10"]
+    assert sorted(report["only_in_profile"]) == ["11", "12", "13"]
+    reasons_by_id = {int(row["match_id"]): set(row["exclusion_reasons"]) for row in report["excluded_only_in_profile"]}
+    assert "popup" in reasons_by_id[11]
+    assert "invalid/zero score" in reasons_by_id[12]
+    assert "tournament match_type" in reasons_by_id[13]
+
+
+def test_dry_run_normalization_reports_changes_without_updating_rows():
+    rows = [
+        {
+            "id": 21,
+            "club_id": "club",
+            "date": "2026-01-04",
+            "league": "L1",
+            "match_type": "League",
+            "score_t1": 0,
+            "score_t2": 0,
+            "team1_score": 11,
+            "team2_score": 9,
+            "t1_p1": 1,
+            "t1_p2": 2,
+            "t2_p1": 3,
+            "t2_p2": 4,
+        },
+    ]
+    ctx = _ctx_from_rows(rows)
+    fake_supabase = FakeSupabase(rows)
+
+    result = normalize_legacy_matches_for_canonical(fake_supabase, ctx=ctx, club_id="club", player_id=1, dry_run=True)
+
+    assert result["proposed_update_count"] == 1
+    assert result["applied_update_count"] == 0
+    assert rows[0]["score_t1"] == 0
+    patch = result["proposals"][0]["patch"]
+    assert patch["score_t1"] == 11
+
+
+def test_apply_normalization_updates_rows_and_leaves_shared_untouched():
+    rows = [
+        {
+            "id": 31,
+            "club_id": "club",
+            "date": "2026-01-05",
+            "league": "L1",
+            "match_type": "League",
+            "score_t1": 0,
+            "score_t2": 0,
+            "score1": 11,
+            "score2": 6,
+            "t1_p1": 1,
+            "t1_p2": 2,
+            "t2_p1": 3,
+            "t2_p2": 4,
+        },
+        {
+            "id": 32,
+            "club_id": "club",
+            "date": "2026-01-06",
+            "league": "L1",
+            "match_type": "League",
+            "score_t1": 11,
+            "score_t2": 8,
+            "t1_p1": 1,
+            "t1_p2": 2,
+            "t2_p1": 3,
+            "t2_p2": 4,
+        },
+    ]
+    ctx = _ctx_from_rows(rows)
+    fake_supabase = FakeSupabase(rows)
+
+    result = normalize_legacy_matches_for_canonical(fake_supabase, ctx=ctx, club_id="club", player_id=1, dry_run=False)
+
+    assert result["applied_update_count"] == 1
+    assert rows[0]["score_t1"] == 11
+    assert rows[1]["score_t1"] == 11
+    assert rows[1]["score_t2"] == 8


### PR DESCRIPTION
### Motivation
- Player profile rating trends are sourced from `matches` and reveal more historical match points than the canonical badge/facts path recognizes, so we must treat `matches` as the source of truth while reconciling legacy rows first. 
- The goal is to identify why rows in `matches` are excluded by canonical processing and provide a safe, operator-driven normalization path before rebuilding aggregates or recomputing badges. 
- Implement an audit that compares profile-visible vs canonical-visible match sets and produces row-level diagnostics to drive safe normalization decisions. 
- Provide an admin UI to run the audit, preview normalization (dry-run), and explicitly apply safe patches with a documented operator flow. 

### Description
- Added `jupr_app/domain/match_canonical_audit.py` with `build_match_canonical_audit(...)` that computes `profile_visible_match_ids`, `canonical_visible_match_ids`, `only_in_profile`, `only_in_canonical`, `shared_ids`, row-level diagnostics, and an `exclusion_reasons_summary`. 
- Implemented classification of exclusion reasons (popup, tournament context / match_type, invalid/zero score, missing required player slots, missing/legacy fields, malformed league/context, duplicate/superseded, unknown) and suggested normalization actions for each row. 
- Added `jupr_app/domain/match_canonical_migration.py` with `normalize_legacy_matches_for_canonical(...)` that builds a dry-run normalization plan and optionally applies explicit safe patches (fill legacy player/score aliases, normalize `match_type`/`context_type`, infer `league`, clear legacy tournament markers) while reporting rows that need manual review. 
- Added admin UI page `jupr_app/ui/pages/match_canonical_audit.py` (label: "🧩 Match Canonical Audit") with player + optional league scopes, summary metrics, detail tabs (Only in Profile / Only in Canonical / Shared / Exclusion Reasons Summary), and explicit `Dry Run Normalize` and `Apply Normalize` buttons that set `force_data_refresh` after apply. 
- Registered the new page in `jupr_app/ui/page_registry.py` and wired it into `streamlit_app.py` lazy imports and router. 
- Added focused tests in `tests/test_match_canonical_audit_and_migration.py` covering audit detection, exclusion reason classification, dry-run proposals, and apply behavior, and updated `tests/test_page_registry.py` usage. 

### Testing
- Ran `pytest -q tests/test_match_canonical_audit_and_migration.py tests/test_page_registry.py` which completed successfully (`6 passed`). 
- Ran `pytest -q tests/test_imports.py` which completed successfully (`1 passed`). 
- Unit tests validate that `build_match_canonical_audit` identifies rows visible to the profile but excluded from canonical facts, classifies exclusion reasons, that `normalize_legacy_matches_for_canonical` produces dry-run proposals, and that applying normalization updates only the intended rows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6677837108326a2ac6d209931f87c)