### PR TITLE
Verified player updates: fix date-window uniqueness, digest delta, and absolute links

### DIFF
--- a/jupr_app/domain/notifications/player_profile_update_repo.py
+++ b/jupr_app/domain/notifications/player_profile_update_repo.py
@@ -366,7 +366,7 @@ def save_digest(
     }
     upserted = _safe_first(
         supabase.table("player_weekly_profile_digests")
-        .upsert(payload, on_conflict="club_id,player_id,week_start")
+        .upsert(payload, on_conflict="club_id,player_id,week_start,week_end")
         .execute()
     )
     if upserted is None:
@@ -428,7 +428,7 @@ def create_outbox_row(
         )
     except Exception as exc:
         if _is_unique_violation(exc):
-            raise ValueError("An outbox row already exists for this subscriber and week_start.") from exc
+            raise ValueError("An outbox row already exists for this subscriber and date window.") from exc
         raise
     if row is None:
         raise RuntimeError("Outbox row could not be created")

--- a/jupr_app/domain/notifications/player_update_sender.py
+++ b/jupr_app/domain/notifications/player_update_sender.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date
 from typing import Any
+from urllib.parse import urlencode
 
 import streamlit as st
 
@@ -42,7 +43,13 @@ def _safe_subscription(supabase, subscription_id: str) -> dict | None:
         return None
 
 
-def _safe_digest_for_week(supabase, club_id: str, player_id: int, week_start: date) -> dict | None:
+def _safe_digest_for_week(
+    supabase,
+    club_id: str,
+    player_id: int,
+    week_start: date,
+    week_end: date,
+) -> dict | None:
     try:
         resp = (
             supabase.table("player_weekly_profile_digests")
@@ -50,6 +57,7 @@ def _safe_digest_for_week(supabase, club_id: str, player_id: int, week_start: da
             .eq("club_id", str(club_id))
             .eq("player_id", int(player_id))
             .eq("week_start", week_start.isoformat())
+            .eq("week_end", week_end.isoformat())
             .limit(1)
             .execute()
         )
@@ -59,11 +67,35 @@ def _safe_digest_for_week(supabase, club_id: str, player_id: int, week_start: da
         return None
 
 
+def _public_base_url() -> str:
+    base = str(st.session_state.get("base_url", "") or "").strip().rstrip("/")
+    if base:
+        return base
+    try:
+        base = str(st.secrets.get("PUBLIC_BASE_URL", "") or "").strip().rstrip("/")
+        if base:
+            return base
+    except Exception:
+        pass
+    return "http://localhost:8501"
+
+
+def _build_public_players_url(params: dict[str, str]) -> str:
+    query = {"page": "players", "public": "1"}
+    for key, value in (params or {}).items():
+        query[str(key)] = str(value)
+    return f"{_public_base_url()}/?{urlencode(query)}"
+
+
 def _merge_links_for_send(*, digest: dict[str, Any], player_id: int, subscription_id: str) -> dict[str, Any]:
     links = dict((digest or {}).get("links") or {})
-    links["player_profile"] = f"/?page=players&public=1&pid={int(player_id)}"
-    links["unsubscribe"] = (
-        f"/?page=players&public=1&pid={int(player_id)}&unsubscribe=1&sid={subscription_id}"
+    links["player_profile"] = _build_public_players_url({"pid": str(int(player_id))})
+    links["unsubscribe"] = _build_public_players_url(
+        {
+            "pid": str(int(player_id)),
+            "unsubscribe": "1",
+            "sid": str(subscription_id),
+        }
     )
     merged = dict(digest or {})
     merged["links"] = links
@@ -158,7 +190,7 @@ def send_pending_player_update_emails(ctx, *, limit: int = 100) -> dict[str, int
             week_end = date.fromisoformat(str(outbox.get("week_end")))
             player_id = int(outbox.get("player_id"))
 
-            digest_row = _safe_digest_for_week(supabase, club_id, player_id, week_start)
+            digest_row = _safe_digest_for_week(supabase, club_id, player_id, week_start, week_end)
             digest = (digest_row or {}).get("final_json") or (digest_row or {}).get("generated_json") or {}
             if not digest:
                 digest = compute_player_weekly_digest(ctx, player_id=player_id, start_date=week_start, end_date=week_end)

--- a/jupr_app/domain/recaps/player_weekly_digest.py
+++ b/jupr_app/domain/recaps/player_weekly_digest.py
@@ -155,8 +155,33 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
     overall_series = build_player_overall_rating_series(supabase, club_id, int(player_id), limit=1200)
     window_series = filter_rating_series_for_window(overall_series, start_date, end_date, tz_name=tz_name)
 
-    before = _safe_float(window_series["Overall After"].iloc[0]) if not window_series.empty else None
+    before = None
     after = _safe_float(window_series["Overall After"].iloc[-1]) if not window_series.empty else None
+    if not window_series.empty:
+        first_window_row = window_series.iloc[0]
+        first_window_id = first_window_row.get("id")
+        overall_sorted = overall_series.copy()
+        overall_sorted["Date"] = pd.to_datetime(overall_sorted.get("Date"), utc=True, errors="coerce")
+        overall_sorted["id"] = pd.to_numeric(overall_sorted.get("id"), errors="coerce")
+        overall_sorted = overall_sorted.dropna(subset=["Date"]).sort_values(["Date", "id"], ascending=[True, True])
+
+        if pd.notna(first_window_id):
+            first_window_id_num = pd.to_numeric(first_window_id, errors="coerce")
+            prior_rows = overall_sorted[
+                (overall_sorted["Date"] < first_window_row.get("Date"))
+                | ((overall_sorted["Date"] == first_window_row.get("Date")) & (overall_sorted["id"] < first_window_id_num))
+            ]
+        else:
+            prior_rows = overall_sorted[overall_sorted["Date"] < first_window_row.get("Date")]
+
+        if not prior_rows.empty:
+            before = _safe_float(prior_rows["Overall After"].iloc[-1])
+        if before is None:
+            first_after = _safe_float(first_window_row.get("Overall After"))
+            first_delta = _safe_float(first_window_row.get("Overall Δ"))
+            if first_after is not None and first_delta is not None:
+                before = first_after - first_delta
+
     overall_delta = None
     if before is not None and after is not None:
         overall_delta = after - before

--- a/migrations/20260421_verified_player_updates_date_window_uniqueness.sql
+++ b/migrations/20260421_verified_player_updates_date_window_uniqueness.sql
@@ -1,0 +1,20 @@
+-- Follow-up migration: make digest/outbox uniqueness respect the full selected date window.
+
+alter table if exists public.player_weekly_profile_digests
+    drop constraint if exists player_weekly_profile_digests_club_id_player_id_week_start_key;
+
+alter table if exists public.player_weekly_profile_digests
+    add constraint player_weekly_profile_digests_club_player_window_key
+    unique (club_id, player_id, week_start, week_end);
+
+alter table if exists public.player_profile_update_outbox
+    drop constraint if exists player_profile_update_outbox_subscription_id_week_start_key;
+
+alter table if exists public.player_profile_update_outbox
+    add constraint player_profile_update_outbox_subscription_window_key
+    unique (subscription_id, week_start, week_end);
+
+drop index if exists public.player_profile_update_outbox_subscription_week_idx;
+
+create index if not exists player_profile_update_outbox_subscription_week_window_idx
+    on public.player_profile_update_outbox (subscription_id, week_start, week_end);


### PR DESCRIPTION
### Motivation
- Custom date-window digests and outbox rows were colliding because uniqueness was keyed only by `week_start` instead of the full `(week_start, week_end)` window.  
- Digest delta calculation lost the first in-window movement by using the first in-window `Overall After` as the `before` value instead of the rating immediately prior to the first in-window match.  
- Outgoing player-profile and unsubscribe links in verification emails were relative paths and must be absolute public URLs.  
- Unsubscribe signing was considered but intentionally not added to keep this change small and surgical.

### Description
- Added a follow-up SQL migration `migrations/20260421_verified_player_updates_date_window_uniqueness.sql` that replaces the single-date uniqueness with full-window uniqueness for `player_weekly_profile_digests` and `player_profile_update_outbox`, and updates the outbox index to include `week_end`.  
- Updated `save_digest` in `jupr_app/domain/notifications/player_profile_update_repo.py` to upsert on conflict using `club_id,player_id,week_start,week_end` so same-start/different-end windows can coexist.  
- Made the outbox duplicate error message more accurate in `create_outbox_row` in `player_profile_update_repo.py` to reference a date window.  
- Adjusted digest lookup in `jupr_app/domain/notifications/player_update_sender.py` to require both `week_start` and `week_end`, added `_public_base_url()` and `_build_public_players_url()` helpers there, and changed `_merge_links_for_send` to produce absolute `player_profile` and `unsubscribe` URLs.  
- Fixed `compute_player_weekly_digest(...)` in `jupr_app/domain/recaps/player_weekly_digest.py` so `overall_jupr_before` is derived from the rating immediately before the first in-window match (or reconstructed from first in-window `after - delta` when needed) while `overall_jupr_after` remains the last in-window `Overall After`, and preserved chart points as only the selected window.  
- Kept unsubscribe behavior unchanged (still sid-based) to avoid scope expansion while ensuring the unsubscribe link in emails is absolute.

### Testing
- Compiled modified modules with `python -m compileall jupr_app/domain/notifications/player_profile_update_repo.py jupr_app/domain/notifications/player_update_sender.py jupr_app/domain/recaps/player_weekly_digest.py` and the compilation completed without errors.  
- Verified the changes were committed (single logical commit containing migration and code updates).  
- No automated unit tests exist for these flows in this change set, so behavior validation should be performed by exercising queueing/sending and inspecting DB constraints after migration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69b20ffa083269bf3c03c6b8d0bcc)