### PR TITLE
Verified player update emails: chart rendering, SMTP send, outbox queue, and public unsubscribe

### DIFF
--- a/jupr_app/domain/notifications/player_update_charts.py
+++ b/jupr_app/domain/notifications/player_update_charts.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+
+def render_player_digest_chart_png(digest_json: dict) -> bytes | None:
+    chart = (digest_json or {}).get("chart") or {}
+    points = chart.get("points") or []
+    parsed: list[tuple[str, float]] = []
+    for point in points:
+        if not isinstance(point, dict):
+            continue
+        date_text = str(point.get("date") or "").strip()
+        try:
+            y = float(point.get("overall_after"))
+        except Exception:
+            continue
+        if not date_text:
+            continue
+        parsed.append((date_text, y))
+
+    if len(parsed) < 2:
+        return None
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.dates as mdates
+    import matplotlib.pyplot as plt
+    import pandas as pd
+
+    x_vals = pd.to_datetime([row[0] for row in parsed], utc=True, errors="coerce")
+    y_vals = [row[1] for row in parsed]
+
+    valid = [(x, y) for x, y in zip(x_vals, y_vals) if not pd.isna(x)]
+    if len(valid) < 2:
+        return None
+
+    fig, ax = plt.subplots(figsize=(8.5, 3.2), dpi=150)
+    x, y = zip(*valid)
+    ax.plot(x, y, color="#1f77b4", linewidth=2.2, marker="o", markersize=3.5)
+    ax.set_title(str(chart.get("title") or "Overall JUPR Trend"), fontsize=11)
+    ax.set_ylabel("JUPR")
+    ax.grid(True, alpha=0.3)
+    ax.xaxis.set_major_locator(mdates.AutoDateLocator())
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+    fig.autofmt_xdate(rotation=30, ha="right")
+    fig.tight_layout()
+
+    output = BytesIO()
+    fig.savefig(output, format="png", bbox_inches="tight")
+    plt.close(fig)
+    return output.getvalue()

--- a/jupr_app/domain/notifications/player_update_email_template.py
+++ b/jupr_app/domain/notifications/player_update_email_template.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import html
+
+
+def _s(value) -> str:
+    return str(value or "").strip()
+
+
+def build_player_update_email_subject(digest_json: dict) -> str:
+    player_name = _s((digest_json or {}).get("player_name")) or "Verified Player"
+    display_range = _s((digest_json or {}).get("display_range"))
+    if display_range:
+        return f"{player_name} verified update · {display_range}"
+    return f"{player_name} verified update"
+
+
+def build_player_update_email_html(digest_json: dict, chart_cid: str | None) -> str:
+    digest = digest_json or {}
+    summary = digest.get("summary") or {}
+    badges = digest.get("badges_earned") or []
+    trophies = digest.get("trophies_earned") or []
+    highlights = digest.get("highlights") or []
+    links = digest.get("links") or {}
+
+    player_name = html.escape(_s(digest.get("player_name")) or "Verified Player")
+    display_range = html.escape(_s(digest.get("display_range")))
+    overall = summary.get("overall_jupr_after")
+    try:
+        overall_text = f"{float(overall):.3f}"
+    except Exception:
+        overall_text = "N/A"
+
+    record = html.escape(_s(summary.get("record")) or "0-0")
+    matches_played = int(summary.get("matches_played") or 0)
+
+    badge_items = "".join(
+        f"<li>{html.escape(_s(item.get('name')) or _s(item.get('badge_id')) or 'Badge')}</li>"
+        for item in badges[:10]
+    )
+    trophy_items = "".join(
+        f"<li>{html.escape(_s(item.get('tournament_name')) or _s(item.get('league_name')) or 'Trophy')}</li>"
+        for item in trophies[:10]
+    )
+    highlight_items = "".join(f"<li>{html.escape(_s(line))}</li>" for line in highlights[:10])
+
+    profile_link = html.escape(_s(links.get("player_profile")))
+    unsubscribe_link = html.escape(_s(links.get("unsubscribe")))
+
+    chart_block = ""
+    if chart_cid:
+        chart_block = (
+            "<h3>Overall JUPR trend</h3>"
+            f"<img alt=\"Overall JUPR trend\" src=\"cid:{html.escape(chart_cid)}\" "
+            "style=\"max-width:100%;height:auto;border:1px solid #ddd;border-radius:6px;\"/>"
+        )
+    else:
+        chart_block = "<p><em>Chart unavailable for this date range (fewer than 2 points).</em></p>"
+
+    return f"""
+    <html>
+      <body style=\"font-family:Arial,sans-serif;line-height:1.5;color:#111;\">
+        <h2>Verified Player Update</h2>
+        <p><strong>Player:</strong> {player_name}<br/>
+           <strong>Date range:</strong> {display_range}<br/>
+           <strong>Current overall JUPR:</strong> {overall_text}</p>
+
+        <p><strong>Weekly record:</strong> {record}<br/>
+           <strong>Matches played:</strong> {matches_played}</p>
+
+        {chart_block}
+
+        <h3>Badges earned</h3>
+        {('<ul>' + badge_items + '</ul>') if badge_items else '<p>None this period.</p>'}
+
+        <h3>Trophies earned</h3>
+        {('<ul>' + trophy_items + '</ul>') if trophy_items else '<p>None this period.</p>'}
+
+        <h3>Highlights</h3>
+        {('<ul>' + highlight_items + '</ul>') if highlight_items else '<p>No highlights available.</p>'}
+
+        <p><a href=\"{profile_link}\">View player profile</a></p>
+        <p style=\"font-size:12px;color:#444;\">To stop these updates, <a href=\"{unsubscribe_link}\">unsubscribe in one click</a>.</p>
+      </body>
+    </html>
+    """.strip()
+
+
+def build_player_update_email_text(digest_json: dict) -> str:
+    digest = digest_json or {}
+    summary = digest.get("summary") or {}
+    badges = digest.get("badges_earned") or []
+    trophies = digest.get("trophies_earned") or []
+    highlights = digest.get("highlights") or []
+    links = digest.get("links") or {}
+
+    badge_lines = [f"- {_s(item.get('name')) or _s(item.get('badge_id')) or 'Badge'}" for item in badges[:10]]
+    trophy_lines = [
+        f"- {_s(item.get('tournament_name')) or _s(item.get('league_name')) or 'Trophy'}"
+        for item in trophies[:10]
+    ]
+    highlight_lines = [f"- {_s(line)}" for line in highlights[:10]]
+
+    return "\n".join(
+        [
+            "Verified Player Update",
+            f"Player: {_s(digest.get('player_name'))}",
+            f"Date range: {_s(digest.get('display_range'))}",
+            f"Current overall JUPR: {summary.get('overall_jupr_after')}",
+            f"Weekly record: {_s(summary.get('record')) or '0-0'}",
+            f"Matches played: {int(summary.get('matches_played') or 0)}",
+            "",
+            "Badges earned:",
+            *(badge_lines or ["- None this period."]),
+            "",
+            "Trophies earned:",
+            *(trophy_lines or ["- None this period."]),
+            "",
+            "Highlights:",
+            *(highlight_lines or ["- No highlights available."]),
+            "",
+            f"Profile link: {_s(links.get('player_profile'))}",
+            f"Unsubscribe: {_s(links.get('unsubscribe'))}",
+        ]
+    ).strip()

--- a/jupr_app/domain/notifications/player_update_sender.py
+++ b/jupr_app/domain/notifications/player_update_sender.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import streamlit as st
+
+from jupr_app.domain.notifications.player_profile_update_repo import (
+    DEFAULT_PREFERENCES,
+    REQUEST_STATUS_ACTIVE,
+    SEND_STATUS_ERROR,
+    SEND_STATUS_SENT,
+    SEND_STATUS_SKIPPED,
+    create_outbox_row,
+    list_active_subscriptions,
+    list_outbox_rows,
+    save_digest,
+    update_outbox_status,
+)
+from jupr_app.domain.notifications.player_update_charts import render_player_digest_chart_png
+from jupr_app.domain.notifications.player_update_email_template import (
+    build_player_update_email_html,
+    build_player_update_email_subject,
+    build_player_update_email_text,
+)
+from jupr_app.domain.notifications.smtp_mailer import send_email_with_inline_chart
+from jupr_app.domain.recaps.player_weekly_digest import compute_player_weekly_digest
+
+
+def _safe_subscription(supabase, subscription_id: str) -> dict | None:
+    try:
+        resp = (
+            supabase.table("player_profile_update_subscriptions")
+            .select("*")
+            .eq("id", str(subscription_id))
+            .limit(1)
+            .execute()
+        )
+        rows = resp.data or []
+        return rows[0] if rows else None
+    except Exception:
+        return None
+
+
+def _safe_digest_for_week(supabase, club_id: str, player_id: int, week_start: date) -> dict | None:
+    try:
+        resp = (
+            supabase.table("player_weekly_profile_digests")
+            .select("*")
+            .eq("club_id", str(club_id))
+            .eq("player_id", int(player_id))
+            .eq("week_start", week_start.isoformat())
+            .limit(1)
+            .execute()
+        )
+        rows = resp.data or []
+        return rows[0] if rows else None
+    except Exception:
+        return None
+
+
+def _merge_links_for_send(*, digest: dict[str, Any], player_id: int, subscription_id: str) -> dict[str, Any]:
+    links = dict((digest or {}).get("links") or {})
+    links["player_profile"] = f"/?page=players&public=1&pid={int(player_id)}"
+    links["unsubscribe"] = (
+        f"/?page=players&public=1&pid={int(player_id)}&unsubscribe=1&sid={subscription_id}"
+    )
+    merged = dict(digest or {})
+    merged["links"] = links
+    return merged
+
+
+def _is_send_only_if_changed_and_unchanged(subscription: dict, digest: dict) -> bool:
+    prefs = subscription.get("preferences_json") or dict(DEFAULT_PREFERENCES)
+    send_only_if_changed = bool((prefs or {}).get("send_only_if_changed", True))
+    if not send_only_if_changed:
+        return False
+
+    summary = digest.get("summary") or {}
+    matches_played = int(summary.get("matches_played") or 0)
+    badges = digest.get("badges_earned") or []
+    trophies = digest.get("trophies_earned") or []
+    return matches_played == 0 and len(badges) == 0 and len(trophies) == 0
+
+
+def queue_digest_outbox_rows_for_range(ctx, *, start_date: date, end_date: date) -> dict[str, int]:
+    supabase = ctx.supabase
+    club_id = str(ctx.club_id)
+
+    active_rows = list_active_subscriptions(supabase, club_id, limit=2000)
+    queued = 0
+    already_exists = 0
+    failed = 0
+
+    for sub in active_rows:
+        try:
+            player_id = int(sub.get("player_id"))
+            digest = compute_player_weekly_digest(ctx, player_id=player_id, start_date=start_date, end_date=end_date)
+            save_digest(
+                supabase,
+                club_id=club_id,
+                player_id=player_id,
+                week_start=start_date,
+                week_end=end_date,
+                generated_json=digest,
+                final_json=digest,
+            )
+            create_outbox_row(
+                supabase,
+                subscription_id=str(sub.get("id") or ""),
+                club_id=club_id,
+                player_id=player_id,
+                week_start=start_date,
+                week_end=end_date,
+                email=str(sub.get("email") or ""),
+            )
+            queued += 1
+        except Exception as exc:
+            if "duplicate key" in str(exc).lower() or "unique" in str(exc).lower():
+                already_exists += 1
+            else:
+                failed += 1
+
+    return {
+        "queued": queued,
+        "already_exists": already_exists,
+        "failed": failed,
+    }
+
+
+def send_pending_player_update_emails(ctx, *, limit: int = 100) -> dict[str, int]:
+    supabase = ctx.supabase
+    club_id = str(ctx.club_id)
+    pending_rows = list_outbox_rows(supabase, club_id, status="pending", limit=max(1, int(limit)))
+
+    sent = 0
+    skipped = 0
+    errors = 0
+
+    for outbox in pending_rows:
+        outbox_id = str(outbox.get("id") or "")
+        subscription = _safe_subscription(supabase, str(outbox.get("subscription_id") or ""))
+        try:
+            if not subscription:
+                raise ValueError("Subscription not found")
+            if str(subscription.get("request_status") or "") != REQUEST_STATUS_ACTIVE:
+                update_outbox_status(
+                    supabase,
+                    outbox_id,
+                    send_status=SEND_STATUS_SKIPPED,
+                    error_text="Subscription is no longer active.",
+                )
+                skipped += 1
+                continue
+
+            week_start = date.fromisoformat(str(outbox.get("week_start")))
+            week_end = date.fromisoformat(str(outbox.get("week_end")))
+            player_id = int(outbox.get("player_id"))
+
+            digest_row = _safe_digest_for_week(supabase, club_id, player_id, week_start)
+            digest = (digest_row or {}).get("final_json") or (digest_row or {}).get("generated_json") or {}
+            if not digest:
+                digest = compute_player_weekly_digest(ctx, player_id=player_id, start_date=week_start, end_date=week_end)
+                save_digest(
+                    supabase,
+                    club_id=club_id,
+                    player_id=player_id,
+                    week_start=week_start,
+                    week_end=week_end,
+                    generated_json=digest,
+                    final_json=digest,
+                )
+
+            digest = _merge_links_for_send(
+                digest=digest,
+                player_id=player_id,
+                subscription_id=str(subscription.get("id") or ""),
+            )
+
+            if _is_send_only_if_changed_and_unchanged(subscription, digest):
+                update_outbox_status(
+                    supabase,
+                    outbox_id,
+                    send_status=SEND_STATUS_SKIPPED,
+                    error_text="Skipped because send_only_if_changed is enabled and no changes were detected.",
+                )
+                skipped += 1
+                continue
+
+            chart_cid = "player-digest-chart"
+            chart_png = render_player_digest_chart_png(digest)
+            subject = build_player_update_email_subject(digest)
+            html_body = build_player_update_email_html(digest, chart_cid if chart_png else None)
+            text_body = build_player_update_email_text(digest)
+
+            provider_message_id = send_email_with_inline_chart(
+                to_email=str(outbox.get("email") or ""),
+                subject=subject,
+                html_body=html_body,
+                text_body=text_body,
+                chart_png_bytes=chart_png,
+                chart_cid=chart_cid if chart_png else None,
+            )
+
+            update_outbox_status(
+                supabase,
+                outbox_id,
+                send_status=SEND_STATUS_SENT,
+                provider_message_id=provider_message_id,
+                error_text=None,
+            )
+            (
+                supabase.table("player_profile_update_subscriptions")
+                .update({"last_digest_week_start": week_start.isoformat()})
+                .eq("id", str(subscription.get("id") or ""))
+                .execute()
+            )
+            sent += 1
+        except Exception as exc:
+            update_outbox_status(
+                supabase,
+                outbox_id,
+                send_status=SEND_STATUS_ERROR,
+                error_text=str(exc),
+            )
+            errors += 1
+
+    return {
+        "attempted": len(pending_rows),
+        "sent": sent,
+        "skipped": skipped,
+        "errors": errors,
+    }
+
+
+def send_test_player_update_email(
+    ctx,
+    *,
+    start_date: date,
+    end_date: date,
+    player_id: int | None = None,
+    to_email: str | None = None,
+) -> dict[str, str]:
+    supabase = ctx.supabase
+    club_id = str(ctx.club_id)
+    admin_email = str(
+        to_email
+        or getattr(ctx, "admin_email", "")
+        or st.session_state.get("admin_email", "")
+        or getattr(ctx, "user_email", "")
+        or st.session_state.get("user_email", "")
+    ).strip()
+    if not admin_email:
+        raise ValueError("No admin email available for test send.")
+
+    selected_player_id = player_id
+    selected_subscription_id = "test-subscription"
+
+    if selected_player_id is None:
+        active = list_active_subscriptions(supabase, club_id, limit=1)
+        if not active:
+            raise ValueError("No active subscriptions available for test send.")
+        selected_player_id = int(active[0].get("player_id"))
+        selected_subscription_id = str(active[0].get("id") or selected_subscription_id)
+
+    digest = compute_player_weekly_digest(
+        ctx,
+        player_id=int(selected_player_id),
+        start_date=start_date,
+        end_date=end_date,
+    )
+    digest = _merge_links_for_send(
+        digest=digest,
+        player_id=int(selected_player_id),
+        subscription_id=selected_subscription_id,
+    )
+
+    chart_cid = "player-digest-chart"
+    chart_png = render_player_digest_chart_png(digest)
+    subject = f"[TEST] {build_player_update_email_subject(digest)}"
+    html_body = build_player_update_email_html(digest, chart_cid if chart_png else None)
+    text_body = build_player_update_email_text(digest)
+
+    provider_message_id = send_email_with_inline_chart(
+        to_email=admin_email,
+        subject=subject,
+        html_body=html_body,
+        text_body=text_body,
+        chart_png_bytes=chart_png,
+        chart_cid=chart_cid if chart_png else None,
+    )
+    return {"to_email": admin_email, "provider_message_id": provider_message_id}

--- a/jupr_app/domain/notifications/smtp_mailer.py
+++ b/jupr_app/domain/notifications/smtp_mailer.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+import smtplib
+from email.mime.image import MIMEImage
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    val = str(os.getenv(name, "")).strip().lower()
+    if not val:
+        return default
+    return val in {"1", "true", "yes", "y", "on"}
+
+
+def _smtp_config_from_env() -> dict:
+    host = str(os.getenv("SMTP_HOST", "")).strip()
+    port_raw = str(os.getenv("SMTP_PORT", "")).strip()
+    username = str(os.getenv("SMTP_USERNAME", "")).strip()
+    password = str(os.getenv("SMTP_PASSWORD", "")).strip()
+    from_email = str(os.getenv("SMTP_FROM_EMAIL", "")).strip()
+    from_name = str(os.getenv("SMTP_FROM_NAME", "")).strip() or "JUPR"
+    use_tls = _env_bool("SMTP_USE_TLS", default=True)
+
+    missing = [
+        name
+        for name, value in [
+            ("SMTP_HOST", host),
+            ("SMTP_PORT", port_raw),
+            ("SMTP_USERNAME", username),
+            ("SMTP_PASSWORD", password),
+            ("SMTP_FROM_EMAIL", from_email),
+        ]
+        if not value
+    ]
+    if missing:
+        raise ValueError(f"Missing SMTP configuration: {', '.join(missing)}")
+
+    try:
+        port = int(port_raw)
+    except Exception as exc:
+        raise ValueError("SMTP_PORT must be an integer") from exc
+
+    return {
+        "host": host,
+        "port": port,
+        "username": username,
+        "password": password,
+        "from_email": from_email,
+        "from_name": from_name,
+        "use_tls": use_tls,
+    }
+
+
+def send_email_with_inline_chart(
+    *,
+    to_email: str,
+    subject: str,
+    html_body: str,
+    text_body: str,
+    chart_png_bytes: bytes | None = None,
+    chart_cid: str | None = None,
+) -> str:
+    cfg = _smtp_config_from_env()
+
+    msg = MIMEMultipart("related")
+    msg["Subject"] = str(subject)
+    msg["From"] = f"{cfg['from_name']} <{cfg['from_email']}>"
+    msg["To"] = str(to_email).strip()
+
+    alt = MIMEMultipart("alternative")
+    alt.attach(MIMEText(text_body or "", "plain", "utf-8"))
+    alt.attach(MIMEText(html_body or "", "html", "utf-8"))
+    msg.attach(alt)
+
+    if chart_png_bytes:
+        image_part = MIMEImage(chart_png_bytes, _subtype="png")
+        cid = (chart_cid or "player-digest-chart").strip()
+        image_part.add_header("Content-ID", f"<{cid}>")
+        image_part.add_header("Content-Disposition", "inline", filename="player-digest-chart.png")
+        msg.attach(image_part)
+
+    with smtplib.SMTP(cfg["host"], cfg["port"], timeout=30) as server:
+        server.ehlo()
+        if cfg["use_tls"]:
+            server.starttls()
+            server.ehlo()
+        server.login(cfg["username"], cfg["password"])
+        server.sendmail(cfg["from_email"], [msg["To"]], msg.as_string())
+
+    return "smtp"

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -10,10 +10,16 @@ from jupr_app.domain.notifications.player_profile_update_repo import (
     list_active_subscriptions,
     list_digests_for_range,
     list_pending_requests,
+    list_outbox_rows,
     mark_unsubscribed,
     reject_request,
     replace_verified_subscriber,
     save_digest,
+)
+from jupr_app.domain.notifications.player_update_sender import (
+    queue_digest_outbox_rows_for_range,
+    send_pending_player_update_emails,
+    send_test_player_update_email,
 )
 from jupr_app.domain.recaps.player_weekly_digest import compute_player_weekly_digest
 from jupr_app.ui.layout import page_shell
@@ -400,4 +406,68 @@ def render(ctx) -> None:
 
     with queue_tab:
         st.subheader("Send Queue")
-        st.info("Email sending is implemented in a later step.")
+
+        today = date.today()
+        queue_start = st.date_input("Queue Start Date", value=today - timedelta(days=7), key="player_updates_queue_start")
+        queue_end = st.date_input("Queue End Date", value=today, key="player_updates_queue_end")
+
+        if queue_end < queue_start:
+            st.error("Queue End Date must be on or after Queue Start Date.")
+            return
+
+        q1, q2, q3 = st.columns(3)
+        with q1:
+            if st.button("Queue Pending for Date Range"):
+                try:
+                    result = queue_digest_outbox_rows_for_range(ctx, start_date=queue_start, end_date=queue_end)
+                    st.success(
+                        f"Queued: {result['queued']} · Existing: {result['already_exists']} · Failed: {result['failed']}"
+                    )
+                except Exception as exc:
+                    st.error(f"Queue failed: {exc}")
+
+        with q2:
+            if st.button("Send Pending"):
+                try:
+                    result = send_pending_player_update_emails(ctx, limit=500)
+                    st.success(
+                        f"Attempted: {result['attempted']} · Sent: {result['sent']} · "
+                        f"Skipped: {result['skipped']} · Errors: {result['errors']}"
+                    )
+                except Exception as exc:
+                    st.error(f"Send pending failed: {exc}")
+
+        with q3:
+            if st.button("Send Test to Admin"):
+                try:
+                    result = send_test_player_update_email(ctx, start_date=queue_start, end_date=queue_end)
+                    st.success(f"Sent test email to {result['to_email']}.")
+                except Exception as exc:
+                    st.error(f"Send test failed: {exc}")
+
+        st.divider()
+        try:
+            outbox_rows = list_outbox_rows(supabase, club_id, limit=500)
+        except Exception as exc:
+            st.warning(f"Unable to load outbox rows: {exc}")
+            outbox_rows = []
+
+        if outbox_rows:
+            display_rows = []
+            for row in outbox_rows:
+                display_rows.append(
+                    {
+                        "id": row.get("id"),
+                        "player_id": row.get("player_id"),
+                        "player_name": _player_name(ctx, row.get("player_id")),
+                        "week_start": row.get("week_start"),
+                        "week_end": row.get("week_end"),
+                        "send_status": row.get("send_status"),
+                        "sent_at": row.get("sent_at"),
+                        "error_text": row.get("error_text"),
+                        "created_at": row.get("created_at"),
+                    }
+                )
+            st.dataframe(pd.DataFrame(display_rows), use_container_width=True, hide_index=True)
+        else:
+            st.caption("No outbox rows.")

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -34,6 +34,7 @@ from jupr_app.domain.notifications.player_profile_update_repo import (
     REQUEST_STATUS_PENDING,
     create_public_request,
     get_open_or_active_subscription,
+    mark_unsubscribed,
 )
 
 logger = logging.getLogger(__name__)
@@ -1100,6 +1101,8 @@ def render(ctx):
     players_df["id"] = players_df["id"].astype(int)
 
     pid_q = qp_get("pid", "").strip()
+    unsub_q = qp_get("unsubscribe", "").strip()
+    sid_q = qp_get("sid", "").strip()
     pid_sig = f"pid:{pid_q}" if pid_q else ""
     last_sig = st.session_state.get("player_pid_sig_applied", "")
 
@@ -1138,9 +1141,38 @@ def render(ctx):
 
     pid = int(pick_id)
     row = players_df[players_df["id"] == pid].iloc[0]
-    pick_name = str(row["name"])
     _supabase = ctx.supabase
     club_id = ctx.club_id
+
+    if PUBLIC_MODE and unsub_q == "1":
+        unsub_sig = f"unsub:{pid}:{sid_q}"
+        if st.session_state.get("verified_updates_unsub_sig") != unsub_sig:
+            st.session_state["verified_updates_unsub_sig"] = unsub_sig
+            try:
+                active_sub = (
+                    _supabase.table("player_profile_update_subscriptions")
+                    .select("id")
+                    .eq("club_id", str(club_id))
+                    .eq("player_id", int(pid))
+                    .eq("request_status", REQUEST_STATUS_ACTIVE)
+                    .limit(1)
+                    .execute()
+                )
+                active_rows = active_sub.data or []
+                active_id = str((active_rows[0] if active_rows else {}).get("id") or "")
+                if sid_q and active_id and sid_q == active_id:
+                    mark_unsubscribed(_supabase, sid_q)
+                    st.success("Verified player updates have been unsubscribed.")
+                else:
+                    st.error("Unable to process unsubscribe request.")
+            except Exception:
+                st.error("Unable to process unsubscribe request.")
+            try:
+                st.query_params.pop("unsubscribe", None)
+                st.query_params.pop("sid", None)
+            except Exception:
+                pass
+    pick_name = str(row["name"])
 
     try:
         current_overall_elo = float(row.get("rating", 1200.0) or 1200.0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 pandas
 supabase
 openpyxl>=3.1
+matplotlib>=3.8


### PR DESCRIPTION
### Motivation
- Provide a complete pipeline to render and deliver Verified Player Updates (chart + HTML/text email), track delivery results, and allow public one-click unsubscribe without changing existing load_data.
- Honor subscriber preferences such as `send_only_if_changed` and avoid sending when no activity occurred in the selected date range.

### Description
- Added static chart rendering via `render_player_digest_chart_png` in `jupr_app/domain/notifications/player_update_charts.py` and added `matplotlib>=3.8` to `requirements.txt`; the renderer returns `None` when fewer than 2 usable points exist so the email shows a text fallback.
- Added templating functions `build_player_update_email_subject`, `build_player_update_email_html`, and `build_player_update_email_text` in `jupr_app/domain/notifications/player_update_email_template.py` that include player name, date range, overall JUPR, weekly record, badges, trophies, highlights, profile link, and unsubscribe link.
- Implemented a stdlib SMTP mailer in `jupr_app/domain/notifications/smtp_mailer.py` using `smtplib` and `email.mime.*` and reading env vars for configuration (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM_EMAIL`, `SMTP_FROM_NAME`, `SMTP_USE_TLS`).
- Added orchestration/sender functions in `jupr_app/domain/notifications/player_update_sender.py`: `queue_digest_outbox_rows_for_range`, `send_pending_player_update_emails`, and `send_test_player_update_email`, which create outbox rows, render digests, embed unsubscribe/profile links, attach inline chart images when available, and update `player_profile_update_outbox` statuses to `sent`, `skipped`, or `error`.
- Updated UI: `jupr_app/ui/pages/player_updates_admin.py` now exposes queue/send/test controls and displays outbox rows, and `jupr_app/ui/pages/players.py` supports public one-click unsubscribe via query params `?page=players&public=1&pid=<pid>&unsubscribe=1&sid=<sid>` with validation against the active subscription.

### Testing
- Ran static compile checks with `python -m py_compile` on new/modified modules and they succeeded.
- Ran `pytest -q tests/test_imports.py` and it passed (`1 passed`).
- The sender handles missing SMTP config and surfaces readable row-level `error_text` instead of crashing the UI when `SMTP_*` env vars are not configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6949660348326ae7fb2a09491d718)