### PR TITLE
Polish Verified Player Updates integration and conflict handling

### DIFF
--- a/jupr_app/domain/notifications/player_profile_update_repo.py
+++ b/jupr_app/domain/notifications/player_profile_update_repo.py
@@ -42,6 +42,11 @@ def _safe_int(value: Any) -> int:
         raise ValueError("player_id must be an integer-like value")
 
 
+def _is_unique_violation(exc: Exception) -> bool:
+    text = str(exc or "").lower()
+    return "duplicate key" in text or "unique" in text
+
+
 def normalize_email(email: str) -> str:
     return str(email or "").strip().lower()
 
@@ -67,6 +72,13 @@ def create_public_request(
     normalized = normalize_email(email_raw)
     player_id_int = _safe_int(player_id)
 
+    existing = get_open_or_active_subscription(supabase, club_id, player_id_int)
+    if existing is not None:
+        existing_status = str(existing.get("request_status") or "").strip().lower()
+        if existing_status == REQUEST_STATUS_ACTIVE:
+            raise ValueError("This player already has an active verified subscriber.")
+        raise ValueError("A verified updates request is already pending for this player.")
+
     payload = {
         "club_id": club_id,
         "player_id": player_id_int,
@@ -76,11 +88,16 @@ def create_public_request(
         "request_note": str(request_note or "").strip() or None,
         "preferences_json": preferences_json or dict(DEFAULT_PREFERENCES),
     }
-    resp = (
-        supabase.table("player_profile_update_subscriptions")
-        .insert(payload)
-        .execute()
-    )
+    try:
+        resp = (
+            supabase.table("player_profile_update_subscriptions")
+            .insert(payload)
+            .execute()
+        )
+    except Exception as exc:
+        if _is_unique_violation(exc):
+            raise ValueError("A verified request or active subscriber already exists for this player.") from exc
+        raise
     row = _safe_first(resp)
     if row is None:
         raise RuntimeError("Failed to create subscription request")
@@ -209,6 +226,13 @@ def approve_request(
     if row.get("request_status") != REQUEST_STATUS_PENDING:
         raise ValueError("approve_request only activates pending requests")
 
+    conflict = get_open_or_active_subscription(supabase, str(row.get("club_id") or ""), int(row.get("player_id")))
+    if conflict is not None and str(conflict.get("id") or "") != subscription_id:
+        conflict_status = str(conflict.get("request_status") or "").strip().lower()
+        if conflict_status == REQUEST_STATUS_ACTIVE:
+            raise ValueError("Cannot approve: this player already has an active verified subscriber.")
+        raise ValueError("Cannot approve: another pending request exists for this player.")
+
     payload = {
         "request_status": REQUEST_STATUS_ACTIVE,
         "admin_note": str(admin_note or "").strip() or None,
@@ -216,13 +240,18 @@ def approve_request(
         "verified_at": _now_iso(),
         "unsubscribed_at": None,
     }
-    updated = _safe_first(
-        supabase.table("player_profile_update_subscriptions")
-        .update(payload)
-        .eq("id", subscription_id)
-        .eq("request_status", REQUEST_STATUS_PENDING)
-        .execute()
-    )
+    try:
+        updated = _safe_first(
+            supabase.table("player_profile_update_subscriptions")
+            .update(payload)
+            .eq("id", subscription_id)
+            .eq("request_status", REQUEST_STATUS_PENDING)
+            .execute()
+        )
+    except Exception as exc:
+        if _is_unique_violation(exc):
+            raise ValueError("Cannot approve: this player already has a pending or active verified subscriber.") from exc
+        raise
     if updated is None:
         raise RuntimeError("Request could not be approved")
     return updated
@@ -280,11 +309,16 @@ def replace_verified_subscriber(
         "verified_at": now_iso,
         "preferences_json": current.get("preferences_json") or dict(DEFAULT_PREFERENCES),
     }
-    inserted = _safe_first(
-        supabase.table("player_profile_update_subscriptions")
-        .insert(new_row_payload)
-        .execute()
-    )
+    try:
+        inserted = _safe_first(
+            supabase.table("player_profile_update_subscriptions")
+            .insert(new_row_payload)
+            .execute()
+        )
+    except Exception as exc:
+        if _is_unique_violation(exc):
+            raise ValueError("Cannot replace subscriber because another pending/active row exists for this player.") from exc
+        raise
     if inserted is None:
         raise RuntimeError("Failed to create replacement active subscription")
     return inserted
@@ -386,11 +420,16 @@ def create_outbox_row(
         "email": email_raw,
         "send_status": SEND_STATUS_PENDING,
     }
-    row = _safe_first(
-        supabase.table("player_profile_update_outbox")
-        .insert(payload)
-        .execute()
-    )
+    try:
+        row = _safe_first(
+            supabase.table("player_profile_update_outbox")
+            .insert(payload)
+            .execute()
+        )
+    except Exception as exc:
+        if _is_unique_violation(exc):
+            raise ValueError("An outbox row already exists for this subscriber and week_start.") from exc
+        raise
     if row is None:
         raise RuntimeError("Outbox row could not be created")
     return row

--- a/jupr_app/domain/notifications/player_update_sender.py
+++ b/jupr_app/domain/notifications/player_update_sender.py
@@ -116,7 +116,8 @@ def queue_digest_outbox_rows_for_range(ctx, *, start_date: date, end_date: date)
             )
             queued += 1
         except Exception as exc:
-            if "duplicate key" in str(exc).lower() or "unique" in str(exc).lower():
+            err = str(exc).lower()
+            if "duplicate key" in err or "unique" in err or "already exists" in err:
                 already_exists += 1
             else:
                 failed += 1

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -134,6 +134,11 @@ def _render_digest_preview(digest: dict) -> None:
             st.write(f"• {line}")
 
 
+def _friendly_error(exc: Exception) -> str:
+    text = str(exc or "").strip()
+    return text or "Unknown error."
+
+
 def render(ctx) -> None:
     mode_label = "Public" if bool(ctx.public_mode) else "Admin"
     page_shell(
@@ -180,10 +185,15 @@ def render(ctx) -> None:
                 st.caption(f"Requested by {row.get('email') or 'unknown'} on {row.get('created_at') or 'n/a'}")
                 st.write(f"Request note: {row.get('request_note') or '—'}")
                 with st.form(f"pending_action_{row_id}"):
-                    admin_note = st.text_area("Admin note", key=f"pending_admin_note_{row_id}")
+                    admin_note = st.text_area(
+                        "Admin note",
+                        key=f"pending_admin_note_{row_id}",
+                        help="Visible to operators for review context.",
+                    )
                     replacement_email = st.text_input(
                         "Replacement email (for Replace Verified Subscriber)",
                         key=f"pending_replace_email_{row_id}",
+                        help="Used only when replacing an existing active subscriber.",
                     )
                     replacement_note = st.text_area(
                         "Replacement request note (optional)",
@@ -199,7 +209,7 @@ def render(ctx) -> None:
                         st.success("Request approved.")
                         st.rerun()
                     except Exception as exc:
-                        st.error(f"Approve failed: {exc}")
+                        st.error(f"Approve failed: {_friendly_error(exc)}")
 
                 if reject_clicked:
                     try:
@@ -207,7 +217,7 @@ def render(ctx) -> None:
                         st.success("Request rejected.")
                         st.rerun()
                     except Exception as exc:
-                        st.error(f"Reject failed: {exc}")
+                        st.error(f"Reject failed: {_friendly_error(exc)}")
 
                 if replace_clicked:
                     try:
@@ -232,7 +242,7 @@ def render(ctx) -> None:
                         st.success("Verified subscriber replaced and pending request closed.")
                         st.rerun()
                     except Exception as exc:
-                        st.error(f"Replace failed: {exc}")
+                        st.error(f"Replace failed: {_friendly_error(exc)}")
 
     with active_tab:
         st.subheader("Active Profiles")
@@ -253,10 +263,15 @@ def render(ctx) -> None:
             with st.expander(header):
                 st.caption(f"Verified email: {row.get('email') or 'unknown'}")
                 with st.form(f"active_action_{row_id}"):
-                    admin_note = st.text_area("Admin note", key=f"active_admin_note_{row_id}")
+                    admin_note = st.text_area(
+                        "Admin note",
+                        key=f"active_admin_note_{row_id}",
+                        help="Optional operator context stored for audit history.",
+                    )
                     replacement_email = st.text_input(
                         "Replacement email",
                         key=f"active_replace_email_{row_id}",
+                        help="Creates a new active row and deactivates the current one.",
                     )
                     replacement_note = st.text_area(
                         "Replacement request note (optional)",
@@ -280,7 +295,7 @@ def render(ctx) -> None:
                         st.success("Verified subscriber replaced.")
                         st.rerun()
                     except Exception as exc:
-                        st.error(f"Replace failed: {exc}")
+                        st.error(f"Replace failed: {_friendly_error(exc)}")
 
                 if unsubscribe_clicked:
                     try:
@@ -288,13 +303,23 @@ def render(ctx) -> None:
                         st.success("Subscription deactivated.")
                         st.rerun()
                     except Exception as exc:
-                        st.error(f"Unsubscribe failed: {exc}")
+                        st.error(f"Unsubscribe failed: {_friendly_error(exc)}")
 
     with digests_tab:
         st.subheader("Weekly Digests")
         today = date.today()
-        start_date = st.date_input("Start Date", value=today - timedelta(days=7), key="player_updates_digest_start")
-        end_date = st.date_input("End Date", value=today, key="player_updates_digest_end")
+        start_date = st.date_input(
+            "Start Date",
+            value=today - timedelta(days=7),
+            key="player_updates_digest_start",
+            help="Custom date windows are supported (not Monday–Sunday only).",
+        )
+        end_date = st.date_input(
+            "End Date",
+            value=today,
+            key="player_updates_digest_end",
+            help="Must be on or after Start Date.",
+        )
 
         if end_date < start_date:
             st.error("End Date must be on or after Start Date.")
@@ -328,7 +353,7 @@ def render(ctx) -> None:
                     st.session_state["player_updates_digest_preview"] = digest
                     st.success("Digest generated and saved.")
                 except Exception as exc:
-                    st.error(f"Digest generation failed: {exc}")
+                    st.error(f"Digest generation failed: {_friendly_error(exc)}")
 
         with c2:
             if st.button("Preview Digest", disabled=selected_pid is None):
@@ -342,7 +367,7 @@ def render(ctx) -> None:
                     st.session_state["player_updates_digest_preview"] = digest
                     st.success("Digest preview loaded.")
                 except Exception as exc:
-                    st.error(f"Digest preview failed: {exc}")
+                    st.error(f"Digest preview failed: {_friendly_error(exc)}")
 
         with st.expander("Generate / Preview by Active Subscription", expanded=False):
             if not active_rows:
@@ -408,8 +433,18 @@ def render(ctx) -> None:
         st.subheader("Send Queue")
 
         today = date.today()
-        queue_start = st.date_input("Queue Start Date", value=today - timedelta(days=7), key="player_updates_queue_start")
-        queue_end = st.date_input("Queue End Date", value=today, key="player_updates_queue_end")
+        queue_start = st.date_input(
+            "Queue Start Date",
+            value=today - timedelta(days=7),
+            key="player_updates_queue_start",
+            help="Queue rows for any custom date window.",
+        )
+        queue_end = st.date_input(
+            "Queue End Date",
+            value=today,
+            key="player_updates_queue_end",
+            help="Must be on or after Queue Start Date.",
+        )
 
         if queue_end < queue_start:
             st.error("Queue End Date must be on or after Queue Start Date.")
@@ -424,7 +459,7 @@ def render(ctx) -> None:
                         f"Queued: {result['queued']} · Existing: {result['already_exists']} · Failed: {result['failed']}"
                     )
                 except Exception as exc:
-                    st.error(f"Queue failed: {exc}")
+                    st.error(f"Queue failed: {_friendly_error(exc)}")
 
         with q2:
             if st.button("Send Pending"):
@@ -435,7 +470,7 @@ def render(ctx) -> None:
                         f"Skipped: {result['skipped']} · Errors: {result['errors']}"
                     )
                 except Exception as exc:
-                    st.error(f"Send pending failed: {exc}")
+                    st.error(f"Send pending failed: {_friendly_error(exc)}")
 
         with q3:
             if st.button("Send Test to Admin"):
@@ -443,7 +478,7 @@ def render(ctx) -> None:
                     result = send_test_player_update_email(ctx, start_date=queue_start, end_date=queue_end)
                     st.success(f"Sent test email to {result['to_email']}.")
                 except Exception as exc:
-                    st.error(f"Send test failed: {exc}")
+                    st.error(f"Send test failed: {_friendly_error(exc)}")
 
         st.divider()
         try:

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -1225,7 +1225,13 @@ def render(ctx):
                             )
                             st.success("Request submitted for admin review.")
                         except Exception as exc:
-                            st.error(f"Could not submit request: {exc}")
+                            msg = str(exc or "").strip().lower()
+                            if "already has an active verified subscriber" in msg:
+                                st.info("This player profile already has verified updates enabled.")
+                            elif "already pending" in msg or "already exists" in msg:
+                                st.info("A verified updates request is already pending for this player profile.")
+                            else:
+                                st.error(f"Could not submit request: {exc}")
 
     tape_tab, ratings_tab, social_tab = st.tabs(["Trophy Room", "Ratings", "Social"])
 


### PR DESCRIPTION
### Motivation
- Harden race and uniqueness edge cases around the one-owner rule so public requests, admin approvals, and replacement flows do not create duplicate open/active rows or surface raw DB errors to operators. 
- Make queueing/sending, digest date selection, and admin UI flows more robust and operator-friendly for routine QA and recovery.

### Description
- Add a helper `_is_unique_violation` and pre-checks to repository paths so `create_public_request` and `approve_request` detect existing open/active subscriptions and return friendly `ValueError`s instead of DB errors. 
- Wrap inserts/updates that can hit the partial unique index with try/except to translate uniqueness collisions into actionable messages for `create_public_request`, `approve_request`, `replace_verified_subscriber`, and `create_outbox_row`. 
- Treat duplicate insert exceptions in the queueing path as `already_exists` so `queue_digest_outbox_rows_for_range` reports duplicates cleanly instead of failing silently. 
- Improve admin UI ergonomics by adding `_friendly_error`, help text on forms, clearer custom date guidance, and friendlier error presentation in `player_updates_admin.py`. 
- Improve public request UX by mapping backend uniqueness/conflict errors to informational messages on the players public page so claimed/pending states are shown clearly instead of raw errors. 
- Files changed: `jupr_app/domain/notifications/player_profile_update_repo.py`, `jupr_app/domain/notifications/player_update_sender.py`, `jupr_app/ui/pages/player_updates_admin.py`, and `jupr_app/ui/pages/players.py`.

### Testing
- Ran Python static compile check with `python -m py_compile jupr_app/domain/notifications/player_profile_update_repo.py jupr_app/domain/notifications/player_update_sender.py jupr_app/ui/pages/player_updates_admin.py jupr_app/ui/pages/players.py` and it succeeded. 
- Ran targeted automated tests with `pytest -q tests/test_schema_preflight.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e697958a00832693160432eae9dc9b)