### PR TITLE
Fix JUPR Live Admin crash when player slot has no substitution

### DIFF
--- a/jupr_app/ui/live/shared.py
+++ b/jupr_app/ui/live/shared.py
@@ -1509,29 +1509,31 @@ def _render_player_slot_editor(
             key=scope_key,
         )
         scoped_sub = game_sub if selected_scope == "This game only" else round_sub
+        scoped_sub_data = scoped_sub or {}
         substitute_key = f"{editor_key}_substitute"
         scope_memory_key = f"{editor_key}_scope_memory"
         default_substitute = ""
-        if scoped_sub:
-            default_substitute = str(scoped_sub.get("substitute_name") or "")
+        if scoped_sub_data:
+            default_substitute = str(scoped_sub_data.get("substitute_name") or "")
         elif active_sub:
             default_substitute = str(active_sub.get("substitute_name") or "")
         note_key = f"{editor_key}_note"
-        if (
+        scope_changed = (
             scope_memory_key not in st.session_state
             or st.session_state.get(scope_memory_key) != selected_scope
-        ):
+        )
+        if scope_changed:
             st.session_state[scope_memory_key] = selected_scope
             st.session_state[substitute_key] = (
                 default_substitute if default_substitute in player_options else player_options[0]
             )
-            st.session_state[note_key] = str(scoped_sub.get("note") or "")
+            st.session_state.pop(note_key, None)
         elif substitute_key not in st.session_state:
             st.session_state[substitute_key] = (
                 default_substitute if default_substitute in player_options else player_options[0]
             )
-        elif note_key not in st.session_state:
-            st.session_state[note_key] = str(scoped_sub.get("note") or "")
+        if note_key not in st.session_state:
+            st.session_state[note_key] = str(scoped_sub_data.get("note") or "")
         selected_name = st.selectbox(
             "Replacement player",
             player_options,


### PR DESCRIPTION
### Motivation
- The player-slot editor could raise `AttributeError: 'NoneType' object has no attribute 'get'` when there was no existing substitution for the selected scope, causing the Live Admin UI to crash.
- Ensure the editor handles empty/absent substitutions gracefully and preserves existing widget state instead of overwriting it during the same run.

### Description
- Normalize the selected-scope substitution into a null-safe dict with `scoped_sub_data = scoped_sub or {}` and use `scoped_sub_data.get(...)` for accesses instead of assuming `scoped_sub` is a dict.
- Update substitute prefill logic to read from `scoped_sub_data` (with fallback to `active_sub`) and initialize `st.session_state` for the substitute key only when needed.
- Stop writing directly to `st.session_state[note_key]` after the note widget may already exist by popping the note on scope changes and only setting `st.session_state[note_key]` if it is missing before rendering the widget.
- Adjusted control flow so the editor shows normal owner/active player info, allows scope selection and substitute selection when no substitution exists, and continues to prefill existing substitutions correctly.

### Testing
- Ran `python -m py_compile jupr_app/ui/live/shared.py`, which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebcb37165883268348e55ee2007cb6)