### PR TITLE
Fix Match Log rated deletions to auto-run full replay

### DIFF
--- a/jupr_app/domain/match_delete.py
+++ b/jupr_app/domain/match_delete.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterable, Optional
+
+import pandas as pd
+
+from jupr_app.domain.player_activity import recompute_last_game_at_for_players
+from jupr_app.domain.replay_history import FULL_RESET_LABEL, replay_history
+
+
+def delete_rated_matches_with_replay(
+    *,
+    supabase,
+    club_id: str,
+    match_ids: Iterable[int],
+    df_meta: Optional[pd.DataFrame],
+    progress_cb: Optional[Callable[[float], None]] = None,
+    actor: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Delete rated matches, recompute player activity, then run FULL replay."""
+    normalized_ids = sorted({int(mid) for mid in (match_ids or []) if mid is not None})
+    if not normalized_ids:
+        return {
+            "deleted_count": 0,
+            "deleted_ids": [],
+            "affected_player_ids": [],
+            "replay_result": None,
+            "warning": "No match IDs supplied for delete.",
+            "error": None,
+            "replay_error": None,
+            "actor": actor,
+        }
+
+    rows_resp = (
+        supabase.table("matches")
+        .select("id,t1_p1,t1_p2,t2_p1,t2_p2")
+        .eq("club_id", str(club_id))
+        .in_("id", normalized_ids)
+        .execute()
+    )
+    before_rows = rows_resp.data or []
+    existing_ids = sorted({int(r.get("id")) for r in before_rows if r.get("id") is not None})
+
+    affected_player_ids: set[int] = set()
+    for row in before_rows:
+        for col in ("t1_p1", "t1_p2", "t2_p1", "t2_p2"):
+            val = row.get(col)
+            if val is None:
+                continue
+            try:
+                affected_player_ids.add(int(val))
+            except Exception:
+                continue
+
+    warning: str | None = None
+    missing_ids = sorted(set(normalized_ids) - set(existing_ids))
+    if missing_ids:
+        warning = f"Some match IDs were not found and could not be deleted: {missing_ids[:10]}"
+
+    if existing_ids:
+        (
+            supabase.table("matches")
+            .delete()
+            .eq("club_id", str(club_id))
+            .in_("id", existing_ids)
+            .execute()
+        )
+
+    if affected_player_ids:
+        recompute_last_game_at_for_players(
+            supabase=supabase,
+            club_id=str(club_id),
+            player_ids=affected_player_ids,
+        )
+
+    replay_result = None
+    replay_error = None
+    try:
+        replay_result = replay_history(
+            supabase=supabase,
+            club_id=str(club_id),
+            df_meta=df_meta,
+            target_reset=FULL_RESET_LABEL,
+            progress_cb=progress_cb,
+        )
+    except Exception as exc:  # noqa: BLE001
+        replay_error = str(exc)
+
+    return {
+        "deleted_count": len(existing_ids),
+        "deleted_ids": existing_ids,
+        "affected_player_ids": sorted(affected_player_ids),
+        "replay_result": replay_result,
+        "warning": warning,
+        "error": None,
+        "replay_error": replay_error,
+        "actor": actor,
+    }

--- a/jupr_app/ui/pages/match_log.py
+++ b/jupr_app/ui/pages/match_log.py
@@ -9,9 +9,9 @@ from jupr_app.domain.live_social import (
     list_social_match_log_rows,
     update_social_match_row,
 )
-from jupr_app.domain.player_activity import recompute_last_game_at_for_players
 from jupr_app.ui.layout import page_shell
-from jupr_app.domain.replay_history import replay_history
+from jupr_app.domain.replay_history import FULL_RESET_LABEL, replay_history
+from jupr_app.domain.match_delete import delete_rated_matches_with_replay
 
 
 
@@ -290,19 +290,29 @@ def render(ctx):
                 confirm = st.text_input("Type DELETE to confirm", value="", key="dup_delete_confirm")
                 if st.button("🗑️ Delete duplicates now", type="primary", disabled=(confirm.strip().upper() != "DELETE")):
                     if ids_to_delete:
-                        deleted_rows = dup_only[dup_only["id"].astype(int).isin(ids_to_delete)]
-                        deleted_pids = set()
-                        for col in ["t1_p1", "t1_p2", "t2_p1", "t2_p2"]:
-                            if col in deleted_rows.columns:
-                                deleted_pids.update(deleted_rows[col].dropna().astype(int).tolist())
-                        ctx.supabase.table("matches").delete().eq("club_id", str(ctx.club_id)).in_("id", ids_to_delete).execute()
-                        if deleted_pids:
-                            recompute_last_game_at_for_players(
+                        bar = st.progress(0.0)
+                        with st.spinner("Deleting duplicates and rebuilding ratings (Replay ALL)..."):
+                            delete_result = delete_rated_matches_with_replay(
                                 supabase=ctx.supabase,
                                 club_id=str(ctx.club_id),
-                                player_ids=deleted_pids,
+                                match_ids=ids_to_delete,
+                                df_meta=getattr(ctx, "df_meta", pd.DataFrame()),
+                                progress_cb=lambda x: bar.progress(float(x)),
+                                actor="match_log.duplicate_delete",
                             )
-                        st.success("Deleted duplicates. Now run Admin Tools → Replay History → ALL.")
+                        if delete_result.get("warning"):
+                            st.warning(delete_result["warning"])
+                        if delete_result.get("replay_error"):
+                            st.warning(
+                                "⚠️ Delete completed, but Replay ALL failed. Ratings may now be stale. "
+                                "Run Admin Tools → Replay History → ALL immediately. "
+                                f"Error: {delete_result['replay_error']}"
+                            )
+                        else:
+                            st.success(
+                                f"Deleted {delete_result['deleted_count']} duplicate rated match(es). "
+                                "Ratings were rebuilt automatically via Replay ALL."
+                            )
                         st.rerun()
 
     st.divider()
@@ -622,7 +632,7 @@ def render(ctx):
         st.caption("Runs the same Replay History as Admin Tools. Use ALL after moving matches between leagues.")
     
         df_meta = getattr(ctx, "df_meta", pd.DataFrame())
-        league_opts = ["ALL (Full System Reset)"]
+        league_opts = [FULL_RESET_LABEL]
         if df_meta is not None and not df_meta.empty and "league_name" in df_meta.columns:
             league_opts += sorted(df_meta["league_name"].dropna().astype(str).unique().tolist())
     
@@ -671,16 +681,27 @@ def render(ctx):
         confirm2 = st.text_input("Type DELETE to confirm bulk delete", value="", key="bulk_delete_confirm")
         if st.button(f"Delete {len(to_delete)} Matches", type="primary", disabled=(confirm2.strip().upper() != "DELETE")):
             delete_ids = to_delete["id"].astype(int).tolist()
-            deleted_pids = set()
-            for col in ["t1_p1", "t1_p2", "t2_p1", "t2_p2"]:
-                if col in to_delete.columns:
-                    deleted_pids.update(to_delete[col].dropna().astype(int).tolist())
-            ctx.supabase.table("matches").delete().eq("club_id", str(ctx.club_id)).in_("id", delete_ids).execute()
-            if deleted_pids:
-                recompute_last_game_at_for_players(
+            bar = st.progress(0.0)
+            with st.spinner("Deleting rated matches and rebuilding ratings (Replay ALL)..."):
+                delete_result = delete_rated_matches_with_replay(
                     supabase=ctx.supabase,
                     club_id=str(ctx.club_id),
-                    player_ids=deleted_pids,
+                    match_ids=delete_ids,
+                    df_meta=getattr(ctx, "df_meta", pd.DataFrame()),
+                    progress_cb=lambda x: bar.progress(float(x)),
+                    actor="match_log.bulk_delete",
                 )
-            st.success("Deleted. Run Replay ALL if you want ratings to be consistent.")
+            if delete_result.get("warning"):
+                st.warning(delete_result["warning"])
+            if delete_result.get("replay_error"):
+                st.warning(
+                    "⚠️ Delete completed, but Replay ALL failed. Ratings may now be stale. "
+                    "Run Admin Tools → Replay History → ALL immediately. "
+                    f"Error: {delete_result['replay_error']}"
+                )
+            else:
+                st.success(
+                    f"Deleted {delete_result['deleted_count']} rated match(es). "
+                    "Ratings were rebuilt automatically via Replay ALL."
+                )
             st.rerun()


### PR DESCRIPTION
### Motivation
- Deleting historical rated matches can change overall `players` ratings, `league_ratings`, and stored match snapshot rating fields and therefore must trigger a full replay automatically.
- The existing Match Log paths deleted matches without rebuilding ratings and incorrectly instructed admins to run Replay ALL manually.
- Centralize deletion + mandatory full replay into a single domain helper to make the workflow safe, conservative, and reusable from other admin pages.

### Description
- Added `jupr_app/domain/match_delete.py` with `delete_rated_matches_with_replay(...)` which fetches rows before delete, deletes the selected rated rows, collects affected player IDs, recomputes `last_game_at` using `recompute_last_game_at_for_players`, and runs `replay_history(...)` with `FULL_RESET_LABEL`, returning a structured result (`deleted_count`, `deleted_ids`, `affected_player_ids`, `replay_result`, `warning`, `replay_error`, etc.).
- Updated `jupr_app/ui/pages/match_log.py` to call `delete_rated_matches_with_replay(...)` from both the duplicate-delete and bulk-delete flows, showing a progress bar/spinner while replay runs and surfacing either automatic-success messaging or a strong stale-data warning if the replay fails.
- Kept Club Social deletion behavior unchanged and still using `delete_social_matches` (no full replay for unrated social rows).
- Reused the `FULL_RESET_LABEL` constant from `replay_history.py` in `match_log.py` instead of hardcoding the full-reset label.

### Testing
- Compiled updated modules with `python -m py_compile jupr_app/ui/pages/match_log.py jupr_app/domain/match_delete.py` and the compile completed successfully. 
- No additional automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97d55b7b08326a26b3a6dfe0c72d0)