### PR TITLE
Admin badge audit & recompute UI + High Roller hybrid-source diagnostics

### DIFF
--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import pandas as pd
 import time
+import json
 from datetime import datetime, timezone
 from jupr_app.domain.replay_history import replay_history
 
@@ -11,7 +12,10 @@ from jupr_app.domain.constants import DEFAULT_K_FACTOR
 from jupr_app.domain.match_processing import process_matches
 from jupr_app.domain.tournament_match_payload import build_tournament_match_payload
 from jupr_app.domain.gamification.ensure_badges import ensure_badges
+from jupr_app.domain.gamification.badge_audit import build_badge_audit_report
+from jupr_app.domain.gamification.recompute import run_badge_recompute
 from jupr_app.domain.gamification.badge_state import ALLOWED_BADGE_STATES, can_transition_badge_state
+from jupr_app.domain.gamification.evaluators import build_evaluation_context
 from jupr_app.domain.gamification.badge_worker import (
     process_badge_eval_queue,
     process_badge_eval_queue_until_empty,
@@ -422,6 +426,12 @@ def render(ctx):
                 st.dataframe(summary, use_container_width=True, hide_index=True)
 
     st.divider()
+    _render_badge_audit_section(ctx, club_id)
+
+    st.divider()
+    _render_badge_recompute_section(ctx, club_id)
+
+    st.divider()
     _render_club_social_review(ctx)
 
     st.divider()
@@ -571,6 +581,164 @@ def _render_club_social_review(ctx) -> None:
         with st.expander("View raw_event_json", expanded=False):
             st.json(row.get("raw_event_json") or {})
         st.divider()
+
+
+def _render_badge_audit_section(ctx, club_id: str) -> None:
+    st.subheader("🎯 Badge Audit")
+    st.caption("Compare expected badge rows vs actual rows for targeted diagnostics and troubleshooting.")
+
+    df_players = getattr(ctx, "df_players_all", pd.DataFrame())
+    player_options = [""] + sorted(df_players.get("id", pd.Series(dtype=int)).dropna().astype(int).unique().tolist())
+    df_badges = getattr(ctx, "df_badges", pd.DataFrame())
+    badge_options = [""] + sorted(df_badges.get("badge_id", pd.Series(dtype=str)).dropna().astype(str).unique().tolist())
+    df_meta = getattr(ctx, "df_meta", pd.DataFrame())
+    league_options = [""] + sorted(df_meta.get("league_name", pd.Series(dtype=str)).dropna().astype(str).unique().tolist())
+
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        player_id = st.selectbox("Player", options=player_options, key="admin_badge_audit_player")
+    with col2:
+        badge_id = st.selectbox("Badge", options=badge_options, key="admin_badge_audit_badge")
+    with col3:
+        league_id = st.selectbox("League (optional)", options=league_options, key="admin_badge_audit_league")
+
+    include_revoked = st.checkbox("Include revoked rows", value=False, key="admin_badge_audit_include_revoked")
+    include_non_live = st.checkbox("Include non-live badges", value=False, key="admin_badge_audit_include_non_live")
+
+    if st.button("Run Badge Audit", key="admin_badge_audit_run"):
+        report = build_badge_audit_report(
+            ctx.supabase,
+            club_id=club_id,
+            ctx=ctx,
+            player_id=int(player_id) if str(player_id).strip() else None,
+            badge_id=str(badge_id).strip() or None,
+            league_id=str(league_id).strip() or None,
+            include_revoked=bool(include_revoked),
+            include_non_live=bool(include_non_live),
+        )
+        st.session_state["admin_badge_audit_report"] = report
+        st.session_state["admin_badge_audit_inputs"] = {
+            "player_id": int(player_id) if str(player_id).strip() else None,
+            "badge_id": str(badge_id).strip() or None,
+            "league_id": str(league_id).strip() or None,
+        }
+
+    report = st.session_state.get("admin_badge_audit_report")
+    if not report:
+        return
+
+    counts = report.get("counts", {})
+    c1, c2, c3, c4 = st.columns(4)
+    c1.metric("Expected", int(counts.get("expected_count", 0)))
+    c2.metric("Actual Active", int(counts.get("actual_active_count", 0)))
+    c3.metric("Missing", int(counts.get("missing_count", 0)))
+    c4.metric("Stale", int(counts.get("stale_count", 0)))
+
+    c5, c6, c7 = st.columns(3)
+    c5.metric("Context Drift", int(counts.get("context_drift_exact_row_count", 0)))
+    c6.metric("Revoked", int(counts.get("revoked_count", 0)))
+    c7.metric("Duplicates", int(counts.get("duplicate_count", 0)))
+
+    tabs = st.tabs(["Expected", "Actual Active", "Revoked", "Missing", "Stale", "Context Drift"])
+    with tabs[0]:
+        st.dataframe(pd.DataFrame(report.get("expected_rows", [])), use_container_width=True, hide_index=True)
+    with tabs[1]:
+        st.dataframe(pd.DataFrame(report.get("actual_active_rows", [])), use_container_width=True, hide_index=True)
+    with tabs[2]:
+        st.dataframe(pd.DataFrame(report.get("revoked_rows", [])), use_container_width=True, hide_index=True)
+    with tabs[3]:
+        st.dataframe(pd.DataFrame(report.get("missing_rows", [])), use_container_width=True, hide_index=True)
+    with tabs[4]:
+        st.dataframe(pd.DataFrame(report.get("stale_rows", [])), use_container_width=True, hide_index=True)
+    with tabs[5]:
+        st.dataframe(pd.DataFrame(report.get("context_drift_rows", [])), use_container_width=True, hide_index=True)
+
+    selected_badge = (st.session_state.get("admin_badge_audit_inputs", {}) or {}).get("badge_id")
+    selected_player = (st.session_state.get("admin_badge_audit_inputs", {}) or {}).get("player_id")
+    selected_league = (st.session_state.get("admin_badge_audit_inputs", {}) or {}).get("league_id")
+    if selected_badge == "high_roller" and selected_player is not None:
+        _render_high_roller_diagnostics(ctx, club_id=club_id, player_id=int(selected_player), league_id=selected_league)
+
+
+def _render_high_roller_diagnostics(ctx, *, club_id: str, player_id: int, league_id: str | None) -> None:
+    st.markdown("**High Roller diagnostics**")
+    eval_ctx = build_evaluation_context(ctx, club_id=club_id, league_id=league_id, as_of=None)
+    facts = eval_ctx.facts_hybrid if eval_ctx.facts_hybrid is not None else eval_ctx.facts
+    wins = facts[(facts["player_id"] == int(player_id)) & (facts["win"] == True)].dropna(subset=["match_id"])
+    unique_match_ids = sorted(wins["match_id"].astype(str).unique().tolist())
+    win_count = len(unique_match_ids)
+    threshold_met = win_count >= 100
+
+    d1, d2, d3 = st.columns(3)
+    d1.metric("Computed wins", win_count)
+    d2.metric("Threshold (100) met", "Yes" if threshold_met else "No")
+    d3.metric("Unique winning match_ids", win_count)
+
+    if unique_match_ids:
+        st.caption("First 5 winning match_ids counted by the badge engine")
+        st.code(", ".join(unique_match_ids[:5]), language="text")
+        st.caption("Last 5 winning match_ids counted by the badge engine")
+        st.code(", ".join(unique_match_ids[-5:]), language="text")
+
+
+def _render_badge_recompute_section(ctx, club_id: str) -> None:
+    st.subheader("🧹 Badge Recompute / Cleanup")
+    st.caption("Run scoped badge recompute. Strict mode can revoke stale rows when safely scoped.")
+
+    df_players = getattr(ctx, "df_players_all", pd.DataFrame())
+    player_options = [""] + sorted(df_players.get("id", pd.Series(dtype=int)).dropna().astype(int).unique().tolist())
+    df_badges = getattr(ctx, "df_badges", pd.DataFrame())
+    badge_options = [""] + sorted(df_badges.get("badge_id", pd.Series(dtype=str)).dropna().astype(str).unique().tolist())
+    df_meta = getattr(ctx, "df_meta", pd.DataFrame())
+    league_options = [""] + sorted(df_meta.get("league_name", pd.Series(dtype=str)).dropna().astype(str).unique().tolist())
+
+    mode = st.selectbox("Mode", ["dry-run", "append-only", "strict"], key="admin_badge_recompute_mode")
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        player_id = st.selectbox("Player (optional)", options=player_options, key="admin_badge_recompute_player")
+    with col2:
+        badge_id = st.selectbox("Badge (optional)", options=badge_options, key="admin_badge_recompute_badge")
+    with col3:
+        league_id = st.selectbox("League (optional)", options=league_options, key="admin_badge_recompute_league")
+    context_id = st.text_input("Context ID (optional advanced)", key="admin_badge_recompute_context")
+    include_non_live = st.checkbox("Include non-live badges", value=False, key="admin_badge_recompute_include_non_live")
+    revoke_reason = st.text_input("Revoke reason (required for strict)", value="", key="admin_badge_recompute_reason")
+    match_limit = st.number_input("Match limit", min_value=100, max_value=200000, step=100, value=5000, key="admin_badge_recompute_match_limit")
+
+    if st.button("Run Badge Recompute", key="admin_badge_recompute_run"):
+        scoped = any(
+            (
+                str(player_id).strip(),
+                str(badge_id).strip(),
+                str(league_id).strip(),
+                str(context_id).strip(),
+            )
+        )
+        if mode == "strict":
+            if not scoped:
+                st.error("Strict mode requires at least one scope filter: player_id, badge_id, league_id, or context_id.")
+                return
+            if not revoke_reason.strip():
+                st.error("Revoke reason is required for strict mode.")
+                return
+
+        result = run_badge_recompute(
+            ctx.supabase,
+            club_id=club_id,
+            mode=mode,
+            player_id=int(player_id) if str(player_id).strip() else None,
+            badge_id=str(badge_id).strip() or None,
+            league_id=str(league_id).strip() or None,
+            context_id=str(context_id).strip() or None,
+            include_non_live=bool(include_non_live),
+            revoke_reason=str(revoke_reason).strip() or None,
+            allow_strict_global=False,
+            match_limit=int(match_limit),
+            ctx=ctx,
+            created_by="admin_tools_ui",
+        )
+        st.success("Recompute finished.")
+        st.code(json.dumps(result, indent=2), language="json")
 
 
 

--- a/tests/test_admin_tools_badge_controls.py
+++ b/tests/test_admin_tools_badge_controls.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ADMIN_TOOLS = Path("jupr_app/ui/pages/admin_tools.py").read_text()
+TREE = ast.parse(ADMIN_TOOLS)
+
+
+def _call_nodes(func_name: str) -> list[ast.Call]:
+    calls: list[ast.Call] = []
+    for node in ast.walk(TREE):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == func_name:
+            calls.append(node)
+    return calls
+
+
+def test_admin_tools_wires_badge_audit_call():
+    calls = _call_nodes("build_badge_audit_report")
+    assert calls, "Expected build_badge_audit_report call in admin_tools page"
+
+
+def test_admin_tools_recompute_forces_scoped_strict_safety():
+    calls = _call_nodes("run_badge_recompute")
+    assert calls, "Expected run_badge_recompute call in admin_tools page"
+
+    allow_strict_global_kwargs = [
+        kw
+        for call in calls
+        for kw in call.keywords
+        if kw.arg == "allow_strict_global"
+    ]
+    assert allow_strict_global_kwargs, "Expected allow_strict_global kwarg in run_badge_recompute call"
+    assert any(isinstance(kw.value, ast.Constant) and kw.value.value is False for kw in allow_strict_global_kwargs)
+
+
+def test_admin_tools_has_strict_scope_guard_message():
+    assert "Strict mode requires at least one scope filter" in ADMIN_TOOLS

--- a/tests/test_badge_hybrid_match_sources.py
+++ b/tests/test_badge_hybrid_match_sources.py
@@ -120,3 +120,46 @@ def test_compute_lifetime_games_counts_legacy_safe_rows_with_dedupe():
     )
     counts = compute_lifetime_games(_ctx(df_matches))
     assert counts == {1: 1, 2: 1}
+
+
+def test_high_roller_joe_style_threshold_met_only_with_hybrid_legacy_fill():
+    rows = []
+    for i in range(99):
+        rows.append(
+            {
+                "id": f"canonical-{i}",
+                "club_id": "club",
+                "date": f"2024-02-{(i % 28) + 1:02d}",
+                "league": "Open",
+                "t1_p1": 1,
+                "t2_p1": 2,
+                "score_t1": 11,
+                "score_t2": 6,
+                "t1_p1_r": 1200.0,
+                "t2_p1_r": 1200.0,
+            }
+        )
+    rows.append(
+        {
+            "id": "legacy-100",
+            "club_id": "club",
+            "date": "2024-03-01",
+            "league_name": "Open",
+            "team1_player1": 1,
+            "team2_player1": 2,
+            "team1_score": 11,
+            "team2_score": 7,
+        }
+    )
+    ctx = _ctx(pd.DataFrame(rows))
+    canonical = build_canonical_player_match_facts(ctx)
+    hybrid = build_hybrid_player_match_facts(ctx)
+
+    canonical_wins = canonical[(canonical["player_id"] == 1) & (canonical["win"] == True)]["match_id"].nunique()
+    hybrid_wins = hybrid[(hybrid["player_id"] == 1) & (hybrid["win"] == True)]["match_id"].nunique()
+    assert canonical_wins == 99
+    assert hybrid_wins == 100
+
+    candidates = list(compute_candidates_for_club("club", ctx=ctx))
+    awarded = {(c.player_id, c.badge_id) for c in candidates}
+    assert (1, "high_roller") in awarded


### PR DESCRIPTION
### Motivation
- Operators need a simple UI to audit why badges differ between engine expectations and stored awards and a safe way to remove stale badges. 
- Joe was missing the `high_roller` badge because some of his wins only existed as legacy-safe match rows and the engine was not counting those in the canonical-only facts used by the badge evaluation.
- Provide targeted diagnostics for `high_roller` (win counts and sampled match_ids) so admins can quickly see whether the 100-win threshold is met when hybrid-safe legacy rows are included.

### Description
- Added a new "🎯 Badge Audit" section in `jupr_app/ui/pages/admin_tools.py` that calls `build_badge_audit_report(...)` and renders counts and tables for expected rows, actual active rows, revoked rows, missing rows, stale rows, and context-drift rows. (file changed: `jupr_app/ui/pages/admin_tools.py`)
- Added a `High Roller diagnostics` block in the audit section that builds an evaluation context, uses the hybrid facts, and shows the computed unique winning `match_id` count, threshold pass/fail, and first/last sample match IDs for the selected player and league. (file changed: `jupr_app/ui/pages/admin_tools.py`)
- Added a new "🧹 Badge Recompute / Cleanup" section in `admin_tools` wired to `run_badge_recompute(...)` with `mode` (`dry-run|append-only|strict`), scope fields (player, badge, league, context_id), `include_non_live`, `revoke_reason` (required for strict), and a guard that prevents unscoped dangerous strict runs from the UI by requiring at least one scope filter and passing `allow_strict_global=False`. (file changed: `jupr_app/ui/pages/admin_tools.py`)
- Added tests to ensure UI wiring and safety and to demonstrate the High Roller hybrid case: `tests/test_admin_tools_badge_controls.py` and an added high-roller case in `tests/test_badge_hybrid_match_sources.py`. The work uses the existing hybrid fact sources and registry `match_source_policy` so canonical rows are preferred and legacy-safe rows fill missing `(player_id, match_id)` pairs (no shared-state mutation). (files changed: `jupr_app/ui/pages/admin_tools.py`, `tests/test_badge_hybrid_match_sources.py`, `tests/test_admin_tools_badge_controls.py`)
- Exact Joe root cause: `high_roller` previously relied only on canonical facts and therefore undercounted wins when some historical wins were only present in legacy-safe match rows; after wiring hybrid-safe facts the missing legacy-safe wins are included for hybrid-safe badges and the true unique win count is used for evaluation.
- Stale badge removal behavior: Admins can run a scoped `run_badge_recompute(..., mode="strict")` from the UI which will mark stale rows revoked (sets `revoked_at`, `revoked_by`, `revoke_reason`) and optionally clear revocations for rows that become valid again; the UI enforces scope and a required revoke reason to avoid global accidental revocations.

### Testing
- Ran targeted tests: `pytest -q tests/test_badge_hybrid_match_sources.py tests/test_badge_recompute.py tests/test_admin_tools_badge_controls.py` and all tests passed (14 passed, with warnings). 
- The new hybrid high-roller test confirms canonical-only wins = 99 but hybrid wins = 100 and that `high_roller` is awarded when hybrid facts are used.
- The recompute tests confirm `strict` mode revokes missing rows and that the UI wiring prevents unscoped strict runs by passing `allow_strict_global=False` to `run_badge_recompute`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67362b5f08326b29ffcb3b6ccea60)