### PR TITLE
Add Reply-To and List-Unsubscribe headers to player update emails

### DIFF
--- a/jupr_app/domain/notifications/player_update_email_template.py
+++ b/jupr_app/domain/notifications/player_update_email_template.py
@@ -61,6 +61,7 @@ def build_player_update_email_html(digest_json: dict, chart_cid: str | None) -> 
     <html>
       <body style=\"font-family:Arial,sans-serif;line-height:1.5;color:#111;\">
         <h2>Verified Player Update</h2>
+        <p style=\"font-size:13px;color:#555;\">You’re receiving this email because you subscribed to JUPR player profile updates.</p>
         <p><strong>Player:</strong> {player_name}<br/>
            <strong>Date range:</strong> {display_range}<br/>
            <strong>Current overall JUPR:</strong> {overall_text}</p>
@@ -104,6 +105,7 @@ def build_player_update_email_text(digest_json: dict) -> str:
     return "\n".join(
         [
             "Verified Player Update",
+            "You’re receiving this email because you subscribed to JUPR player profile updates.",
             f"Player: {_s(digest.get('player_name'))}",
             f"Date range: {_s(digest.get('display_range'))}",
             f"Current overall JUPR: {summary.get('overall_jupr_after')}",

--- a/jupr_app/domain/notifications/player_update_sender.py
+++ b/jupr_app/domain/notifications/player_update_sender.py
@@ -233,6 +233,7 @@ def send_pending_player_update_emails(ctx, *, limit: int = 100) -> dict[str, int
                 text_body=text_body,
                 chart_png_bytes=chart_png,
                 chart_cid=chart_cid if chart_png else None,
+                unsubscribe_url=str(((digest.get("links") or {}).get("unsubscribe")) or "").strip() or None,
             )
 
             update_outbox_status(

--- a/jupr_app/domain/notifications/smtp_mailer.py
+++ b/jupr_app/domain/notifications/smtp_mailer.py
@@ -37,7 +37,8 @@ def _read_smtp_config_raw() -> dict:
     username = _secret_or_env("SMTP_USERNAME")
     password = _secret_or_env("SMTP_PASSWORD")
     from_email = _secret_or_env("SMTP_FROM_EMAIL")
-    from_name = _secret_or_env("SMTP_FROM_NAME") or "JUPR"
+    from_name = _secret_or_env("SMTP_FROM_NAME") or "JUPR Updates"
+    reply_to = _secret_or_env("SMTP_REPLY_TO")
     use_tls = _env_bool("SMTP_USE_TLS", default=True)
 
     return {
@@ -47,6 +48,7 @@ def _read_smtp_config_raw() -> dict:
         "password": password,
         "from_email": from_email,
         "from_name": from_name,
+        "reply_to": reply_to,
         "use_tls": use_tls,
     }
 
@@ -80,6 +82,8 @@ def get_smtp_config_status() -> dict:
         "port": port,
         "from_email": raw.get("from_email"),
         "from_name": raw.get("from_name"),
+        "reply_to": raw.get("reply_to"),
+        "reply_to_configured": bool(raw.get("reply_to")),
         "use_tls": bool(raw.get("use_tls", True)),
         "port_error": port_error,
     }
@@ -100,6 +104,7 @@ def _smtp_config_from_env() -> dict:
         "password": raw["password"],
         "from_email": status["from_email"],
         "from_name": status["from_name"],
+        "reply_to": raw["reply_to"],
         "use_tls": status["use_tls"],
     }
 
@@ -112,6 +117,7 @@ def send_email_with_inline_chart(
     text_body: str,
     chart_png_bytes: bytes | None = None,
     chart_cid: str | None = None,
+    unsubscribe_url: str | None = None,
 ) -> str:
     cfg = _smtp_config_from_env()
 
@@ -119,6 +125,13 @@ def send_email_with_inline_chart(
     msg["Subject"] = str(subject)
     msg["From"] = f"{cfg['from_name']} <{cfg['from_email']}>"
     msg["To"] = str(to_email).strip()
+    if cfg.get("reply_to"):
+        msg["Reply-To"] = str(cfg["reply_to"]).strip()
+
+    normalized_unsubscribe_url = str(unsubscribe_url or "").strip()
+    if normalized_unsubscribe_url:
+        msg["List-Unsubscribe"] = f"<{normalized_unsubscribe_url}>"
+        msg["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
 
     alt = MIMEMultipart("alternative")
     alt.attach(MIMEText(text_body or "", "plain", "utf-8"))


### PR DESCRIPTION
### Motivation
- Improve deliverability and make player update messages look like legitimate opted-in product notifications without changing the SMTP flow.
- Surface whether a Reply-To is configured in the SMTP status helper for observability while keeping secrets hidden.
- Preserve backward compatibility when new settings are not provided and avoid redesigning the email template.

### Description
- Read optional `SMTP_REPLY_TO` in `jupr_app/domain/notifications/smtp_mailer.py` and include a `Reply-To` header only when configured, and expose `reply_to` + `reply_to_configured` in `get_smtp_config_status`.
- Default the sender display name fallback from `JUPR` to `JUPR Updates` by updating `SMTP_FROM_NAME` fallback in `smtp_mailer.py`.
- Extend `send_email_with_inline_chart(...)` to accept `unsubscribe_url` and conditionally add `List-Unsubscribe` and `List-Unsubscribe-Post: List-Unsubscribe=One-Click` headers when a non-empty URL is provided in `smtp_mailer.py`.
- Pass the unsubscribe URL from the digest (`digest["links"]["unsubscribe"]`) into the mailer call in `jupr_app/domain/notifications/player_update_sender.py`.
- Add a short, subtle subscription-reason line near the top of both the HTML and plain-text player update templates in `jupr_app/domain/notifications/player_update_email_template.py`.

### Testing
- Compiled the modified modules with `python -m compileall jupr_app/domain/notifications/smtp_mailer.py jupr_app/domain/notifications/player_update_sender.py jupr_app/domain/notifications/player_update_email_template.py` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a30fc5508326b6478fc493493ac8)