### PR TITLE
Add Streamlit secrets fallback for SMTP mailer config

### DIFF
--- a/jupr_app/domain/notifications/smtp_mailer.py
+++ b/jupr_app/domain/notifications/smtp_mailer.py
@@ -6,21 +6,38 @@ from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
+import streamlit as st
+
+
+def _secret_or_env(name: str, default: str = "") -> str:
+    env_val = str(os.getenv(name, "")).strip()
+    if env_val:
+        return env_val
+
+    try:
+        secret_val = st.secrets.get(name, default)
+    except Exception:
+        return str(default).strip()
+
+    if secret_val is None:
+        return str(default).strip()
+    return str(secret_val).strip()
+
 
 def _env_bool(name: str, default: bool = False) -> bool:
-    val = str(os.getenv(name, "")).strip().lower()
+    val = _secret_or_env(name).lower()
     if not val:
         return default
     return val in {"1", "true", "yes", "y", "on"}
 
 
 def _smtp_config_from_env() -> dict:
-    host = str(os.getenv("SMTP_HOST", "")).strip()
-    port_raw = str(os.getenv("SMTP_PORT", "")).strip()
-    username = str(os.getenv("SMTP_USERNAME", "")).strip()
-    password = str(os.getenv("SMTP_PASSWORD", "")).strip()
-    from_email = str(os.getenv("SMTP_FROM_EMAIL", "")).strip()
-    from_name = str(os.getenv("SMTP_FROM_NAME", "")).strip() or "JUPR"
+    host = _secret_or_env("SMTP_HOST")
+    port_raw = _secret_or_env("SMTP_PORT")
+    username = _secret_or_env("SMTP_USERNAME")
+    password = _secret_or_env("SMTP_PASSWORD")
+    from_email = _secret_or_env("SMTP_FROM_EMAIL")
+    from_name = _secret_or_env("SMTP_FROM_NAME") or "JUPR"
     use_tls = _env_bool("SMTP_USE_TLS", default=True)
 
     missing = [


### PR DESCRIPTION
### Motivation
- Streamlit deployments often store credentials in `st.secrets`, but the mailer previously read only environment variables causing missing-config failures.
- Preserve existing env-var-first behavior while enabling Streamlit-hosted apps to provide SMTP values via `st.secrets` without breaking non-Streamlit deployments.

### Description
- Import `streamlit as st` and add helper `_secret_or_env(name: str, default: str = "")` that returns a non-empty env var if present, otherwise safely reads `st.secrets.get(...)`, strips strings, and handles missing secrets with `try/except` and `None` checks.
- Update `_env_bool(...)` to use `_secret_or_env(...)` so `SMTP_USE_TLS` supports truthy strings from either env or secrets (`1/true/yes/y/on`) and preserves the `default` behavior.
- Replace direct `os.getenv(...)` calls in `_smtp_config_from_env()` with `_secret_or_env(...)` for `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM_EMAIL`, and `SMTP_FROM_NAME`, keeping `from_name` defaulting to `JUPR` if blank.
- Preserve validation: missing required fields still raise `ValueError(...)`, `SMTP_PORT` is still parsed with `int(...)` and will raise `ValueError("SMTP_PORT must be an integer")` on invalid input, and the public function `send_email_with_inline_chart(...)` signature is unchanged.

### Testing
- Ran a compile check using `python -m py_compile jupr_app/domain/notifications/smtp_mailer.py` which succeeded.
- No other automated tests were added or modified as the change is a small config-loading fallback and non-invasive to behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a29f2cb88326af2ab7dd40359490)