### PR TITLE
Fix durable public routing for verified updates flow

### DIFF
--- a/jupr_app/ui/page_registry.py
+++ b/jupr_app/ui/page_registry.py
@@ -50,6 +50,12 @@ PAGE_DEFINITIONS: tuple[PageDefinition, ...] = (
     PageDefinition("weekly_recap_admin", "🗞️ Weekly Recap Admin", admin_only=True),
     PageDefinition("player_updates_admin", "📬 Player Updates Admin", admin_only=True),
     PageDefinition("reset_password", "🔐 Reset Password", show_in_nav=False),
+    PageDefinition(
+        "verified_updates_request",
+        "📬 Verified Updates Request",
+        public=True,
+        show_in_nav=False,
+    ),
 )
 
 PAGE_KEY_TO_LABEL = {page.key: page.label for page in PAGE_DEFINITIONS}

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -1113,6 +1113,7 @@ def build_league_snapshot_map(_supabase, club_id: str, league_name: str, df_meta
 
 def render(ctx):
     PUBLIC_MODE = bool(getattr(ctx, "public_mode", False))
+    current_page_key = qp_get("page", "").strip().lower()
     mode_label = "Public" if PUBLIC_MODE else "Admin"
     page_shell("🔍 Player Search", "Find players and view ratings.", mode_label=mode_label)
 
@@ -1137,21 +1138,20 @@ def render(ctx):
     players_df["id"] = players_df["id"].astype(int)
 
     pid_q = qp_get("pid", "").strip()
+    player_id_q = qp_get("player_id", "").strip()
     unsub_q = qp_get("unsubscribe", "").strip()
     sid_q = qp_get("sid", "").strip()
     verified_updates_view_q = qp_get("view", "").strip().lower()
-    pid_sig = f"pid:{pid_q}" if pid_q else ""
+    route_requests_verified_updates = current_page_key == "verified_updates_request"
+    selected_pid_q = player_id_q or pid_q
+    pid_sig = f"pid:{selected_pid_q}" if selected_pid_q else ""
     last_sig = st.session_state.get("player_pid_sig_applied", "")
 
-    if pid_q.isdigit() and pid_sig != last_sig:
-        pid_int = int(pid_q)
+    if selected_pid_q.isdigit() and pid_sig != last_sig:
+        pid_int = int(selected_pid_q)
         hit = players_df[players_df["id"] == pid_int]
         if not hit.empty:
             st.session_state["player_search_id"] = int(hit.iloc[0]["id"])
-            try:
-                st.query_params.pop("pid", None)
-            except Exception:
-                pass
         st.session_state["player_pid_sig_applied"] = pid_sig
 
     players_df = players_df.sort_values("name").copy()
@@ -1177,6 +1177,15 @@ def render(ctx):
         return
 
     pid = int(pick_id)
+    if PUBLIC_MODE:
+        try:
+            st.query_params["pid"] = str(pid)
+            st.query_params["player_id"] = str(pid)
+            if str(qp_get("club_id", "")).strip() == "":
+                st.query_params["club_id"] = str(getattr(ctx, "club_id", ""))
+        except Exception:
+            pass
+
     row = players_df[players_df["id"] == pid].iloc[0]
     _supabase = ctx.supabase
     club_id = ctx.club_id
@@ -1227,10 +1236,21 @@ def render(ctx):
         open_or_active = get_open_or_active_subscription(_supabase, str(club_id), pid)
         request_status = str((open_or_active or {}).get("request_status") or "").strip().lower()
 
-        verified_updates_manage_params = {"page": "players", "public": 1, "pid": int(pid)}
+        verified_updates_manage_params = {
+            "page": "players",
+            "public": 1,
+            "club_id": str(club_id),
+            "pid": int(pid),
+            "player_id": int(pid),
+        }
         verified_updates_manage_url = f"/?{urlencode(verified_updates_manage_params)}"
-        verified_updates_request_params = dict(verified_updates_manage_params)
-        verified_updates_request_params["view"] = "verified_updates_request"
+        verified_updates_request_params = {
+            "page": "verified_updates_request",
+            "public": 1,
+            "club_id": str(club_id),
+            "pid": int(pid),
+            "player_id": int(pid),
+        }
         verified_updates_request_url = f"/?{urlencode(verified_updates_request_params)}"
 
     with c1:
@@ -1271,7 +1291,9 @@ def render(ctx):
                 st.markdown(f"[Subscribe to verified updates]({verified_updates_request_url})")
     c2.metric("Overall JUPR", f"{current_jupr:.3f}")
 
-    if PUBLIC_MODE and verified_updates_view_q == "verified_updates_request":
+    if PUBLIC_MODE and (
+        route_requests_verified_updates or verified_updates_view_q == "verified_updates_request"
+    ):
         st.markdown("---")
         st.markdown("### Subscribe to verified updates")
         st.caption(f"You’re subscribing to updates for **{pick_name}**.")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import traceback
 from collections.abc import Mapping
+import logging
 
 import pandas as pd  # kept because pages may rely on it
 import streamlit as st
@@ -37,6 +38,8 @@ from jupr_app.ui.page_registry import (
 from jupr_app.ui.public_nav import render_public_top_nav
 from jupr_app.ui.theme_clean import apply_clean_theme
 from jupr_app.ui.url import qp_get
+
+logger = logging.getLogger(__name__)
 
 
 # -------------------------
@@ -388,6 +391,7 @@ def main():
             "🧾 Top Active Players PDF": top_players_printable,
             # Hidden deep-link page
             "🔐 Reset Password": reset_password,
+            "📬 Verified Updates Request": players,
             # Admin-only
             "🗞️ Weekly Recap Admin": weekly_recap_admin,
             "📬 Player Updates Admin": player_updates_admin,
@@ -415,11 +419,20 @@ def main():
         if PUBLIC_MODE:
             # Block admin-only deep links in public mode
             if deep_label in ADMIN_ONLY_LABELS:
+                logger.warning(
+                    "Public route request blocked for admin-only page. page=%s",
+                    incoming_page_param,
+                )
                 deep_label = ""
 
             if deep_label in HIDDEN_PAGE_LABELS:
                 sel = deep_label
             else:
+                if incoming_page_param and not deep_label:
+                    logger.warning(
+                        "Public route fallback to default page due to unknown page key. page=%s",
+                        incoming_page_param,
+                    )
                 current_label = (
                     deep_label
                     if deep_label in public_labels_in_order

--- a/tests/test_verified_updates_public_routing.py
+++ b/tests/test_verified_updates_public_routing.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from jupr_app.ui.page_registry import HIDDEN_PAGE_KEYS, PAGE_KEY_TO_LABEL, PUBLIC_NAV_KEYS
+
+
+def test_verified_updates_request_page_registered_as_hidden_public_route():
+    assert "verified_updates_request" in PAGE_KEY_TO_LABEL
+    assert PAGE_KEY_TO_LABEL["verified_updates_request"] == "📬 Verified Updates Request"
+    assert "verified_updates_request" in HIDDEN_PAGE_KEYS
+    assert "verified_updates_request" not in PUBLIC_NAV_KEYS
+
+
+def test_players_page_uses_durable_verified_updates_route_params():
+    contents = Path("jupr_app/ui/pages/players.py").read_text(encoding="utf-8")
+
+    assert '"page": "verified_updates_request"' in contents
+    assert '"player_id": int(pid)' in contents
+    assert '"club_id": str(club_id)' in contents
+    assert 'st.query_params["pid"] = str(pid)' in contents
+    assert 'st.query_params["player_id"] = str(pid)' in contents
+    assert 'st.query_params.pop("pid", None)' not in contents


### PR DESCRIPTION
### Motivation
- Public player-profile links (eg. “Request verified player updates”) were losing route/player context on rerun because `pid` was copied into `session_state` and then removed from the URL, causing the UI to fall back to the generic player search.
- The verified-updates flow needs a durable, bookmarkable deep-link (carrying `player_id`/`pid`/`club_id`) so non-admin/public navigation survives refreshes and new sessions.
- Public routes and admin-only checks were masking the real failure by silently defaulting to search without logging why a route was rejected.

### Description
- Added a hidden public page key `verified_updates_request` to the shared registry so it is a canonical deep-linkable route (`jupr_app/ui/page_registry.py`).
- Mapped the hidden `📬 Verified Updates Request` label to the existing `players` renderer in the main router so `?page=verified_updates_request...` resolves to the player page instead of bouncing (`streamlit_app.py`).
- Updated `players.render()` to derive player context directly from durable URL params (`player_id` or `pid`) and to stop removing `pid`; it now syncs `pid`, `player_id`, and `club_id` back into `st.query_params` in public mode so context persists across reruns (`jupr_app/ui/pages/players.py`).
- Rewrote the verified-updates internal links to target the dedicated canonical route (`?page=verified_updates_request&public=1&club_id=...&player_id=...&pid=...`) while preserving support for the legacy `view=verified_updates_request` flag.
- Added lightweight public-route logging to surface when an incoming `page` param is unknown or blocked so fallback causes are easier to debug (`streamlit_app.py`).
- Files changed: `jupr_app/ui/page_registry.py`, `streamlit_app.py`, `jupr_app/ui/pages/players.py`, and new tests `tests/test_verified_updates_public_routing.py`.

### Testing
- Ran `pytest -q tests/test_verified_updates_public_routing.py tests/test_page_registry.py` and all tests in those files passed.
- Ran `pytest -q tests/test_players_explain_link_is_relative.py tests/test_players_explain_linkcolumn.py` and those tests passed as a sanity check for existing link behavior.
- All automated tests executed during the change passed (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93ed67ae083269b14508e2833e6b4)