### PR TITLE
Add foundation for Verified Player Updates feature

### DIFF
--- a/jupr_app/domain/notifications/player_profile_update_repo.py
+++ b/jupr_app/domain/notifications/player_profile_update_repo.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+
+REQUEST_STATUS_PENDING = "pending_admin_review"
+REQUEST_STATUS_ACTIVE = "active"
+REQUEST_STATUS_REJECTED = "rejected"
+REQUEST_STATUS_UNSUBSCRIBED = "unsubscribed"
+
+SEND_STATUS_PENDING = "pending"
+SEND_STATUS_SENT = "sent"
+SEND_STATUS_SKIPPED = "skipped"
+SEND_STATUS_ERROR = "error"
+
+DEFAULT_PREFERENCES = {
+    "frequency": "weekly",
+    "send_only_if_changed": True,
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_data(resp: Any) -> list[dict[str, Any]]:
+    try:
+        return list(resp.data or [])
+    except Exception:
+        return []
+
+
+def _safe_first(resp: Any) -> dict[str, Any] | None:
+    rows = _safe_data(resp)
+    return rows[0] if rows else None
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise ValueError("player_id must be an integer-like value")
+
+
+def normalize_email(email: str) -> str:
+    return str(email or "").strip().lower()
+
+
+def _require_nonempty(value: Any, field_name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field_name} is required")
+    return text
+
+
+def create_public_request(
+    supabase,
+    *,
+    club_id: str,
+    player_id: int,
+    email: str,
+    request_note: str | None = None,
+    preferences_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    club_id = _require_nonempty(club_id, "club_id")
+    email_raw = _require_nonempty(email, "email")
+    normalized = normalize_email(email_raw)
+    player_id_int = _safe_int(player_id)
+
+    payload = {
+        "club_id": club_id,
+        "player_id": player_id_int,
+        "email": email_raw,
+        "email_normalized": normalized,
+        "request_status": REQUEST_STATUS_PENDING,
+        "request_note": str(request_note or "").strip() or None,
+        "preferences_json": preferences_json or dict(DEFAULT_PREFERENCES),
+    }
+    resp = (
+        supabase.table("player_profile_update_subscriptions")
+        .insert(payload)
+        .execute()
+    )
+    row = _safe_first(resp)
+    if row is None:
+        raise RuntimeError("Failed to create subscription request")
+    return row
+
+
+def get_open_or_active_subscription(supabase, club_id: str, player_id: int) -> dict[str, Any] | None:
+    club_id = _require_nonempty(club_id, "club_id")
+    player_id_int = _safe_int(player_id)
+    resp = (
+        supabase.table("player_profile_update_subscriptions")
+        .select("*")
+        .eq("club_id", club_id)
+        .eq("player_id", player_id_int)
+        .in_("request_status", [REQUEST_STATUS_PENDING, REQUEST_STATUS_ACTIVE])
+        .order("created_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+    return _safe_first(resp)
+
+
+def list_pending_requests(
+    supabase,
+    club_id: str,
+    *,
+    limit: int = 200,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    club_id = _require_nonempty(club_id, "club_id")
+    upper = max(0, int(limit) - 1)
+    start = max(0, int(offset))
+    end = start + upper
+    resp = (
+        supabase.table("player_profile_update_subscriptions")
+        .select("*")
+        .eq("club_id", club_id)
+        .eq("request_status", REQUEST_STATUS_PENDING)
+        .order("created_at", desc=True)
+        .range(start, end)
+        .execute()
+    )
+    return _safe_data(resp)
+
+
+def list_active_subscriptions(
+    supabase,
+    club_id: str,
+    *,
+    limit: int = 200,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    club_id = _require_nonempty(club_id, "club_id")
+    upper = max(0, int(limit) - 1)
+    start = max(0, int(offset))
+    end = start + upper
+    resp = (
+        supabase.table("player_profile_update_subscriptions")
+        .select("*")
+        .eq("club_id", club_id)
+        .eq("request_status", REQUEST_STATUS_ACTIVE)
+        .order("verified_at", desc=True)
+        .range(start, end)
+        .execute()
+    )
+    return _safe_data(resp)
+
+
+def reject_request(
+    supabase,
+    subscription_id: str,
+    admin_note: str | None,
+    verified_by: str,
+) -> dict[str, Any]:
+    subscription_id = _require_nonempty(subscription_id, "subscription_id")
+    verified_by = _require_nonempty(verified_by, "verified_by")
+
+    row = _safe_first(
+        supabase.table("player_profile_update_subscriptions")
+        .select("*")
+        .eq("id", subscription_id)
+        .limit(1)
+        .execute()
+    )
+    if row is None:
+        raise ValueError("Subscription not found")
+    if row.get("request_status") != REQUEST_STATUS_PENDING:
+        raise ValueError("Only pending requests can be rejected")
+
+    payload = {
+        "request_status": REQUEST_STATUS_REJECTED,
+        "admin_note": str(admin_note or "").strip() or None,
+        "verified_by": verified_by,
+        "verified_at": _now_iso(),
+    }
+    updated = _safe_first(
+        supabase.table("player_profile_update_subscriptions")
+        .update(payload)
+        .eq("id", subscription_id)
+        .eq("request_status", REQUEST_STATUS_PENDING)
+        .execute()
+    )
+    if updated is None:
+        raise RuntimeError("Request could not be rejected")
+    return updated
+
+
+def approve_request(
+    supabase,
+    subscription_id: str,
+    verified_by: str,
+    admin_note: str | None = None,
+) -> dict[str, Any]:
+    subscription_id = _require_nonempty(subscription_id, "subscription_id")
+    verified_by = _require_nonempty(verified_by, "verified_by")
+
+    row = _safe_first(
+        supabase.table("player_profile_update_subscriptions")
+        .select("*")
+        .eq("id", subscription_id)
+        .limit(1)
+        .execute()
+    )
+    if row is None:
+        raise ValueError("Subscription not found")
+    if row.get("request_status") != REQUEST_STATUS_PENDING:
+        raise ValueError("approve_request only activates pending requests")
+
+    payload = {
+        "request_status": REQUEST_STATUS_ACTIVE,
+        "admin_note": str(admin_note or "").strip() or None,
+        "verified_by": verified_by,
+        "verified_at": _now_iso(),
+        "unsubscribed_at": None,
+    }
+    updated = _safe_first(
+        supabase.table("player_profile_update_subscriptions")
+        .update(payload)
+        .eq("id", subscription_id)
+        .eq("request_status", REQUEST_STATUS_PENDING)
+        .execute()
+    )
+    if updated is None:
+        raise RuntimeError("Request could not be approved")
+    return updated
+
+
+def replace_verified_subscriber(
+    supabase,
+    old_subscription_id: str,
+    new_email: str,
+    new_request_note: str | None,
+    verified_by: str,
+    admin_note: str | None = None,
+) -> dict[str, Any]:
+    old_subscription_id = _require_nonempty(old_subscription_id, "old_subscription_id")
+    verified_by = _require_nonempty(verified_by, "verified_by")
+    new_email_raw = _require_nonempty(new_email, "new_email")
+
+    current = _safe_first(
+        supabase.table("player_profile_update_subscriptions")
+        .select("*")
+        .eq("id", old_subscription_id)
+        .limit(1)
+        .execute()
+    )
+    if current is None:
+        raise ValueError("Old subscription not found")
+    if current.get("request_status") != REQUEST_STATUS_ACTIVE:
+        raise ValueError("Only active subscriptions can be replaced")
+
+    now_iso = _now_iso()
+    unsub_payload = {
+        "request_status": REQUEST_STATUS_UNSUBSCRIBED,
+        "unsubscribed_at": now_iso,
+        "admin_note": str(admin_note or "").strip() or current.get("admin_note"),
+    }
+    unsubscribed = _safe_first(
+        supabase.table("player_profile_update_subscriptions")
+        .update(unsub_payload)
+        .eq("id", old_subscription_id)
+        .eq("request_status", REQUEST_STATUS_ACTIVE)
+        .execute()
+    )
+    if unsubscribed is None:
+        raise RuntimeError("Unable to unsubscribe the prior active subscription")
+
+    new_row_payload = {
+        "club_id": current.get("club_id"),
+        "player_id": current.get("player_id"),
+        "email": new_email_raw,
+        "email_normalized": normalize_email(new_email_raw),
+        "request_status": REQUEST_STATUS_ACTIVE,
+        "request_note": str(new_request_note or "").strip() or None,
+        "admin_note": str(admin_note or "").strip() or None,
+        "verified_by": verified_by,
+        "verified_at": now_iso,
+        "preferences_json": current.get("preferences_json") or dict(DEFAULT_PREFERENCES),
+    }
+    inserted = _safe_first(
+        supabase.table("player_profile_update_subscriptions")
+        .insert(new_row_payload)
+        .execute()
+    )
+    if inserted is None:
+        raise RuntimeError("Failed to create replacement active subscription")
+    return inserted
+
+
+def mark_unsubscribed(supabase, subscription_id: str) -> dict[str, Any]:
+    subscription_id = _require_nonempty(subscription_id, "subscription_id")
+
+    payload = {
+        "request_status": REQUEST_STATUS_UNSUBSCRIBED,
+        "unsubscribed_at": _now_iso(),
+    }
+    updated = _safe_first(
+        supabase.table("player_profile_update_subscriptions")
+        .update(payload)
+        .eq("id", subscription_id)
+        .in_("request_status", [REQUEST_STATUS_PENDING, REQUEST_STATUS_ACTIVE])
+        .execute()
+    )
+    if updated is None:
+        raise RuntimeError("Subscription could not be marked unsubscribed")
+    return updated
+
+
+def save_digest(
+    supabase,
+    *,
+    club_id: str,
+    player_id: int,
+    week_start: date,
+    week_end: date,
+    generated_json: dict[str, Any] | None = None,
+    final_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    club_id = _require_nonempty(club_id, "club_id")
+    player_id_int = _safe_int(player_id)
+
+    payload = {
+        "club_id": club_id,
+        "player_id": player_id_int,
+        "week_start": week_start.isoformat(),
+        "week_end": week_end.isoformat(),
+        "generated_json": generated_json or {},
+        "final_json": final_json or {},
+    }
+    upserted = _safe_first(
+        supabase.table("player_weekly_profile_digests")
+        .upsert(payload, on_conflict="club_id,player_id,week_start")
+        .execute()
+    )
+    if upserted is None:
+        raise RuntimeError("Digest could not be saved")
+    return upserted
+
+
+def list_digests_for_range(
+    supabase,
+    club_id: str,
+    *,
+    week_start_from: date,
+    week_start_to: date,
+    player_id: int | None = None,
+) -> list[dict[str, Any]]:
+    club_id = _require_nonempty(club_id, "club_id")
+
+    query = (
+        supabase.table("player_weekly_profile_digests")
+        .select("*")
+        .eq("club_id", club_id)
+        .gte("week_start", week_start_from.isoformat())
+        .lte("week_start", week_start_to.isoformat())
+        .order("week_start", desc=True)
+    )
+    if player_id is not None:
+        query = query.eq("player_id", _safe_int(player_id))
+    return _safe_data(query.execute())
+
+
+def create_outbox_row(
+    supabase,
+    *,
+    subscription_id: str,
+    club_id: str,
+    player_id: int,
+    week_start: date,
+    week_end: date,
+    email: str,
+) -> dict[str, Any]:
+    subscription_id = _require_nonempty(subscription_id, "subscription_id")
+    club_id = _require_nonempty(club_id, "club_id")
+    email_raw = _require_nonempty(email, "email")
+
+    payload = {
+        "subscription_id": subscription_id,
+        "club_id": club_id,
+        "player_id": _safe_int(player_id),
+        "week_start": week_start.isoformat(),
+        "week_end": week_end.isoformat(),
+        "email": email_raw,
+        "send_status": SEND_STATUS_PENDING,
+    }
+    row = _safe_first(
+        supabase.table("player_profile_update_outbox")
+        .insert(payload)
+        .execute()
+    )
+    if row is None:
+        raise RuntimeError("Outbox row could not be created")
+    return row
+
+
+def list_outbox_rows(
+    supabase,
+    club_id: str,
+    *,
+    status: str | None = None,
+    limit: int = 200,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    club_id = _require_nonempty(club_id, "club_id")
+
+    upper = max(0, int(limit) - 1)
+    start = max(0, int(offset))
+    end = start + upper
+    query = (
+        supabase.table("player_profile_update_outbox")
+        .select("*")
+        .eq("club_id", club_id)
+        .order("created_at", desc=True)
+        .range(start, end)
+    )
+    if status:
+        normalized_status = str(status).strip().lower()
+        if normalized_status not in {
+            SEND_STATUS_PENDING,
+            SEND_STATUS_SENT,
+            SEND_STATUS_SKIPPED,
+            SEND_STATUS_ERROR,
+        }:
+            raise ValueError("Invalid outbox status")
+        query = query.eq("send_status", normalized_status)
+    return _safe_data(query.execute())
+
+
+def update_outbox_status(
+    supabase,
+    outbox_id: str,
+    *,
+    send_status: str,
+    provider_message_id: str | None = None,
+    error_text: str | None = None,
+    sent_at: datetime | None = None,
+) -> dict[str, Any]:
+    outbox_id = _require_nonempty(outbox_id, "outbox_id")
+    normalized_status = str(send_status or "").strip().lower()
+    if normalized_status not in {SEND_STATUS_PENDING, SEND_STATUS_SENT, SEND_STATUS_SKIPPED, SEND_STATUS_ERROR}:
+        raise ValueError("Invalid send_status")
+
+    payload: dict[str, Any] = {
+        "send_status": normalized_status,
+        "provider_message_id": str(provider_message_id or "").strip() or None,
+        "error_text": str(error_text or "").strip() or None,
+    }
+    if sent_at is not None:
+        payload["sent_at"] = sent_at.astimezone(timezone.utc).isoformat()
+    elif normalized_status == SEND_STATUS_SENT:
+        payload["sent_at"] = _now_iso()
+
+    updated = _safe_first(
+        supabase.table("player_profile_update_outbox")
+        .update(payload)
+        .eq("id", outbox_id)
+        .execute()
+    )
+    if updated is None:
+        raise RuntimeError("Outbox row could not be updated")
+    return updated

--- a/jupr_app/ui/page_registry.py
+++ b/jupr_app/ui/page_registry.py
@@ -48,6 +48,7 @@ PAGE_DEFINITIONS: tuple[PageDefinition, ...] = (
     PageDefinition("weekly_recap", "🗞️ Weekly Recap", public=True),
     PageDefinition("top_players_printable", "🧾 Top Active Players PDF", admin_only=True),
     PageDefinition("weekly_recap_admin", "🗞️ Weekly Recap Admin", admin_only=True),
+    PageDefinition("player_updates_admin", "📬 Player Updates Admin", admin_only=True),
     PageDefinition("reset_password", "🔐 Reset Password", show_in_nav=False),
 )
 

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import streamlit as st
+
+from jupr_app.ui.layout import page_shell
+
+
+def render(ctx) -> None:
+    mode_label = "Public" if bool(ctx.public_mode) else "Admin"
+    page_shell(
+        "📬 Player Updates Admin",
+        "Review verified player update requests and monitor delivery pipeline.",
+        mode_label=mode_label,
+    )
+
+    if not bool(getattr(ctx, "admin_logged_in", False)):
+        st.error("Admin login required.")
+        st.stop()
+
+    pending_tab, active_tab, digests_tab, queue_tab = st.tabs(
+        [
+            "Pending Requests",
+            "Active Profiles",
+            "Weekly Digests",
+            "Send Queue",
+        ]
+    )
+
+    with pending_tab:
+        st.subheader("Pending Requests")
+        with st.form("player_updates_pending_filters"):
+            st.text_input("Search email", key="player_updates_pending_email")
+            st.number_input("Limit", min_value=1, max_value=500, value=100, step=1, key="player_updates_pending_limit")
+            st.form_submit_button("Apply Filters")
+        st.info("Placeholder: pending request moderation tools will be added in a follow-up.")
+
+    with active_tab:
+        st.subheader("Active Profiles")
+        with st.form("player_updates_active_filters"):
+            st.text_input("Search player id", key="player_updates_active_player")
+            st.number_input("Limit", min_value=1, max_value=500, value=100, step=1, key="player_updates_active_limit")
+            st.form_submit_button("Apply Filters")
+        st.info("Placeholder: active subscription management tools will be added in a follow-up.")
+
+    with digests_tab:
+        st.subheader("Weekly Digests")
+        today = date.today()
+        with st.form("player_updates_digests_filters"):
+            st.date_input("Week start (from)", value=today - timedelta(days=28), key="player_updates_digest_start")
+            st.date_input("Week start (to)", value=today, key="player_updates_digest_end")
+            st.form_submit_button("Apply Filters")
+        st.info("Placeholder: digest review UI will be added after generation logic is implemented.")
+
+    with queue_tab:
+        st.subheader("Send Queue")
+        with st.form("player_updates_queue_filters"):
+            st.selectbox("Status", ["pending", "sent", "skipped", "error"], key="player_updates_queue_status")
+            st.number_input("Limit", min_value=1, max_value=500, value=100, step=1, key="player_updates_queue_limit")
+            st.form_submit_button("Apply Filters")
+        st.info("Placeholder: queue operations and retries will be added in a follow-up.")

--- a/migrations/20260420_verified_player_updates.sql
+++ b/migrations/20260420_verified_player_updates.sql
@@ -1,0 +1,93 @@
+create table if not exists public.player_profile_update_subscriptions (
+    id uuid primary key default gen_random_uuid(),
+    club_id text not null,
+    player_id bigint not null,
+    email text not null,
+    email_normalized text not null,
+    request_status text not null default 'pending_admin_review',
+    request_note text null,
+    admin_note text null,
+    verified_at timestamptz null,
+    verified_by text null,
+    unsubscribed_at timestamptz null,
+    preferences_json jsonb not null default '{"frequency":"weekly","send_only_if_changed":true}'::jsonb,
+    last_digest_week_start date null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint player_profile_update_subscriptions_status_check
+        check (request_status in ('pending_admin_review', 'active', 'rejected', 'unsubscribed'))
+);
+
+create index if not exists player_profile_update_subscriptions_club_player_idx
+    on public.player_profile_update_subscriptions (club_id, player_id);
+
+create index if not exists player_profile_update_subscriptions_status_created_idx
+    on public.player_profile_update_subscriptions (request_status, created_at desc);
+
+create index if not exists player_profile_update_subscriptions_email_norm_idx
+    on public.player_profile_update_subscriptions (email_normalized);
+
+create unique index if not exists player_profile_update_subscriptions_open_uidx
+    on public.player_profile_update_subscriptions (club_id, player_id)
+    where request_status in ('pending_admin_review', 'active');
+
+create table if not exists public.player_weekly_profile_digests (
+    id uuid primary key default gen_random_uuid(),
+    club_id text not null,
+    player_id bigint not null,
+    week_start date not null,
+    week_end date not null,
+    generated_json jsonb not null default '{}'::jsonb,
+    final_json jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    unique (club_id, player_id, week_start)
+);
+
+create table if not exists public.player_profile_update_outbox (
+    id uuid primary key default gen_random_uuid(),
+    subscription_id uuid not null references public.player_profile_update_subscriptions(id) on delete cascade,
+    club_id text not null,
+    player_id bigint not null,
+    week_start date not null,
+    week_end date not null,
+    email text not null,
+    send_status text not null default 'pending',
+    provider_message_id text null,
+    sent_at timestamptz null,
+    error_text text null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint player_profile_update_outbox_status_check
+        check (send_status in ('pending', 'sent', 'skipped', 'error')),
+    unique (subscription_id, week_start)
+);
+
+create index if not exists player_profile_update_outbox_subscription_week_idx
+    on public.player_profile_update_outbox (subscription_id, week_start);
+
+create or replace function public.set_updated_at_timestamp()
+returns trigger as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists player_profile_update_subscriptions_set_updated_at on public.player_profile_update_subscriptions;
+create trigger player_profile_update_subscriptions_set_updated_at
+before update on public.player_profile_update_subscriptions
+for each row
+execute function public.set_updated_at_timestamp();
+
+drop trigger if exists player_weekly_profile_digests_set_updated_at on public.player_weekly_profile_digests;
+create trigger player_weekly_profile_digests_set_updated_at
+before update on public.player_weekly_profile_digests
+for each row
+execute function public.set_updated_at_timestamp();
+
+drop trigger if exists player_profile_update_outbox_set_updated_at on public.player_profile_update_outbox;
+create trigger player_profile_update_outbox_set_updated_at
+before update on public.player_profile_update_outbox
+for each row
+execute function public.set_updated_at_timestamp();

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -331,6 +331,7 @@ def main():
             match_log,
             match_uploader,
             moneyball,
+            player_updates_admin,
             player_editor,
             players,
             reset_password,
@@ -383,6 +384,7 @@ def main():
             "🔐 Reset Password": reset_password,
             # Admin-only
             "🗞️ Weekly Recap Admin": weekly_recap_admin,
+            "📬 Player Updates Admin": player_updates_admin,
         }
 
         # Visible labels based on auth


### PR DESCRIPTION
### Motivation
- Provide the database, repository helpers, routing, and admin UI skeleton needed to implement a Verified Player Updates feature without adding digest/email sending or modifying `load.py` yet.
- Centralize subscription/digest/outbox access behind a dedicated repo helper so other code can query the new tables directly.
- Keep the admin surface minimal and explicit (no autosubmit or generation/email behavior) so follow-up rollouts can add generation and sending safely.

### Description
- Add migration `migrations/20260420_verified_player_updates.sql` creating `player_profile_update_subscriptions`, `player_weekly_profile_digests`, and `player_profile_update_outbox` with constraints, status checks, indexes, unique partials, and `updated_at` triggers.
- Add repo helper `jupr_app/domain/notifications/player_profile_update_repo.py` implementing defensive helpers including `normalize_email`, `create_public_request`, `get_open_or_active_subscription`, `list_pending_requests`, `list_active_subscriptions`, `reject_request`, `approve_request` (activates only pending), `replace_verified_subscriber` (unsubscribes old active row and inserts new active row preserving history), `mark_unsubscribed`, `save_digest`, `list_digests_for_range`, `create_outbox_row`, `list_outbox_rows`, and `update_outbox_status`.
- Add admin page skeleton `jupr_app/ui/pages/player_updates_admin.py` (key/label `player_updates_admin` / “📬 Player Updates Admin”) that requires admin login, renders `page_shell`, and shows placeholder tabs: Pending Requests, Active Profiles, Weekly Digests, and Send Queue with explicit forms.
- Wire the new page into routing by updating `jupr_app/ui/page_registry.py` and `streamlit_app.py` lazy imports and router mapping; no changes to `jupr_app/data/load.py`.

### Testing
- Compiled new/updated modules with `python -m compileall` successfully for the repo helper and page files.
- Ran `pytest -q tests/test_page_registry.py tests/test_imports.py` and all tests passed (`4 passed`).
- No runtime UI/email/digest behavior was added or exercised in tests; those behaviors will be implemented in follow-ups.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68f59b9488326a11453662ce17688)