### PR TITLE
Polish verified player update: chart, dates, badges, and match list

### DIFF
--- a/jupr_app/domain/notifications/player_update_charts.py
+++ b/jupr_app/domain/notifications/player_update_charts.py
@@ -1,25 +1,31 @@
 from __future__ import annotations
 
 from io import BytesIO
+from datetime import datetime, timedelta
 
 
 def render_player_digest_chart_png(digest_json: dict) -> bytes | None:
     chart = (digest_json or {}).get("chart") or {}
     points = chart.get("points") or []
-    parsed: list[tuple[int, float]] = []
+    parsed: list[tuple[datetime | None, int, float]] = []
     for point in points:
         if not isinstance(point, dict):
             continue
         try:
-            x = int(point.get("match_number"))
             y = float(point.get("overall_after"))
         except Exception:
             continue
-        if x < 1:
-            continue
-        parsed.append((x, y))
+        match_number = int(point.get("match_number") or 0)
+        dt = None
+        try:
+            raw_dt = str(point.get("date") or "").strip()
+            if raw_dt:
+                dt = datetime.fromisoformat(raw_dt.replace("Z", "+00:00"))
+        except Exception:
+            dt = None
+        parsed.append((dt, match_number, y))
 
-    if len(parsed) < 2:
+    if not parsed:
         return None
 
     import matplotlib
@@ -28,26 +34,25 @@ def render_player_digest_chart_png(digest_json: dict) -> bytes | None:
     import matplotlib.pyplot as plt
 
     fig, ax = plt.subplots(figsize=(8.5, 3.2), dpi=150)
-    x, y = zip(*sorted(parsed, key=lambda row: row[0]))
-    ax.plot(x, y, color="#1f77b4", linewidth=2.2, marker="o", markersize=3.5)
+    parsed = sorted(parsed, key=lambda row: (row[0] or datetime.min, row[1]))
+    y = [row[2] for row in parsed]
+    x_dates = [row[0] for row in parsed]
+    if all(x_dates):
+        ax.plot(x_dates, y, color="#1f77b4", linewidth=2.2, marker="o", markersize=3.5)
+        ax.set_xlabel("Date")
+        if len(x_dates) == 1:
+            ax.set_xlim(x_dates[0] - timedelta(days=1), x_dates[0] + timedelta(days=1))
+    else:
+        x_idx = list(range(1, len(parsed) + 1))
+        ax.plot(x_idx, y, color="#1f77b4", linewidth=2.2, marker="o", markersize=3.5)
+        ax.set_xlabel("Match")
+        if len(x_idx) == 1:
+            ax.set_xlim(0, 2)
+        else:
+            ax.set_xlim(1, max(x_idx))
     ax.set_title(str(chart.get("title") or "Overall JUPR by Match"), fontsize=11)
-    ax.set_xlabel("Match")
     ax.set_ylabel("JUPR")
     ax.grid(True, alpha=0.3)
-    max_match = max(x)
-    if max_match <= 10:
-        tick_step = 1
-    elif max_match <= 30:
-        tick_step = 2
-    elif max_match <= 75:
-        tick_step = 5
-    else:
-        tick_step = 10
-    tick_values = list(range(1, max_match + 1, tick_step))
-    if tick_values[-1] != max_match:
-        tick_values.append(max_match)
-    ax.set_xticks(tick_values)
-    ax.set_xlim(1, max_match)
     fig.tight_layout()
 
     output = BytesIO()

--- a/jupr_app/domain/notifications/player_update_email_template.py
+++ b/jupr_app/domain/notifications/player_update_email_template.py
@@ -31,6 +31,19 @@ def _people_html(items: list[dict], empty_text: str) -> str:
     return "".join(rows)
 
 
+def _badge_line(item: dict) -> str:
+    name = _s(item.get("name")) or _s(item.get("badge_id")) or "Badge"
+    count = int(item.get("count") or 1)
+    label = f"{name} x{count}" if count > 1 else name
+    desc = _s(item.get("description")) or "Award earned during this update window."
+    return (
+        "<tr><td style='padding:4px 0;'>"
+        f"<div><strong>{html.escape(label)}</strong></div>"
+        f"<div style='color:#5A6678;font-size:12px;line-height:1.3;'>{html.escape(desc)}</div>"
+        "</td></tr>"
+    )
+
+
 def build_player_update_email_subject(digest_json: dict) -> str:
     player_name = _s((digest_json or {}).get("player_name")) or "Verified Player"
     display_range = _s((digest_json or {}).get("display_range"))
@@ -42,8 +55,9 @@ def build_player_update_email_subject(digest_json: dict) -> str:
 def build_player_update_email_html(digest_json: dict, chart_cid: str | None) -> str:
     digest = digest_json or {}
     summary = digest.get("summary") or {}
-    badges = digest.get("badges_earned") or []
+    badges = digest.get("badges_grouped") or digest.get("badges_earned") or []
     trophies = digest.get("trophies_earned") or []
+    matches = digest.get("matches_played_rows") or []
     highlights = digest.get("highlights") or []
     glance = digest.get("week_at_a_glance") or []
     people = digest.get("people") or {}
@@ -67,13 +81,15 @@ def build_player_update_email_html(digest_json: dict, chart_cid: str | None) -> 
         if _s(line)
     )
 
-    badge_items = "".join(
-        f"<tr><td style='padding:3px 0;'>• {html.escape(_s(item.get('name')) or _s(item.get('badge_id')) or 'Badge')}</td></tr>"
-        for item in badges[:8]
-    )
+    badge_items = "".join(_badge_line(item) for item in badges[:10])
     trophy_items = "".join(
         f"<tr><td style='padding:3px 0;'>• {html.escape(_s(item.get('tournament_name')) or _s(item.get('league_name')) or 'Trophy')}</td></tr>"
         for item in trophies[:8]
+    )
+    match_items = "".join(
+        f"<tr><td style='padding:5px 0;font-size:13px;line-height:1.35;'>{html.escape(_s(item.get('summary')))}</td></tr>"
+        for item in matches
+        if _s(item.get("summary"))
     )
 
     profile_link = html.escape(_s(links.get("player_profile")))
@@ -114,12 +130,24 @@ def build_player_update_email_html(digest_json: dict, chart_cid: str | None) -> 
                 </table>
               </td>
             </tr>
-            <tr><td style="padding:14px 24px 0;"><div style="font-size:17px;font-weight:700;">Week at a glance</div><table role="presentation" width="100%">{glance_items or "<tr><td style='padding:4px 0;color:#5A6678;'>No activity in this date window.</td></tr>"}</table></td></tr>
             <tr><td style="padding:16px 24px 0;"><div style="font-size:17px;font-weight:700;margin-bottom:8px;">Overall JUPR Trend</div>{chart_block}</td></tr>
+            <tr><td style="padding:14px 24px 0;"><div style="font-size:17px;font-weight:700;">Short Summary</div><table role="presentation" width="100%">{glance_items or "<tr><td style='padding:4px 0;color:#5A6678;'>No activity in this date window.</td></tr>"}</table></td></tr>
             <tr>
               <td style="padding:18px 24px 0;">
                 <div style="font-size:17px;font-weight:700;margin-bottom:6px;">Highlights</div>
                 <table role="presentation" width="100%">{highlight_items or "<tr><td style='padding:4px 0;color:#5A6678;'>No highlights available.</td></tr>"}</table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:18px 24px 0;">
+                <div style="font-size:16px;font-weight:700;margin-bottom:6px;">Badges earned</div>
+                <table role='presentation' width='100%'>{badge_items or "<tr><td style='padding:3px 0;color:#5A6678;'>None this period.</td></tr>"}</table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:14px 24px 0;">
+                <div style="font-size:16px;font-weight:700;margin-bottom:6px;">Matches Played</div>
+                <table role='presentation' width='100%'>{match_items or "<tr><td style='padding:3px 0;color:#5A6678;'>No matches in this date range.</td></tr>"}</table>
               </td>
             </tr>
             <tr>
@@ -138,16 +166,7 @@ def build_player_update_email_html(digest_json: dict, chart_cid: str | None) -> 
                 </table>
               </td>
             </tr>
-            <tr>
-              <td style="padding:18px 24px 0;">
-                <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
-                  <tr>
-                    <td width="50%" valign="top" style="padding-right:8px;"><div style="font-size:16px;font-weight:700;margin-bottom:6px;">Badges</div><table role='presentation' width='100%'>{badge_items or "<tr><td style='padding:3px 0;color:#5A6678;'>None this period.</td></tr>"}</table></td>
-                    <td width="50%" valign="top" style="padding-left:8px;"><div style="font-size:16px;font-weight:700;margin-bottom:6px;">Trophies</div><table role='presentation' width='100%'>{trophy_items or "<tr><td style='padding:3px 0;color:#5A6678;'>None this period.</td></tr>"}</table></td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
+            {"<tr><td style='padding:18px 24px 0;'><div style='font-size:16px;font-weight:700;margin-bottom:6px;'>Trophies</div><table role='presentation' width='100%'>" + trophy_items + "</table></td></tr>" if trophy_items else ""}
             <tr>
               <td align="center" style="padding:22px 24px 10px;">
                 <a href="{profile_link}" style="display:inline-block;background:#14223A;color:#FFFFFF;text-decoration:none;padding:10px 18px;border-radius:8px;font-weight:700;font-size:14px;">View player profile</a>
@@ -170,20 +189,27 @@ def build_player_update_email_html(digest_json: dict, chart_cid: str | None) -> 
 def build_player_update_email_text(digest_json: dict) -> str:
     digest = digest_json or {}
     summary = digest.get("summary") or {}
-    badges = digest.get("badges_earned") or []
+    badges = digest.get("badges_grouped") or digest.get("badges_earned") or []
     trophies = digest.get("trophies_earned") or []
+    matches = digest.get("matches_played_rows") or []
     highlights = digest.get("highlights") or []
     glance = digest.get("week_at_a_glance") or []
     people = digest.get("people") or {}
     links = digest.get("links") or {}
 
-    badge_lines = [f"- {_s(item.get('name')) or _s(item.get('badge_id')) or 'Badge'}" for item in badges[:10]]
+    badge_lines = []
+    for item in badges[:10]:
+        name = _s(item.get("name")) or _s(item.get("badge_id")) or "Badge"
+        count = int(item.get("count") or 1)
+        label = f"{name} x{count}" if count > 1 else name
+        badge_lines.append(f"- {label}: {_s(item.get('description')) or 'Award earned during this update window.'}")
     trophy_lines = [
         f"- {_s(item.get('tournament_name')) or _s(item.get('league_name')) or 'Trophy'}"
         for item in trophies[:10]
     ]
     highlight_lines = [f"- {_s(line)}" for line in highlights[:10] if _s(line)]
     glance_lines = [f"- {_s(line)}" for line in glance[:6] if _s(line)]
+    match_lines = [f"- {_s(item.get('summary'))}" for item in matches if _s(item.get("summary"))]
 
     partner_lines = [
         f"- {_s(item.get('player_name')) or ('Player #' + _s(item.get('player_id')))} · {int(item.get('matches') or 0)} matches · {_s(item.get('record')) or '0-0'}"
@@ -208,6 +234,9 @@ def build_player_update_email_text(digest_json: dict) -> str:
             "Week at a glance:",
             *(glance_lines or ["- No activity in this date window."]),
             "",
+            "Matches played:",
+            *(match_lines or ["- No matches in this date window."]),
+            "",
             "Highlights:",
             *(highlight_lines or ["- No highlights available."]),
             "",
@@ -219,9 +248,11 @@ def build_player_update_email_text(digest_json: dict) -> str:
             "",
             "Badges earned:",
             *(badge_lines or ["- None this period."]),
-            "",
-            "Trophies earned:",
-            *(trophy_lines or ["- None this period."]),
+            *(
+                ["", "Trophies earned:", *trophy_lines]
+                if trophy_lines
+                else []
+            ),
             "",
             f"Profile link: {_s(links.get('player_profile'))}",
             f"Unsubscribe: {_s(links.get('unsubscribe'))}",

--- a/jupr_app/domain/recaps/player_weekly_digest.py
+++ b/jupr_app/domain/recaps/player_weekly_digest.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timezone
 
 import pandas as pd
 
+from jupr_app.domain.gamification.badge_registry import badge_schema_by_id
 from jupr_app.domain.gamification.trophies import get_player_tournament_trophies
 from jupr_app.domain.player_rating_series import (
     build_player_overall_rating_series,
@@ -32,7 +33,32 @@ def _safe_int(value) -> int | None:
 
 
 def _display_range(start_date: date, end_date: date) -> str:
-    return f"{start_date.isoformat()} – {end_date.isoformat()}"
+    return f"{_format_display_date(start_date)} – {_format_display_date(end_date)}"
+
+
+def _ordinal_suffix(day: int) -> str:
+    if 11 <= (day % 100) <= 13:
+        return "th"
+    return {1: "st", 2: "nd", 3: "rd"}.get(day % 10, "th")
+
+
+def _format_display_date(value: date | datetime | pd.Timestamp | None) -> str:
+    if value is None:
+        return "Unknown date"
+    if isinstance(value, pd.Timestamp):
+        if pd.isna(value):
+            return "Unknown date"
+        day_value = value.date()
+    elif isinstance(value, datetime):
+        day_value = value.date()
+    elif isinstance(value, date):
+        day_value = value
+    else:
+        dt = pd.to_datetime(value, errors="coerce")
+        if pd.isna(dt):
+            return "Unknown date"
+        day_value = dt.date()
+    return f"{day_value.strftime('%B')} {day_value.day}{_ordinal_suffix(day_value.day)}"
 
 
 def _player_name(ctx, player_id: int) -> str:
@@ -102,6 +128,12 @@ def _load_badges_earned(supabase, club_id: str, player_id: int, start_dt_utc: da
 
     badge_ids = sorted({str(row.get("badge_id") or "").strip() for row in badge_rows if row.get("badge_id")})
     badge_name_map: dict[str, str] = {}
+    badge_desc_map: dict[str, str] = {}
+    for badge_id, schema in badge_schema_by_id().items():
+        badge_name_map[str(badge_id)] = str(schema.title or badge_id)
+        badge_desc_map[str(badge_id)] = str(
+            schema.display.flavor or schema.display.requirements or "Award earned during this update window."
+        ).strip()
     if badge_ids:
         try:
             badge_defs = (
@@ -112,12 +144,14 @@ def _load_badges_earned(supabase, club_id: str, player_id: int, start_dt_utc: da
                 .data
                 or []
             )
-            badge_name_map = {
-                str(row.get("badge_id")): str(row.get("name") or row.get("badge_id") or "Badge")
-                for row in badge_defs
-            }
+            badge_name_map.update(
+                {
+                    str(row.get("badge_id")): str(row.get("name") or row.get("badge_id") or "Badge")
+                    for row in badge_defs
+                }
+            )
         except Exception:
-            badge_name_map = {}
+            pass
 
     out: list[dict] = []
     for row in badge_rows:
@@ -128,12 +162,37 @@ def _load_badges_earned(supabase, club_id: str, player_id: int, start_dt_utc: da
             {
                 "badge_id": bid,
                 "name": badge_name_map.get(bid, bid),
+                "description": badge_desc_map.get(bid, "Award earned during this update window."),
                 "earned_at": row.get("earned_at"),
                 "context_type": row.get("context_type"),
                 "context_id": row.get("context_id"),
             }
         )
     return out
+
+
+def _group_badges_for_display(badges: list[dict]) -> list[dict]:
+    grouped: dict[str, dict] = {}
+    for badge in badges or []:
+        badge_id = str(badge.get("badge_id") or "").strip()
+        name = str(badge.get("name") or badge_id or "Badge").strip() or "Badge"
+        key = badge_id or name.lower()
+        if key not in grouped:
+            grouped[key] = {
+                "badge_id": badge_id or None,
+                "name": name,
+                "description": str(badge.get("description") or "Award earned during this update window.").strip(),
+                "count": 0,
+                "last_earned_at": None,
+            }
+        grouped[key]["count"] = int(grouped[key]["count"]) + 1
+        earned_at = badge.get("earned_at")
+        if earned_at and (grouped[key]["last_earned_at"] is None or str(earned_at) > str(grouped[key]["last_earned_at"])):
+            grouped[key]["last_earned_at"] = earned_at
+
+    grouped_items = list(grouped.values())
+    grouped_items.sort(key=lambda item: str(item.get("last_earned_at") or ""), reverse=True)
+    return grouped_items
 
 
 def _load_trophies_earned(supabase, club_id: str, player_id: int, start_dt_utc: datetime, end_dt_utc: datetime) -> list[dict]:
@@ -339,7 +398,7 @@ def _build_notable_results(window_series: pd.DataFrame) -> list[dict]:
 
     def _note(row: pd.Series, title: str, detail: str) -> dict:
         played_at = pd.to_datetime(row.get("Date"), utc=True, errors="coerce")
-        date_text = played_at.date().isoformat() if pd.notna(played_at) else "Unknown date"
+        date_text = _format_display_date(played_at) if pd.notna(played_at) else "Unknown date"
         league = str(row.get("League") or "Unspecified league")
         score = str(row.get("Score") or "")
         suffix = f" · {score}" if score else ""
@@ -484,12 +543,28 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
         "record": f"{wins}-{losses}",
     }
 
+    start_dt_utc, end_dt_utc = get_date_range_bounds(start_date, end_date, tz_name)
     points = []
-    for _, row in window_series.sort_values(["Date", "id"], ascending=[True, True]).iterrows():
+    if before is not None and not window_series.empty:
+        points.append(
+            {
+                "id": "anchor",
+                "match_number": 0,
+                "date": start_dt_utc.isoformat(),
+                "overall_after": round(float(before), 3),
+                "overall_delta": 0.0,
+                "league": "",
+                "score": "",
+                "result": "ANCHOR",
+                "is_anchor": True,
+            }
+        )
+    for idx, (_, row) in enumerate(window_series.sort_values(["Date", "id"], ascending=[True, True]).iterrows(), start=1):
         dt = pd.to_datetime(row.get("Date"), utc=True, errors="coerce")
         points.append(
             {
                 "id": int(row.get("id")) if pd.notna(row.get("id")) else None,
+                "match_number": idx,
                 "date": dt.isoformat() if pd.notna(dt) else None,
                 "overall_after": round(float(row.get("Overall After")), 3)
                 if pd.notna(row.get("Overall After"))
@@ -501,8 +576,8 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
             }
         )
 
-    start_dt_utc, end_dt_utc = get_date_range_bounds(start_date, end_date, tz_name)
     badges_earned = _load_badges_earned(supabase, club_id, int(player_id), start_dt_utc, end_dt_utc)
+    badges_grouped = _group_badges_for_display(badges_earned)
     trophies_earned = _load_trophies_earned(supabase, club_id, int(player_id), start_dt_utc, end_dt_utc)
 
     player_name = _player_name(ctx, int(player_id))
@@ -524,6 +599,40 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
         people=people,
     )
     notable_results = _build_notable_results(window_series)
+    matches_played_rows: list[dict] = []
+    for _, row in window_series.sort_values(["Date", "id"], ascending=[False, False]).iterrows():
+        player_on_t1 = _is_player_on_t1(row, int(player_id))
+        if player_on_t1 is None:
+            continue
+
+        if player_on_t1:
+            partner_ids = [pid for pid in [_safe_int(row.get("t1_p1")), _safe_int(row.get("t1_p2"))] if pid not in {None, int(player_id)}]
+            opponent_ids = [pid for pid in [_safe_int(row.get("t2_p1")), _safe_int(row.get("t2_p2"))] if pid is not None]
+        else:
+            partner_ids = [pid for pid in [_safe_int(row.get("t2_p1")), _safe_int(row.get("t2_p2"))] if pid not in {None, int(player_id)}]
+            opponent_ids = [pid for pid in [_safe_int(row.get("t1_p1")), _safe_int(row.get("t1_p2"))] if pid is not None]
+
+        result = str(row.get("Result") or "").upper()
+        result_short = "W" if result == "WIN" else ("L" if result == "LOSS" else (result[:1] if result else "—"))
+        score = str(row.get("Score") or "").strip() or None
+        played_at = pd.to_datetime(row.get("Date"), utc=True, errors="coerce")
+        date_text = _format_display_date(played_at) if pd.notna(played_at) else "Unknown date"
+        partners = " / ".join(_player_name(ctx, int(pid)) for pid in partner_ids) if partner_ids else "No partner listed"
+        opponents = " / ".join(_player_name(ctx, int(pid)) for pid in opponent_ids) if opponent_ids else "Unknown opponents"
+        summary_line = f"{date_text} — with {partners} vs {opponents} — {result_short}"
+        if score:
+            summary_line = f"{summary_line} {score}"
+        matches_played_rows.append(
+            {
+                "date": played_at.isoformat() if pd.notna(played_at) else None,
+                "date_display": date_text,
+                "partners": partners,
+                "opponents": opponents,
+                "result": result_short,
+                "score": score,
+                "summary": summary_line,
+            }
+        )
 
     win_pct = _format_pct(wins, matches_played)
     numbers_cards = [
@@ -560,7 +669,9 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
             "points": points,
         },
         "badges_earned": badges_earned,
+        "badges_grouped": badges_grouped,
         "trophies_earned": trophies_earned,
+        "matches_played_rows": matches_played_rows,
         "highlights": highlights,
         "links": {
             "player_profile": f"/?page=players&pid={int(player_id)}",

--- a/jupr_app/ui/components/player_digest_layout.py
+++ b/jupr_app/ui/components/player_digest_layout.py
@@ -61,8 +61,9 @@ def render_player_digest(digest: dict) -> None:
     glance = digest.get("week_at_a_glance") or []
     leagues = digest.get("league_breakdown") or []
     people = digest.get("people") or {}
-    badges = digest.get("badges_earned") or []
+    badges = digest.get("badges_grouped") or digest.get("badges_earned") or []
     trophies = digest.get("trophies_earned") or []
+    matches = digest.get("matches_played_rows") or []
     notable = digest.get("notable_results") or []
 
     _inject_styles()
@@ -105,14 +106,6 @@ def render_player_digest(digest: dict) -> None:
         unsafe_allow_html=True,
     )
 
-    with st.container(border=True):
-        st.markdown("#### Week at a glance")
-        if glance:
-            for line in glance:
-                st.write(f"• {line}")
-        else:
-            st.caption("Quiet week — no match activity in this date range.")
-
     chart_points = (digest.get("chart") or {}).get("points") or []
     with st.container(border=True):
         st.markdown("#### Overall JUPR Trend")
@@ -127,6 +120,14 @@ def render_player_digest(digest: dict) -> None:
                 st.caption("No chartable points in selected range.")
         else:
             st.caption("No chart points available in selected date range.")
+
+    with st.container(border=True):
+        st.markdown("#### Short Summary")
+        if glance:
+            for line in glance:
+                st.write(f"• {line}")
+        else:
+            st.caption("Quiet week — no match activity in this date range.")
 
     left, right = st.columns(2)
     with left:
@@ -159,25 +160,35 @@ def render_player_digest(digest: dict) -> None:
             )
 
     with st.container(border=True):
-        st.markdown("#### Awards")
-        badge_names = [str(item.get("name") or item.get("badge_id") or "Badge") for item in badges[:6]]
-        trophy_names = [str(item.get("tournament_name") or item.get("league_name") or "Trophy") for item in trophies[:6]]
+        st.markdown("#### Badges earned")
+        for badge in badges[:10]:
+            count = int(badge.get("count") or 1)
+            label = f"{badge.get('name') or badge.get('badge_id') or 'Badge'} x{count}" if count > 1 else str(
+                badge.get("name") or badge.get("badge_id") or "Badge"
+            )
+            st.markdown(f"**{label}**")
+            st.caption(str(badge.get("description") or "Award earned during this update window."))
+        if not badges:
+            st.caption("No badges earned in this date range.")
 
-        c1, c2 = st.columns(2)
-        with c1:
-            st.markdown("**Badges earned**")
-            for name in badge_names or ["None this period."]:
-                st.write(f"• {name}")
-        with c2:
-            st.markdown("**Trophies earned**")
-            for name in trophy_names or ["None this period."]:
-                st.write(f"• {name}")
+    with st.container(border=True):
+        st.markdown("#### Matches Played")
+        for item in matches:
+            st.write(f"• {item.get('summary')}")
+        if not matches:
+            st.caption("No matches in this date range.")
 
     if notable:
         with st.container(border=True):
             st.markdown("#### Notable Results")
             for item in notable[:5]:
                 st.write(f"**{item.get('title')}:** {item.get('detail')}")
+
+    if trophies:
+        with st.container(border=True):
+            st.markdown("#### Trophies")
+            for name in [str(item.get("tournament_name") or item.get("league_name") or "Trophy") for item in trophies[:6]]:
+                st.write(f"• {name}")
 
     links = digest.get("links") or {}
     profile_link = links.get("player_profile")

--- a/tests/test_verified_player_update_pipeline.py
+++ b/tests/test_verified_player_update_pipeline.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pandas as pd
+
+from jupr_app.domain.notifications.player_update_charts import render_player_digest_chart_png
+from jupr_app.domain.notifications.player_update_email_template import build_player_update_email_html
+from jupr_app.domain.recaps import player_weekly_digest as digest_mod
+
+
+class _FakeExec:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeQuery:
+    def __init__(self, table_name: str, data_map: dict[str, list[dict]]):
+        self._table_name = table_name
+        self._data_map = data_map
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, *_args, **_kwargs):
+        return self
+
+    def gte(self, *_args, **_kwargs):
+        return self
+
+    def lte(self, *_args, **_kwargs):
+        return self
+
+    def order(self, *_args, **_kwargs):
+        return self
+
+    def in_(self, *_args, **_kwargs):
+        return self
+
+    def execute(self):
+        return _FakeExec(self._data_map.get(self._table_name, []))
+
+
+class _FakeSupabase:
+    def __init__(self, data_map: dict[str, list[dict]]):
+        self._data_map = data_map
+
+    def table(self, table_name: str):
+        return _FakeQuery(table_name, self._data_map)
+
+
+class _Ctx:
+    def __init__(self):
+        self.club_id = "club-1"
+        self.supabase = None
+        self.id_to_name = {1: "Ada", 2: "Joel", 3: "Keith", 4: "Natasha"}
+
+
+def test_display_range_uses_month_day_ordinals():
+    assert digest_mod._display_range(date(2026, 3, 15), date(2026, 4, 22)) == "March 15th – April 22nd"
+
+
+def test_load_badges_uses_canonical_description(monkeypatch):
+    class _Badge:
+        title = "Blowout Artist"
+
+        class display:
+            flavor = "Win by a big margin."
+            requirements = "Win by 6+"
+
+    monkeypatch.setattr(digest_mod, "badge_schema_by_id", lambda: {"blowout_artist": _Badge()})
+
+    supabase = _FakeSupabase(
+        {
+            "player_badges": [
+                {
+                    "badge_id": "blowout_artist",
+                    "earned_at": datetime(2026, 4, 10, tzinfo=timezone.utc).isoformat(),
+                    "context_type": "match",
+                    "context_id": "m1",
+                },
+                {
+                    "badge_id": "blowout_artist",
+                    "earned_at": datetime(2026, 4, 11, tzinfo=timezone.utc).isoformat(),
+                    "context_type": "match",
+                    "context_id": "m2",
+                },
+            ],
+            "badges": [],
+        }
+    )
+
+    rows = digest_mod._load_badges_earned(
+        supabase,
+        "club-1",
+        1,
+        datetime(2026, 4, 1, tzinfo=timezone.utc),
+        datetime(2026, 4, 30, tzinfo=timezone.utc),
+    )
+    grouped = digest_mod._group_badges_for_display(rows)
+
+    assert grouped[0]["name"] == "Blowout Artist"
+    assert grouped[0]["count"] == 2
+    assert grouped[0]["description"] == "Win by a big margin."
+
+
+def test_digest_has_chart_points_and_match_rows_when_window_active(monkeypatch):
+    base_df = pd.DataFrame(
+        [
+            {
+                "id": 10,
+                "Date": pd.Timestamp("2026-04-01T16:00:00Z"),
+                "League": "L1",
+                "Score": "11-8",
+                "Result": "WIN",
+                "Overall Δ": 0.01,
+                "Overall After": 3.2,
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+                "score_t1": 11,
+                "score_t2": 8,
+            },
+            {
+                "id": 11,
+                "Date": pd.Timestamp("2026-04-03T16:00:00Z"),
+                "League": "L1",
+                "Score": "9-11",
+                "Result": "LOSS",
+                "Overall Δ": -0.005,
+                "Overall After": 3.195,
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+                "score_t1": 9,
+                "score_t2": 11,
+            },
+        ]
+    )
+
+    monkeypatch.setattr(digest_mod, "build_player_overall_rating_series", lambda *_args, **_kwargs: base_df)
+    monkeypatch.setattr(digest_mod, "filter_rating_series_for_window", lambda *_args, **_kwargs: base_df)
+    monkeypatch.setattr(digest_mod, "_load_badges_earned", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(digest_mod, "_load_trophies_earned", lambda *_args, **_kwargs: [])
+
+    digest = digest_mod.compute_player_weekly_digest(_Ctx(), 1, date(2026, 4, 1), date(2026, 4, 10))
+
+    assert digest["chart"]["points"], "Expected chart points for active span"
+    assert digest["chart"]["points"][0]["result"] == "ANCHOR"
+    assert digest["matches_played_rows"], "Expected matches list rows"
+    assert digest["matches_played_rows"][0]["summary"].startswith("April")
+
+
+def test_chart_renderer_accepts_date_points_without_match_numbers():
+    digest = {
+        "chart": {
+            "points": [
+                {"date": "2026-04-22T00:00:00+00:00", "overall_after": 3.2},
+            ]
+        }
+    }
+
+    png = render_player_digest_chart_png(digest)
+    assert isinstance(png, bytes)
+    assert len(png) > 100
+
+
+def test_email_html_renders_matches_and_quiet_empty_trophies():
+    digest = {
+        "player_name": "Ada",
+        "display_range": "March 15th – April 22nd",
+        "summary": {"overall_jupr_after": 3.2, "overall_delta": 0.02, "record": "2-1", "matches_played": 3},
+        "chart": {"points": [{"date": "2026-04-22T00:00:00+00:00", "overall_after": 3.2}]},
+        "badges_grouped": [{"name": "Blowout Artist", "count": 3, "description": "Win by a big margin."}],
+        "matches_played_rows": [
+            {"summary": "April 3rd — with Joel vs Keith / Natasha — W 15-11"},
+        ],
+        "people": {"top_partners": [], "top_opponents": []},
+        "links": {"player_profile": "https://example.com/p", "unsubscribe": "https://example.com/u"},
+        "trophies_earned": [],
+    }
+
+    html = build_player_update_email_html(digest, chart_cid="chart-1")
+    assert "Chart unavailable for this date range" not in html
+    assert "Matches Played" in html
+    assert "Blowout Artist x3" in html
+    assert "None this period" not in html


### PR DESCRIPTION
### Motivation
- Improve the verified player update so it reads and feels like a finished, player-facing product by fixing the rating chart, making dates human-friendly, collapsing repeated badges with descriptions, and adding a compact match list.

### Description
- Changed date presentation to Month-Day with ordinal suffixes by replacing ISO presentation with `_format_display_date` used in `display_range` and notable-result text (`jupr_app/domain/recaps/player_weekly_digest.py`).
- Fixed chart payload and renderer by emitting per-event `match_number` and a start-of-window anchor point in the digest, and updated `render_player_digest_chart_png` to accept date-based points and single-point series so active windows always render when data exists (`player_weekly_digest.py`, `player_update_charts.py`).
- Pulled canonical badge metadata and added grouping: badge rows are enriched with canonical name/description (fallback provided) and collapsed into grouped `xN` entries; email/HTML/Streamlit renderers now use the grouped badges and show the short description (`player_weekly_digest.py`, `player_update_email_template.py`, `player_digest_layout.py`).
- Added a compact "Matches Played" payload and rendering: `matches_played_rows` contains date (formatted), partners, opponents, result and score and is rendered in email and the Streamlit preview (`player_weekly_digest.py`, `player_update_email_template.py`, `player_digest_layout.py`).
- UX polish: reordered sections to the requested flow and made trophies quieter by hiding the trophies section when empty (email and Streamlit templates updated).
- Files touched: `jupr_app/domain/recaps/player_weekly_digest.py`, `jupr_app/domain/notifications/player_update_charts.py`, `jupr_app/domain/notifications/player_update_email_template.py`, `jupr_app/ui/components/player_digest_layout.py`, and tests added at `tests/test_verified_player_update_pipeline.py`.

### Testing
- Added `tests/test_verified_player_update_pipeline.py` covering ordinal date formatting, canonical badge description + grouping, active-span chart points with anchor, chart renderer acceptance of date-only points, match-list rendering, and quiet trophies behavior.
- Ran `pytest -q tests/test_verified_player_update_pipeline.py` and all tests passed: `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92f786e988326aa6488ee74d0fc8f)