### PR TITLE
Add dedicated admin login landing page and gate admin shell until authenticated

### DIFF
--- a/jupr_app/ui/layout.py
+++ b/jupr_app/ui/layout.py
@@ -10,12 +10,9 @@ from jupr_app.ui.theme_clean import topbar
 
 def build_admin_entry_url() -> str:
     """
-    Build a deterministic URL that explicitly enters the admin shell.
+    Build a deterministic URL that explicitly enters the admin login landing page.
     """
-    preserved_page = str(st.query_params.get("page", "") or "").strip()
-    params: dict[str, str] = {"admin": "1"}
-    if preserved_page:
-        params["page"] = preserved_page
+    params: dict[str, str] = {"admin": "1", "page": "admin_login"}
     return f"/?{urlencode(params)}"
 
 

--- a/jupr_app/ui/page_registry.py
+++ b/jupr_app/ui/page_registry.py
@@ -49,6 +49,7 @@ PAGE_DEFINITIONS: tuple[PageDefinition, ...] = (
     PageDefinition("top_players_printable", "🧾 Top Active Players PDF", admin_only=True),
     PageDefinition("weekly_recap_admin", "🗞️ Weekly Recap Admin", admin_only=True),
     PageDefinition("player_updates_admin", "📬 Player Updates Admin", admin_only=True),
+    PageDefinition("admin_login", "🔐 Admin Login", show_in_nav=False),
     PageDefinition("reset_password", "🔐 Reset Password", show_in_nav=False),
     PageDefinition(
         "verified_updates_request",

--- a/jupr_app/ui/pages/admin_login.py
+++ b/jupr_app/ui/pages/admin_login.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from jupr_app.ui.admin_auth import (
+    AdminAuthConfigError,
+    AdminAuthError,
+    is_allowed_admin_email,
+    login_admin,
+    logout_admin,
+    send_password_reset_email,
+)
+from jupr_app.ui.layout import page_shell
+from jupr_app.ui.page_registry import ADMIN_ONLY_PAGE_KEYS
+
+DEFAULT_ADMIN_PAGE_KEY = "league_manager"
+RESET_PASSWORD_REDIRECT_URL = "https://juprtrespalapas.streamlit.app/?page=reset_password&public=1"
+
+
+def _resolve_post_login_target() -> str:
+    requested_key = str(st.session_state.pop("post_login_admin_page_key", "") or "").strip().lower()
+    if requested_key in ADMIN_ONLY_PAGE_KEYS:
+        return requested_key
+
+    requested_query_page = str(st.query_params.get("next", "") or "").strip().lower()
+    if requested_query_page in ADMIN_ONLY_PAGE_KEYS:
+        return requested_query_page
+
+    return DEFAULT_ADMIN_PAGE_KEY
+
+
+def render(ctx):
+    page_shell(
+        "🔐 Admin Login",
+        "Authorized Tres Palapas staff only. Sign in to access JUPR administration.",
+        mode_label="Public",
+        right_html="",
+    )
+
+    st.markdown("<div style='max-width:560px;margin:1.5rem auto 0 auto;'>", unsafe_allow_html=True)
+
+    st.markdown("### Sign in")
+
+    with st.form("admin_login_page_form", clear_on_submit=False):
+        email = st.text_input("Email", placeholder="name@trespalapas.com")
+        password = st.text_input("Password", type="password")
+        login_submitted = st.form_submit_button("Login", type="primary", use_container_width=True)
+
+    if login_submitted:
+        try:
+            result = login_admin(email=email, password=password)
+            login_user = result.get("user")
+            login_email = str(getattr(login_user, "email", "") or "").strip().lower()
+            admin_allowlist = st.session_state.get("admin_allowlist", set())
+            if not is_allowed_admin_email(login_email, admin_allowlist):
+                logout_admin()
+                st.error("Authenticated but not authorized for admin access.")
+            else:
+                st.query_params["admin"] = "1"
+                st.query_params.pop("public", None)
+                st.query_params["page"] = _resolve_post_login_target()
+                st.rerun()
+        except AdminAuthConfigError as exc:
+            st.error(str(exc))
+        except AdminAuthError as exc:
+            st.error(str(exc))
+
+    with st.expander("Forgot password?"):
+        with st.form("admin_login_page_reset_form", clear_on_submit=False):
+            reset_email = st.text_input("Email for reset link")
+            send_reset_submitted = st.form_submit_button("Send reset email", use_container_width=True)
+
+        if send_reset_submitted:
+            try:
+                send_password_reset_email(
+                    reset_email,
+                    redirect_to=RESET_PASSWORD_REDIRECT_URL,
+                )
+            except AdminAuthConfigError as exc:
+                st.error(str(exc))
+            except AdminAuthError as exc:
+                st.error(str(exc))
+            else:
+                st.success("If that email exists, a reset link has been sent.")
+
+    st.markdown("</div>", unsafe_allow_html=True)

--- a/jupr_app/ui/pages/reset_password.py
+++ b/jupr_app/ui/pages/reset_password.py
@@ -158,4 +158,4 @@ def render(ctx):
 
         clear_local_admin_auth_state()
         st.success("Password updated successfully. Return to login and sign in with your new password.")
-        st.link_button("Return to login", "?page=leaderboards")
+        st.link_button("Return to login", "/?page=admin_login&admin=1")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -14,18 +14,14 @@ from jupr_app.data.load import load_data
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
 from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
 from jupr_app.ui.admin_auth import (
-    AdminAuthConfigError,
-    AdminAuthError,
     bootstrap_admin_auth,
     get_current_admin_user,
     is_allowed_admin_email,
     is_recovery_flow_query,
     load_admin_allowlist,
-    login_admin,
     logout_admin,
     maybe_restore_admin_login_from_browser,
     render_admin_browser_session_bridge,
-    send_password_reset_email,
 )
 from jupr_app.ui.context import AppContext
 from jupr_app.ui.page_registry import (
@@ -42,7 +38,6 @@ from jupr_app.ui.theme_clean import apply_clean_theme
 from jupr_app.ui.url import qp_get
 
 logger = logging.getLogger(__name__)
-DEFAULT_ADMIN_PAGE_KEY = "league_manager"
 
 
 def _debug_exceptions_enabled() -> bool:
@@ -65,7 +60,6 @@ CLUB_ID = "tres_palapas"
 
 # Public base URL used for share links + link buttons (Streamlit Cloud)
 PUBLIC_BASE_URL = "https://juprtrespalapas.streamlit.app"
-RESET_PASSWORD_REDIRECT_URL = f"{PUBLIC_BASE_URL}/?page=reset_password&public=1"
 
 
 # -------------------------
@@ -166,6 +160,7 @@ def main():
         public_requested = _is_truthy(qp_get("public", "0"))
         admin_requested = _is_truthy(qp_get("admin", "0"))
         incoming_page_param = qp_get("page", "").strip().lower()
+        admin_login_requested = incoming_page_param == "admin_login"
         requested_admin_page = incoming_page_param in ADMIN_ONLY_PAGE_KEYS
         recovery_flow = is_recovery_flow_query()
         debug_exceptions = _debug_exceptions_enabled()
@@ -183,9 +178,9 @@ def main():
         render_admin_browser_session_bridge()
 
         admin_allowlist = load_admin_allowlist()
-        auth_config_error: str | None = None
-
-        should_restore_admin = admin_requested or requested_admin_page or recovery_flow
+        should_restore_admin = (
+            admin_requested or requested_admin_page or admin_login_requested or recovery_flow
+        )
         if should_restore_admin:
             maybe_restore_admin_login_from_browser()
 
@@ -200,85 +195,31 @@ def main():
             current_admin_email = ""
             authenticated = False
 
-        effective_admin_shell = admin_requested or requested_admin_page or recovery_flow
-        PUBLIC_MODE = not effective_admin_shell
-        if public_requested and not effective_admin_shell:
+        effective_admin_entry = (
+            admin_requested or requested_admin_page or admin_login_requested or recovery_flow
+        )
+        PUBLIC_MODE = not effective_admin_entry
+        if public_requested and not effective_admin_entry:
             PUBLIC_MODE = True
-        admin_logged_in = (not PUBLIC_MODE) and authenticated
+        unauthenticated_admin_page_request = requested_admin_page and not authenticated
+        if unauthenticated_admin_page_request:
+            st.session_state["post_login_admin_page_key"] = incoming_page_param
+            st.query_params["admin"] = "1"
+            st.query_params.pop("public", None)
+            st.query_params["page"] = "admin_login"
+            st.rerun()
+
+        admin_logged_in = authenticated and authorized and (not admin_login_requested)
         st.session_state["jupr_public_mode"] = bool(PUBLIC_MODE)
-        st.session_state["jupr_admin_entry_active"] = bool(effective_admin_shell)
+        st.session_state["jupr_admin_entry_active"] = bool(effective_admin_entry)
+        st.session_state["admin_allowlist"] = admin_allowlist
 
         # ---- Sidebar / Auth ----
-        if PUBLIC_MODE:
+        if PUBLIC_MODE or admin_login_requested:
             hide_sidebar_and_header_for_public()
         else:
             st.sidebar.title("JUPR Leagues 🌵")
-
-            if not authenticated:
-                if requested_admin_page:
-                    st.session_state["post_login_admin_page_key"] = incoming_page_param
-                with st.sidebar.expander("🔒 Admin Login"):
-                    show_forgot_password = st.session_state.get("show_forgot_password", False)
-
-                    with st.form("admin_login_form", clear_on_submit=False):
-                        email = st.text_input("Email", key="admin_email")
-                        password = st.text_input("Password", type="password", key="admin_pwd")
-                        login_submitted = st.form_submit_button("Login")
-
-                    if login_submitted:
-                        if not admin_allowlist:
-                            auth_config_error = "Supabase auth is not configured. Set SUPABASE_URL, SUPABASE_ANON_KEY, and admin.allowed_emails."
-                        else:
-                            try:
-                                result = login_admin(email=email, password=password)
-                                login_user = result.get("user")
-                                login_email = str(getattr(login_user, "email", "") or "").strip().lower()
-                                if not is_allowed_admin_email(login_email, admin_allowlist):
-                                    logout_admin()
-                                    st.sidebar.error("Authenticated but not authorized for admin access.")
-                                else:
-                                    requested_key = (
-                                        st.session_state.pop("post_login_admin_page_key", "")
-                                        or incoming_page_param
-                                    )
-                                    if requested_key not in ADMIN_ONLY_PAGE_KEYS:
-                                        requested_key = DEFAULT_ADMIN_PAGE_KEY
-                                    st.query_params["admin"] = "1"
-                                    st.query_params.pop("public", None)
-                                    st.query_params["page"] = requested_key
-                                    st.rerun()
-                            except AdminAuthConfigError as exc:
-                                auth_config_error = str(exc)
-                            except AdminAuthError as exc:
-                                st.sidebar.error(str(exc))
-
-                    if st.button("Forgot password?", key="admin_forgot_password_btn"):
-                        st.session_state["show_forgot_password"] = not show_forgot_password
-                        st.rerun()
-
-                    if st.session_state.get("show_forgot_password", False):
-                        with st.form("admin_reset_password_form", clear_on_submit=False):
-                            reset_email = st.text_input("Email for reset link", key="admin_reset_email")
-                            send_reset_submitted = st.form_submit_button("Send reset email")
-
-                        if send_reset_submitted:
-                            try:
-                                send_password_reset_email(
-                                    reset_email,
-                                    redirect_to=RESET_PASSWORD_REDIRECT_URL,
-                                )
-                            except AdminAuthConfigError as exc:
-                                auth_config_error = str(exc)
-                            except AdminAuthError as exc:
-                                st.sidebar.error(str(exc))
-                            else:
-                                st.sidebar.success(
-                                    "If that email exists, a reset link has been sent."
-                                )
-
-                if auth_config_error:
-                    st.sidebar.error(auth_config_error)
-            else:
+            if authenticated:
                 st.sidebar.success(f"Logged In: {current_admin_email}")
                 if st.sidebar.button("Log Out", key="admin_logout_btn"):
                     logout_admin()
@@ -362,6 +303,7 @@ def main():
         # -------------------------
         from jupr_app.ui.pages import (
             admin_guide,
+            admin_login,
             admin_tools,
             badge_codex,
             badge_debug,
@@ -430,6 +372,7 @@ def main():
             "🗞️ Weekly Recap": weekly_recap,
             "🧾 Top Active Players PDF": top_players_printable,
             # Hidden deep-link page
+            "🔐 Admin Login": admin_login,
             "🔐 Reset Password": reset_password,
             "📬 Verified Updates Request": players,
             # Admin-only
@@ -486,7 +429,9 @@ def main():
             visible_labels = [x for x in visible_labels if x not in HIDDEN_PAGE_LABELS]
 
             valid_admin_deep_label = ""
-            if deep_label in HIDDEN_PAGE_LABELS and is_recovery_flow_query():
+            if deep_page_key == "admin_login" and not authenticated:
+                valid_admin_deep_label = deep_label
+            elif deep_label in HIDDEN_PAGE_LABELS and is_recovery_flow_query():
                 valid_admin_deep_label = deep_label
             elif deep_label in visible_labels:
                 valid_admin_deep_label = deep_label


### PR DESCRIPTION
### Motivation
- Prevent public users from seeing the admin shell/sidebar before authenticating by providing a dedicated full-page admin login entry point.
- Ensure deep-links to admin pages are protected by redirecting unauthenticated requests to a focused login landing page and preserving the intended admin destination for post-login routing.

### Description
- Added a hidden `admin_login` page to the shared page registry so it is routable but not shown in normal nav (`jupr_app/ui/page_registry.py`).
- Implemented a full-page login landing module `jupr_app/ui/pages/admin_login.py` that provides email/password login, a forgot-password flow, and resolves post-login target pages.
- Updated the public topbar/admin entry URL to point to the login landing (`jupr_app/ui/layout.py`) so public pages show an `Admin Login` button that leads to `/?page=admin_login&admin=1`.
- Refactored `streamlit_app.py` routing and auth behavior so admin session restore is constrained to admin contexts, unauthenticated admin deep-links are redirected to the login landing with the target saved to `post_login_admin_page_key`, and the admin sidebar/shell is only rendered after a successful, allowlisted login.
- Updated reset-password success flow to return to the new admin login landing page (`jupr_app/ui/pages/reset_password.py`).

### Testing
- Ran `python -m py_compile streamlit_app.py jupr_app/ui/pages/admin_login.py jupr_app/ui/pages/reset_password.py jupr_app/ui/layout.py jupr_app/ui/page_registry.py`, which completed successfully (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7fc297f48326bccdcef481cb9bbb)