### PR TITLE
Deterministic public/admin routing and admin login restoration

### DIFF
--- a/jupr_app/ui/pages/admin_login.py
+++ b/jupr_app/ui/pages/admin_login.py
@@ -30,6 +30,21 @@ def _resolve_post_login_target() -> str:
 
 
 def render(ctx):
+    if bool(getattr(ctx, "admin_logged_in", False)):
+        params_changed = False
+        if str(st.query_params.get("admin", "")) != "1":
+            st.query_params["admin"] = "1"
+            params_changed = True
+        if str(st.query_params.get("page", "")) != DEFAULT_ADMIN_PAGE_KEY:
+            st.query_params["page"] = DEFAULT_ADMIN_PAGE_KEY
+            params_changed = True
+        if "public" in st.query_params:
+            st.query_params.pop("public", None)
+            params_changed = True
+        if params_changed:
+            st.rerun()
+        return
+
     page_shell(
         "🔐 Admin Login",
         "Authorized Tres Palapas staff only. Sign in to access JUPR administration.",

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -1081,7 +1081,7 @@ def render(ctx):
         with st.container(border=True):
             st.markdown("#### Public standings")
             st.caption("Share this link with players.")
-            st.text_input("", value=public_url, label_visibility="collapsed")
+            st.text_input("Public share URL", value=public_url, label_visibility="collapsed")
             public_link_button("Open Public Standings", public_url)
     if inactive_notice and not PUBLIC_MODE:
         callout("info", "Heads up", inactive_notice)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -134,6 +134,34 @@ def hide_sidebar_and_header_for_public():
     )
 
 
+def _query_param_value(key: str) -> str:
+    value = st.query_params.get(key, "")
+    if isinstance(value, list):
+        value = value[0] if value else ""
+    return str(value or "")
+
+
+def _set_query_params_idempotent(
+    *,
+    updates: dict[str, str] | None = None,
+    removals: set[str] | None = None,
+) -> bool:
+    changed = False
+
+    for key, value in (updates or {}).items():
+        value_text = str(value)
+        if _query_param_value(key) != value_text:
+            st.query_params[key] = value_text
+            changed = True
+
+    for key in removals or set():
+        if key in st.query_params:
+            st.query_params.pop(key, None)
+            changed = True
+
+    return changed
+
+
 def main():
     """
     Main Streamlit entrypoint. Keep this deterministic for reloads.
@@ -163,6 +191,9 @@ def main():
         admin_login_requested = incoming_page_param == "admin_login"
         requested_admin_page = incoming_page_param in ADMIN_ONLY_PAGE_KEYS
         recovery_flow = is_recovery_flow_query()
+        admin_entry_requested = (
+            admin_requested or admin_login_requested or requested_admin_page or recovery_flow
+        )
         debug_exceptions = _debug_exceptions_enabled()
 
         # Make base_url available to all pages (leaderboards uses this for share links)
@@ -178,10 +209,7 @@ def main():
         render_admin_browser_session_bridge()
 
         admin_allowlist = load_admin_allowlist()
-        should_restore_admin = (
-            admin_requested or requested_admin_page or admin_login_requested or recovery_flow
-        )
-        if should_restore_admin:
+        if admin_entry_requested:
             maybe_restore_admin_login_from_browser()
 
         current_admin = get_current_admin_user()
@@ -194,24 +222,52 @@ def main():
             current_admin = None
             current_admin_email = ""
             authenticated = False
+            authorized = False
 
-        effective_admin_entry = (
-            admin_requested or requested_admin_page or admin_login_requested or recovery_flow
-        )
-        PUBLIC_MODE = not effective_admin_entry
-        if public_requested and not effective_admin_entry:
+        admin_authenticated = authenticated and authorized
+
+        if admin_login_requested and admin_authenticated:
+            post_login_target = str(
+                st.session_state.get("post_login_admin_page_key", "") or ""
+            ).strip().lower()
+            if post_login_target not in ADMIN_ONLY_PAGE_KEYS:
+                post_login_target = str(qp_get("next", "") or "").strip().lower()
+            if post_login_target not in ADMIN_ONLY_PAGE_KEYS:
+                post_login_target = "league_manager"
+
+            st.session_state.pop("post_login_admin_page_key", None)
+            params_changed = _set_query_params_idempotent(
+                updates={
+                    "admin": "1",
+                    "page": post_login_target,
+                },
+                removals={
+                    "public",
+                    "next",
+                    "jupr_admin_access_token",
+                    "jupr_admin_refresh_token",
+                    "jupr_admin_restore_from_storage",
+                },
+            )
+            if params_changed:
+                st.rerun()
+
+        PUBLIC_MODE = not admin_entry_requested
+        if public_requested and not admin_entry_requested:
             PUBLIC_MODE = True
-        unauthenticated_admin_page_request = requested_admin_page and not authenticated
+        unauthenticated_admin_page_request = requested_admin_page and not admin_authenticated
         if unauthenticated_admin_page_request:
             st.session_state["post_login_admin_page_key"] = incoming_page_param
-            st.query_params["admin"] = "1"
-            st.query_params.pop("public", None)
-            st.query_params["page"] = "admin_login"
-            st.rerun()
+            params_changed = _set_query_params_idempotent(
+                updates={"admin": "1", "page": "admin_login"},
+                removals={"public"},
+            )
+            if params_changed:
+                st.rerun()
 
-        admin_logged_in = authenticated and authorized and (not admin_login_requested)
+        admin_logged_in = admin_authenticated and (not PUBLIC_MODE) and (not admin_login_requested)
         st.session_state["jupr_public_mode"] = bool(PUBLIC_MODE)
-        st.session_state["jupr_admin_entry_active"] = bool(effective_admin_entry)
+        st.session_state["jupr_admin_entry_active"] = bool(admin_entry_requested)
         st.session_state["admin_allowlist"] = admin_allowlist
 
         # ---- Sidebar / Auth ----
@@ -487,15 +543,18 @@ def main():
                 st.query_params["page"] = target_page
 
             if PUBLIC_MODE:
-                st.query_params.pop("admin", None)
                 if target_page == "leaderboards":
-                    st.query_params.pop("page", None)
+                    _set_query_params_idempotent(removals={"admin", "page"})
                 elif current_page != target_page:
-                    st.query_params["page"] = target_page
+                    _set_query_params_idempotent(
+                        updates={"page": target_page},
+                        removals={"admin"},
+                    )
             else:
-                st.query_params["admin"] = "1"
-                if "public" in st.query_params:
-                    st.query_params.pop("public", None)
+                _set_query_params_idempotent(
+                    updates={"admin": "1"},
+                    removals={"public"},
+                )
 
             st.session_state["_last_rendered_nav"] = sel
         except Exception:


### PR DESCRIPTION
### Motivation
- Fix the unstable public→admin navigation (flashing/bouncing) when a browser/session already has admin tokens by making routing/auth intent deterministic.
- Ensure public browsing remains a true public experience (no admin UI or controls) unless an explicit admin entry route is requested.
- Restore browser auth only when entering admin flows and immediately redirect already-authenticated admins away from the login page to avoid rendering the login form.

### Description
- Centralized route intent in `streamlit_app.py` with explicit booleans including `admin_entry_requested` and used that to drive `PUBLIC_MODE` and admin activation logic.
- Added idempotent query-param helpers `_query_param_value` and `_set_query_params_idempotent` and used them to reduce repeated `st.query_params` writes and avoid rerun churn.
- Limited `maybe_restore_admin_login_from_browser()` to run only when `admin_entry_requested` is true so browser token restoration only occurs for admin entry routes.
- Introduced `admin_authenticated` and changed `admin_logged_in` to only be true when admin UI should be active (not public and not on the login page).
- Added a pre-render redirect guard in `streamlit_app.py` so when `admin_login_requested` and the user is already authorized the app resolves a target admin page, sanitizes/removes sensitive params, sets `admin=1`/`page=<target>`, and `st.rerun()` only if params actually changed.
- Added a defensive guard at the top of `jupr_app/ui/pages/admin_login.py::render()` to immediately redirect already-signed-in admins to the default admin page and remove `public` leakage.
- Small UI cleanup in `jupr_app/ui/pages/leaderboards.py` to replace an empty label `st.text_input("", ...)` with `st.text_input("Public share URL", ...)` to remove noisy Streamlit warnings.

### Testing
- Compiled modified modules with `python -m compileall streamlit_app.py jupr_app/ui/pages/admin_login.py jupr_app/ui/pages/leaderboards.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb3e427648326b2fb0b3f364dc4be)