### PR TITLE
Add centralized Admin Login CTA in public page shell

### DIFF
--- a/jupr_app/ui/layout.py
+++ b/jupr_app/ui/layout.py
@@ -1,10 +1,22 @@
 from __future__ import annotations
 
 import html
+from urllib.parse import urlencode
 
 import streamlit as st
 
 from jupr_app.ui.theme_clean import topbar
+
+
+def build_admin_entry_url() -> str:
+    """
+    Build a deterministic URL that explicitly enters the admin shell.
+    """
+    preserved_page = str(st.query_params.get("page", "") or "").strip()
+    params: dict[str, str] = {"admin": "1"}
+    if preserved_page:
+        params["page"] = preserved_page
+    return f"/?{urlencode(params)}"
 
 
 def page_shell(
@@ -18,8 +30,21 @@ def page_shell(
     Render a consistent page chrome wrapper (topbar + spacing).
     """
     resolved_right_html = right_html
-    if not resolved_right_html and mode_label:
-        resolved_right_html = f'<span class="jupr-pill neutral">{html.escape(mode_label)}</span>'
+    if not resolved_right_html:
+        chips: list[str] = []
+        if mode_label:
+            chips.append(f'<span class="jupr-pill neutral">{html.escape(mode_label)}</span>')
+
+        in_public_shell = bool(st.session_state.get("jupr_public_mode", False))
+        in_admin_entry = bool(st.session_state.get("jupr_admin_entry_active", False))
+        if in_public_shell and not in_admin_entry:
+            admin_href = html.escape(build_admin_entry_url(), quote=True)
+            chips.append(
+                f'<a class="jupr-topbar-action" href="{admin_href}" '
+                'aria-label="Open admin login">Admin Login</a>'
+            )
+
+        resolved_right_html = "".join(chips)
 
     topbar(title, subtitle, right_html=resolved_right_html)
     st.markdown("<div style='height:6px'></div>", unsafe_allow_html=True)

--- a/jupr_app/ui/theme_clean.py
+++ b/jupr_app/ui/theme_clean.py
@@ -216,6 +216,34 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         color: var(--muted);
         font-size: var(--font-sm);
       }}
+      .jupr-topbar-action {{
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 1.8rem;
+        padding: 0.2rem 0.7rem;
+        border-radius: 999px;
+        border: 1px solid var(--border-strong);
+        background: var(--panel);
+        color: var(--text-primary);
+        font-size: 0.78rem;
+        font-weight: 700;
+        line-height: 1;
+        white-space: nowrap;
+        text-decoration: none;
+        box-shadow: 0 1px 1px rgba(0, 0, 0, 0.03);
+        transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+      }}
+      .jupr-topbar-action:hover {{
+        border-color: var(--accent-border);
+        background: var(--accent-soft);
+        color: var(--text-primary);
+        transform: translateY(-1px);
+      }}
+      .jupr-topbar-action:focus-visible {{
+        outline: 3px solid var(--focus);
+        outline-offset: 2px;
+      }}
 
       /* Cards + sections */
       .jupr-card {{

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -205,6 +205,8 @@ def main():
         if public_requested and not effective_admin_shell:
             PUBLIC_MODE = True
         admin_logged_in = (not PUBLIC_MODE) and authenticated
+        st.session_state["jupr_public_mode"] = bool(PUBLIC_MODE)
+        st.session_state["jupr_admin_entry_active"] = bool(effective_admin_shell)
 
         # ---- Sidebar / Auth ----
         if PUBLIC_MODE:


### PR DESCRIPTION
### Motivation
- Provide an obvious but unobtrusive “Admin Login” entry on public pages in a single, centralized place (shared topbar) so public visitors can intentionally enter the admin shell without exposing admin content.
- Work with the public-first routing model by making the shell state available to shared layout helpers so rendering is deterministic.
- Preserve the current look-and-feel and avoid per-page duplication by using the existing page shell/topbar for the CTA.

### Description
- Expose shell routing state to shared UI by setting `st.session_state["jupr_public_mode"]` and `st.session_state["jupr_admin_entry_active"]` after route resolution in `streamlit_app.py`.
- Add a reusable `build_admin_entry_url()` helper in `jupr_app/ui/layout.py` that returns an explicit admin-shell URL (base `/?admin=1`) and preserves the current `page` query param when present.
- Update `page_shell()` in `jupr_app/ui/layout.py` to append a right-side `Admin Login` link to the shared topbar when rendering public pages while preserving any existing `mode_label` pill.
- Add compact, theme-aware topbar CTA styles (`.jupr-topbar-action`) to `jupr_app/ui/theme_clean.py` with subtle border/hover/focus states to match light/dark tokens.

### Testing
- Ran `python -m compileall streamlit_app.py jupr_app/ui/layout.py jupr_app/ui/theme_clean.py`, and all three modules compiled successfully.
- Verified the changes were committed to the branch and no runtime syntax errors were introduced by the edit and compilation step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7e913e148326996365631cfa7e52)