### PR TITLE
Use match sequence axis for player digest chart

### DIFF
--- a/jupr_app/domain/notifications/player_update_charts.py
+++ b/jupr_app/domain/notifications/player_update_charts.py
@@ -6,18 +6,18 @@ from io import BytesIO
 def render_player_digest_chart_png(digest_json: dict) -> bytes | None:
     chart = (digest_json or {}).get("chart") or {}
     points = chart.get("points") or []
-    parsed: list[tuple[str, float]] = []
+    parsed: list[tuple[int, float]] = []
     for point in points:
         if not isinstance(point, dict):
             continue
-        date_text = str(point.get("date") or "").strip()
         try:
+            x = int(point.get("match_number"))
             y = float(point.get("overall_after"))
         except Exception:
             continue
-        if not date_text:
+        if x < 1:
             continue
-        parsed.append((date_text, y))
+        parsed.append((x, y))
 
     if len(parsed) < 2:
         return None
@@ -25,26 +25,29 @@ def render_player_digest_chart_png(digest_json: dict) -> bytes | None:
     import matplotlib
 
     matplotlib.use("Agg")
-    import matplotlib.dates as mdates
     import matplotlib.pyplot as plt
-    import pandas as pd
-
-    x_vals = pd.to_datetime([row[0] for row in parsed], utc=True, errors="coerce")
-    y_vals = [row[1] for row in parsed]
-
-    valid = [(x, y) for x, y in zip(x_vals, y_vals) if not pd.isna(x)]
-    if len(valid) < 2:
-        return None
 
     fig, ax = plt.subplots(figsize=(8.5, 3.2), dpi=150)
-    x, y = zip(*valid)
+    x, y = zip(*sorted(parsed, key=lambda row: row[0]))
     ax.plot(x, y, color="#1f77b4", linewidth=2.2, marker="o", markersize=3.5)
-    ax.set_title(str(chart.get("title") or "Overall JUPR Trend"), fontsize=11)
+    ax.set_title(str(chart.get("title") or "Overall JUPR by Match"), fontsize=11)
+    ax.set_xlabel("Match")
     ax.set_ylabel("JUPR")
     ax.grid(True, alpha=0.3)
-    ax.xaxis.set_major_locator(mdates.AutoDateLocator())
-    ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
-    fig.autofmt_xdate(rotation=30, ha="right")
+    max_match = max(x)
+    if max_match <= 10:
+        tick_step = 1
+    elif max_match <= 30:
+        tick_step = 2
+    elif max_match <= 75:
+        tick_step = 5
+    else:
+        tick_step = 10
+    tick_values = list(range(1, max_match + 1, tick_step))
+    if tick_values[-1] != max_match:
+        tick_values.append(max_match)
+    ax.set_xticks(tick_values)
+    ax.set_xlim(1, max_match)
     fig.tight_layout()
 
     output = BytesIO()

--- a/jupr_app/domain/recaps/player_weekly_digest.py
+++ b/jupr_app/domain/recaps/player_weekly_digest.py
@@ -201,10 +201,12 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
     }
 
     points = []
-    for _, row in window_series.sort_values(["Date", "id"], ascending=[True, True]).iterrows():
+    ordered_window_series = window_series.sort_values(["Date", "id"], ascending=[True, True])
+    for match_number, (_, row) in enumerate(ordered_window_series.iterrows(), start=1):
         points.append(
             {
                 "id": int(row.get("id")) if pd.notna(row.get("id")) else None,
+                "match_number": match_number,
                 "date": pd.to_datetime(row.get("Date"), utc=True, errors="coerce").isoformat()
                 if pd.notna(pd.to_datetime(row.get("Date"), utc=True, errors="coerce"))
                 else None,
@@ -235,7 +237,7 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
         "subject_line": f"{player_name} weekly digest · {display_range}",
         "summary": summary,
         "chart": {
-            "title": "Overall JUPR Trend",
+            "title": "Overall JUPR by Match",
             "window_label": display_range,
             "series_key": "overall_after",
             "points": points,


### PR DESCRIPTION
### Motivation
- The weekly player digest chart stacks points when multiple matches occur on the same date because the x-axis uses datetime values, so the chart should instead plot matches by game sequence to avoid vertical stacking and improve readability in emails.

### Description
- Assign a deterministic 1-based `match_number` to each in-window match after sorting `window_series` by `Date` ascending then `id` ascending and preserve existing point metadata (`date`, `league`, `score`, `result`, `overall_after`, `overall_delta`).
- Change the digest chart payload title fallback to `Overall JUPR by Match` to reflect the new x-axis meaning.
- Update the PNG renderer to use numeric `match_number` values as the x-axis, add an `Match` x-axis label, keep `JUPR` as the y-axis label, and remove pandas datetime formatting for this chart.
- Add integer tick handling with a simple density rule (`1`/`2`/`5`/`10` step depending on series length), ensure the x-axis spans `1` to `max_match`, and keep the existing email-friendly figure sizing and styling.
- Preserve the existing short-series behavior so the renderer returns `None` when fewer than 2 usable points exist.

### Testing
- Ran `python -m py_compile jupr_app/domain/recaps/player_weekly_digest.py jupr_app/domain/notifications/player_update_charts.py`, which succeeded.
- Match order is determined by sorting by `Date` ascending, then `id` ascending, and then enumerating the sorted rows starting at `1` to produce `match_number` values.
- Logical verification confirms this eliminates same-day vertical stacking because each match receives a unique sequential x-position instead of sharing a datetime x-coordinate.
- The renderer still returns `None` when there are fewer than two valid points, preserving prior short-series behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c81dab50832686328f3088737cf8)