### PR TITLE
Redesign player weekly digest data, preview, and email layout

### DIFF
--- a/jupr_app/domain/notifications/player_update_email_template.py
+++ b/jupr_app/domain/notifications/player_update_email_template.py
@@ -7,6 +7,30 @@ def _s(value) -> str:
     return str(value or "").strip()
 
 
+def _num(value, digits: int = 3, prefix_sign: bool = False, default: str = "N/A") -> str:
+    try:
+        if prefix_sign:
+            return f"{float(value):+.{digits}f}"
+        return f"{float(value):.{digits}f}"
+    except Exception:
+        return default
+
+
+def _people_html(items: list[dict], empty_text: str) -> str:
+    if not items:
+        return f"<tr><td style='padding:4px 0;color:#5A6678;font-size:13px;'>{html.escape(empty_text)}</td></tr>"
+    rows = []
+    for item in items[:3]:
+        name = _s(item.get("player_name")) or f"Player #{_s(item.get('player_id'))}"
+        matches = int(item.get("matches") or 0)
+        record = _s(item.get("record")) or "0-0"
+        rows.append(
+            f"<tr><td style='padding:4px 0;font-size:13px;line-height:1.35;'><strong>{html.escape(name)}</strong>"
+            f"<span style='color:#5A6678;'> · {matches} matches · {html.escape(record)}</span></td></tr>"
+        )
+    return "".join(rows)
+
+
 def build_player_update_email_subject(digest_json: dict) -> str:
     player_name = _s((digest_json or {}).get("player_name")) or "Verified Player"
     display_range = _s((digest_json or {}).get("display_range"))
@@ -21,69 +45,126 @@ def build_player_update_email_html(digest_json: dict, chart_cid: str | None) -> 
     badges = digest.get("badges_earned") or []
     trophies = digest.get("trophies_earned") or []
     highlights = digest.get("highlights") or []
+    glance = digest.get("week_at_a_glance") or []
+    people = digest.get("people") or {}
     links = digest.get("links") or {}
 
     player_name = html.escape(_s(digest.get("player_name")) or "Verified Player")
     display_range = html.escape(_s(digest.get("display_range")))
-    overall = summary.get("overall_jupr_after")
-    try:
-        overall_text = f"{float(overall):.3f}"
-    except Exception:
-        overall_text = "N/A"
-
+    overall_text = _num(summary.get("overall_jupr_after"), digits=3)
+    delta_text = _num(summary.get("overall_delta"), digits=4, prefix_sign=True, default="—")
     record = html.escape(_s(summary.get("record")) or "0-0")
     matches_played = int(summary.get("matches_played") or 0)
 
+    highlight_items = "".join(
+        f"<tr><td style='padding:4px 0;'><span style='color:#FF7A00;'>•</span> {html.escape(_s(line))}</td></tr>"
+        for line in highlights[:6]
+        if _s(line)
+    )
+    glance_items = "".join(
+        f"<tr><td style='padding:3px 0;color:#314155;'>{html.escape(_s(line))}</td></tr>"
+        for line in glance[:4]
+        if _s(line)
+    )
+
     badge_items = "".join(
-        f"<li>{html.escape(_s(item.get('name')) or _s(item.get('badge_id')) or 'Badge')}</li>"
-        for item in badges[:10]
+        f"<tr><td style='padding:3px 0;'>• {html.escape(_s(item.get('name')) or _s(item.get('badge_id')) or 'Badge')}</td></tr>"
+        for item in badges[:8]
     )
     trophy_items = "".join(
-        f"<li>{html.escape(_s(item.get('tournament_name')) or _s(item.get('league_name')) or 'Trophy')}</li>"
-        for item in trophies[:10]
+        f"<tr><td style='padding:3px 0;'>• {html.escape(_s(item.get('tournament_name')) or _s(item.get('league_name')) or 'Trophy')}</td></tr>"
+        for item in trophies[:8]
     )
-    highlight_items = "".join(f"<li>{html.escape(_s(line))}</li>" for line in highlights[:10])
 
     profile_link = html.escape(_s(links.get("player_profile")))
     unsubscribe_link = html.escape(_s(links.get("unsubscribe")))
 
-    chart_block = ""
-    if chart_cid:
-        chart_block = (
-            "<h3>Overall JUPR trend</h3>"
-            f"<img alt=\"Overall JUPR trend\" src=\"cid:{html.escape(chart_cid)}\" "
-            "style=\"max-width:100%;height:auto;border:1px solid #ddd;border-radius:6px;\"/>"
-        )
-    else:
-        chart_block = "<p><em>Chart unavailable for this date range (fewer than 2 points).</em></p>"
+    chart_block = (
+        f"<img alt='Overall JUPR trend' src='cid:{html.escape(chart_cid)}' style='display:block;width:100%;max-width:560px;height:auto;border:1px solid #D9E0EB;border-radius:10px;'/>"
+        if chart_cid
+        else "<div style='color:#5A6678;font-size:13px;'>Chart unavailable for this date range.</div>"
+    )
 
     return f"""
-    <html>
-      <body style=\"font-family:Arial,sans-serif;line-height:1.5;color:#111;\">
-        <h2>Verified Player Update</h2>
-        <p><strong>Player:</strong> {player_name}<br/>
-           <strong>Date range:</strong> {display_range}<br/>
-           <strong>Current overall JUPR:</strong> {overall_text}</p>
-
-        <p><strong>Weekly record:</strong> {record}<br/>
-           <strong>Matches played:</strong> {matches_played}</p>
-
-        {chart_block}
-
-        <h3>Badges earned</h3>
-        {('<ul>' + badge_items + '</ul>') if badge_items else '<p>None this period.</p>'}
-
-        <h3>Trophies earned</h3>
-        {('<ul>' + trophy_items + '</ul>') if trophy_items else '<p>None this period.</p>'}
-
-        <h3>Highlights</h3>
-        {('<ul>' + highlight_items + '</ul>') if highlight_items else '<p>No highlights available.</p>'}
-
-        <p><a href=\"{profile_link}\">View player profile</a></p>
-        <p style=\"font-size:12px;color:#444;\">To stop these updates, <a href=\"{unsubscribe_link}\">unsubscribe in one click</a>.</p>
-      </body>
-    </html>
-    """.strip()
+<html>
+  <body style="margin:0;padding:0;background:#F2F4F8;font-family:Arial,sans-serif;color:#172033;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#F2F4F8;padding:22px 10px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="640" cellspacing="0" cellpadding="0" style="width:640px;max-width:100%;background:#FFFFFF;border:1px solid #D9E0EB;border-radius:14px;overflow:hidden;">
+            <tr>
+              <td style="padding:24px;background:linear-gradient(135deg,#FFF3E6,#FFE3C9);border-bottom:1px solid #ECD7BF;">
+                <div style="font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:#935A22;font-weight:700;">Verified Player Update</div>
+                <div style="font-size:28px;line-height:1.15;font-weight:700;color:#111A2B;margin-top:4px;">{player_name}</div>
+                <div style="font-size:14px;color:#3E4E67;margin-top:4px;">{display_range}</div>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:18px 24px 6px;">
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                  <tr>
+                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="25%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">JUPR</div><div style="font-size:22px;font-weight:700;">{overall_text}</div></td>
+                    <td width="2%"></td>
+                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="23%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">Record</div><div style="font-size:22px;font-weight:700;">{record}</div></td>
+                    <td width="2%"></td>
+                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="23%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">Matches</div><div style="font-size:22px;font-weight:700;">{matches_played}</div></td>
+                    <td width="2%"></td>
+                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="23%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">Delta</div><div style="font-size:22px;font-weight:700;">{delta_text}</div></td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr><td style="padding:14px 24px 0;"><div style="font-size:17px;font-weight:700;">Week at a glance</div><table role="presentation" width="100%">{glance_items or "<tr><td style='padding:4px 0;color:#5A6678;'>No activity in this date window.</td></tr>"}</table></td></tr>
+            <tr><td style="padding:16px 24px 0;"><div style="font-size:17px;font-weight:700;margin-bottom:8px;">Overall JUPR Trend</div>{chart_block}</td></tr>
+            <tr>
+              <td style="padding:18px 24px 0;">
+                <div style="font-size:17px;font-weight:700;margin-bottom:6px;">Highlights</div>
+                <table role="presentation" width="100%">{highlight_items or "<tr><td style='padding:4px 0;color:#5A6678;'>No highlights available.</td></tr>"}</table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:18px 24px 0;">
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                  <tr>
+                    <td width="50%" valign="top" style="padding-right:8px;">
+                      <div style="font-size:16px;font-weight:700;margin-bottom:6px;">Played With</div>
+                      <table role="presentation" width="100%">{_people_html(people.get('top_partners') or [], 'No partner data in this period.')}</table>
+                    </td>
+                    <td width="50%" valign="top" style="padding-left:8px;">
+                      <div style="font-size:16px;font-weight:700;margin-bottom:6px;">Faced Most</div>
+                      <table role="presentation" width="100%">{_people_html(people.get('top_opponents') or [], 'No opponent data in this period.')}</table>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:18px 24px 0;">
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                  <tr>
+                    <td width="50%" valign="top" style="padding-right:8px;"><div style="font-size:16px;font-weight:700;margin-bottom:6px;">Badges</div><table role='presentation' width='100%'>{badge_items or "<tr><td style='padding:3px 0;color:#5A6678;'>None this period.</td></tr>"}</table></td>
+                    <td width="50%" valign="top" style="padding-left:8px;"><div style="font-size:16px;font-weight:700;margin-bottom:6px;">Trophies</div><table role='presentation' width='100%'>{trophy_items or "<tr><td style='padding:3px 0;color:#5A6678;'>None this period.</td></tr>"}</table></td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td align="center" style="padding:22px 24px 10px;">
+                <a href="{profile_link}" style="display:inline-block;background:#14223A;color:#FFFFFF;text-decoration:none;padding:10px 18px;border-radius:8px;font-weight:700;font-size:14px;">View player profile</a>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 24px 20px;font-size:12px;color:#5A6678;text-align:center;">
+                Receiving these because you're subscribed to verified player updates. <a href="{unsubscribe_link}" style="color:#1B4FA3;">Unsubscribe</a>.
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+""".strip()
 
 
 def build_player_update_email_text(digest_json: dict) -> str:
@@ -92,6 +173,8 @@ def build_player_update_email_text(digest_json: dict) -> str:
     badges = digest.get("badges_earned") or []
     trophies = digest.get("trophies_earned") or []
     highlights = digest.get("highlights") or []
+    glance = digest.get("week_at_a_glance") or []
+    people = digest.get("people") or {}
     links = digest.get("links") or {}
 
     badge_lines = [f"- {_s(item.get('name')) or _s(item.get('badge_id')) or 'Badge'}" for item in badges[:10]]
@@ -99,25 +182,45 @@ def build_player_update_email_text(digest_json: dict) -> str:
         f"- {_s(item.get('tournament_name')) or _s(item.get('league_name')) or 'Trophy'}"
         for item in trophies[:10]
     ]
-    highlight_lines = [f"- {_s(line)}" for line in highlights[:10]]
+    highlight_lines = [f"- {_s(line)}" for line in highlights[:10] if _s(line)]
+    glance_lines = [f"- {_s(line)}" for line in glance[:6] if _s(line)]
+
+    partner_lines = [
+        f"- {_s(item.get('player_name')) or ('Player #' + _s(item.get('player_id')))} · {int(item.get('matches') or 0)} matches · {_s(item.get('record')) or '0-0'}"
+        for item in (people.get("top_partners") or [])[:3]
+    ]
+    opp_lines = [
+        f"- {_s(item.get('player_name')) or ('Player #' + _s(item.get('player_id')))} · {int(item.get('matches') or 0)} matches · {_s(item.get('record')) or '0-0'}"
+        for item in (people.get("top_opponents") or [])[:3]
+    ]
 
     return "\n".join(
         [
             "Verified Player Update",
             f"Player: {_s(digest.get('player_name'))}",
             f"Date range: {_s(digest.get('display_range'))}",
-            f"Current overall JUPR: {summary.get('overall_jupr_after')}",
+            f"Current overall JUPR: {_num(summary.get('overall_jupr_after'), digits=3)}",
             f"Weekly record: {_s(summary.get('record')) or '0-0'}",
             f"Matches played: {int(summary.get('matches_played') or 0)}",
+            f"Overall delta: {_num(summary.get('overall_delta'), digits=4, prefix_sign=True, default='—')}",
+            "",
+            "Week at a glance:",
+            *(glance_lines or ["- No activity in this date window."]),
+            "",
+            "Highlights:",
+            *(highlight_lines or ["- No highlights available."]),
+            "",
+            "Played with:",
+            *(partner_lines or ["- No partner data in this period."]),
+            "",
+            "Faced most:",
+            *(opp_lines or ["- No opponent data in this period."]),
             "",
             "Badges earned:",
             *(badge_lines or ["- None this period."]),
             "",
             "Trophies earned:",
             *(trophy_lines or ["- None this period."]),
-            "",
-            "Highlights:",
-            *(highlight_lines or ["- No highlights available."]),
             "",
             f"Profile link: {_s(links.get('player_profile'))}",
             f"Unsubscribe: {_s(links.get('unsubscribe'))}",

--- a/jupr_app/domain/recaps/player_weekly_digest.py
+++ b/jupr_app/domain/recaps/player_weekly_digest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from datetime import date, datetime, timezone
 
 import pandas as pd
@@ -17,6 +18,15 @@ def _safe_float(value) -> float | None:
         if value is None or str(value).strip() == "":
             return None
         return float(value)
+    except Exception:
+        return None
+
+
+def _safe_int(value) -> int | None:
+    try:
+        if value is None or str(value).strip() == "":
+            return None
+        return int(float(value))
     except Exception:
         return None
 
@@ -52,6 +62,22 @@ def _player_name(ctx, player_id: int) -> str:
     except Exception:
         pass
     return f"Player #{int(player_id)}"
+
+
+def _format_record(wins: int, losses: int) -> str:
+    return f"{int(wins)}-{int(losses)}"
+
+
+def _format_delta(delta: float | None, decimals: int = 3) -> str:
+    if delta is None:
+        return "—"
+    return f"{delta:+.{decimals}f}"
+
+
+def _format_pct(numerator: int, denominator: int) -> str:
+    if denominator <= 0:
+        return "0.0%"
+    return f"{(100.0 * float(numerator) / float(denominator)):.1f}%"
 
 
 def _load_badges_earned(supabase, club_id: str, player_id: int, start_dt_utc: datetime, end_dt_utc: datetime) -> list[dict]:
@@ -127,24 +153,280 @@ def _load_trophies_earned(supabase, club_id: str, player_id: int, start_dt_utc: 
     return kept
 
 
-def _build_highlights(summary: dict, badges_earned: list[dict], trophies_earned: list[dict]) -> list[str]:
+def _league_breakdown(window_series: pd.DataFrame) -> list[dict]:
+    if window_series.empty:
+        return []
+
+    rows: list[dict] = []
+    grouped = window_series.copy()
+    grouped["League"] = grouped.get("League", "").fillna("Unspecified").astype(str)
+
+    for league_name, league_df in grouped.groupby("League"):
+        matches = int(len(league_df.index))
+        wins = int((league_df.get("Result") == "WIN").sum())
+        losses = int((league_df.get("Result") == "LOSS").sum())
+        delta = pd.to_numeric(league_df.get("Overall Δ"), errors="coerce").fillna(0.0).sum()
+        rows.append(
+            {
+                "league_name": str(league_name or "Unspecified"),
+                "matches": matches,
+                "wins": wins,
+                "losses": losses,
+                "record": _format_record(wins, losses),
+                "overall_delta": round(float(delta), 4),
+            }
+        )
+
+    rows.sort(key=lambda item: (-int(item.get("matches", 0)), -int(item.get("wins", 0)), str(item.get("league_name", ""))))
+    return rows
+
+
+def _is_player_on_t1(row: pd.Series, player_id: int) -> bool | None:
+    p = int(player_id)
+    t1 = {_safe_int(row.get("t1_p1")), _safe_int(row.get("t1_p2"))}
+    t2 = {_safe_int(row.get("t2_p1")), _safe_int(row.get("t2_p2"))}
+    if p in t1:
+        return True
+    if p in t2:
+        return False
+    return None
+
+
+def _aggregate_people(ctx, window_series: pd.DataFrame, player_id: int) -> dict:
+    partner_stats: dict[int, dict] = defaultdict(lambda: {"matches": 0, "wins": 0, "losses": 0, "point_diff": 0})
+    opponent_stats: dict[int, dict] = defaultdict(lambda: {"matches": 0, "wins": 0, "losses": 0, "point_diff": 0})
+
+    if window_series.empty:
+        return {
+            "top_partners": [],
+            "top_opponents": [],
+            "best_partner": None,
+            "most_faced_opponent": None,
+        }
+
+    for _, row in window_series.iterrows():
+        player_on_t1 = _is_player_on_t1(row, player_id)
+        if player_on_t1 is None:
+            continue
+
+        if player_on_t1:
+            partner_id = _safe_int(row.get("t1_p2")) if _safe_int(row.get("t1_p1")) == int(player_id) else _safe_int(row.get("t1_p1"))
+            opponent_ids = [_safe_int(row.get("t2_p1")), _safe_int(row.get("t2_p2"))]
+            my_score = _safe_int(row.get("score_t1"))
+            opp_score = _safe_int(row.get("score_t2"))
+        else:
+            partner_id = _safe_int(row.get("t2_p2")) if _safe_int(row.get("t2_p1")) == int(player_id) else _safe_int(row.get("t2_p1"))
+            opponent_ids = [_safe_int(row.get("t1_p1")), _safe_int(row.get("t1_p2"))]
+            my_score = _safe_int(row.get("score_t2"))
+            opp_score = _safe_int(row.get("score_t1"))
+
+        result = str(row.get("Result") or "").upper()
+        won = result == "WIN"
+        if result not in {"WIN", "LOSS"} and my_score is not None and opp_score is not None:
+            won = my_score > opp_score
+        point_diff = (my_score - opp_score) if (my_score is not None and opp_score is not None) else 0
+
+        if partner_id is not None and partner_id != int(player_id):
+            entry = partner_stats[int(partner_id)]
+            entry["matches"] += 1
+            entry["wins"] += int(won)
+            entry["losses"] += int(not won)
+            entry["point_diff"] += int(point_diff)
+
+        for opp_id in opponent_ids:
+            if opp_id is None or opp_id == int(player_id):
+                continue
+            entry = opponent_stats[int(opp_id)]
+            entry["matches"] += 1
+            entry["wins"] += int(won)
+            entry["losses"] += int(not won)
+            entry["point_diff"] += int(point_diff)
+
+    def _finalize(stat_map: dict[int, dict]) -> list[dict]:
+        out: list[dict] = []
+        for pid, vals in stat_map.items():
+            wins = int(vals.get("wins", 0))
+            losses = int(vals.get("losses", 0))
+            out.append(
+                {
+                    "player_id": int(pid),
+                    "player_name": _player_name(ctx, int(pid)),
+                    "matches": int(vals.get("matches", 0)),
+                    "wins": wins,
+                    "losses": losses,
+                    "record": _format_record(wins, losses),
+                    "point_diff": int(vals.get("point_diff", 0)),
+                }
+            )
+        out.sort(key=lambda item: (-int(item.get("matches", 0)), -int(item.get("wins", 0)), -int(item.get("point_diff", 0))))
+        return out
+
+    top_partners = _finalize(partner_stats)[:3]
+    top_opponents = _finalize(opponent_stats)[:3]
+
+    best_partner = None
+    for entry in _finalize(partner_stats):
+        if int(entry.get("matches", 0)) >= 3:
+            best_partner = entry
+            break
+
+    most_faced_opponent = top_opponents[0] if top_opponents else None
+    return {
+        "top_partners": top_partners,
+        "top_opponents": top_opponents,
+        "best_partner": best_partner,
+        "most_faced_opponent": most_faced_opponent,
+    }
+
+
+def _build_week_at_a_glance(
+    *,
+    player_name: str,
+    summary: dict,
+    league_breakdown: list[dict],
+    people: dict,
+) -> list[str]:
+    lines: list[str] = []
+    matches_played = int(summary.get("matches_played", 0) or 0)
+    lines.append(f"{player_name} logged {matches_played} matches in this window.")
+
+    before_val = _safe_float(summary.get("overall_jupr_before"))
+    after_val = _safe_float(summary.get("overall_jupr_after"))
+    delta_val = _safe_float(summary.get("overall_delta"))
+    if after_val is not None:
+        if before_val is not None and delta_val is not None:
+            lines.append(f"Overall JUPR moved {_format_delta(delta_val)} to {after_val:.3f}.")
+        else:
+            lines.append(f"Overall JUPR closed at {after_val:.3f}.")
+
+    if league_breakdown:
+        top = league_breakdown[0]
+        lines.append(
+            f"Most of the volume came in {top.get('league_name')} ({int(top.get('matches', 0))} matches, {top.get('record')})."
+        )
+
+    top_partner = (people or {}).get("top_partners") or []
+    top_opp = (people or {}).get("top_opponents") or []
+    if top_partner:
+        p = top_partner[0]
+        lines.append(
+            f"Most played with {p.get('player_name')} ({int(p.get('matches', 0))} matches, {p.get('record')})."
+        )
+    elif top_opp:
+        o = top_opp[0]
+        lines.append(f"Most often faced {o.get('player_name')} ({int(o.get('matches', 0))} meetings).")
+
+    return lines[:4]
+
+
+def _build_notable_results(window_series: pd.DataFrame) -> list[dict]:
+    if window_series.empty:
+        return []
+
+    df = window_series.copy()
+    df["overall_delta"] = pd.to_numeric(df.get("Overall Δ"), errors="coerce")
+    df["player_on_t1"] = df.apply(lambda row: _is_player_on_t1(row, _safe_int(row.get("player_id") or -1) or -1), axis=1)
+    # margin from player perspective
+    def _row_margin(row) -> float | None:
+        on_t1 = _is_player_on_t1(row, _safe_int(row.get("player_id") or -1) or -1)
+        s1 = _safe_float(row.get("score_t1"))
+        s2 = _safe_float(row.get("score_t2"))
+        if s1 is None or s2 is None or on_t1 is None:
+            return None
+        return float(s1 - s2) if on_t1 else float(s2 - s1)
+
+    df["margin"] = df.apply(_row_margin, axis=1)
+
+    def _note(row: pd.Series, title: str, detail: str) -> dict:
+        played_at = pd.to_datetime(row.get("Date"), utc=True, errors="coerce")
+        date_text = played_at.date().isoformat() if pd.notna(played_at) else "Unknown date"
+        league = str(row.get("League") or "Unspecified league")
+        score = str(row.get("Score") or "")
+        suffix = f" · {score}" if score else ""
+        return {"title": title, "detail": f"{date_text} · {league}{suffix}. {detail}"}
+
+    notes: list[dict] = []
+    if not df["overall_delta"].dropna().empty:
+        best_jump = df.loc[df["overall_delta"].idxmax()]
+        if _safe_float(best_jump.get("overall_delta")) and float(best_jump.get("overall_delta")) > 0:
+            notes.append(
+                _note(
+                    best_jump,
+                    "Biggest ratings lift",
+                    f"Overall moved {_format_delta(float(best_jump.get('overall_delta')), 4)} in this match.",
+                )
+            )
+
+    losses = df[df.get("Result") == "LOSS"]
+    if not losses.empty and not losses["margin"].dropna().empty:
+        tough = losses.loc[losses["margin"].idxmin()]
+        notes.append(_note(tough, "Toughest loss", "Largest negative margin in the date window."))
+
+    wins = df[df.get("Result") == "WIN"]
+    if not wins.empty and not wins["margin"].dropna().empty:
+        strong = wins.loc[wins["margin"].idxmax()]
+        notes.append(_note(strong, "Strongest scoreline win", "Best positive margin in the date window."))
+
+    close = df[df["margin"].notna()]
+    if not close.empty:
+        close_row = close.iloc[(close["margin"].abs()).argsort().iloc[0]]
+        result = str(close_row.get("Result") or "match").lower()
+        notes.append(_note(close_row, "Closest finish", f"A one-score style {result} by margin."))
+
+    unique: list[dict] = []
+    seen = set()
+    for item in notes:
+        key = (item.get("title"), item.get("detail"))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(item)
+    return unique[:5]
+
+
+def _build_highlights(
+    *,
+    summary: dict,
+    badges_earned: list[dict],
+    trophies_earned: list[dict],
+    people: dict,
+    league_breakdown: list[dict],
+) -> list[str]:
     lines: list[str] = []
     before_val = _safe_float(summary.get("overall_jupr_before"))
     after_val = _safe_float(summary.get("overall_jupr_after"))
-    if before_val is not None and after_val is not None:
-        lines.append(f"Overall JUPR moved from {before_val:.3f} to {after_val:.3f}.")
+    delta_val = _safe_float(summary.get("overall_delta"))
+    if before_val is not None and after_val is not None and delta_val is not None:
+        lines.append(f"Overall JUPR moved {_format_delta(delta_val)} from {before_val:.3f} to {after_val:.3f}.")
 
-    lines.append(
-        f"Finished the week {summary.get('record', '0-0')} across {int(summary.get('matches_played', 0) or 0)} matches."
-    )
+    matches_played = int(summary.get("matches_played", 0) or 0)
+    lines.append(f"Finished {_format_record(int(summary.get('wins', 0) or 0), int(summary.get('losses', 0) or 0))} across {matches_played} matches.")
+
+    top_partner = (people or {}).get("top_partners") or []
+    if top_partner:
+        p = top_partner[0]
+        lines.append(
+            f"Most played with {p.get('player_name')} — {int(p.get('matches', 0))} matches, {p.get('record')}."
+        )
+
+    top_opp = (people or {}).get("top_opponents") or []
+    if top_opp:
+        o = top_opp[0]
+        lines.append(f"Most faced {o.get('player_name')} — {int(o.get('matches', 0))} meetings, {o.get('record')}.")
+
+    if league_breakdown:
+        top_league = league_breakdown[0]
+        lines.append(
+            f"Heaviest league segment: {top_league.get('league_name')} ({int(top_league.get('matches', 0))} matches)."
+        )
 
     if badges_earned:
-        lines.append(f"Earned {str(badges_earned[0].get('name') or 'a badge')}.")
-    elif trophies_earned:
-        t_name = str(trophies_earned[0].get("tournament_name") or "a tournament")
-        lines.append(f"Reached the podium in {t_name}.")
+        lines.append(f"Earned badge: {str(badges_earned[0].get('name') or 'Badge')}.")
+    if trophies_earned:
+        t_name = str(trophies_earned[0].get("tournament_name") or trophies_earned[0].get("league_name") or "Tournament")
+        lines.append(f"Podium finish recorded in {t_name}.")
 
-    return lines[:3]
+    return lines[:6]
 
 
 def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date: date, tz_name: str = "America/Mazatlan") -> dict:
@@ -153,7 +435,9 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
     club_id = str(getattr(ctx, "club_id", "") or "")
 
     overall_series = build_player_overall_rating_series(supabase, club_id, int(player_id), limit=1200)
-    window_series = filter_rating_series_for_window(overall_series, start_date, end_date, tz_name=tz_name)
+    window_series = filter_rating_series_for_window(overall_series, start_date, end_date, tz_name=tz_name).copy()
+    if not window_series.empty:
+        window_series["player_id"] = int(player_id)
 
     before = None
     after = _safe_float(window_series["Overall After"].iloc[-1]) if not window_series.empty else None
@@ -202,12 +486,11 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
 
     points = []
     for _, row in window_series.sort_values(["Date", "id"], ascending=[True, True]).iterrows():
+        dt = pd.to_datetime(row.get("Date"), utc=True, errors="coerce")
         points.append(
             {
                 "id": int(row.get("id")) if pd.notna(row.get("id")) else None,
-                "date": pd.to_datetime(row.get("Date"), utc=True, errors="coerce").isoformat()
-                if pd.notna(pd.to_datetime(row.get("Date"), utc=True, errors="coerce"))
-                else None,
+                "date": dt.isoformat() if pd.notna(dt) else None,
                 "overall_after": round(float(row.get("Overall After")), 3)
                 if pd.notna(row.get("Overall After"))
                 else None,
@@ -225,6 +508,37 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
     player_name = _player_name(ctx, int(player_id))
     display_range = _display_range(start_date, end_date)
 
+    league_breakdown = _league_breakdown(window_series)
+    people = _aggregate_people(ctx, window_series, int(player_id))
+    highlights = _build_highlights(
+        summary=summary,
+        badges_earned=badges_earned,
+        trophies_earned=trophies_earned,
+        people=people,
+        league_breakdown=league_breakdown,
+    )
+    week_at_a_glance = _build_week_at_a_glance(
+        player_name=player_name,
+        summary=summary,
+        league_breakdown=league_breakdown,
+        people=people,
+    )
+    notable_results = _build_notable_results(window_series)
+
+    win_pct = _format_pct(wins, matches_played)
+    numbers_cards = [
+        {"key": "matches", "label": "Matches", "value": matches_played},
+        {"key": "record", "label": "Record", "value": summary.get("record")},
+        {"key": "win_pct", "label": "Win %", "value": win_pct},
+        {"key": "overall_delta", "label": "Overall Δ", "value": _format_delta(summary.get("overall_delta"), 4)},
+        {"key": "leagues", "label": "Leagues", "value": len(league_breakdown)},
+        {
+            "key": "awards",
+            "label": "Badges/Trophies",
+            "value": f"{len(badges_earned)}/{len(trophies_earned)}",
+        },
+    ]
+
     digest = {
         "club_id": club_id,
         "player_id": int(player_id),
@@ -234,6 +548,11 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
         "display_range": display_range,
         "subject_line": f"{player_name} weekly digest · {display_range}",
         "summary": summary,
+        "numbers_cards": numbers_cards,
+        "week_at_a_glance": week_at_a_glance,
+        "league_breakdown": league_breakdown,
+        "people": people,
+        "notable_results": notable_results,
         "chart": {
             "title": "Overall JUPR Trend",
             "window_label": display_range,
@@ -242,7 +561,7 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
         },
         "badges_earned": badges_earned,
         "trophies_earned": trophies_earned,
-        "highlights": _build_highlights(summary, badges_earned, trophies_earned),
+        "highlights": highlights,
         "links": {
             "player_profile": f"/?page=players&pid={int(player_id)}",
         },

--- a/jupr_app/ui/components/player_digest_layout.py
+++ b/jupr_app/ui/components/player_digest_layout.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import html
+
+import pandas as pd
+import streamlit as st
+
+
+def _inject_styles() -> None:
+    st.markdown(
+        """
+<style>
+  .player-digest-wrap { max-width: 980px; margin: 0 auto; }
+  .player-digest { font-family: 'Inter', sans-serif; border: 1px solid gainsboro; border-radius: 14px; padding: 18px; }
+  .digest-card { border-radius: 16px; padding: 16px 18px; margin-bottom: 14px; background: var(--secondary-background-color); }
+  .digest-header { background: linear-gradient(135deg, #FFF3E6, #FFE7CF); border-left: 6px solid #FF7A00; color: #111; }
+  .digest-title { font-size: 28px; font-weight: 700; margin-bottom: 4px; }
+  .digest-subtitle { opacity: 0.8; font-size: 14px; }
+  .digest-metrics { display: grid; grid-template-columns: repeat(auto-fit,minmax(120px,1fr)); gap: 8px; }
+  .digest-metric { border-radius: 12px; background: var(--background-color); padding: 10px; text-align: center; }
+  .digest-metric-label { font-size: 11px; text-transform: uppercase; letter-spacing: .05em; }
+  .digest-metric-value { font-size: 20px; font-weight: 700; }
+  .digest-section-title { font-size: 17px; font-weight: 700; margin-bottom: 8px; }
+  .digest-soft { background: linear-gradient(135deg, #EAF4FF, #D8E9FF); border-left: 5px solid #1976D2; color: #111; }
+  .digest-soft-green { background: linear-gradient(135deg, #E8FFF4, #D2F7E7); border-left: 5px solid #1B9E77; color: #111; }
+  .digest-list { margin: 0; padding-left: 18px; }
+  .digest-list li { margin: 6px 0; }
+  .digest-row { border-bottom: 1px solid rgba(128,128,128,.25); padding: 7px 0; }
+  .digest-row:last-child { border-bottom: none; }
+  .digest-muted { opacity: .8; font-size: 13px; }
+  .digest-cta { text-align:center; }
+</style>
+""",
+        unsafe_allow_html=True,
+    )
+
+
+def _esc(value) -> str:
+    return html.escape(str(value or ""))
+
+
+def _render_people_rows(items: list[dict], empty_text: str) -> str:
+    if not items:
+        return f"<div class='digest-muted'>{_esc(empty_text)}</div>"
+    rows = []
+    for item in items[:3]:
+        rows.append(
+            "<div class='digest-row'>"
+            f"<strong>{_esc(item.get('player_name') or ('Player #' + str(item.get('player_id') or '')))}</strong>"
+            f"<div class='digest-muted'>{int(item.get('matches') or 0)} matches · {_esc(item.get('record') or '0-0')} · {int(item.get('point_diff') or 0):+d} point diff</div>"
+            "</div>"
+        )
+    return "".join(rows)
+
+
+def render_player_digest(digest: dict) -> None:
+    digest = digest or {}
+    summary = digest.get("summary") or {}
+    numbers = digest.get("numbers_cards") or []
+    highlights = digest.get("highlights") or []
+    glance = digest.get("week_at_a_glance") or []
+    leagues = digest.get("league_breakdown") or []
+    people = digest.get("people") or {}
+    badges = digest.get("badges_earned") or []
+    trophies = digest.get("trophies_earned") or []
+    notable = digest.get("notable_results") or []
+
+    _inject_styles()
+
+    player_name = _esc(digest.get("player_name") or "Verified Player")
+    display_range = _esc(digest.get("display_range") or "")
+    overall_after = summary.get("overall_jupr_after")
+    overall_delta = summary.get("overall_delta")
+
+    try:
+        overall_text = f"{float(overall_after):.3f}"
+    except Exception:
+        overall_text = "—"
+    try:
+        delta_text = f"{float(overall_delta):+0.4f}"
+    except Exception:
+        delta_text = "—"
+
+    metric_html = "".join(
+        f"<div class='digest-metric'><div class='digest-metric-value'>{_esc(card.get('value'))}</div><div class='digest-metric-label'>{_esc(card.get('label'))}</div></div>"
+        for card in numbers
+    )
+
+    st.markdown(
+        f"""
+<div class="player-digest-wrap">
+  <div class="player-digest">
+    <div class="digest-card digest-header">
+      <div class="digest-title">{player_name}</div>
+      <div class="digest-subtitle">Verified player update · {display_range}</div>
+      <div style="margin-top:8px;"><strong>Current JUPR:</strong> {overall_text} &nbsp;·&nbsp; <strong>Range Δ:</strong> {delta_text}</div>
+    </div>
+    <div class="digest-card">
+      <div class="digest-section-title">Quick Numbers</div>
+      <div class="digest-metrics">{metric_html}</div>
+    </div>
+  </div>
+</div>
+""",
+        unsafe_allow_html=True,
+    )
+
+    with st.container(border=True):
+        st.markdown("#### Week at a glance")
+        if glance:
+            for line in glance:
+                st.write(f"• {line}")
+        else:
+            st.caption("Quiet week — no match activity in this date range.")
+
+    chart_points = (digest.get("chart") or {}).get("points") or []
+    with st.container(border=True):
+        st.markdown("#### Overall JUPR Trend")
+        if chart_points:
+            chart_df = pd.DataFrame(chart_points)
+            chart_df["date"] = pd.to_datetime(chart_df.get("date"), errors="coerce")
+            chart_df = chart_df.dropna(subset=["date", "overall_after"]).sort_values("date")
+            if not chart_df.empty:
+                st.line_chart(chart_df.set_index("date")["overall_after"], use_container_width=True)
+                st.caption(f"{len(chart_df)} chart points in selected range")
+            else:
+                st.caption("No chartable points in selected range.")
+        else:
+            st.caption("No chart points available in selected date range.")
+
+    left, right = st.columns(2)
+    with left:
+        with st.container(border=True):
+            st.markdown("#### Highlights")
+            for line in highlights[:6] or ["No highlights available for this period."]:
+                st.write(f"• {line}")
+        with st.container(border=True):
+            st.markdown("#### League Breakdown")
+            if leagues:
+                for row in leagues[:8]:
+                    st.write(
+                        f"**{row.get('league_name')}** — {int(row.get('matches') or 0)} matches · {row.get('record') or '0-0'} · Δ {float(row.get('overall_delta') or 0):+0.4f}"
+                    )
+            else:
+                st.caption("No league data in this date range.")
+
+    with right:
+        with st.container(border=True):
+            st.markdown("#### Played With")
+            st.markdown(
+                _render_people_rows(people.get("top_partners") or [], "No partner data in this date range."),
+                unsafe_allow_html=True,
+            )
+        with st.container(border=True):
+            st.markdown("#### Faced Most")
+            st.markdown(
+                _render_people_rows(people.get("top_opponents") or [], "No opponent data in this date range."),
+                unsafe_allow_html=True,
+            )
+
+    with st.container(border=True):
+        st.markdown("#### Awards")
+        badge_names = [str(item.get("name") or item.get("badge_id") or "Badge") for item in badges[:6]]
+        trophy_names = [str(item.get("tournament_name") or item.get("league_name") or "Trophy") for item in trophies[:6]]
+
+        c1, c2 = st.columns(2)
+        with c1:
+            st.markdown("**Badges earned**")
+            for name in badge_names or ["None this period."]:
+                st.write(f"• {name}")
+        with c2:
+            st.markdown("**Trophies earned**")
+            for name in trophy_names or ["None this period."]:
+                st.write(f"• {name}")
+
+    if notable:
+        with st.container(border=True):
+            st.markdown("#### Notable Results")
+            for item in notable[:5]:
+                st.write(f"**{item.get('title')}:** {item.get('detail')}")
+
+    links = digest.get("links") or {}
+    profile_link = links.get("player_profile")
+    if profile_link:
+        st.markdown(f"[View player profile]({_esc(profile_link)})")

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -22,6 +22,7 @@ from jupr_app.domain.notifications.player_update_sender import (
     send_test_player_update_email,
 )
 from jupr_app.domain.recaps.player_weekly_digest import compute_player_weekly_digest
+from jupr_app.ui.components.player_digest_layout import render_player_digest
 from jupr_app.ui.layout import page_shell
 
 
@@ -112,26 +113,17 @@ def _digest_player_options(ctx, active_rows: list[dict]) -> tuple[list[str], dic
 
 def _render_digest_preview(digest: dict) -> None:
     st.markdown("#### Preview")
-    st.write(
-        {
-            "player": digest.get("player_name"),
-            "range": digest.get("display_range"),
-            "subject_line": digest.get("subject_line"),
-        }
-    )
-    st.json(digest.get("summary") or {})
+    render_player_digest(digest)
 
-    points = (digest.get("chart") or {}).get("points") or []
-    if points:
-        st.dataframe(pd.DataFrame(points), use_container_width=True, hide_index=True)
-    else:
-        st.caption("No chart points available in selected date range.")
+    with st.expander("Debug payload", expanded=False):
+        st.json(digest)
 
-    highlights = digest.get("highlights") or []
-    if highlights:
-        st.markdown("**Highlights**")
-        for line in highlights:
-            st.write(f"• {line}")
+    with st.expander("Raw chart points", expanded=False):
+        points = (digest.get("chart") or {}).get("points") or []
+        if points:
+            st.dataframe(pd.DataFrame(points), use_container_width=True, hide_index=True)
+        else:
+            st.caption("No chart points available in selected date range.")
 
 
 def _friendly_error(exc: Exception) -> str:


### PR DESCRIPTION
### Motivation
- The player weekly digest was previously delivered as a thin JSON payload and raw data view, which felt developer-centric rather than a polished player-facing mini-report. The intent is to make digests feel branded and human while keeping data truthful to the selected window. 
- Add meaningful context about other people the player partnered with or faced so the update reads like a personable recap rather than a table dump. 
- Surface the polished preview in the admin UI and make outbound email HTML more attractive while keeping send/unsubscribe behavior unchanged.

### Description
- Expanded the digest payload returned by `compute_player_weekly_digest(...)` to include ready-to-render sections: `numbers_cards`, `week_at_a_glance`, `league_breakdown`, `people` (top partners/opponents + `best_partner` / `most_faced_opponent`), `notable_results`, and a richer `highlights` list, while preserving existing keys (`summary`, `chart`, `badges_earned`, `trophies_earned`, `links`, `meta`). (`jupr_app/domain/recaps/player_weekly_digest.py`).
- Added helper logic inside `player_weekly_digest.py` for partner/opponent aggregation, league breakdown, narrative builders, notable-result extraction, safe formatting helpers, and graceful handling of empty windows. (`_aggregate_people`, `_league_breakdown`, `_build_week_at_a_glance`, `_build_notable_results`, etc.).
- New Streamlit renderer `jupr_app/ui/components/player_digest_layout.py` that renders a branded mini-report (header card, metric strip, week-at-a-glance, chart, two-column highlights/people rhythm, awards, notable results, CTA) using the Weekly Recap visual family as inspiration. (new file).
- Replaced the raw JSON-first admin preview in `jupr_app/ui/pages/player_updates_admin.py` so `_render_digest_preview` now uses the new renderer and moves raw JSON / raw chart points into optional expanders labeled `Debug payload` and `Raw chart points`.
- Upgraded the outbound email template in `jupr_app/domain/notifications/player_update_email_template.py` to an email-safe branded HTML layout (header, quick stats band, chart image, highlights, Played With / Faced Most tables, badges/trophies, profile CTA, unsubscribe footer) and expanded the plain-text template to include the week-at-a-glance and people sections.
- Kept integration boundaries intact (no DB schema changes, outbox flow, subscription workflow, subject-line semantics, or send/unsubscribe behavior altered).

### Testing
- Compiled the modified Python files to validate syntax and imports using `python -m compileall jupr_app/domain/recaps/player_weekly_digest.py jupr_app/ui/components/player_digest_layout.py jupr_app/ui/pages/player_updates_admin.py jupr_app/domain/notifications/player_update_email_template.py`, which completed successfully. 
- No new unit tests were added; recommend adding focused tests for `people` aggregation and `notable_results` edge cases in follow-up work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ab836e1883269f387946270684fa)