### PR TITLE
Harden Player Updates Admin send queue reliability and retry UX

### DIFF
--- a/jupr_app/domain/notifications/player_profile_update_repo.py
+++ b/jupr_app/domain/notifications/player_profile_update_repo.py
@@ -501,3 +501,53 @@ def update_outbox_status(
     if updated is None:
         raise RuntimeError("Outbox row could not be updated")
     return updated
+
+
+def reset_outbox_rows_to_pending(
+    supabase,
+    *,
+    club_id: str,
+    week_start_from: date | None = None,
+    week_start_to: date | None = None,
+    only_status: str = SEND_STATUS_ERROR,
+) -> dict[str, int]:
+    club_id = _require_nonempty(club_id, "club_id")
+    normalized_status = str(only_status or "").strip().lower()
+    if normalized_status not in {SEND_STATUS_PENDING, SEND_STATUS_SENT, SEND_STATUS_SKIPPED, SEND_STATUS_ERROR}:
+        raise ValueError("Invalid only_status")
+
+    query = (
+        supabase.table("player_profile_update_outbox")
+        .select("id")
+        .eq("club_id", club_id)
+        .eq("send_status", normalized_status)
+    )
+    if week_start_from is not None:
+        query = query.gte("week_start", week_start_from.isoformat())
+    if week_start_to is not None:
+        query = query.lte("week_start", week_start_to.isoformat())
+
+    rows = _safe_data(query.execute())
+    if not rows:
+        return {"matched": 0, "reset_to_pending": 0, "failed": 0}
+
+    row_ids = [str(row.get("id") or "").strip() for row in rows if str(row.get("id") or "").strip()]
+    if not row_ids:
+        return {"matched": len(rows), "reset_to_pending": 0, "failed": 0}
+
+    payload = {
+        "send_status": SEND_STATUS_PENDING,
+        "error_text": None,
+        "provider_message_id": None,
+        "sent_at": None,
+    }
+    updated_rows = _safe_data(
+        supabase.table("player_profile_update_outbox")
+        .update(payload)
+        .eq("club_id", club_id)
+        .in_("id", row_ids)
+        .execute()
+    )
+    reset_count = len(updated_rows)
+    failed_count = max(0, len(row_ids) - reset_count)
+    return {"matched": len(row_ids), "reset_to_pending": reset_count, "failed": failed_count}

--- a/jupr_app/domain/notifications/smtp_mailer.py
+++ b/jupr_app/domain/notifications/smtp_mailer.py
@@ -31,7 +31,7 @@ def _env_bool(name: str, default: bool = False) -> bool:
     return val in {"1", "true", "yes", "y", "on"}
 
 
-def _smtp_config_from_env() -> dict:
+def _read_smtp_config_raw() -> dict:
     host = _secret_or_env("SMTP_HOST")
     port_raw = _secret_or_env("SMTP_PORT")
     username = _secret_or_env("SMTP_USERNAME")
@@ -40,33 +40,67 @@ def _smtp_config_from_env() -> dict:
     from_name = _secret_or_env("SMTP_FROM_NAME") or "JUPR"
     use_tls = _env_bool("SMTP_USE_TLS", default=True)
 
-    missing = [
-        name
-        for name, value in [
-            ("SMTP_HOST", host),
-            ("SMTP_PORT", port_raw),
-            ("SMTP_USERNAME", username),
-            ("SMTP_PASSWORD", password),
-            ("SMTP_FROM_EMAIL", from_email),
-        ]
-        if not value
-    ]
-    if missing:
-        raise ValueError(f"Missing SMTP configuration: {', '.join(missing)}")
-
-    try:
-        port = int(port_raw)
-    except Exception as exc:
-        raise ValueError("SMTP_PORT must be an integer") from exc
-
     return {
         "host": host,
-        "port": port,
+        "port_raw": port_raw,
         "username": username,
         "password": password,
         "from_email": from_email,
         "from_name": from_name,
         "use_tls": use_tls,
+    }
+
+
+def get_smtp_config_status() -> dict:
+    raw = _read_smtp_config_raw()
+    missing = [
+        key
+        for key, value in [
+            ("SMTP_HOST", raw.get("host")),
+            ("SMTP_PORT", raw.get("port_raw")),
+            ("SMTP_USERNAME", raw.get("username")),
+            ("SMTP_PASSWORD", raw.get("password")),
+            ("SMTP_FROM_EMAIL", raw.get("from_email")),
+        ]
+        if not value
+    ]
+
+    port: int | None = None
+    port_error: str | None = None
+    if raw.get("port_raw"):
+        try:
+            port = int(raw["port_raw"])
+        except Exception:
+            port_error = "SMTP_PORT must be an integer"
+
+    return {
+        "ok": len(missing) == 0 and port_error is None,
+        "missing": missing,
+        "host": raw.get("host"),
+        "port": port,
+        "from_email": raw.get("from_email"),
+        "from_name": raw.get("from_name"),
+        "use_tls": bool(raw.get("use_tls", True)),
+        "port_error": port_error,
+    }
+
+
+def _smtp_config_from_env() -> dict:
+    status = get_smtp_config_status()
+    if status["missing"]:
+        raise ValueError(f"Missing SMTP configuration: {', '.join(status['missing'])}")
+    if status.get("port_error"):
+        raise ValueError(str(status["port_error"]))
+
+    raw = _read_smtp_config_raw()
+    return {
+        "host": status["host"],
+        "port": int(status["port"]),
+        "username": raw["username"],
+        "password": raw["password"],
+        "from_email": status["from_email"],
+        "from_name": status["from_name"],
+        "use_tls": status["use_tls"],
     }
 
 

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -13,6 +13,7 @@ from jupr_app.domain.notifications.player_profile_update_repo import (
     list_outbox_rows,
     mark_unsubscribed,
     reject_request,
+    reset_outbox_rows_to_pending,
     replace_verified_subscriber,
     save_digest,
 )
@@ -21,6 +22,7 @@ from jupr_app.domain.notifications.player_update_sender import (
     send_pending_player_update_emails,
     send_test_player_update_email,
 )
+from jupr_app.domain.notifications.smtp_mailer import get_smtp_config_status
 from jupr_app.domain.recaps.player_weekly_digest import compute_player_weekly_digest
 from jupr_app.ui.layout import page_shell
 
@@ -137,6 +139,15 @@ def _render_digest_preview(digest: dict) -> None:
 def _friendly_error(exc: Exception) -> str:
     text = str(exc or "").strip()
     return text or "Unknown error."
+
+
+def _smtp_not_ready_message(smtp_status: dict) -> str:
+    missing = smtp_status.get("missing") or []
+    if missing:
+        return f"Mail config missing required keys: {', '.join(missing)}."
+    if smtp_status.get("port_error"):
+        return str(smtp_status.get("port_error"))
+    return "Mail config is not ready."
 
 
 def render(ctx) -> None:
@@ -450,7 +461,24 @@ def render(ctx) -> None:
             st.error("Queue End Date must be on or after Queue Start Date.")
             return
 
-        q1, q2, q3 = st.columns(3)
+        smtp_status = get_smtp_config_status()
+        missing = smtp_status.get("missing") or []
+        mail_ready = bool(smtp_status.get("ok"))
+        if mail_ready:
+            st.success(
+                "Mail Config Status: Ready"
+                f" · host={smtp_status.get('host')}"
+                f" · port={smtp_status.get('port')}"
+                f" · from_email={smtp_status.get('from_email')}"
+                f" · tls={'on' if smtp_status.get('use_tls') else 'off'}"
+            )
+        else:
+            detail = f"Missing: {', '.join(missing)}." if missing else ""
+            if smtp_status.get("port_error"):
+                detail = f"{detail} {smtp_status.get('port_error')}".strip()
+            st.warning(f"Mail Config Status: Not Ready. {detail}".strip())
+
+        q1, q2, q3, q4 = st.columns(4)
         with q1:
             if st.button("Queue Pending for Date Range"):
                 try:
@@ -462,7 +490,12 @@ def render(ctx) -> None:
                     st.error(f"Queue failed: {_friendly_error(exc)}")
 
         with q2:
-            if st.button("Send Pending"):
+            send_pending_disabled_reason = _smtp_not_ready_message(smtp_status)
+            if st.button(
+                "Send Pending",
+                disabled=not mail_ready,
+                help=None if mail_ready else send_pending_disabled_reason,
+            ):
                 try:
                     result = send_pending_player_update_emails(ctx, limit=500)
                     st.success(
@@ -473,12 +506,42 @@ def render(ctx) -> None:
                     st.error(f"Send pending failed: {_friendly_error(exc)}")
 
         with q3:
-            if st.button("Send Test to Admin"):
+            if st.button(
+                "Send Test to Admin",
+                disabled=not mail_ready,
+                help=None if mail_ready else _smtp_not_ready_message(smtp_status),
+            ):
                 try:
                     result = send_test_player_update_email(ctx, start_date=queue_start, end_date=queue_end)
                     st.success(f"Sent test email to {result['to_email']}.")
                 except Exception as exc:
-                    st.error(f"Send test failed: {_friendly_error(exc)}")
+                    if "Missing SMTP configuration:" in str(exc):
+                        st.error(f"Send test failed: {_smtp_not_ready_message(smtp_status)}")
+                    else:
+                        st.error(f"Send test failed: {_friendly_error(exc)}")
+
+        with q4:
+            if st.button(
+                "Retry Errored Rows",
+                help="Reset errored rows in the selected date window back to pending.",
+            ):
+                try:
+                    result = reset_outbox_rows_to_pending(
+                        supabase,
+                        club_id=club_id,
+                        week_start_from=queue_start,
+                        week_start_to=queue_end,
+                        only_status="error",
+                    )
+                    st.success(
+                        "Retry reset complete: "
+                        f"matched={result['matched']} · "
+                        f"reset_to_pending={result['reset_to_pending']} · "
+                        f"failed={result['failed']}"
+                    )
+                    st.rerun()
+                except Exception as exc:
+                    st.error(f"Retry errored rows failed: {_friendly_error(exc)}")
 
         st.divider()
         try:


### PR DESCRIPTION
### Motivation
- The Send Queue flow crashes on missing SMTP configuration and exposes operators to opaque error blobs instead of actionable guidance.
- Operators need safe, upfront visibility into SMTP readiness and an easy, idempotent way to retry errored outbox rows without creating duplicates.
- Keep queueing behavior available even when mail is not configured so digest generation is not blocked by delivery issues.

### Description
- Added a non-raising status helper `get_smtp_config_status()` and a raw reader ` _read_smtp_config_raw()` in `jupr_app/domain/notifications/smtp_mailer.py` to return structured info (`ok`, `missing`, `host`, `port`, `from_email`, `from_name`, `use_tls`, `port_error`) while keeping ` _smtp_config_from_env()` strict for send-time validation.
- Added a repo-layer bulk reset helper `reset_outbox_rows_to_pending(...)` in `jupr_app/domain/notifications/player_profile_update_repo.py` that filters by `club_id` and optional week window and updates existing outbox rows in-place (clearing `error_text`, `provider_message_id`, `sent_at` and setting `send_status` to `pending`) without inserting duplicates.
- Enhanced `jupr_app/ui/pages/player_updates_admin.py` Send Queue tab to render a top `Mail Config Status` card showing Ready/Not Ready with safe fields (`host`, `port`, `from_email`, `tls`) or an explicit missing-keys list and port validation error, and to reuse the SMTP status message via a small helper ` _smtp_not_ready_message()`.
- Disabled the `Send Pending` and `Send Test to Admin` buttons when SMTP is not ready (while keeping `Queue Pending for Date Range` enabled) and added a `Retry Errored Rows` bulk action scoped to the selected queue date window that returns counts and triggers an immediate page rerun to refresh the table.

### Testing
- Compiled updated modules with `python -m compileall jupr_app/domain/notifications/smtp_mailer.py jupr_app/domain/notifications/player_profile_update_repo.py jupr_app/ui/pages/player_updates_admin.py` and the compilation completed successfully.
- Verified the Send Queue UI code paths render and call the new helpers (manual UI runtime validation recommended in a deployed Streamlit environment since full UI tests are not available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78a3b98588326a678bdd395b7180d)