### PR TITLE
Stabilize admin auth UI, deep-linking, and query-param sync

### DIFF
--- a/jupr_app/ui/admin_auth.py
+++ b/jupr_app/ui/admin_auth.py
@@ -19,6 +19,7 @@ _BROWSER_REFRESH_TOKEN_KEY = "jupr_admin_refresh_token"
 _BROWSER_RESTORE_FLAG_KEY = "jupr_admin_restore_from_storage"
 _BROWSER_SYNC_PAYLOAD_KEY = "_admin_browser_sync_payload"
 _BROWSER_CLEAR_PENDING_KEY = "_admin_browser_clear_pending"
+_BROWSER_RESTORE_ATTEMPTED_SESSION_KEY = "jupr_admin_restore_attempted"
 
 
 class AdminAuthError(RuntimeError):
@@ -357,7 +358,9 @@ def restore_admin_browser_session() -> dict[str, str] | None:
           const appUrl = new URL(appWindow.location.href);
           const params = appUrl.searchParams;
           const hasHandshake = params.get("{_BROWSER_RESTORE_FLAG_KEY}") === "1";
-          if (access && refresh && !hasHandshake) {{
+          const restoreAttempted = appWindow.sessionStorage.getItem("{_BROWSER_RESTORE_ATTEMPTED_SESSION_KEY}") === "1";
+          if (access && refresh && !hasHandshake && !restoreAttempted) {{
+            appWindow.sessionStorage.setItem("{_BROWSER_RESTORE_ATTEMPTED_SESSION_KEY}", "1");
             params.set("jupr_admin_access_token", access);
             params.set("jupr_admin_refresh_token", refresh);
             params.set("{_BROWSER_RESTORE_FLAG_KEY}", "1");

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -148,7 +148,7 @@ def main():
         st.session_state["base_url"] = PUBLIC_BASE_URL
 
         # ---- Session defaults ----
-        st.session_state.setdefault("deep_link_applied", False)
+        st.session_state.setdefault("_last_rendered_nav", None)
 
         # Admin auth uses Supabase email/password + allowlist and can restore
         # a previously persisted browser token pair after refresh.
@@ -182,11 +182,14 @@ def main():
 
             if not authenticated:
                 with st.sidebar.expander("🔒 Admin Login"):
-                    email = st.text_input("Email", key="admin_email")
-                    password = st.text_input("Password", type="password", key="admin_pwd")
                     show_forgot_password = st.session_state.get("show_forgot_password", False)
 
-                    if st.button("Login", key="admin_login_btn"):
+                    with st.form("admin_login_form", clear_on_submit=False):
+                        email = st.text_input("Email", key="admin_email")
+                        password = st.text_input("Password", type="password", key="admin_pwd")
+                        login_submitted = st.form_submit_button("Login")
+
+                    if login_submitted:
                         if not admin_allowlist:
                             auth_config_error = "Supabase auth is not configured. Set SUPABASE_URL, SUPABASE_ANON_KEY, and admin.allowed_emails."
                         else:
@@ -209,8 +212,11 @@ def main():
                         st.rerun()
 
                     if st.session_state.get("show_forgot_password", False):
-                        reset_email = st.text_input("Email for reset link", key="admin_reset_email")
-                        if st.button("Send reset email", key="admin_send_reset_email_btn"):
+                        with st.form("admin_reset_password_form", clear_on_submit=False):
+                            reset_email = st.text_input("Email for reset link", key="admin_reset_email")
+                            send_reset_submitted = st.form_submit_button("Send reset email")
+
+                        if send_reset_submitted:
                             try:
                                 send_password_reset_email(
                                     reset_email,
@@ -426,18 +432,17 @@ def main():
         else:
             visible_labels = [x for x in visible_labels if x not in HIDDEN_PAGE_LABELS]
 
-            # Recovery links should always land on reset_password when detected.
+            valid_admin_deep_label = ""
             if deep_label in HIDDEN_PAGE_LABELS and is_recovery_flow_query():
-                st.session_state["main_nav"] = deep_label
-
-            # Apply deep link once (including hidden pages like reset_password)
-            if (not bool(st.session_state.get("deep_link_applied", False))) and (
-                deep_label in visible_labels or deep_label in HIDDEN_PAGE_LABELS
-            ):
-                st.session_state["main_nav"] = deep_label
-                st.session_state["deep_link_applied"] = True
+                valid_admin_deep_label = deep_label
+            elif deep_label in visible_labels:
+                valid_admin_deep_label = deep_label
 
             current_nav = st.session_state.get("main_nav")
+            if valid_admin_deep_label and current_nav != valid_admin_deep_label:
+                st.session_state["main_nav"] = valid_admin_deep_label
+                current_nav = valid_admin_deep_label
+
             if (
                 "main_nav" not in st.session_state
                 or (current_nav not in visible_labels and current_nav not in HIDDEN_PAGE_LABELS)
@@ -471,7 +476,10 @@ def main():
         try:
             target_page = LABEL_TO_PAGE_KEY.get(sel, "leaderboards")
             current_page = qp_get("page", "").strip()
-            if current_page != target_page:
+            last_rendered_nav = st.session_state.get("_last_rendered_nav")
+            nav_changed = sel != last_rendered_nav
+
+            if nav_changed and current_page != target_page:
                 st.query_params["page"] = target_page
 
             current_public = qp_get("public", "").strip().lower()
@@ -481,6 +489,8 @@ def main():
             else:
                 if "public" in st.query_params:
                     st.query_params.pop("public", None)
+
+            st.session_state["_last_rendered_nav"] = sel
         except Exception:
             pass
 


### PR DESCRIPTION
### Motivation
- Deep links and incidental reruns were causing navigation to flash or reset due to a one-shot deep-link gate and eager URL rewriting. 
- Admin login inputs were triggering reruns while typing, making the auth UI feel unstable. 
- Browser-stored session restore could repeatedly trigger a `location.replace` handshake and cause surprise reloads.

### Description
- Replace the `deep_link_applied` one-shot behavior by applying valid incoming `?page=` values to `st.session_state["main_nav"]` whenever they differ from the current nav, including recovery/reset handling. 
- Add `_last_rendered_nav` tracking and only write `st.query_params["page"]` when the navigation actually changed to avoid query-param churn. 
- Move admin login and reset-email widgets into `st.form` blocks with `st.form_submit_button` so typing does not trigger reruns before submit. 
- Add a `sessionStorage`-backed guard (`_BROWSER_RESTORE_ATTEMPTED_SESSION_KEY`) in the browser restore JS to ensure the token-restore `location.replace` handshake runs at most once per tab/session-load while preserving restore capability.

### Testing
- Compiled modified modules with `python -m py_compile streamlit_app.py jupr_app/ui/admin_auth.py` and the compilation succeeded. 
- No additional automated tests were present or run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90a757128832686e283781ea7e145)