### PR TITLE
Match-by-match JUPR chart, Previous/New JUPR stat cards, and prestige-only badges in verified update email

### DIFF
--- a/jupr_app/domain/notifications/player_update_charts.py
+++ b/jupr_app/domain/notifications/player_update_charts.py
@@ -1,31 +1,36 @@
 from __future__ import annotations
 
 from io import BytesIO
-from datetime import datetime, timedelta
 
 
 def render_player_digest_chart_png(digest_json: dict) -> bytes | None:
     chart = (digest_json or {}).get("chart") or {}
     points = chart.get("points") or []
-    parsed: list[tuple[datetime | None, int, float]] = []
-    for point in points:
+    point_rows: list[dict] = []
+    for idx, point in enumerate(points, start=1):
         if not isinstance(point, dict):
             continue
         try:
             y = float(point.get("overall_after"))
         except Exception:
             continue
-        match_number = int(point.get("match_number") or 0)
-        dt = None
+        match_number = None
         try:
-            raw_dt = str(point.get("date") or "").strip()
-            if raw_dt:
-                dt = datetime.fromisoformat(raw_dt.replace("Z", "+00:00"))
+            raw_match_number = point.get("match_number")
+            if raw_match_number not in (None, ""):
+                match_number = int(raw_match_number)
         except Exception:
-            dt = None
-        parsed.append((dt, match_number, y))
+            match_number = None
+        point_rows.append(
+            {
+                "overall_after": y,
+                "match_number": match_number,
+                "fallback_x": idx,
+                "is_anchor": bool(point.get("is_anchor")),
+            }
+        )
 
-    if not parsed:
+    if not point_rows:
         return None
 
     import matplotlib
@@ -34,22 +39,34 @@ def render_player_digest_chart_png(digest_json: dict) -> bytes | None:
     import matplotlib.pyplot as plt
 
     fig, ax = plt.subplots(figsize=(8.5, 3.2), dpi=150)
-    parsed = sorted(parsed, key=lambda row: (row[0] or datetime.min, row[1]))
-    y = [row[2] for row in parsed]
-    x_dates = [row[0] for row in parsed]
-    if all(x_dates):
-        ax.plot(x_dates, y, color="#1f77b4", linewidth=2.2, marker="o", markersize=3.5)
-        ax.set_xlabel("Date")
-        if len(x_dates) == 1:
-            ax.set_xlim(x_dates[0] - timedelta(days=1), x_dates[0] + timedelta(days=1))
+    point_rows = sorted(
+        point_rows,
+        key=lambda row: (
+            0 if row["is_anchor"] else 1,
+            row["match_number"] if row["match_number"] is not None else row["fallback_x"],
+            row["fallback_x"],
+        ),
+    )
+    parsed: list[tuple[int, float]] = []
+    for sequence_idx, row in enumerate(point_rows, start=1):
+        x_value = row["match_number"] if row["match_number"] is not None else sequence_idx
+        parsed.append((x_value, row["overall_after"]))
+
+    x_values = [row[0] for row in parsed]
+    y_values = [row[1] for row in parsed]
+    ax.plot(x_values, y_values, color="#1f77b4", linewidth=2.2, marker="o", markersize=3.5)
+    ax.set_xlabel("Match")
+
+    if len(x_values) == 1:
+        x_single = float(x_values[0])
+        ax.set_xlim(x_single - 1, x_single + 1)
     else:
-        x_idx = list(range(1, len(parsed) + 1))
-        ax.plot(x_idx, y, color="#1f77b4", linewidth=2.2, marker="o", markersize=3.5)
-        ax.set_xlabel("Match")
-        if len(x_idx) == 1:
-            ax.set_xlim(0, 2)
+        x_min = min(x_values)
+        x_max = max(x_values)
+        if x_min == x_max:
+            ax.set_xlim(float(x_min) - 1, float(x_max) + 1)
         else:
-            ax.set_xlim(1, max(x_idx))
+            ax.set_xlim(float(x_min), float(x_max))
     ax.set_title(str(chart.get("title") or "Overall JUPR by Match"), fontsize=11)
     ax.set_ylabel("JUPR")
     ax.grid(True, alpha=0.3)

--- a/jupr_app/domain/notifications/player_update_email_template.py
+++ b/jupr_app/domain/notifications/player_update_email_template.py
@@ -44,12 +44,13 @@ def _badge_line(item: dict) -> str:
 def build_player_update_email_subject(digest_json: dict) -> str:
     player_name = _s((digest_json or {}).get("player_name")) or "Verified Player"
     summary = (digest_json or {}).get("summary") or {}
+    before_text = _num(summary.get("overall_jupr_before"), digits=3, default="")
     rating_text = _num(summary.get("overall_jupr_after"), digits=3, default="")
     delta_text = _num(summary.get("overall_delta"), digits=4, prefix_sign=True, default="")
-    if rating_text:
+    if before_text and rating_text:
         if delta_text:
-            return f"{player_name} verified update: {rating_text} JUPR ({delta_text})"
-        return f"{player_name} verified update: {rating_text} JUPR"
+            return f"{player_name} verified update: {before_text} → {rating_text} ({delta_text})"
+        return f"{player_name} verified update: {before_text} → {rating_text}"
     display_range = _s((digest_json or {}).get("display_range"))
     if display_range:
         return f"{player_name} verified update · {display_range}"
@@ -66,12 +67,14 @@ def build_player_update_email_html(digest_json: dict, chart_cid: str | None) -> 
 
     player_name = html.escape(_s(digest.get("player_name")) or "Verified Player")
     display_range = html.escape(_s(digest.get("display_range")))
-    overall_text = _num(summary.get("overall_jupr_after"), digits=3)
+    before_text = _num(summary.get("overall_jupr_before"), digits=3, default="—")
+    overall_text = _num(summary.get("overall_jupr_after"), digits=3, default="—")
     delta_text = _num(summary.get("overall_delta"), digits=4, prefix_sign=True, default="—")
     record = html.escape(_s(summary.get("record")) or "0-0")
     matches_played = int(summary.get("matches_played") or 0)
+    prestige_badges = [item for item in badges if int(item.get("prestige") or 0) >= 50]
 
-    badge_items = "".join(_badge_line(item) for item in badges[:3])
+    badge_items = "".join(_badge_line(item) for item in prestige_badges[:3])
     trophy_items = "".join(
         f"<tr><td style='padding:3px 0;'>• {html.escape(_s(item.get('tournament_name')) or _s(item.get('league_name')) or 'Trophy')}</td></tr>"
         for item in trophies[:3]
@@ -81,7 +84,7 @@ def build_player_update_email_html(digest_json: dict, chart_cid: str | None) -> 
         new_period_block = (
             "<tr><td style='padding:18px 24px 0;'>"
             "<div style='font-size:16px;font-weight:700;margin-bottom:6px;'>New this period</div>"
-            + (f"<div style='font-size:14px;font-weight:700;margin-top:6px;'>Badges</div><table role='presentation' width='100%'>{badge_items}</table>" if badge_items else "")
+            + (f"<div style='font-size:14px;font-weight:700;margin-top:6px;'>Prestige badges</div><table role='presentation' width='100%'>{badge_items}</table>" if badge_items else "")
             + (f"<div style='font-size:14px;font-weight:700;margin-top:10px;'>Trophies</div><table role='presentation' width='100%'>{trophy_items}</table>" if trophy_items else "")
             + "</td></tr>"
         )
@@ -126,13 +129,15 @@ def build_player_update_email_html(digest_json: dict, chart_cid: str | None) -> 
               <td style="padding:18px 24px 6px;">
                 <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
                   <tr>
-                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="25%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">JUPR</div><div style="font-size:22px;font-weight:700;">{overall_text}</div></td>
+                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="19%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">Previous JUPR</div><div style="font-size:22px;font-weight:700;">{before_text}</div></td>
                     <td width="2%"></td>
-                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="23%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">Change</div><div style="font-size:22px;font-weight:700;">{delta_text}</div></td>
+                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="19%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">New JUPR</div><div style="font-size:22px;font-weight:700;">{overall_text}</div></td>
                     <td width="2%"></td>
-                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="23%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">Record</div><div style="font-size:22px;font-weight:700;">{record}</div></td>
+                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="19%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">Change</div><div style="font-size:22px;font-weight:700;">{delta_text}</div></td>
                     <td width="2%"></td>
-                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="23%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">Matches played</div><div style="font-size:22px;font-weight:700;">{matches_played}</div></td>
+                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="19%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">Record</div><div style="font-size:22px;font-weight:700;">{record}</div></td>
+                    <td width="2%"></td>
+                    <td style="padding:8px;border-radius:10px;background:#F7FAFF;text-align:center;" width="19%"><div style="font-size:11px;color:#617189;text-transform:uppercase;">Matches</div><div style="font-size:22px;font-weight:700;">{matches_played}</div></td>
                   </tr>
                 </table>
               </td>
@@ -166,9 +171,10 @@ def build_player_update_email_text(digest_json: dict) -> str:
     trophies = digest.get("trophies_earned") or []
     matches = digest.get("matches_played_rows") or []
     links = digest.get("links") or {}
+    prestige_badges = [item for item in badges if int(item.get("prestige") or 0) >= 50]
 
     badge_lines = []
-    for item in badges[:3]:
+    for item in prestige_badges[:3]:
         name = _s(item.get("name")) or _s(item.get("badge_id")) or "Badge"
         count = int(item.get("count") or 1)
         label = f"{name} x{count}" if count > 1 else name
@@ -186,13 +192,14 @@ def build_player_update_email_text(digest_json: dict) -> str:
             "You’re receiving this email because you subscribed to JUPR player profile updates.",
             f"Player: {_s(digest.get('player_name'))}",
             f"Date range: {_s(digest.get('display_range'))}",
-            f"Current overall JUPR: {_num(summary.get('overall_jupr_after'), digits=3)}",
-            f"Overall delta: {_num(summary.get('overall_delta'), digits=4, prefix_sign=True, default='—')}",
-            f"Weekly record: {_s(summary.get('record')) or '0-0'}",
+            f"Before JUPR: {_num(summary.get('overall_jupr_before'), digits=3, default='—')}",
+            f"New JUPR: {_num(summary.get('overall_jupr_after'), digits=3, default='—')}",
+            f"Change: {_num(summary.get('overall_delta'), digits=4, prefix_sign=True, default='—')}",
+            f"Record: {_s(summary.get('record')) or '0-0'}",
             f"Matches played: {int(summary.get('matches_played') or 0)}",
             "Rating trend graph: Available in the HTML version of this email and on your profile page.",
             "",
-            *(["New this period:", "Badges:", *badge_lines] if badge_lines else []),
+            *(["New this period:", "Prestige badges:", *badge_lines] if badge_lines else []),
             *(["Trophies:", *trophy_lines] if trophy_lines else []),
             *([""] if badge_lines or trophy_lines else []),
             *(["Recent matches:", *match_lines, ""] if match_lines else []),

--- a/jupr_app/domain/recaps/player_weekly_digest.py
+++ b/jupr_app/domain/recaps/player_weekly_digest.py
@@ -129,11 +129,14 @@ def _load_badges_earned(supabase, club_id: str, player_id: int, start_dt_utc: da
     badge_ids = sorted({str(row.get("badge_id") or "").strip() for row in badge_rows if row.get("badge_id")})
     badge_name_map: dict[str, str] = {}
     badge_desc_map: dict[str, str] = {}
+    badge_prestige_map: dict[str, int] = {}
     for badge_id, schema in badge_schema_by_id().items():
-        badge_name_map[str(badge_id)] = str(schema.title or badge_id)
-        badge_desc_map[str(badge_id)] = str(
+        schema_id = str(badge_id)
+        badge_name_map[schema_id] = str(schema.title or badge_id)
+        badge_desc_map[schema_id] = str(
             schema.display.flavor or schema.display.requirements or "Award earned during this update window."
         ).strip()
+        badge_prestige_map[schema_id] = int(getattr(schema, "prestige", 0) or 0)
     if badge_ids:
         try:
             badge_defs = (
@@ -163,6 +166,7 @@ def _load_badges_earned(supabase, club_id: str, player_id: int, start_dt_utc: da
                 "badge_id": bid,
                 "name": badge_name_map.get(bid, bid),
                 "description": badge_desc_map.get(bid, "Award earned during this update window."),
+                "prestige": int(badge_prestige_map.get(bid, 0) or 0),
                 "earned_at": row.get("earned_at"),
                 "context_type": row.get("context_type"),
                 "context_id": row.get("context_id"),
@@ -182,9 +186,14 @@ def _group_badges_for_display(badges: list[dict]) -> list[dict]:
                 "badge_id": badge_id or None,
                 "name": name,
                 "description": str(badge.get("description") or "Award earned during this update window.").strip(),
+                "prestige": int(badge.get("prestige") or 0),
                 "count": 0,
                 "last_earned_at": None,
             }
+        grouped[key]["prestige"] = max(
+            int(grouped[key].get("prestige") or 0),
+            int(badge.get("prestige") or 0),
+        )
         grouped[key]["count"] = int(grouped[key]["count"]) + 1
         earned_at = badge.get("earned_at")
         if earned_at and (grouped[key]["last_earned_at"] is None or str(earned_at) > str(grouped[key]["last_earned_at"])):


### PR DESCRIPTION
### Motivation
- Improve the verified player update email by plotting rating progression by match (not date), surface before/after ratings in the stat cards, and only surface meaningful (prestige) badges to reduce noise.
- Keep the simplified email structure and ensure small/mobile-friendly rendering while preserving existing unsubscribe and send/skip behavior.

### Description
- Update `render_player_digest_chart_png()` to always plot the chart with a match-based x-axis using `chart["points"]`, sorting anchor first and using `match_number` with a sequential fallback, and keeping marker dots and sane single-point x-limits. (`jupr_app/domain/notifications/player_update_charts.py`, `render_player_digest_chart_png`)
- Change subject formatting to show `old → new (delta)` when available and fall back to the display range, by reading `summary["overall_jupr_before"]` and `summary["overall_jupr_after"]`. (`jupr_app/domain/notifications/player_update_email_template.py`, `build_player_update_email_subject`)
- Replace top email stat cards to show `Previous JUPR`, `New JUPR`, `Change`, `Record`, and `Matches` with safe fallbacks for missing values, in both HTML and text outputs. (`jupr_app/domain/notifications/player_update_email_template.py`, `build_player_update_email_html` and `build_player_update_email_text`)
- Add `prestige` to badges returned by the weekly digest and preserve max prestige when grouping duplicates, by pulling prestige from `badge_schema_by_id()` and carrying it through grouping. (`jupr_app/domain/recaps/player_weekly_digest.py`, `_load_badges_earned` and `_group_badges_for_display`)
- Filter badges shown in the email to only those with `prestige >= 50`, cap displayed badges/trophies at 3, cap recent matches at 5, rename the badge block to “Prestige badges”, and hide empty badge/trophy sections. (`jupr_app/domain/notifications/player_update_email_template.py`)

### Testing
- Ran a compile check with `python -m py_compile jupr_app/domain/notifications/player_update_charts.py jupr_app/domain/notifications/player_update_email_template.py jupr_app/domain/recaps/player_weekly_digest.py`, which completed successfully.
- Changes were committed to the branch after the compile check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc0445e188326acbb76c3b581d2e1)