### PR TITLE
Fix JUPR Live Admin quick-paste reset crash

### DIFF
--- a/jupr_app/ui/live/shared.py
+++ b/jupr_app/ui/live/shared.py
@@ -95,6 +95,7 @@ def _default_state(config: LivePageConfig) -> dict:
         "resolved_roster_ids": {},
         "admin_roster_rows": [],
         "default_new_player_rating": 3.5,
+        "quick_paste_nonce": 0,
     }
 
 
@@ -804,6 +805,8 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
         "League / Ladder",
     }
     if use_admin_roster_builder:
+        quick_paste_nonce = int(state.get("quick_paste_nonce") or 0)
+        quick_paste_key = f"{config.state_key}_quick_paste_{quick_paste_nonce}"
         state["default_new_player_rating"] = float(
             st.number_input(
                 "Default new-player rating (JUPR)",
@@ -819,7 +822,7 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
             value="",
             height=120,
             placeholder=placeholder,
-            key=f"{config.state_key}_quick_paste",
+            key=quick_paste_key,
         )
         if st.button("Append pasted names", key=f"{config.state_key}_append_paste"):
             incoming = _participant_lines(quick_paste)
@@ -829,7 +832,7 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
                 player_name_to_id=player_name_to_id,
                 default_new_player_rating=float(state["default_new_player_rating"]),
             )
-            st.session_state[f"{config.state_key}_quick_paste"] = ""
+            state["quick_paste_nonce"] = quick_paste_nonce + 1
             st.rerun()
         prev_selected = set(previous_selected_existing_players)
         newly_added = [


### PR DESCRIPTION
### Motivation
- The admin "Quick paste" flow crashed with `StreamlitAPIException` because code attempted to directly mutate a widget-backed `st.session_state` key after the widget was instantiated. 
- The goal is to clear the quick-paste box after appending names without writing to an already-instantiated widget key. 
- Clearing the paste box must not lose previously selected roster players or cause Streamlit runtime errors.

### Description
- Add `"quick_paste_nonce": 0` to the live page default state so the quick-paste widget key can be rotated safely. 
- Compute a nonce-based key in `render_setup` as `quick_paste_key = f"{config.state_key}_quick_paste_{quick_paste_nonce}"` and bind `st.text_area` to that dynamic key. 
- On the "Append pasted names" action, append parsed names into `state["admin_roster_rows"]`, increment `state["quick_paste_nonce"]`, and call `st.rerun()` so the paste box is cleared via key rotation. 
- Remove the illegal direct assignment to the original widget key (`st.session_state[f"{config.state_key}_quick_paste"] = ""`) to prevent `StreamlitAPIException`.
- File modified: `jupr_app/ui/live/shared.py`.

### Testing
- Ran `python -m py_compile jupr_app/ui/live/shared.py` and the file compiled successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc87153a883269f5bd8723533992c)