### PR TITLE
Fix verified-updates navigation crash and surface page-render exceptions

### DIFF
--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -1165,6 +1165,10 @@ def render(ctx):
             return f"#{x}"
         return f"{str(r.iloc[0]['name'])}  (#{int(x)})"
 
+    current_pick = st.session_state.get("player_search_id", "")
+    if current_pick not in options:
+        st.session_state["player_search_id"] = ""
+
     pick_id = st.selectbox(
         "Select a player",
         options=options,
@@ -1173,6 +1177,19 @@ def render(ctx):
     )
 
     if pick_id == "":
+        if PUBLIC_MODE and route_requests_verified_updates:
+            bad_player_id = player_id_q or pid_q
+            if bad_player_id:
+                st.error(
+                    "Player not found for verified updates request. "
+                    "Please check the URL player_id and try again."
+                )
+            else:
+                st.error(
+                    "Missing required player_id for verified updates request. "
+                    "Please open this page from a player profile."
+                )
+            return
         st.info("Select a player to view details.")
         return
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,7 @@
 # jupr/streamlit_app.py
 from __future__ import annotations
 
+import os
 import traceback
 from collections.abc import Mapping
 import logging
@@ -40,6 +41,19 @@ from jupr_app.ui.theme_clean import apply_clean_theme
 from jupr_app.ui.url import qp_get
 
 logger = logging.getLogger(__name__)
+
+
+def _debug_exceptions_enabled() -> bool:
+    qp_debug = str(qp_get("debug", "")).strip().lower()
+    if qp_debug in {"1", "true", "yes", "y", "on"}:
+        return True
+
+    env_debug = str(os.getenv("JUPR_DEBUG", "")).strip().lower()
+    if env_debug in {"1", "true", "yes", "y", "on", "dev", "debug"}:
+        return True
+
+    env_name = str(os.getenv("ENV", "")).strip().lower()
+    return env_name in {"dev", "development", "local"}
 
 
 # -------------------------
@@ -145,6 +159,7 @@ def main():
 
         # ---- Public mode ----
         PUBLIC_MODE = qp_get("public", "0").lower() in ("1", "true", "yes", "y")
+        debug_exceptions = _debug_exceptions_enabled()
 
         # Make base_url available to all pages (leaderboards uses this for share links)
         # Use session_state because ctx is a frozen-ish dataclass and you don't want to refactor it mid-stream.
@@ -509,7 +524,9 @@ def main():
 
             st.session_state["_last_rendered_nav"] = sel
         except Exception:
-            pass
+            logger.exception("Failed to sync canonical query params for page selection.")
+            if debug_exceptions:
+                st.warning("Failed to sync URL query params for the selected page.")
 
         # -------------------------
         # Render page
@@ -524,9 +541,26 @@ def main():
             st.error(f"Page module for '{sel}' has no render(ctx) function.")
             st.stop()
 
-        render_fn(ctx)
+        try:
+            render_fn(ctx)
+        except Exception as exc:
+            target_page_key = LABEL_TO_PAGE_KEY.get(sel, "")
+            logger.exception(
+                "Page render failed. sel=%s target_page_key=%s public_mode=%s query=%s",
+                sel,
+                target_page_key,
+                PUBLIC_MODE,
+                dict(st.query_params),
+            )
+            st.error("This page failed to render.")
+            if debug_exceptions:
+                st.exception(exc)
+            else:
+                st.caption("Append ?debug=1 to the URL to view exception details in development.")
+            st.stop()
 
     except Exception:
+        logger.exception("streamlit_app.main() crashed before page render.")
         st.error("streamlit_app.main() crashed")
         st.code(traceback.format_exc())
         st.stop()

--- a/tests/test_verified_updates_public_routing.py
+++ b/tests/test_verified_updates_public_routing.py
@@ -19,3 +19,22 @@ def test_players_page_uses_durable_verified_updates_route_params():
     assert 'st.query_params["pid"] = str(pid)' in contents
     assert 'st.query_params["player_id"] = str(pid)' in contents
     assert 'st.query_params.pop("pid", None)' not in contents
+
+
+def test_players_page_guards_invalid_selectbox_state_for_verified_route():
+    contents = Path("jupr_app/ui/pages/players.py").read_text(encoding="utf-8")
+
+    assert 'current_pick = st.session_state.get("player_search_id", "")' in contents
+    assert 'if current_pick not in options:' in contents
+    assert 'st.session_state["player_search_id"] = ""' in contents
+    assert 'Missing required player_id for verified updates request' in contents
+    assert 'Player not found for verified updates request' in contents
+
+
+def test_streamlit_main_surfaces_page_render_exceptions_without_route_fallback():
+    contents = Path("streamlit_app.py").read_text(encoding="utf-8")
+
+    assert 'Page render failed.' in contents
+    assert 'st.error("This page failed to render.")' in contents
+    assert 'st.exception(exc)' in contents
+    assert 'Append ?debug=1 to the URL to view exception details in development.' in contents


### PR DESCRIPTION
### Motivation
- Prevent a fast crash when navigating from a public player profile to the verified-updates request flow caused by stale widget session state and opaque app fallback behavior. 
- Make the verified-updates request page resilient to direct deep-links and missing query params so public users see clear errors instead of being dumped back to the search page. 
- Improve developer visibility for page-render failures so exceptions are logged and can be inspected in development. 

### Description
- Sanitize the selectbox state in `players.render()` by clearing `st.session_state['player_search_id']` when its value is not present in the current `options`, preventing Streamlit render errors from stale keys (file: `jupr_app/ui/pages/players.py`).
- Add explicit inline error states for the `verified_updates_request` deep-link when `player_id`/`pid` is missing or not found so the page returns a helpful error instead of crashing (file: `jupr_app/ui/pages/players.py`).
- Add a debug helper and per-page render exception handling in `streamlit_app.py` to log route/query context on failure and surface exception details in development via `?debug=1` or `JUPR_DEBUG`/`ENV` (file: `streamlit_app.py`).
- Extend tests to cover the new guards and diagnostics by updating `tests/test_verified_updates_public_routing.py` to assert the new session-state guard and the presence of render-exception surfacing logic. 

### Testing
- Ran `pytest -q tests/test_verified_updates_public_routing.py tests/test_page_registry.py` and observed all tests passing (`7 passed`).
- Verified syntax/compile sanity with `python -m py_compile streamlit_app.py jupr_app/ui/pages/players.py` which completed without errors.
- No browser E2E was run in this environment; the change adds server-side guards and diagnostics to make manual/interactive verification straightforward.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e940c17cd8832681418aab5468f3ea)