### PR TITLE
Add focused High Roller diagnostic pipeline and admin visibility

### DIFF
--- a/jupr_app/domain/gamification/badge_audit.py
+++ b/jupr_app/domain/gamification/badge_audit.py
@@ -9,7 +9,14 @@ import pandas as pd
 from jupr_app.domain.gamification.badge_catalog import BADGE_DEFINITIONS
 from jupr_app.data.load import load_data
 from jupr_app.domain.gamification.badge_engine import compute_candidates_for_club
+from jupr_app.domain.gamification.evaluators import compute_high_roller_win_counts
+from jupr_app.domain.gamification.match_facts import (
+    build_canonical_player_match_facts,
+    build_hybrid_player_match_facts,
+    filter_matches_for_badge_facts,
+)
 from jupr_app.domain.gamification.badge_registry import is_badge_active, registry
+from jupr_app.domain.match_filters import summarize_match_filter_audit
 
 
 KEY_FIELDS = ("player_id", "badge_id", "context_id")
@@ -110,7 +117,7 @@ def build_badge_audit_report(
     missing_soft_rows = [row for row in expected_rows if _soft_key(row) in missing_soft_keys]
     stale_soft_rows = [row for row in actual_active_rows if _soft_key(row) in stale_soft_keys]
 
-    return {
+    report = {
         "scope": {
             "club_id": str(club_id),
             "league_id": league_id,
@@ -171,6 +178,109 @@ def build_badge_audit_report(
         "missing_keys": sorted(missing_exact_keys),
         "stale_keys": sorted(stale_exact_keys),
     }
+    if str(badge_id or "").strip() == "high_roller":
+        report["high_roller_debug"] = _build_high_roller_badge_debug(
+            supabase=supabase,
+            club_id=club_id,
+            player_id=player_id,
+            expected_rows=expected_rows,
+            actual_rows=actual_rows,
+            ctx=ctx,
+            match_limit=match_limit,
+        )
+    return report
+
+
+def _build_high_roller_badge_debug(
+    *,
+    supabase: Any,
+    club_id: str,
+    player_id: int | None,
+    expected_rows: list[dict[str, Any]],
+    actual_rows: list[dict[str, Any]],
+    ctx: Any,
+    match_limit: int,
+) -> dict[str, Any]:
+    scoped_ctx = ctx if ctx is not None else _load_ctx(supabase, club_id, match_limit)
+    facts_hybrid = build_hybrid_player_match_facts(scoped_ctx, club_id_override=club_id)
+    win_counts = compute_high_roller_win_counts(facts_hybrid)
+    debug: dict[str, Any] = {
+        "computed_win_counts_by_player": {str(int(pid)): int(count) for pid, count in win_counts.items()},
+        "qualifies_by_player": {str(int(pid)): int(count) >= 100 for pid, count in win_counts.items()},
+    }
+    if player_id is not None:
+        pid = int(player_id)
+        debug["player_id"] = pid
+        debug["player_qualifies"] = int(win_counts.get(pid, 0)) >= 100
+        debug["player_computed_wins"] = int(win_counts.get(pid, 0))
+        debug["player_expected_rows"] = [row for row in expected_rows if int(row.get("player_id")) == pid]
+        debug["player_existing_badge_rows"] = [row for row in actual_rows if int(row.get("player_id")) == pid]
+    return debug
+
+
+def build_high_roller_diagnostic_report(
+    supabase: Any,
+    club_id: str,
+    player_id: int | None = None,
+    match_limit: int = 5000,
+    ctx: Any | None = None,
+) -> dict[str, Any]:
+    scoped_ctx = ctx if ctx is not None else _load_ctx(supabase, club_id, match_limit)
+    df_matches = getattr(scoped_ctx, "df_matches", pd.DataFrame())
+    filters = {"club_id": club_id, "exclude_popups": True}
+    filtered_matches, audit = filter_matches_for_badge_facts(df_matches, filters, include_audit=True)
+    canonical = build_canonical_player_match_facts(scoped_ctx, club_id_override=club_id)
+    hybrid = build_hybrid_player_match_facts(scoped_ctx, club_id_override=club_id)
+    canonical_win_counts = compute_high_roller_win_counts(canonical)
+    hybrid_win_counts = compute_high_roller_win_counts(hybrid)
+
+    report: dict[str, Any] = {
+        "raw_matches_count": int(len(df_matches)),
+        "filtered_matches_count": int(len(filtered_matches)),
+        "filter_steps": summarize_match_filter_audit(audit),
+        "canonical_fact_rows_count": int(len(canonical)),
+        "hybrid_fact_rows_count": int(len(hybrid)),
+        "canonical_win_rows_count": int((canonical.get("win") == True).sum()) if not canonical.empty else 0,
+        "hybrid_win_rows_count": int((hybrid.get("win") == True).sum()) if not hybrid.empty else 0,
+        "canonical_unique_win_match_ids_by_player": {
+            str(int(pid)): int(count) for pid, count in canonical_win_counts.items()
+        },
+        "hybrid_unique_win_match_ids_by_player": {
+            str(int(pid)): int(count) for pid, count in hybrid_win_counts.items()
+        },
+        "top_20_players_by_hybrid_unique_win_count": [
+            {"player_id": int(pid), "hybrid_unique_wins": int(count)}
+            for pid, count in hybrid_win_counts.head(20).items()
+        ],
+    }
+
+    if player_id is not None:
+        pid = int(player_id)
+        player_hybrid = hybrid[(hybrid["player_id"] == pid) & (hybrid["win"] == True)].copy()
+        player_hybrid["match_id"] = player_hybrid["match_id"].astype(str)
+        unique_hybrid_ids = sorted(player_hybrid["match_id"].dropna().unique().tolist())
+        if not player_hybrid.empty:
+            source_col = (
+                player_hybrid["fact_source"].fillna("canonical")
+                if "fact_source" in player_hybrid.columns
+                else pd.Series(["canonical"] * len(player_hybrid), index=player_hybrid.index)
+            )
+            source_breakdown = source_col.value_counts()
+        else:
+            source_breakdown = pd.Series(dtype="int64")
+        leagues = sorted(player_hybrid.get("league", pd.Series(dtype=str)).dropna().astype(str).unique().tolist())
+        report["selected_player"] = {
+            "player_id": pid,
+            "canonical_unique_win_match_ids": int(canonical_win_counts.get(pid, 0)),
+            "hybrid_unique_win_match_ids": int(hybrid_win_counts.get(pid, 0)),
+            "qualifies_high_roller_canonical": int(canonical_win_counts.get(pid, 0)) >= 100,
+            "qualifies_high_roller_hybrid": int(hybrid_win_counts.get(pid, 0)) >= 100,
+            "first_20_hybrid_win_match_ids": unique_hybrid_ids[:20],
+            "last_20_hybrid_win_match_ids": unique_hybrid_ids[-20:],
+            "leagues_represented": leagues,
+            "fact_source_breakdown": {str(k): int(v) for k, v in source_breakdown.items()},
+        }
+    return report
 
 
 def _load_ctx(supabase: Any, club_id: str, match_limit: int) -> Any:

--- a/jupr_app/domain/gamification/evaluators.py
+++ b/jupr_app/domain/gamification/evaluators.py
@@ -463,8 +463,7 @@ def evaluate_clean_sweep_week(ctx: BadgeEvaluationContext) -> Iterable[BadgeCand
 
 def evaluate_high_roller(ctx: BadgeEvaluationContext) -> Iterable[BadgeCandidate]:
     facts = _as_of_filter(ctx.facts, ctx.as_of)
-    wins = facts[facts["win"] == True].dropna(subset=["match_id"])
-    grouped = wins.groupby("player_id")["match_id"].nunique()
+    grouped = compute_high_roller_win_counts(facts)
     candidates: list[BadgeCandidate] = []
     for player_id, win_count in grouped.items():
         if int(win_count) >= 100:
@@ -481,6 +480,15 @@ def evaluate_high_roller(ctx: BadgeEvaluationContext) -> Iterable[BadgeCandidate
                 )
             )
     return candidates
+
+
+def compute_high_roller_win_counts(facts: pd.DataFrame) -> pd.Series:
+    if facts is None or facts.empty:
+        return pd.Series(dtype="int64")
+    wins = facts[facts["win"] == True].dropna(subset=["match_id"])
+    if wins.empty:
+        return pd.Series(dtype="int64")
+    return wins.groupby("player_id")["match_id"].nunique().sort_values(ascending=False)
 
 
 def evaluate_social_butterfly(ctx: BadgeEvaluationContext) -> Iterable[BadgeCandidate]:

--- a/jupr_app/domain/gamification/match_facts.py
+++ b/jupr_app/domain/gamification/match_facts.py
@@ -12,7 +12,13 @@ from typing import Any
 
 import pandas as pd
 
-from jupr_app.domain.match_filters import apply_match_filters, normalize_player_id, normalize_score
+from jupr_app.domain.match_filters import (
+    MatchFilterAudit,
+    apply_match_filters,
+    apply_match_filters_with_audit,
+    normalize_player_id,
+    normalize_score,
+)
 
 
 _FACT_COLUMNS = [
@@ -72,7 +78,7 @@ def build_canonical_player_match_facts(
 
     club_id = club_id_override if club_id_override is not None else getattr(ctx, "club_id", None)
     filters = {"club_id": club_id, "exclude_popups": True}
-    filtered = apply_match_filters(df_matches, filters)
+    filtered = filter_matches_for_badge_facts(df_matches, filters)
     if filtered.empty:
         return _empty_facts()
 
@@ -172,7 +178,7 @@ def build_legacy_safe_player_match_facts(
 
     club_id = club_id_override if club_id_override is not None else getattr(ctx, "club_id", None)
     filters = {"club_id": club_id, "exclude_popups": True}
-    filtered = apply_match_filters(df_matches, filters)
+    filtered = filter_matches_for_badge_facts(df_matches, filters)
     if filtered.empty:
         return _empty_facts_with_source()
 
@@ -281,6 +287,17 @@ def build_hybrid_player_match_facts(
 
 def _empty_facts_with_source() -> pd.DataFrame:
     return pd.DataFrame(columns=[*_FACT_COLUMNS, "fact_source"])
+
+
+def filter_matches_for_badge_facts(
+    df_matches: pd.DataFrame,
+    context_filters: dict | None,
+    *,
+    include_audit: bool = False,
+) -> pd.DataFrame | tuple[pd.DataFrame, MatchFilterAudit]:
+    if include_audit:
+        return apply_match_filters_with_audit(df_matches, context_filters)
+    return apply_match_filters(df_matches, context_filters)
 
 
 def _resolve_player(row: dict[str, Any], target: str) -> int | None:

--- a/jupr_app/domain/match_filters.py
+++ b/jupr_app/domain/match_filters.py
@@ -32,6 +32,23 @@ def apply_match_filters_with_audit(
     return filtered, audit
 
 
+def summarize_match_filter_audit(audit: MatchFilterAudit) -> dict[str, object]:
+    return {
+        "raw_count": len(audit.raw_match_ids),
+        "final_count": len(audit.final_match_ids),
+        "steps": [
+            {
+                "step_name": step.step_name,
+                "before_count": int(step.before_count),
+                "after_count": int(step.after_count),
+                "removed_count": int(step.before_count - step.after_count),
+                "removed_match_ids": list(step.removed_match_ids),
+            }
+            for step in audit.steps
+        ],
+    }
+
+
 def resolve_match_id_column(df_matches: pd.DataFrame) -> str:
     for col in ("match_id", "id", "matchId", "matchID"):
         if col in df_matches.columns:

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -12,7 +12,10 @@ from jupr_app.domain.constants import DEFAULT_K_FACTOR
 from jupr_app.domain.match_processing import process_matches
 from jupr_app.domain.tournament_match_payload import build_tournament_match_payload
 from jupr_app.domain.gamification.ensure_badges import ensure_badges
-from jupr_app.domain.gamification.badge_audit import build_badge_audit_report
+from jupr_app.domain.gamification.badge_audit import (
+    build_badge_audit_report,
+    build_high_roller_diagnostic_report,
+)
 from jupr_app.domain.gamification.recompute import run_badge_recompute
 from jupr_app.domain.gamification.badge_state import ALLOWED_BADGE_STATES, can_transition_badge_state
 from jupr_app.domain.gamification.evaluators import build_evaluation_context
@@ -429,6 +432,9 @@ def render(ctx):
     _render_badge_audit_section(ctx, club_id)
 
     st.divider()
+    _render_high_roller_diagnostic_section(ctx, club_id)
+
+    st.divider()
     _render_badge_recompute_section(ctx, club_id)
 
     st.divider()
@@ -679,6 +685,74 @@ def _render_high_roller_diagnostics(ctx, *, club_id: str, player_id: int, league
         st.code(", ".join(unique_match_ids[:5]), language="text")
         st.caption("Last 5 winning match_ids counted by the badge engine")
         st.code(", ".join(unique_match_ids[-5:]), language="text")
+
+
+def _render_high_roller_diagnostic_section(ctx, club_id: str) -> None:
+    st.subheader("🕵️ High Roller Diagnostic")
+    st.caption("Run focused diagnostics for High Roller counting and match-filter removals.")
+
+    df_players = getattr(ctx, "df_players_all", pd.DataFrame()).copy()
+    if df_players is None or df_players.empty or "id" not in df_players.columns:
+        st.info("No players available for High Roller diagnostic.")
+        return
+
+    df_players["id"] = pd.to_numeric(df_players["id"], errors="coerce")
+    df_players = df_players.dropna(subset=["id"])
+    if df_players.empty:
+        st.info("No players available for High Roller diagnostic.")
+        return
+    df_players["id"] = df_players["id"].astype(int)
+
+    player_options = sorted(df_players["id"].unique().tolist())
+    player_id = st.selectbox("Diagnostic player", player_options, key="high_roller_diag_player")
+    if st.button("Run High Roller Diagnostic", key="high_roller_diag_run"):
+        report = build_high_roller_diagnostic_report(
+            ctx.supabase,
+            club_id=club_id,
+            player_id=int(player_id),
+            match_limit=5000,
+            ctx=ctx,
+        )
+        st.session_state["high_roller_diag_report"] = report
+
+    report = st.session_state.get("high_roller_diag_report")
+    if not report:
+        return
+
+    selected = report.get("selected_player", {}) or {}
+    col1, col2, col3, col4 = st.columns(4)
+    col1.metric("Canonical wins", int(selected.get("canonical_unique_win_match_ids", 0)))
+    col2.metric("Hybrid wins", int(selected.get("hybrid_unique_win_match_ids", 0)))
+    col3.metric("Qualifies canonical", "Yes" if selected.get("qualifies_high_roller_canonical") else "No")
+    col4.metric("Qualifies hybrid", "Yes" if selected.get("qualifies_high_roller_hybrid") else "No")
+
+    filter_steps = ((report.get("filter_steps", {}) or {}).get("steps")) or []
+    if filter_steps:
+        st.caption("Filter-step removal summary")
+        step_df = pd.DataFrame(filter_steps)
+        st.dataframe(
+            step_df[["step_name", "before_count", "after_count", "removed_count"]],
+            use_container_width=True,
+            hide_index=True,
+        )
+
+    top_df = pd.DataFrame(report.get("top_20_players_by_hybrid_unique_win_count", []))
+    if not top_df.empty:
+        st.caption("Top players by hybrid unique win count")
+        st.dataframe(top_df, use_container_width=True, hide_index=True)
+
+    ui_win_columns = [name for name in ("wins", "win_count", "total_wins", "lifetime_wins") if name in df_players.columns]
+    if ui_win_columns and selected:
+        ui_col = ui_win_columns[0]
+        player_row = df_players[df_players["id"] == int(selected.get("player_id", -1))]
+        if not player_row.empty:
+            ui_wins = int(pd.to_numeric(player_row.iloc[0][ui_col], errors="coerce") or 0)
+            hybrid_wins = int(selected.get("hybrid_unique_win_match_ids", 0))
+            if abs(ui_wins - hybrid_wins) >= 10:
+                st.warning(
+                    f"Material mismatch: UI wins={ui_wins}, High Roller hybrid wins={hybrid_wins}. "
+                    "Badge and UI counts may be out of sync."
+                )
 
 
 def _render_badge_recompute_section(ctx, club_id: str) -> None:

--- a/tests/test_badge_audit.py
+++ b/tests/test_badge_audit.py
@@ -232,3 +232,49 @@ def test_badge_audit_filters_non_live_actual_rows_by_default(monkeypatch):
 
     report_with_non_live = build_badge_audit_report(FakeSupabase(storage), club_id="club", ctx=ctx, include_non_live=True)
     assert report_with_non_live["counts"]["actual_active_exact_count"] == 2
+
+
+def test_badge_audit_high_roller_debug_payload(monkeypatch):
+    storage = {
+        "player_badges": [
+            {
+                "id": "hr1",
+                "club_id": "club",
+                "player_id": 11,
+                "badge_id": "high_roller",
+                "context_id": "lifetime_wins_100",
+                "revoked_at": None,
+            }
+        ]
+    }
+    candidate = BadgeCandidate(
+        badge_id="high_roller",
+        player_id=11,
+        club_id="club",
+        context_type="overall",
+        context_id="lifetime_wins_100",
+        match_id=None,
+        value_json={"wins": 112},
+    )
+    monkeypatch.setattr(
+        "jupr_app.domain.gamification.badge_audit.compute_candidates_for_club",
+        lambda **kwargs: [candidate],
+    )
+    monkeypatch.setattr(
+        "jupr_app.domain.gamification.badge_audit.build_hybrid_player_match_facts",
+        lambda *_args, **_kwargs: pd.DataFrame(
+            [{"player_id": 11, "match_id": f"m-{i}", "win": True} for i in range(112)]
+        ),
+    )
+
+    report = build_badge_audit_report(
+        FakeSupabase(storage),
+        club_id="club",
+        ctx=_ctx(),
+        badge_id="high_roller",
+        player_id=11,
+    )
+    debug = report["high_roller_debug"]
+    assert debug["player_computed_wins"] == 112
+    assert debug["player_qualifies"] is True
+    assert len(debug["player_existing_badge_rows"]) == 1

--- a/tests/test_high_roller_badge.py
+++ b/tests/test_high_roller_badge.py
@@ -2,8 +2,9 @@ from types import SimpleNamespace
 
 import pandas as pd
 
+from jupr_app.domain.gamification.badge_audit import build_high_roller_diagnostic_report
 from jupr_app.domain.gamification.badge_types import BadgeEvaluationContext
-from jupr_app.domain.gamification.evaluators import evaluate_high_roller
+from jupr_app.domain.gamification.evaluators import compute_high_roller_win_counts, evaluate_high_roller
 
 
 def _context_with_facts(facts: pd.DataFrame) -> BadgeEvaluationContext:
@@ -43,3 +44,130 @@ def test_high_roller_awards_at_100_wins():
     candidate = candidates[0]
     assert candidate.player_id == 7
     assert candidate.value_json["wins"] == 100
+
+
+def test_compute_high_roller_win_counts_112_qualifies_99_not():
+    rows = [{"player_id": 11, "match_id": f"j-{i}", "win": True} for i in range(112)]
+    rows.extend({"player_id": 22, "match_id": f"t-{i}", "win": True} for i in range(99))
+    rows.extend({"player_id": 11, "match_id": f"j-loss-{i}", "win": False} for i in range(10))
+    counts = compute_high_roller_win_counts(pd.DataFrame(rows))
+
+    assert int(counts[11]) == 112
+    assert int(counts[22]) == 99
+    assert int(counts[11]) >= 100
+    assert int(counts[22]) < 100
+
+
+def test_high_roller_diagnostic_report_exclusions_and_stable_counts():
+    rows = []
+    for i in range(112):
+        rows.append(
+            {
+                "id": f"j-{i}",
+                "club_id": "club",
+                "league": "A",
+                "date": f"2024-01-{(i % 28) + 1:02d}",
+                "score_t1": 11,
+                "score_t2": 7,
+                "t1_p1": 11,
+                "t2_p1": 33,
+                "match_type": "League",
+                "is_valid": True,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+            }
+        )
+    for i in range(99):
+        rows.append(
+            {
+                "id": f"t-{i}",
+                "club_id": "club",
+                "league": "A",
+                "date": f"2024-02-{(i % 28) + 1:02d}",
+                "score_t1": 11,
+                "score_t2": 8,
+                "t1_p1": 22,
+                "t2_p1": 44,
+                "match_type": "League",
+                "is_valid": True,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+            }
+        )
+    rows.extend(
+        [
+            {
+                "id": "popup-1",
+                "club_id": "club",
+                "date": "2024-03-01",
+                "score_t1": 11,
+                "score_t2": 5,
+                "t1_p1": 11,
+                "t2_p1": 33,
+                "match_type": "PopUp",
+                "is_valid": True,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+            },
+            {
+                "id": "tournament-1",
+                "club_id": "club",
+                "date": "2024-03-02",
+                "score_t1": 11,
+                "score_t2": 5,
+                "t1_p1": 11,
+                "t2_p1": 33,
+                "match_type": "League",
+                "is_valid": True,
+                "context_type": "TOURNAMENT",
+                "tournament_id": None,
+            },
+            {
+                "id": "invalid-1",
+                "club_id": "club",
+                "date": "2024-03-03",
+                "score_t1": 11,
+                "score_t2": 5,
+                "t1_p1": 11,
+                "t2_p1": 33,
+                "match_type": "League",
+                "is_valid": False,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+            },
+            {
+                "id": None,
+                "match_id": "j-0",
+                "club_id": "club",
+                "date": "2024-03-04",
+                "score1": 11,
+                "score2": 7,
+                "player1_id": 11,
+                "player3_id": 33,
+                "match_type": "League",
+                "is_valid": True,
+                "context_type": "LEAGUE",
+                "tournament_id": None,
+            },
+        ]
+    )
+    ctx = SimpleNamespace(club_id="club", df_matches=pd.DataFrame(rows))
+
+    report = build_high_roller_diagnostic_report(
+        supabase=SimpleNamespace(),
+        club_id="club",
+        player_id=11,
+        ctx=ctx,
+    )
+
+    selected = report["selected_player"]
+    assert selected["hybrid_unique_win_match_ids"] == 112
+    assert selected["canonical_unique_win_match_ids"] == 112
+    assert selected["qualifies_high_roller_hybrid"] is True
+    assert report["hybrid_unique_win_match_ids_by_player"]["22"] == 99
+    assert len(report["top_20_players_by_hybrid_unique_win_count"]) >= 2
+
+    removed_by_step = {step["step_name"]: step["removed_count"] for step in report["filter_steps"]["steps"]}
+    assert removed_by_step["exclude_popups"] == 1
+    assert removed_by_step["is_valid"] == 1
+    assert removed_by_step["exclude_context_type_tournament"] == 1

--- a/tests/test_match_filter_audit.py
+++ b/tests/test_match_filter_audit.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from jupr_app.domain.match_filters import apply_match_filters_with_audit
+from jupr_app.domain.match_filters import apply_match_filters_with_audit, summarize_match_filter_audit
 
 
 def test_apply_match_filters_with_audit_tracks_removed_ids():
@@ -68,3 +68,7 @@ def test_apply_match_filters_with_audit_tracks_removed_ids():
     assert removed_by_step["start_date"] == ["9"]
     assert removed_by_step["end_date"] == ["11"]
     assert removed_by_step["eligible_player_ids"] == ["10"]
+
+    summary = summarize_match_filter_audit(audit)
+    assert summary["raw_count"] == 11
+    assert summary["final_count"] == 1


### PR DESCRIPTION
### Motivation
- Provide a read-only, focused diagnostic path for the High Roller badge so admins can explain discrepancies (UI wins vs badge-counted wins) before revoking awards.
- Surface per-step match-filter removals, canonical vs legacy/hybrid counts, and per-player details to isolate undercounting or over-filtering issues.

### Description
- Expose match-filter auditing and a concise summarizer via `summarize_match_filter_audit(...)` and a reusable filter entrypoint `filter_matches_for_badge_facts(...)` so badge fact builders can return audit details (files changed: `jupr_app/domain/match_filters.py`, `jupr_app/domain/gamification/match_facts.py`).
- Add `compute_high_roller_win_counts(facts)` and switch `evaluate_high_roller(...)` to call the shared helper so counting logic is shared between evaluator and diagnostics (`jupr_app/domain/gamification/evaluators.py`).
- Implement `build_high_roller_diagnostic_report(...)` that returns raw/filtered match counts, per-step removal summaries, canonical/hybrid fact & win counts, per-player unique-win maps, selected-player detail (first/last match ids, leagues, fact-source breakdown), and top-20 hybrid winners (`jupr_app/domain/gamification/badge_audit.py`).
- Extend the badge audit output for `badge_id == "high_roller"` with computed win counts and existing badge rows, add a new Admin Tools UI section **🕵️ High Roller Diagnostic** with player select + run button, canonical/hybrid qualification metrics, filter-step summary, top-player table, and a UI-vs-badge mismatch warning (`jupr_app/ui/pages/admin_tools.py`).
- Add/update unit tests to cover the counting helper, diagnostic exclusions, legacy+canonical dedupe behavior, and audit debug payload (`tests/test_high_roller_badge.py`, `tests/test_badge_audit.py`, `tests/test_match_filter_audit.py`).

### Testing
- Ran the focused test suite: `pytest -q tests/test_high_roller_badge.py tests/test_badge_audit.py tests/test_match_filter_audit.py`, and all tests passed (`12 passed`, `3 warnings`).
- New tests validate that a fixture player (Joe / player 11) with 112 hybrid-safe wins qualifies and that another fixture (Tyson / player 22) with 99 wins does not, and that popup/tournament/invalid rows are excluded and reported in the filter-step summary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e676080a2083269a651d11ef825c99)