### PR TITLE
Add JUPR Live rated/unrated modes with explicit rating_scope

### DIFF
--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -63,7 +63,7 @@ def process_matches(
 
     skipped_incomplete = 0
     skipped_empty = 0
-    has_non_popup_match = False
+    has_badge_eligible_match = False
 
     def as_pid(x):
         """Accept int IDs OR numeric strings OR exact names. Returns int player_id or None."""
@@ -168,7 +168,15 @@ def process_matches(
         start = float(get_island_r(int(pid), str(league_name)))
         island_updates[key] = {"r": start, "start": start, "w": 0, "l": 0, "mp": 0}
 
-    def apply_updates(pid: int, d_ov: float, d_isl: float, outcome, is_popup: bool, league_name: str) -> float:
+    def apply_updates(
+        pid: int,
+        d_ov: float,
+        d_isl: float,
+        outcome,
+        *,
+        update_island: bool,
+        league_name: str,
+    ) -> float:
         """
         outcome:
           - True  => this player won
@@ -185,7 +193,7 @@ def process_matches(
         elif outcome is False:
             overall_updates[pid]["l"] += 1
 
-        if not bool(is_popup):
+        if update_island:
             ensure_island_entry(pid, league_name)
             key = (pid, league_name)
             island_updates[key]["r"] += float(d_isl)
@@ -221,9 +229,14 @@ def process_matches(
         league_name = str(m.get("league", "") or "").strip()
         week_tag = str(m.get("week_tag", "") or "")
         match_type = str(m.get("match_type", "") or "")
+        rating_scope = str(m.get("rating_scope", "") or "").strip().lower()
+        if rating_scope not in {"overall_only", "unrated"}:
+            rating_scope = ""
         is_popup = bool(m.get("is_popup", False)) or (match_type == "PopUp")
-        if not is_popup:
-            has_non_popup_match = True
+        is_unrated = rating_scope == "unrated"
+        update_island = (not is_popup) and (rating_scope != "overall_only") and (not is_unrated)
+        if (not is_popup) and (not is_unrated):
+            has_badge_eligible_match = True
 
         dt_val = m.get("date", None)
         match_dt = coerce_utc_datetime(dt_val)
@@ -233,18 +246,20 @@ def process_matches(
 
         ro1, ro2, ro3, ro4 = get_overall_r(p1), get_overall_r(p2), get_overall_r(p3), get_overall_r(p4)
 
-        do1, do2 = calculate_hybrid_elo(
-            (ro1 + ro2) / 2.0,
-            (ro3 + ro4) / 2.0,
-            s1,
-            s2,
-            k_factor=float(default_k_factor),
-            min_win_delta=float(min_win_delta_elo),
-            cap_loser_gain=cap_loser_gain_elo,
-        )
+        do1, do2 = 0.0, 0.0
+        if not is_unrated:
+            do1, do2 = calculate_hybrid_elo(
+                (ro1 + ro2) / 2.0,
+                (ro3 + ro4) / 2.0,
+                s1,
+                s2,
+                k_factor=float(default_k_factor),
+                min_win_delta=float(min_win_delta_elo),
+                cap_loser_gain=cap_loser_gain_elo,
+            )
 
         di1, di2 = 0.0, 0.0
-        if not is_popup:
+        if update_island:
             k_val = get_k(league_name)
             ri1, ri2, ri3, ri4 = (
                 get_island_r(p1, league_name),
@@ -269,16 +284,26 @@ def process_matches(
             t1_outcome = (s1 > s2)
             t2_outcome = (s2 > s1)
 
-        end_r1 = apply_updates(p1, do1, di1, t1_outcome, is_popup, league_name)
-        end_r2 = apply_updates(p2, do1, di1, t1_outcome, is_popup, league_name)
-        end_r3 = apply_updates(p3, do2, di2, t2_outcome, is_popup, league_name)
-        end_r4 = apply_updates(p4, do2, di2, t2_outcome, is_popup, league_name)
-
-        for pid in (p1, p2, p3, p4):
-            last_game_updates[pid] = max_activity_time(last_game_updates.get(pid), match_dt)
-            affected_players.add(int(pid))
-
-        stored_elo_delta = abs(do1) if (t1_outcome is True) else abs(do2)
+        if is_unrated:
+            end_r1, end_r2, end_r3, end_r4 = ro1, ro2, ro3, ro4
+            stored_elo_delta = 0.0
+        else:
+            end_r1 = apply_updates(
+                p1, do1, di1, t1_outcome, update_island=update_island, league_name=league_name
+            )
+            end_r2 = apply_updates(
+                p2, do1, di1, t1_outcome, update_island=update_island, league_name=league_name
+            )
+            end_r3 = apply_updates(
+                p3, do2, di2, t2_outcome, update_island=update_island, league_name=league_name
+            )
+            end_r4 = apply_updates(
+                p4, do2, di2, t2_outcome, update_island=update_island, league_name=league_name
+            )
+            for pid in (p1, p2, p3, p4):
+                last_game_updates[pid] = max_activity_time(last_game_updates.get(pid), match_dt)
+                affected_players.add(int(pid))
+            stored_elo_delta = abs(do1) if (t1_outcome is True) else abs(do2)
 
         db_matches.append(
             {
@@ -340,7 +365,7 @@ def process_matches(
                     f"error={error_obj!r}; sample_row={debug_payload}"
                 )
 
-        if supabase is not None and has_non_popup_match:
+        if supabase is not None and has_badge_eligible_match:
             enqueue_result = enqueue_badge_eval(
                 supabase,
                 club_id=str(club_id),

--- a/jupr_app/ui/live/shared.py
+++ b/jupr_app/ui/live/shared.py
@@ -66,6 +66,7 @@ class LivePageConfig:
     allow_official: bool = False
     allow_tournament: bool = False
     show_official_context: bool = False
+    show_rating_mode: bool = False
     persistent_save_label: str | None = None
     requires_roster_resolution: bool = False
 
@@ -82,6 +83,7 @@ def _default_state(config: LivePageConfig) -> dict:
         "league_rounds": 3,
         "official_league": "",
         "official_week_tag": "Week 1",
+        "rating_mode": "Rated",
         "last_saved_rounds": [],
         "editing_substitution_id": None,
         "parsed_roster_lines": [],
@@ -474,6 +476,39 @@ def _official_context_ui(ctx, state: dict) -> tuple[dict, bool]:
     }, not disabled
 
 
+def _rating_mode_context_ui(ctx, state: dict) -> tuple[dict, bool]:
+    disabled = not bool(getattr(ctx, "admin_logged_in", False))
+    options = ["Rated", "Unrated"]
+    current_mode = str(state.get("rating_mode") or "Rated")
+    if current_mode not in options:
+        current_mode = "Rated"
+    state["rating_mode"] = st.radio(
+        "Rating mode",
+        options,
+        horizontal=True,
+        index=options.index(current_mode),
+        key="jupr_live_rating_mode",
+        disabled=disabled,
+    )
+    if disabled:
+        st.warning("Official mode requires admin login before event creation or save.")
+    if state["rating_mode"] == "Unrated":
+        return {
+            "league": "JUPR Live",
+            "week_tag": "",
+            "match_type": "JUPR Live Unrated",
+            "is_popup": False,
+            "rating_scope": "unrated",
+        }, not disabled
+    return {
+        "league": "JUPR Live",
+        "week_tag": "",
+        "match_type": "JUPR Live Rated",
+        "is_popup": False,
+        "rating_scope": "overall_only",
+    }, not disabled
+
+
 def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
     st.markdown('<div class="jupr-live-card">', unsafe_allow_html=True)
     st.markdown('<div class="jupr-live-kicker">Setup</div>', unsafe_allow_html=True)
@@ -582,6 +617,8 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
     official_context: dict = {}
     if config.show_official_context:
         official_context, can_create = _official_context_ui(ctx, state)
+    elif config.show_rating_mode:
+        official_context, can_create = _rating_mode_context_ui(ctx, state)
     participant_names = _participant_lines(state["participant_text"])
     roster_requires_resolution = bool(config.requires_roster_resolution) and state["type_label"] in {
         "Round Robin",
@@ -1213,13 +1250,21 @@ def official_base_payload(state: dict) -> dict:
     }
 
 
+def official_context_payload(event: dict, state: dict) -> dict:
+    context = dict(event.get("official_context") or {})
+    if context:
+        return context
+    return official_base_payload(state)
+
+
 def build_rr_official_payloads(state: dict, event: dict) -> list[dict]:
     payloads = resolve_payload_player_ids(
         event,
         match_payloads_from_rr(event),
         materialize_substitutions=True,
     )
-    return [{**payload, **official_base_payload(state)} for payload in payloads]
+    context = official_context_payload(event, state)
+    return [{**payload, **context} for payload in payloads]
 
 
 def build_league_round_official_payloads(state: dict, event: dict) -> list[dict]:
@@ -1228,11 +1273,14 @@ def build_league_round_official_payloads(state: dict, event: dict) -> list[dict]
         match_payloads_from_current_league_round(event),
         materialize_substitutions=True,
     )
-    return [{**payload, **official_base_payload(state)} for payload in payloads]
+    context = official_context_payload(event, state)
+    return [{**payload, **context} for payload in payloads]
 
 
-def build_tournament_official_payloads(event: dict) -> list[dict]:
-    return tournament_completed_match_payloads(event, unsaved_only=True)
+def build_tournament_official_payloads(state: dict, event: dict) -> list[dict]:
+    payloads = tournament_completed_match_payloads(event, unsaved_only=True)
+    context = official_context_payload(event, state)
+    return [{**payload, **context} for payload in payloads]
 
 
 def mark_tournament_payloads_saved(event: dict, payloads: list[dict]) -> None:

--- a/jupr_app/ui/pages/jupr_live_admin.py
+++ b/jupr_app/ui/pages/jupr_live_admin.py
@@ -18,14 +18,14 @@ from jupr_app.ui.live.shared import (
 ADMIN_CONFIG = LivePageConfig(
     state_key="jupr_live_admin_state",
     intro_markdown=(
-        "Use the official JUPR Live workflow for roster-resolved Round Robin and League / Ladder events. "
-        "League/session context and official finalize/save actions only live here."
+        "Run JUPR Live events as rated overall matches or unrated recorded games. "
+        "No league/session setup required."
     ),
     event_types=("Round Robin", "League / Ladder", "Tournament"),
     mode_pill_label="Official",
     allow_official=True,
     allow_tournament=True,
-    show_official_context=True,
+    show_rating_mode=True,
 )
 
 
@@ -79,7 +79,7 @@ def _save_league_round_official(ctx, state: dict, event: dict) -> bool:
 
 
 def _save_tournament_official(ctx, state: dict, event: dict) -> None:
-    payloads = build_tournament_official_payloads(event)
+    payloads = build_tournament_official_payloads(state, event)
     if not payloads:
         st.info("No newly completed tournament matches to save yet.")
         return
@@ -92,7 +92,7 @@ def _save_tournament_official(ctx, state: dict, event: dict) -> None:
 def render(ctx):
     page_shell(
         "🔴 JUPR Live Admin",
-        "Run official JUPR Live events with save controls and league/session context.",
+        "Run JUPR Live events as rated overall matches or unrated recorded games. No league/session setup required.",
         mode_label="Admin",
     )
     if not bool(getattr(ctx, "admin_logged_in", False)):

--- a/tests/test_jupr_live_rating_scope.py
+++ b/tests/test_jupr_live_rating_scope.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+from jupr_app.domain.match_processing import process_matches
+from jupr_app.ui.live.shared import (
+    build_league_round_official_payloads,
+    build_rr_official_payloads,
+    build_tournament_official_payloads,
+)
+from jupr_app.ui.pages.jupr_live_admin import ADMIN_CONFIG
+
+
+class _Query:
+    def __init__(self, sb, table):
+        self.sb = sb
+        self.table = table
+        self._op = "select"
+        self._payload = None
+        self._filters = []
+        self._limit = None
+
+    def select(self, _cols):
+        self._op = "select"
+        return self
+
+    def insert(self, payload):
+        self._op = "insert"
+        self._payload = payload
+        return self
+
+    def update(self, payload):
+        self._op = "update"
+        self._payload = payload
+        return self
+
+    def eq(self, col, val):
+        self._filters.append(("eq", col, val))
+        return self
+
+    def limit(self, n):
+        self._limit = int(n)
+        return self
+
+    def execute(self):
+        return self.sb.execute(self)
+
+
+class _Supabase:
+    def __init__(self):
+        self.tables = {
+            "matches": [],
+            "players": [],
+            "league_ratings": [],
+        }
+
+    def table(self, name):
+        return _Query(self, name)
+
+    def execute(self, q: _Query):
+        rows = self.tables.setdefault(q.table, [])
+        data = list(rows)
+        for op, col, val in q._filters:
+            if op == "eq":
+                data = [r for r in data if str(r.get(col)) == str(val)]
+        if q._limit is not None:
+            data = data[: q._limit]
+        if q._op == "select":
+            return SimpleNamespace(data=data)
+        if q._op == "insert":
+            payload = q._payload if isinstance(q._payload, list) else [q._payload]
+            for row in payload:
+                rows.append(dict(row))
+            return SimpleNamespace(data=payload)
+        if q._op == "update":
+            for row in data:
+                row.update(dict(q._payload))
+            return SimpleNamespace(data=data)
+        return SimpleNamespace(data=[])
+
+
+def _players_df():
+    return pd.DataFrame(
+        [
+            {"id": 1, "name": "A", "rating": 1200, "wins": 0, "losses": 0, "matches_played": 0},
+            {"id": 2, "name": "B", "rating": 1200, "wins": 0, "losses": 0, "matches_played": 0},
+            {"id": 3, "name": "C", "rating": 1200, "wins": 0, "losses": 0, "matches_played": 0},
+            {"id": 4, "name": "D", "rating": 1200, "wins": 0, "losses": 0, "matches_played": 0},
+        ]
+    )
+
+
+def _patch_side_effects(monkeypatch):
+    monkeypatch.setattr(
+        "jupr_app.domain.match_processing.enqueue_badge_eval",
+        lambda *args, **kwargs: {"queued": False},
+    )
+    monkeypatch.setattr(
+        "jupr_app.domain.match_processing.run_live_badge_awards",
+        lambda *args, **kwargs: {"mode": "inline", "awarded_count": 0},
+    )
+    monkeypatch.setattr(
+        "jupr_app.domain.match_processing.queue_player_updates_for_affected_subscribers",
+        lambda *args, **kwargs: {"week_windows": 0, "queued": 0, "already_queued": 0, "no_active_subscription": 0, "failed": 0},
+    )
+
+
+def test_admin_config_uses_rating_mode_not_official_context():
+    assert ADMIN_CONFIG.show_rating_mode is True
+    assert ADMIN_CONFIG.show_official_context is False
+
+
+def test_official_payload_builders_preserve_rating_scope_context():
+    state = {"official_league": "ignored", "official_week_tag": "ignored"}
+    rr_event = {
+        "official_context": {
+            "league": "JUPR Live",
+            "week_tag": "",
+            "match_type": "JUPR Live Rated",
+            "rating_scope": "overall_only",
+            "is_popup": False,
+        },
+        "participants": [
+            {"id": "p1", "player_id": 1},
+            {"id": "p2", "player_id": 2},
+            {"id": "p3", "player_id": 3},
+            {"id": "p4", "player_id": 4},
+        ],
+        "rounds": [{"number": 1, "matches": [{"id": "m1", "teamA": ["p1", "p2"], "teamB": ["p3", "p4"], "scoreA": 11, "scoreB": 9}]}],
+    }
+    rr_payload = build_rr_official_payloads(state, rr_event)[0]
+    assert rr_payload["rating_scope"] == "overall_only"
+    assert rr_payload["match_type"] == "JUPR Live Rated"
+    assert rr_payload["league"] == "JUPR Live"
+    assert rr_payload["week_tag"] == ""
+
+    rr_event["official_context"]["match_type"] = "JUPR Live Unrated"
+    rr_event["official_context"]["rating_scope"] = "unrated"
+    rr_payload_unrated = build_rr_official_payloads(state, rr_event)[0]
+    assert rr_payload_unrated["rating_scope"] == "unrated"
+    assert rr_payload_unrated["match_type"] == "JUPR Live Unrated"
+
+    league_event = {
+        "official_context": dict(rr_event["official_context"]),
+        "participants": rr_event["participants"],
+        "currentRoundNumber": 1,
+        "rounds": [
+            {
+                "number": 1,
+                "courts": [
+                    {
+                        "courtNumber": 1,
+                        "miniRounds": [
+                            {
+                                "number": 1,
+                                "matches": [{"id": "lm1", "teamA": ["p1", "p2"], "teamB": ["p3", "p4"], "scoreA": 11, "scoreB": 3}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    league_payload = build_league_round_official_payloads(state, league_event)[0]
+    assert league_payload["rating_scope"] == "unrated"
+    assert league_payload["match_type"] == "JUPR Live Unrated"
+
+
+def test_tournament_payload_builder_preserves_context():
+    state = {"official_league": "", "official_week_tag": ""}
+    event = {
+        "name": "Live Admin Cup",
+        "official_context": {
+            "league": "JUPR Live",
+            "week_tag": "",
+            "match_type": "JUPR Live Rated",
+            "rating_scope": "overall_only",
+            "is_popup": False,
+        },
+        "teams": [
+            {"id": "a", "player1_id": 1, "player2_id": 2},
+            {"id": "b", "player1_id": 3, "player2_id": 4},
+        ],
+        "rounds": [{"number": 1, "matches": [{"slot": 1, "participantAId": "a", "participantBId": "b", "scoreA": 11, "scoreB": 6, "winnerId": "a"}]}],
+    }
+    payload = build_tournament_official_payloads(state, event)[0]
+    assert payload["rating_scope"] == "overall_only"
+    assert payload["league"] == "JUPR Live"
+    assert payload["match_type"] == "JUPR Live Rated"
+
+
+def test_process_matches_overall_only_updates_players_not_league_ratings(monkeypatch):
+    _patch_side_effects(monkeypatch)
+    sb = _Supabase()
+    sb.tables["players"] = _players_df().to_dict("records")
+    result = process_matches(
+        [{
+            "league": "JUPR Live",
+            "t1_p1": 1,
+            "t1_p2": 2,
+            "t2_p1": 3,
+            "t2_p2": 4,
+            "s1": 11,
+            "s2": 7,
+            "rating_scope": "overall_only",
+        }],
+        supabase=sb,
+        club_id="club",
+        name_to_id={},
+        df_players_all=_players_df(),
+        df_leagues=pd.DataFrame(),
+        df_meta=pd.DataFrame(),
+    )
+    assert result["inserted"] == 1
+    assert sb.tables["league_ratings"] == []
+    updated_players = {int(p["id"]): p for p in sb.tables["players"]}
+    assert int(updated_players[1]["matches_played"]) == 1
+    assert float(updated_players[1]["rating"]) != 1200.0
+
+
+def test_process_matches_unrated_inserts_without_rating_changes(monkeypatch):
+    _patch_side_effects(monkeypatch)
+    sb = _Supabase()
+    initial_players = _players_df().to_dict("records")
+    sb.tables["players"] = [dict(row) for row in initial_players]
+    process_matches(
+        [{
+            "league": "JUPR Live",
+            "t1_p1": 1,
+            "t1_p2": 2,
+            "t2_p1": 3,
+            "t2_p2": 4,
+            "s1": 11,
+            "s2": 8,
+            "rating_scope": "unrated",
+        }],
+        supabase=sb,
+        club_id="club",
+        name_to_id={},
+        df_players_all=_players_df(),
+        df_leagues=pd.DataFrame(),
+        df_meta=pd.DataFrame(),
+    )
+    assert sb.tables["league_ratings"] == []
+    before = {int(row["id"]): row for row in initial_players}
+    after = {int(row["id"]): row for row in sb.tables["players"]}
+    assert int(after[1]["matches_played"]) == int(before[1]["matches_played"])
+    assert float(after[1]["rating"]) == float(before[1]["rating"])
+    match_row = sb.tables["matches"][0]
+    assert float(match_row["elo_delta"]) == 0.0
+    assert float(match_row["t1_p1_r"]) == float(match_row["t1_p1_r_end"])
+    assert float(match_row["t2_p2_r"]) == float(match_row["t2_p2_r_end"])
+
+
+def test_process_matches_without_rating_scope_keeps_legacy_league_updates(monkeypatch):
+    _patch_side_effects(monkeypatch)
+    sb = _Supabase()
+    sb.tables["players"] = _players_df().to_dict("records")
+    process_matches(
+        [{"league": "Main", "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "s1": 11, "s2": 4}],
+        supabase=sb,
+        club_id="club",
+        name_to_id={},
+        df_players_all=_players_df(),
+        df_leagues=pd.DataFrame(),
+        df_meta=pd.DataFrame(),
+    )
+    assert len(sb.tables["league_ratings"]) == 4


### PR DESCRIPTION
### Motivation
- Remove the requirement for League/Week context in JUPR Live Admin and let admins choose between Rated or Unrated submissions. 
- Provide a clear, explicit `rating_scope` instead of overloading `is_popup`/`PopUp` so match processing can distinguish overall-only rated games from unrated recorded games.
- Preserve existing behavior for legacy/other flows when `rating_scope` is absent.

### Description
- Added `LivePageConfig.show_rating_mode` and default state key `rating_mode` and implemented `_rating_mode_context_ui` which emits stable JUPR Live context (`league: "JUPR Live"`, `week_tag: ""`, `match_type: "JUPR Live Rated"` or `"JUPR Live Unrated"`, and `rating_scope: "overall_only"` or `"unrated"`). (`jupr_app/ui/live/shared.py`)
- Switched JUPR Live Admin to use `show_rating_mode=True`, updated intro text, and stopped using `show_official_context`; tournament payload builder now receives state so context (including `rating_scope`) is preserved. (`jupr_app/ui/pages/jupr_live_admin.py`, `jupr_app/ui/live/shared.py`)
- Modified official payload builders (`build_rr_official_payloads`, `build_league_round_official_payloads`, `build_tournament_official_payloads`) to preserve `event["official_context"]` (so `rating_scope`, `match_type`, `league`, and `week_tag` propagate into payloads). (`jupr_app/ui/live/shared.py`)
- Extended `process_matches` to parse `rating_scope` and implement new behaviors: `overall_only` updates only overall `players` ratings/wins/losses/matches_played and skips `league_ratings`; `unrated` inserts match rows but does not change overall/league ratings or player W/L/mp and records `elo_delta = 0` with end snapshots equal to start snapshots; missing `rating_scope` retains legacy behavior. Adjusted badge-eligibility logic to ignore unrated matches. (`jupr_app/domain/match_processing.py`)
- Added focused unit tests (`tests/test_jupr_live_rating_scope.py`) to assert Admin config, payload propagation, and `process_matches` behavior for `overall_only`, `unrated`, and legacy (no `rating_scope`) cases.

### Testing
- Ran the new focused test file with `pytest -q tests/test_jupr_live_rating_scope.py` and it passed: `6 passed`.
- Ran targeted compatibility checks `pytest -q tests/test_tournament_match_insert_guards.py tests/test_match_processing_badges.py::test_popup_matches_do_not_trigger_live_awards` and they passed: `3 passed`.
- A broader run including `tests/test_jupr_live_modes.py` surfaced an unrelated test failure due to the test attempting to monkeypatch a missing symbol in `jupr_app.ui.pages.jupr_live`; this failure is orthogonal to the changes and focused tests for the new rating modes passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc22399d48326b044f61d458024b8)