### PR TITLE
Fix admin sidebar routing state overwrite and reduce query-param churn

### DIFF
--- a/jupr_app/ui/pages/tournament_live.py
+++ b/jupr_app/ui/pages/tournament_live.py
@@ -76,7 +76,9 @@ def _parse_optional_date(value: Any) -> str | None:
 
 def _go_to_tournament_manager(tournament_id: Any) -> None:
     st.query_params["page"] = "tournament_manager"
-    st.query_params["tournament_id"] = tournament_id
+    current_tournament_id = _safe_text(st.query_params.get("tournament_id"))
+    if current_tournament_id != str(tournament_id):
+        st.query_params["tournament_id"] = tournament_id
     st.rerun()
 
 
@@ -307,7 +309,9 @@ def render(ctx):
     selected_label = st.selectbox("Select tournament", tournament_labels, index=default_index)
     tournament = tournaments[tournament_labels.index(selected_label)]
     tournament_id = tournament["id"]
-    st.query_params["tournament_id"] = tournament_id
+    current_tournament_id = _safe_text(st.query_params.get("tournament_id"))
+    if current_tournament_id != str(tournament_id):
+        st.query_params["tournament_id"] = tournament_id
 
     available, _ = registration_feature_available(supabase)
     registration_bridge = None
@@ -396,7 +400,9 @@ def render(ctx):
             st.rerun()
         if action_cols[1].button("Configure registration", key=f"goto_reg_{tournament_id}"):
             st.query_params["page"] = "tournament_manager"
-            st.query_params["tournament_id"] = tournament_id
+            current_tournament_id = _safe_text(st.query_params.get("tournament_id"))
+            if current_tournament_id != str(tournament_id):
+                st.query_params["tournament_id"] = tournament_id
             st.rerun()
         if action_cols[2].button("Refresh draw list", key=f"refresh_draws_{tournament_id}"):
             st.rerun()

--- a/jupr_app/ui/pages/tournament_ops.py
+++ b/jupr_app/ui/pages/tournament_ops.py
@@ -80,7 +80,9 @@ def _parse_optional_date(value: Any) -> str | None:
 
 def _go_to_tournament_manager(tournament_id: Any) -> None:
     st.query_params["page"] = "tournament_manager"
-    st.query_params["tournament_id"] = tournament_id
+    current_tournament_id = _safe_text(st.query_params.get("tournament_id"))
+    if current_tournament_id != str(tournament_id):
+        st.query_params["tournament_id"] = tournament_id
     st.rerun()
 
 
@@ -311,7 +313,9 @@ def render(ctx):
     selected_label = st.selectbox("Select tournament", tournament_labels, index=default_index)
     tournament = tournaments[tournament_labels.index(selected_label)]
     tournament_id = tournament["id"]
-    st.query_params["tournament_id"] = tournament_id
+    current_tournament_id = _safe_text(st.query_params.get("tournament_id"))
+    if current_tournament_id != str(tournament_id):
+        st.query_params["tournament_id"] = tournament_id
 
     available, _ = registration_feature_available(supabase)
     registration_bridge = None
@@ -431,7 +435,9 @@ def render(ctx):
             st.rerun()
         if action_cols[1].button("Configure registration", key=f"goto_reg_{tournament_id}"):
             st.query_params["page"] = "tournament_manager"
-            st.query_params["tournament_id"] = tournament_id
+            current_tournament_id = _safe_text(st.query_params.get("tournament_id"))
+            if current_tournament_id != str(tournament_id):
+                st.query_params["tournament_id"] = tournament_id
             st.rerun()
         if action_cols[2].button("Refresh draw list", key=f"refresh_draws_{tournament_id}"):
             st.rerun()

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -44,7 +44,9 @@ def _parse_optional_date(value: Any) -> str | None:
 
 def _go_to_page(page: str, tournament_id: Any) -> None:
     st.query_params["page"] = page
-    st.query_params["tournament_id"] = tournament_id
+    current_tournament_id = _safe_text(st.query_params.get("tournament_id"))
+    if current_tournament_id != str(tournament_id):
+        st.query_params["tournament_id"] = tournament_id
     st.rerun()
 
 
@@ -160,7 +162,9 @@ def render(ctx):
     picked = st.selectbox("Select tournament", labels, index=default_index)
     tournament = tournaments[labels.index(picked)]
     tournament_id = tournament["id"]
-    st.query_params["tournament_id"] = tournament_id
+    current_tournament_id = _safe_text(st.query_params.get("tournament_id"))
+    if current_tournament_id != str(tournament_id):
+        st.query_params["tournament_id"] = tournament_id
 
     st.subheader("Tournament Overview")
     settings = get_registration_settings(supabase, tournament_id, tournament_name=_safe_text(tournament.get("name")))

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -405,7 +405,8 @@ def main():
         # -------------------------
         # Deep link resolution
         # -------------------------
-        deep_page_key = qp_get("page", "").strip().lower()
+        incoming_page_param = qp_get("page", "").strip().lower()
+        deep_page_key = incoming_page_param
         if not deep_page_key and is_recovery_flow_query():
             deep_page_key = "reset_password"
 
@@ -438,10 +439,13 @@ def main():
             elif deep_label in visible_labels:
                 valid_admin_deep_label = deep_label
 
+            last_seen_page_param = st.session_state.get("_last_seen_page_param")
+            if incoming_page_param != last_seen_page_param:
+                st.session_state["_last_seen_page_param"] = incoming_page_param
+                if valid_admin_deep_label:
+                    st.session_state["main_nav"] = valid_admin_deep_label
+
             current_nav = st.session_state.get("main_nav")
-            if valid_admin_deep_label and current_nav != valid_admin_deep_label:
-                st.session_state["main_nav"] = valid_admin_deep_label
-                current_nav = valid_admin_deep_label
 
             if (
                 "main_nav" not in st.session_state


### PR DESCRIPTION
### Motivation

- Prevent the app shell from repeatedly overwriting the admin sidebar selection with a stale `?page=` URL param so sidebar clicks remain authoritative during normal reruns.  
- Preserve deep-linking (including the hidden `reset_password` recovery flow) so real incoming URLs still navigate the app correctly.  
- Reduce unnecessary URL / query-param churn during normal page render, especially around tournament pages that were unconditionally writing `tournament_id` on every render.

### Description

- In `streamlit_app.py` read the raw incoming `?page=` into `incoming_page_param` and track the last-seen value in `st.session_state["_last_seen_page_param"]`, applying the deep-link to `st.session_state["main_nav"]` only when the raw page param actually changes.  
- Preserve the recovery-flow fallback to `reset_password` while restricting repeated re-application of the same deep-link on incidental reruns.  
- Keep existing canonical sync from sidebar navigation into `st.query_params["page"]` when navigation actually changes, so URL sync remains one-way after real nav changes.  
- Reduce query-param churn in tournament flows by changing unconditional `st.query_params["tournament_id"]` writes into conditional writes that first compare the current value via `_safe_text(...)` and only set `tournament_id` when it differs; applied in `jupr_app/ui/pages/tournaments.py`, `jupr_app/ui/pages/tournament_ops.py`, and `jupr_app/ui/pages/tournament_live.py` and in navigation helpers that navigate to tournament manager.

### Testing

- Ran `python -m py_compile streamlit_app.py jupr_app/ui/pages/tournaments.py jupr_app/ui/pages/tournament_ops.py jupr_app/ui/pages/tournament_live.py` and the files compiled successfully.  
- Verified the app-level logic change preserves the existing URL->nav deep-link behavior while preventing repeated URL-driven resets during normal reruns (manual verification during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92a856bc0832693c5ffead2036c3b)