### PR TITLE
Preserve admin auth on internal player navigation; harden browser restore

### DIFF
--- a/jupr_app/ui/admin_auth.py
+++ b/jupr_app/ui/admin_auth.py
@@ -19,7 +19,7 @@ _BROWSER_REFRESH_TOKEN_KEY = "jupr_admin_refresh_token"
 _BROWSER_RESTORE_FLAG_KEY = "jupr_admin_restore_from_storage"
 _BROWSER_SYNC_PAYLOAD_KEY = "_admin_browser_sync_payload"
 _BROWSER_CLEAR_PENDING_KEY = "_admin_browser_clear_pending"
-_BROWSER_RESTORE_ATTEMPTED_SESSION_KEY = "jupr_admin_restore_attempted"
+_BROWSER_RESTORE_INFLIGHT_SESSION_KEY = "jupr_admin_restore_inflight_at"
 
 
 class AdminAuthError(RuntimeError):
@@ -302,11 +302,13 @@ def render_admin_browser_session_bridge() -> None:
           if (persistRequested) {{
             appWindow.localStorage.setItem("{_BROWSER_ACCESS_TOKEN_KEY}", {persist_access!r});
             appWindow.localStorage.setItem("{_BROWSER_REFRESH_TOKEN_KEY}", {persist_refresh!r});
+            appWindow.sessionStorage.removeItem("{_BROWSER_RESTORE_INFLIGHT_SESSION_KEY}");
           }}
 
           if (clearPending) {{
             appWindow.localStorage.removeItem("{_BROWSER_ACCESS_TOKEN_KEY}");
             appWindow.localStorage.removeItem("{_BROWSER_REFRESH_TOKEN_KEY}");
+            appWindow.sessionStorage.removeItem("{_BROWSER_RESTORE_INFLIGHT_SESSION_KEY}");
           }}
         }} catch (e) {{}}
         </script>
@@ -345,8 +347,25 @@ def restore_admin_browser_session() -> dict[str, str] | None:
     restore_flag = _query_param_text(_BROWSER_RESTORE_FLAG_KEY)
 
     if access and refresh and restore_flag == "1":
+        logger.info(
+            "Admin restore handshake consumed (full_reload=True): access+refresh tokens present in query params"
+        )
         _clear_sensitive_query_params()
+        components.html(
+            f"""
+            <script>
+            try {{
+              const appWindow = window.parent || window;
+              appWindow.sessionStorage.removeItem("{_BROWSER_RESTORE_INFLIGHT_SESSION_KEY}");
+            }} catch (e) {{}}
+            </script>
+            """,
+            height=0,
+        )
         return {"access_token": access, "refresh_token": refresh}
+
+    if restore_flag == "1":
+        logger.info("Admin restore skipped: handshake flag present but token query params missing")
 
     components.html(
         f"""
@@ -358,9 +377,15 @@ def restore_admin_browser_session() -> dict[str, str] | None:
           const appUrl = new URL(appWindow.location.href);
           const params = appUrl.searchParams;
           const hasHandshake = params.get("{_BROWSER_RESTORE_FLAG_KEY}") === "1";
-          const restoreAttempted = appWindow.sessionStorage.getItem("{_BROWSER_RESTORE_ATTEMPTED_SESSION_KEY}") === "1";
-          if (access && refresh && !hasHandshake && !restoreAttempted) {{
-            appWindow.sessionStorage.setItem("{_BROWSER_RESTORE_ATTEMPTED_SESSION_KEY}", "1");
+          const inflightRaw = appWindow.sessionStorage.getItem("{_BROWSER_RESTORE_INFLIGHT_SESSION_KEY}") || "";
+          const inflightAt = Number(inflightRaw || "0");
+          const now = Date.now();
+          const inflightActive = Number.isFinite(inflightAt) && inflightAt > 0 && (now - inflightAt) < 15000;
+          if (hasHandshake) {{
+            appWindow.sessionStorage.removeItem("{_BROWSER_RESTORE_INFLIGHT_SESSION_KEY}");
+          }}
+          if (access && refresh && !hasHandshake && !inflightActive) {{
+            appWindow.sessionStorage.setItem("{_BROWSER_RESTORE_INFLIGHT_SESSION_KEY}", String(now));
             params.set("jupr_admin_access_token", access);
             params.set("jupr_admin_refresh_token", refresh);
             params.set("{_BROWSER_RESTORE_FLAG_KEY}", "1");
@@ -387,13 +412,15 @@ def maybe_restore_admin_login_from_browser() -> bool:
     existing_user = get_current_admin_user()
     if existing_user is not None:
         existing_email = str(getattr(existing_user, "email", "") or "").strip().lower()
+        logger.info("Browser restore skipped: user already present in session state")
         return bool(
             existing_email and is_allowed_admin_email(existing_email, load_admin_allowlist())
         )
 
-    logger.info("Browser token restore attempted")
+    logger.info("Browser token restore attempt started")
     stored_tokens = restore_admin_browser_session()
     if not stored_tokens:
+        logger.info("Browser token restore skipped: no handshake tokens available yet")
         return False
 
     try:
@@ -419,7 +446,7 @@ def maybe_restore_admin_login_from_browser() -> bool:
             user_email, load_admin_allowlist()
         ):
             clear_local_admin_auth_state()
-            logger.info("Browser token restore failed")
+            logger.info("Browser token restore failed: invalid session/user or disallowed email")
             return False
 
         st.session_state[_AUTH_USER_KEY] = user

--- a/jupr_app/ui/nav.py
+++ b/jupr_app/ui/nav.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+
+import streamlit as st
+
+
+logger = logging.getLogger(__name__)
+
+
+def navigate_to_player_profile(
+    pid: int,
+    public_mode: bool,
+    extra_params: dict | None = None,
+) -> None:
+    """Navigate internally to the players page using Streamlit query params + rerun."""
+    try:
+        player_id = int(pid)
+    except Exception:
+        logger.warning("Navigation skipped: invalid player id pid=%r", pid)
+        return
+
+    next_params: dict[str, str] = {"page": "players", "pid": str(player_id)}
+    if public_mode:
+        next_params["public"] = "1"
+
+    for key, value in (extra_params or {}).items():
+        if value is None:
+            continue
+        text_value = str(value).strip()
+        if text_value:
+            next_params[str(key)] = text_value
+
+    st.query_params.clear()
+    st.query_params.update(next_params)
+    logger.info(
+        "Internal navigation to player profile via query-param mutation (full_reload=False): pid=%s public_mode=%s extra_keys=%s",
+        player_id,
+        public_mode,
+        sorted((extra_params or {}).keys()),
+    )
+    st.rerun()

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -1,11 +1,11 @@
 import html
 import logging
-import urllib.parse
 from dataclasses import dataclass
 import streamlit as st
 import pandas as pd
 
 from jupr_app.domain.awards import build_top_performer_entries
+from jupr_app.ui.nav import navigate_to_player_profile
 from jupr_app.ui.url import qp_get
 from jupr_app.ui.public_links import build_public_url, public_link_button
 from jupr_app.ui.layout import page_shell
@@ -90,9 +90,15 @@ def _delta_class(delta_value: float | None) -> str:
     return "zero"
 
 
-def render_leaderboard_row(row, rank: int, badges: list[LeaderboardBadge]) -> None:
-    profile_url = row.get("_profile_url")
+def render_leaderboard_row(
+    row,
+    rank: int,
+    badges: list[LeaderboardBadge],
+    public_mode: bool,
+    ctx=None,
+) -> None:
     player_name = str(row.get("name", "Player") or "Player")
+    player_id = safe_int(row.get("_pid"))
     wins = safe_int(row.get("wins")) or 0
     losses = safe_int(row.get("losses")) or 0
     rating = safe_float(row.get("JUPR"))
@@ -109,16 +115,26 @@ def render_leaderboard_row(row, rank: int, badges: list[LeaderboardBadge]) -> No
 
     with st.container():
         left_col, right_col = st.columns([0.7, 0.3])
-        if profile_url:
-            left_col.markdown(
-                f"<p class='lb-player-name'><strong>#{rank} <a href='{profile_url}' target='_self'>{_safe_text(player_name)}</a></strong></p>",
-                unsafe_allow_html=True,
-            )
+        left_col.markdown(
+            f"<p class='lb-player-name'><strong>#{rank}</strong></p>",
+            unsafe_allow_html=True,
+        )
+        if player_id is not None:
+            nav_extra = {}
+            if public_mode and getattr(ctx, "club_id", None):
+                nav_extra["club_id"] = str(ctx.club_id)
+            if left_col.button(
+                player_name,
+                key=f"lb_row_nav_{rank}_{player_id}",
+                use_container_width=False,
+            ):
+                navigate_to_player_profile(
+                    player_id,
+                    public_mode=public_mode,
+                    extra_params=nav_extra,
+                )
         else:
-            left_col.markdown(
-                f"<p class='lb-player-name'><strong>#{rank} {_safe_text(player_name)}</strong></p>",
-                unsafe_allow_html=True,
-            )
+            left_col.markdown(f"**{_safe_text(player_name)}**")
         left_col.markdown(f"<p class='lb-wl'>W-L: {wins}–{losses}</p>", unsafe_allow_html=True)
 
         rating_display = f"{rating:.3f}" if rating is not None else "—"
@@ -159,30 +175,6 @@ def render_leaderboard_row(row, rank: int, badges: list[LeaderboardBadge]) -> No
             )
 
         st.divider()
-
-def _player_profile_url(pid, public_mode, ctx):
-    if pd.isna(pid):
-        return None
-    try:
-        player_id = int(pid)
-    except Exception:
-        return None
-    params = {"page": "players", "pid": str(player_id)}
-    if public_mode:
-        params["public"] = "1"
-        if getattr(ctx, "club_id", None):
-            params["club_id"] = str(ctx.club_id)
-    query = urllib.parse.urlencode(params, quote_via=urllib.parse.quote_plus)
-    return f"/?{query}"
-
-
-def _build_player_link(pid, name, public_mode, ctx):
-    safe_name = _safe_text(name)
-    url = _player_profile_url(pid, public_mode, ctx)
-    if not url:
-        return safe_name
-    return f'<a href="{url}" target="_self" class="lb-link">{safe_name}</a>'
-
 
 def select_leaderboard_players(
     df_players_active: pd.DataFrame | None,
@@ -437,16 +429,11 @@ def render_top_performers_cards(
             for entry in category.get("entries", []):
                 name = entry.get("name", "")
                 pid = entry.get("player_id")
-                name_html = (
-                    _build_player_link(pid, name, public_mode, ctx)
-                    if ctx is not None
-                    else html.escape(str(name))
-                )
                 rows.append(
                     {
                         "value": entry.get("metric_display", "—"),
                         "name": str(name),
-                        "name_html": name_html,
+                        "player_id": safe_int(pid),
                     }
                 )
             top_perf_dict.append(
@@ -523,19 +510,34 @@ def render_top_performers_cards(
         secondary = entries[1:5]
         list_items = "".join(
             f'<div class="tp-list-item"><span class="tp-list-value">{html.escape(entry["value"])}</span>'
-            f'<span class="tp-list-name">{entry.get("name_html", html.escape(entry["name"]))}</span></div>'
+            f'<span class="tp-list-name">{html.escape(entry["name"])}</span></div>'
             for entry in secondary
         )
         card_html = f"""
         <div class="tp-card" style="--tp-accent: {accent};">
             <div class="tp-label">{html.escape(str(card.get("label", "")))}</div>
             <div class="tp-value">{html.escape(primary["value"])}</div>
-            <div class="tp-name">{primary.get("name_html", html.escape(primary["name"]))}</div>
+            <div class="tp-name">{html.escape(primary["name"])}</div>
             <div class="tp-list">{list_items}</div>
         </div>
         """
         with col:
             st.markdown(card_html, unsafe_allow_html=True)
+            if ctx is not None:
+                nav_extra = {}
+                if public_mode and getattr(ctx, "club_id", None):
+                    nav_extra["club_id"] = str(ctx.club_id)
+                primary_pid = safe_int(primary.get("player_id"))
+                if primary_pid is not None and st.button(
+                    f"View {primary['name']}",
+                    key=f"tp_primary_nav_{idx}_{primary_pid}",
+                    use_container_width=True,
+                ):
+                    navigate_to_player_profile(
+                        primary_pid,
+                        public_mode=public_mode,
+                        extra_params=nav_extra,
+                    )
 
 
 def render(ctx):
@@ -1208,11 +1210,12 @@ def render(ctx):
                 player_badges = []
 
         row_payload = row.copy()
-        row_payload["_profile_url"] = _player_profile_url(row.get("_pid"), PUBLIC_MODE, ctx)
         render_leaderboard_row(
             row_payload,
             rank=safe_int(row.get("RankNum")) or 0,
             badges=player_badges,
+            public_mode=PUBLIC_MODE,
+            ctx=ctx,
         )
 
     if len(standings) > limit:

--- a/jupr_app/ui/pages/league_results.py
+++ b/jupr_app/ui/pages/league_results.py
@@ -7,7 +7,7 @@ import pandas as pd
 import streamlit as st
 
 from jupr_app.ui.layout import page_shell
-from jupr_app.ui.pages.leaderboards import _build_player_link
+from jupr_app.ui.nav import navigate_to_player_profile
 
 try:
     import altair as alt
@@ -291,6 +291,42 @@ def _render_html_table(headers: list[str], rows: list[list[str]]) -> None:
     st.markdown(table_html, unsafe_allow_html=True)
 
 
+def _render_player_table(
+    title: str,
+    rows: list[dict],
+    public_mode: bool,
+    club_id: str | None = None,
+) -> None:
+    if title:
+        st.markdown(title)
+    if not rows:
+        st.caption("No rows to display.")
+        return
+
+    headers = [key for key in rows[0].keys() if not str(key).startswith("_")]
+    header_cols = st.columns([1.8] + [1] * (len(headers) - 1))
+    for idx, header in enumerate(headers):
+        header_cols[idx].markdown(f"**{header}**")
+
+    nav_extra = {"club_id": str(club_id)} if public_mode and club_id else {}
+    for index, row in enumerate(rows):
+        cols = st.columns([1.8] + [1] * (len(headers) - 1))
+        pid = _safe_int(row.get("_pid"))
+        for cidx, header in enumerate(headers):
+            value = row.get(header, "—")
+            if header == "Player":
+                label = str(value or "Player")
+                if pid is not None and cols[cidx].button(
+                    label,
+                    key=f"league_results_nav_{title}_{index}_{pid}",
+                    use_container_width=True,
+                ):
+                    navigate_to_player_profile(pid, public_mode=public_mode, extra_params=nav_extra)
+            else:
+                cols[cidx].write(value)
+        st.divider()
+
+
 def _replay_league_ratings(
     df_matches: pd.DataFrame,
     league_name: str,
@@ -542,27 +578,24 @@ def render(ctx):
         else:
             table_rows = []
             for _, row in standings.iterrows():
-                player_link = _build_player_link(row["player_id"], row["player_name"], PUBLIC_MODE, ctx)
                 win_pct = f"{float(row['win_pct']):.1f}%" if pd.notna(row["win_pct"]) else "—"
                 rating_delta = row.get("rating_delta")
                 rating_delta_display = f"{float(rating_delta):+.3f}" if pd.notna(rating_delta) else "—"
                 table_rows.append(
-                    [
-                        str(int(row["rank"])),
-                        player_link,
-                        f"{float(row['JUPR']):.3f}",
-                        str(int(row["games"])),
-                        str(int(row["wins"])),
-                        str(int(row["losses"])),
-                        win_pct,
-                        rating_delta_display,
-                    ]
+                    {
+                        "Rank": str(int(row["rank"])),
+                        "Player": str(row["player_name"]),
+                        "Rating (JUPR)": f"{float(row['JUPR']):.3f}",
+                        "Games": str(int(row["games"])),
+                        "Wins": str(int(row["wins"])),
+                        "Losses": str(int(row["losses"])),
+                        "Win %": win_pct,
+                        "Rating Δ": rating_delta_display,
+                        "_pid": int(row["player_id"]),
+                    }
                 )
 
-            _render_html_table(
-                ["Rank", "Player", "Rating (JUPR)", "Games", "Wins", "Losses", "Win %", "Rating Δ"],
-                table_rows,
-            )
+            _render_player_table("", table_rows, PUBLIC_MODE, getattr(ctx, "club_id", None))
 
         st.markdown("### League Match Totals")
         if overall_stats.empty:
@@ -571,18 +604,18 @@ def render(ctx):
             overall_stats = overall_stats.sort_values(["wins", "games"], ascending=[False, False])
             table_rows = []
             for _, row in overall_stats.iterrows():
-                player_link = _build_player_link(row["player_id"], row["player_name"], PUBLIC_MODE, ctx)
                 win_pct = f"{float(row['win_pct']):.1f}%" if pd.notna(row["win_pct"]) else "—"
                 table_rows.append(
-                    [
-                        player_link,
-                        str(int(row["games"])),
-                        str(int(row["wins"])),
-                        str(int(row["losses"])),
-                        win_pct,
-                    ]
+                    {
+                        "Player": str(row["player_name"]),
+                        "Games": str(int(row["games"])),
+                        "Wins": str(int(row["wins"])),
+                        "Losses": str(int(row["losses"])),
+                        "Win %": win_pct,
+                        "_pid": int(row["player_id"]),
+                    }
                 )
-            _render_html_table(["Player", "Games", "Wins", "Losses", "Win %"], table_rows)
+            _render_player_table("", table_rows, PUBLIC_MODE, getattr(ctx, "club_id", None))
 
     with tabs[1]:
         st.subheader("Weekly Results")
@@ -608,28 +641,25 @@ def render(ctx):
         else:
             table_rows = []
             for _, row in weekly_view.iterrows():
-                player_link = _build_player_link(row["player_id"], row["player_name"], PUBLIC_MODE, ctx)
                 win_pct = f"{float(row['win_pct']):.1f}%" if pd.notna(row["win_pct"]) else "—"
                 rating_delta = row.get("rating_delta")
                 rating_delta_display = f"{float(rating_delta):+.3f}" if pd.notna(rating_delta) else "—"
                 rank_delta = row.get("rank_delta")
                 rank_delta_display = f"{int(rank_delta):+d}" if pd.notna(rank_delta) else "—"
                 table_rows.append(
-                    [
-                        player_link,
-                        str(int(row["games"])),
-                        str(int(row["wins"])),
-                        str(int(row["losses"])),
-                        win_pct,
-                        rating_delta_display,
-                        rank_delta_display,
-                    ]
+                    {
+                        "Player": str(row["player_name"]),
+                        "Games": str(int(row["games"])),
+                        "Wins": str(int(row["wins"])),
+                        "Losses": str(int(row["losses"])),
+                        "Win %": win_pct,
+                        "Weekly Rating Δ": rating_delta_display,
+                        "Rank Δ": rank_delta_display,
+                        "_pid": int(row["player_id"]),
+                    }
                 )
 
-            _render_html_table(
-                ["Player", "Games", "Wins", "Losses", "Win %", "Weekly Rating Δ", "Rank Δ"],
-                table_rows,
-            )
+            _render_player_table("", table_rows, PUBLIC_MODE, getattr(ctx, "club_id", None))
 
         st.markdown("### Weekly Highlights")
         highlight_cols = st.columns(3)


### PR DESCRIPTION
### Motivation
- Clicking internal player links used raw anchor URLs which triggered browser-level navigation and could break admin auth rehydration, and the previous restore flow used a sticky sessionStorage flag that made restore attempts one-shot and fragile.

### Description
- Add `jupr_app/ui/nav.py` with `navigate_to_player_profile(pid, public_mode, extra_params)` that mutates `st.query_params` and calls `st.rerun()` for in-app navigation without a full browser reload.
- Replace raw anchor-driven player links in leaderboards and league results with Streamlit-native button-driven navigation that calls the centralized helper, and add optional per-card “View …” buttons in top-performers cards.
- Harden admin browser restore by replacing the persistent `jupr_admin_restore_attempted` gate with a short-lived in-flight timestamp guard (`jupr_admin_restore_inflight_at`), clear the guard after handshake/persist/clear/logout, and add logging for restore attempt/skip/success/failure and navigation actions.
- Files changed: `jupr_app/ui/nav.py` (new), `jupr_app/ui/pages/leaderboards.py`, `jupr_app/ui/pages/league_results.py`, `jupr_app/ui/admin_auth.py`.

### Testing
- Compiled modified modules with `python -m compileall jupr_app/ui/nav.py jupr_app/ui/pages/leaderboards.py jupr_app/ui/pages/league_results.py jupr_app/ui/admin_auth.py` which completed successfully.
- Searched code to validate migration away from `href="/?..."` in the modified areas and confirmed the updated pages use the navigation helper, with one remaining internal anchor flagged in `jupr_app/ui/pages/players.py` for follow-up.
- Verified code changes were staged and committed locally (no runtime integration tests were required for this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6c59080883269f56d93f3bc9c332)