### PR TITLE
Fix live admin roster builder ratings for existing players

### DIFF
--- a/jupr_app/ui/live/shared.py
+++ b/jupr_app/ui/live/shared.py
@@ -255,6 +255,23 @@ def _best_fuzzy_score(target: str, candidate: str) -> float:
     return float(difflib.SequenceMatcher(None, target, candidate).ratio())
 
 
+def _existing_player_rating_jupr(ctx, player_id: int | None) -> float | None:
+    if player_id is None:
+        return None
+    df_players_all = getattr(ctx, "df_players_all", pd.DataFrame())
+    if df_players_all is None or df_players_all.empty:
+        return None
+    if "id" not in df_players_all.columns or "rating" not in df_players_all.columns:
+        return None
+    matches = df_players_all[df_players_all["id"] == int(player_id)]
+    if matches.empty:
+        return None
+    rating_elo = pd.to_numeric(matches["rating"], errors="coerce").dropna()
+    if rating_elo.empty:
+        return None
+    return round(float(rating_elo.iloc[0]) / 400.0, 2)
+
+
 def _build_roster_candidate_rows(
     participant_names: list[str],
     player_name_to_id: dict[str, int],
@@ -405,6 +422,7 @@ def _fetch_player_by_exact_name(supabase, *, club_id: str, display_name: str) ->
 
 
 def _default_admin_roster_row(
+    ctx,
     display_name: str,
     *,
     order: int,
@@ -429,12 +447,20 @@ def _default_admin_roster_row(
     if exact_pid is not None:
         status = "existing_player"
         selected_name = normalized_display
+        starting_rating = _existing_player_rating_jupr(ctx, exact_pid)
     elif suggestion:
         status = "needs_review"
         selected_name = suggestion
+        suggested_pid = player_name_to_id.get(suggestion)
+        starting_rating = (
+            _existing_player_rating_jupr(ctx, suggested_pid)
+            if suggested_pid is not None
+            else None
+        )
     else:
         status = "create_new_player"
         selected_name = ""
+        starting_rating = float(default_new_player_rating)
     return {
         "order": int(order),
         "display_name": normalized_display,
@@ -442,11 +468,12 @@ def _default_admin_roster_row(
         "player_id": int(exact_pid) if exact_pid is not None else None,
         "selected_existing_name": selected_name,
         "suggested_existing_name": suggestion,
-        "starting_jupr_rating": float(default_new_player_rating),
+        "starting_jupr_rating": starting_rating,
     }
 
 
 def _append_roster_names(
+    ctx,
     roster_rows: list[dict],
     incoming_names: list[str],
     *,
@@ -469,6 +496,7 @@ def _append_roster_names(
             continue
         updated.append(
             _default_admin_roster_row(
+                ctx,
                 name,
                 order=next_order,
                 player_name_to_id=player_name_to_id,
@@ -480,7 +508,13 @@ def _append_roster_names(
     return updated
 
 
-def _rows_from_admin_editor_df(editor_df: pd.DataFrame, *, player_name_to_id: dict[str, int]) -> list[dict]:
+def _rows_from_admin_editor_df(
+    editor_df: pd.DataFrame,
+    *,
+    player_name_to_id: dict[str, int],
+    ctx,
+    default_new_player_rating: float,
+) -> list[dict]:
     rows: list[dict] = []
     for _, row in editor_df.iterrows():
         display_name = normalize_name(row.get("Name"))
@@ -499,10 +533,20 @@ def _rows_from_admin_editor_df(editor_df: pd.DataFrame, *, player_name_to_id: di
             if selected_existing_name and selected_existing_name in player_name_to_id
             else None
         )
-        try:
-            starting_rating = float(row.get("Starting JUPR"))
-        except Exception:
-            starting_rating = 3.5
+        if resolution_status == "existing_player" and selected_player_id is not None:
+            starting_rating = _existing_player_rating_jupr(ctx, selected_player_id)
+        elif resolution_status == "create_new_player":
+            try:
+                starting_rating = float(row.get("Current / Starting JUPR"))
+            except Exception:
+                starting_rating = float(default_new_player_rating)
+            if starting_rating <= 0:
+                starting_rating = float(default_new_player_rating)
+        else:
+            try:
+                starting_rating = float(row.get("Current / Starting JUPR"))
+            except Exception:
+                starting_rating = None
         rows.append(
             {
                 "order": int(order),
@@ -510,7 +554,7 @@ def _rows_from_admin_editor_df(editor_df: pd.DataFrame, *, player_name_to_id: di
                 "resolution_status": resolution_status,
                 "player_id": selected_player_id,
                 "selected_existing_name": selected_existing_name,
-                "starting_jupr_rating": float(starting_rating),
+                "starting_jupr_rating": starting_rating,
             }
         )
     rows.sort(key=lambda item: (int(item.get("order") or 0), str(item.get("display_name") or "")))
@@ -827,6 +871,7 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
         if st.button("Append pasted names", key=f"{config.state_key}_append_paste"):
             incoming = _participant_lines(quick_paste)
             state["admin_roster_rows"] = _append_roster_names(
+                ctx,
                 list(state.get("admin_roster_rows") or []),
                 incoming,
                 player_name_to_id=player_name_to_id,
@@ -842,6 +887,7 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
         ]
         if newly_added:
             state["admin_roster_rows"] = _append_roster_names(
+                ctx,
                 list(state.get("admin_roster_rows") or []),
                 newly_added,
                 player_name_to_id=player_name_to_id,
@@ -850,6 +896,7 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
         roster_rows = list(state.get("admin_roster_rows") or [])
         if not roster_rows and state.get("participant_text"):
             roster_rows = _append_roster_names(
+                ctx,
                 [],
                 _participant_lines(state["participant_text"]),
                 player_name_to_id=player_name_to_id,
@@ -864,13 +911,19 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
                     "Name": str(row.get("display_name") or ""),
                     "Resolution": str(row.get("resolution_status") or "create_new_player"),
                     "Matched Player": str(row.get("selected_existing_name") or ""),
-                    "Starting JUPR": float(
-                        row.get("starting_jupr_rating") or state["default_new_player_rating"]
+                    "Current / Starting JUPR": (
+                        row.get("starting_jupr_rating")
+                        if row.get("resolution_status") == "existing_player"
+                        else float(
+                            row.get("starting_jupr_rating")
+                            if row.get("starting_jupr_rating") is not None
+                            else state["default_new_player_rating"]
+                        )
                     ),
                 }
                 for idx, row in enumerate(roster_rows)
             ],
-            columns=["Order", "Name", "Resolution", "Matched Player", "Starting JUPR"],
+            columns=["Order", "Name", "Resolution", "Matched Player", "Current / Starting JUPR"],
         )
         edited_df = st.data_editor(
             editor_source,
@@ -888,8 +941,8 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
                     "Matched Player",
                     options=[""] + player_options,
                 ),
-                "Starting JUPR": st.column_config.NumberColumn(
-                    "Starting JUPR",
+                "Current / Starting JUPR": st.column_config.NumberColumn(
+                    "Current / Starting JUPR",
                     min_value=1.0,
                     max_value=8.0,
                     step=0.05,
@@ -899,6 +952,8 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
         state["admin_roster_rows"] = _rows_from_admin_editor_df(
             edited_df,
             player_name_to_id=player_name_to_id,
+            ctx=ctx,
+            default_new_player_rating=float(state["default_new_player_rating"]),
         )
         state["participant_text"] = "\n".join(
             row["display_name"] for row in (state.get("admin_roster_rows") or [])

--- a/tests/test_jupr_live_admin_roster_builder.py
+++ b/tests/test_jupr_live_admin_roster_builder.py
@@ -6,7 +6,9 @@ import pandas as pd
 
 from jupr_app.ui.live.shared import (
     _append_roster_names,
+    _default_admin_roster_row,
     _create_and_resolve_admin_players,
+    _existing_player_rating_jupr,
     _rows_from_admin_editor_df,
 )
 from jupr_app.ui.pages.jupr_live_admin import ADMIN_CONFIG
@@ -66,6 +68,7 @@ def _ctx(players: list[dict]):
         supabase=sb,
         club_id="club-1",
         name_to_id={str(p["name"]): int(p["id"]) for p in players},
+        df_players_all=pd.DataFrame(players),
     )
 
 
@@ -77,12 +80,14 @@ def test_admin_config_uses_ordered_roster_builder():
 def test_append_roster_names_preserves_custom_order_and_appends_existing_players():
     player_name_to_id = {"Amy": 1, "Brooke": 2, "Chris": 3}
     rows = _append_roster_names(
+        _ctx([]),
         [],
         ["Brooke", "Zoe"],
         player_name_to_id=player_name_to_id,
         default_new_player_rating=3.5,
     )
     rows = _append_roster_names(
+        _ctx([]),
         rows,
         ["Amy"],
         player_name_to_id=player_name_to_id,
@@ -94,14 +99,64 @@ def test_append_roster_names_preserves_custom_order_and_appends_existing_players
 
 def test_rows_from_editor_preserve_admin_order():
     player_name_to_id = {"Amy": 1, "Brooke": 2}
+    ctx = _ctx([{"id": 1, "club_id": "club-1", "name": "Amy", "rating": 1720.0}])
     df = pd.DataFrame(
         [
-            {"Order": 2, "Name": "Amy", "Resolution": "existing_player", "Matched Player": "Amy", "Starting JUPR": 3.5},
-            {"Order": 1, "Name": "Zoe", "Resolution": "create_new_player", "Matched Player": "", "Starting JUPR": 3.8},
+            {"Order": 2, "Name": "Amy", "Resolution": "existing_player", "Matched Player": "Amy", "Current / Starting JUPR": 1.5},
+            {"Order": 1, "Name": "Zoe", "Resolution": "create_new_player", "Matched Player": "", "Current / Starting JUPR": 3.8},
         ]
     )
-    rows = _rows_from_admin_editor_df(df, player_name_to_id=player_name_to_id)
+    rows = _rows_from_admin_editor_df(
+        df,
+        player_name_to_id=player_name_to_id,
+        ctx=ctx,
+        default_new_player_rating=3.5,
+    )
     assert [r["display_name"] for r in rows] == ["Zoe", "Amy"]
+    assert rows[1]["starting_jupr_rating"] == 4.3
+
+
+def test_existing_player_uses_current_rating_from_players_table():
+    ctx = _ctx([{"id": 1, "club_id": "club-1", "name": "Richard Bartolowits", "rating": 1720.0}])
+    assert _existing_player_rating_jupr(ctx, 1) == 4.3
+    row = _default_admin_roster_row(
+        ctx,
+        "Richard Bartolowits",
+        order=1,
+        player_name_to_id={"Richard Bartolowits": 1},
+        default_new_player_rating=3.5,
+    )
+    assert row["resolution_status"] == "existing_player"
+    assert row["starting_jupr_rating"] == 4.3
+
+
+def test_new_player_uses_default_rating_in_default_row():
+    ctx = _ctx([])
+    row = _default_admin_roster_row(
+        ctx,
+        "Lance Zonneveld",
+        order=1,
+        player_name_to_id={},
+        default_new_player_rating=3.9,
+    )
+    assert row["resolution_status"] == "create_new_player"
+    assert row["starting_jupr_rating"] == 3.9
+
+
+def test_mixed_roster_keeps_distinct_existing_and_new_ratings():
+    ctx = _ctx([
+        {"id": 1, "club_id": "club-1", "name": "Kirsten Giacomini", "rating": 1720.0},
+    ])
+    rows = _append_roster_names(
+        ctx,
+        [],
+        ["Kirsten Giacomini", "Lance Zonneveld"],
+        player_name_to_id={"Kirsten Giacomini": 1},
+        default_new_player_rating=3.5,
+    )
+    by_name = {row["display_name"]: row for row in rows}
+    assert by_name["Kirsten Giacomini"]["starting_jupr_rating"] == 4.3
+    assert by_name["Lance Zonneveld"]["starting_jupr_rating"] == 3.5
 
 
 def test_create_and_resolve_mixed_existing_and_new_players(monkeypatch):
@@ -188,3 +243,31 @@ def test_existing_player_only_roster_still_resolves_without_creation(monkeypatch
     assert resolved_ids == {"Brooke": 2, "Amy": 1}
     assert review_messages == []
     assert created_names == []
+
+
+def test_existing_player_creation_path_ignores_starting_jupr_and_does_not_overwrite(monkeypatch):
+    ctx = _ctx([
+        {"id": 1, "club_id": "club-1", "name": "Amy", "rating": 1720.0},
+    ])
+    safe_add_calls = []
+
+    def _safe_add_player(**kwargs):
+        safe_add_calls.append(kwargs)
+        return True, ""
+
+    monkeypatch.setattr("jupr_app.ui.live.shared.safe_add_player", _safe_add_player)
+    _create_and_resolve_admin_players(
+        ctx,
+        roster_rows=[
+            {
+                "order": 1,
+                "display_name": "Amy",
+                "resolution_status": "existing_player",
+                "player_id": 1,
+                "starting_jupr_rating": 1.0,
+            }
+        ],
+        default_new_player_rating=3.5,
+        player_name_to_id={"Amy": 1},
+    )
+    assert safe_add_calls == []


### PR DESCRIPTION
### Motivation
- The admin roster editor was showing the default new-player JUPR for every row rather than displaying an existing player’s current rating derived from the players table, which risked confusing admins and accidentally seeding wrong ratings.

### Description
- Add `_existing_player_rating_jupr(ctx, player_id)` in `jupr_app/ui/live/shared.py` to resolve an existing player’s current JUPR as `players.rating / 400.0` (safe `None` fallback). 
- Update `_default_admin_roster_row` and `_append_roster_names` to use the helper so `existing_player` rows show the matched player’s current rating and `create_new_player` rows use `default_new_player_rating`; `needs_review` rows can show the suggested player rating when available. 
- Change `_rows_from_admin_editor_df` to accept `ctx` and `default_new_player_rating` and to: recompute display rating for `existing_player` rows from the matched player, accept editable value for `create_new_player` rows with fallback to default, and treat the value for existing players as informational only. 
- Rename the UI/editor column from `Starting JUPR` to `Current / Starting JUPR` and wire the editor code to the new parsing/column name; ensure creation flow only applies starting rating for new players and that existing players are not passed to `safe_add_player` for rating changes.

### Testing
- Updated `tests/test_jupr_live_admin_roster_builder.py` to cover existing-player rating resolution, new-player default behavior, mixed rosters, editor recomputation, ensuring existing-player paths do not call `safe_add_player`, and that new-player rating is passed to creation. 
- Ran `pytest -q tests/test_jupr_live_admin_roster_builder.py` and all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc953b1508326ade796940a6d31af)