### PR TITLE
Follow-up: test sends use unsubscribe path and show SMTP status in UI

### DIFF
--- a/jupr_app/domain/notifications/player_update_sender.py
+++ b/jupr_app/domain/notifications/player_update_sender.py
@@ -405,6 +405,7 @@ def send_test_player_update_email(
     subject = f"[TEST] {build_player_update_email_subject(digest)}"
     html_body = build_player_update_email_html(digest, chart_cid if chart_png else None)
     text_body = build_player_update_email_text(digest)
+    unsubscribe_url = str(((digest.get("links") or {}).get("unsubscribe")) or "").strip() or None
 
     provider_message_id = send_email_with_inline_chart(
         to_email=admin_email,
@@ -413,5 +414,6 @@ def send_test_player_update_email(
         text_body=text_body,
         chart_png_bytes=chart_png,
         chart_cid=chart_cid if chart_png else None,
+        unsubscribe_url=unsubscribe_url,
     )
     return {"to_email": admin_email, "provider_message_id": provider_message_id}

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -23,6 +23,7 @@ from jupr_app.domain.notifications.player_update_sender import (
     queue_saved_digest_rows,
     send_pending_player_update_emails,
 )
+from jupr_app.domain.notifications.smtp_mailer import get_smtp_config_status
 from jupr_app.domain.recaps.player_weekly_digest import compute_player_weekly_digest
 from jupr_app.ui.layout import page_shell
 
@@ -453,6 +454,27 @@ def render(ctx) -> None:
     with queue_tab:
         st.subheader("Send Queue")
         st.caption("Choose from digests that have already been generated, then queue and send them.")
+        st.markdown("#### Mail Config Status")
+        smtp_status = get_smtp_config_status()
+        st.write(
+            {
+                "from_email": smtp_status.get("from_email") or "",
+                "from_name": smtp_status.get("from_name") or "",
+                "reply_to": smtp_status.get("reply_to") or "",
+                "reply_to_configured": bool(smtp_status.get("reply_to_configured")),
+                "use_tls": bool(smtp_status.get("use_tls")),
+                "missing_required_smtp_keys": smtp_status.get("missing") or [],
+            }
+        )
+        if smtp_status.get("port_error"):
+            st.warning(f"SMTP config warning: {smtp_status['port_error']}")
+        elif smtp_status.get("missing"):
+            st.warning(
+                "SMTP config missing required keys: "
+                + ", ".join(str(key) for key in (smtp_status.get("missing") or []))
+            )
+        else:
+            st.caption("SMTP config appears complete.")
 
         active_rows = list_active_subscriptions(supabase, club_id, limit=2000)
         active_by_player: dict[int, dict] = {}


### PR DESCRIPTION
### Motivation
- Ensure test email sends use the exact same unsubscribe header path as real sends so mailbox providers see consistent headers.
- Improve admin visibility into SMTP configuration so operators can quickly verify from/reply-to/TLS and missing keys without exposing secrets.
- Make this a small, backward-compatible follow-up with no template redesign.

### Description
- Pass the digest-produced unsubscribe link into `send_email_with_inline_chart(...)` in `send_test_player_update_email(...)` so test sends include the same `List-Unsubscribe`/`List-Unsubscribe-Post` headers as real sends when a link exists.
- Add a Mail Config Status section to the Player Updates Admin (Send Queue tab) that displays `from_email`, `from_name`, `reply_to`, a `reply_to_configured` boolean, `use_tls`, and any `missing_required_smtp_keys`, while keeping SMTP password/secret contents hidden.
- Preserve backward compatibility by keeping `Reply-To` optional and only adding unsubscribe headers when the `unsubscribe_url` is non-blank.

### Testing
- Ran a compile check with `python -m py_compile jupr_app/domain/notifications/player_update_sender.py jupr_app/domain/notifications/smtp_mailer.py jupr_app/ui/pages/player_updates_admin.py` which completed successfully.
- Verified logically that test sends will now include the unsubscribe-header path when the digest `links.unsubscribe` value is present, matching real send behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c28050d483268fabc46ed4362752)