### PR TITLE
Add public homepage and replace public radio nav with website shell

### DIFF
--- a/jupr_app/ui/page_registry.py
+++ b/jupr_app/ui/page_registry.py
@@ -13,6 +13,7 @@ class PageDefinition:
 
 
 PAGE_DEFINITIONS: tuple[PageDefinition, ...] = (
+    PageDefinition("home", "Home", public=True),
     PageDefinition("leaderboards", "🏆 Leaderboards", public=True),
     PageDefinition("league_results", "📊 League Results", public=True),
     PageDefinition("league_printout", "🖨️ League Night Printout", admin_only=True),
@@ -72,16 +73,11 @@ HIDDEN_PAGE_LABELS = frozenset(
     page.label for page in PAGE_DEFINITIONS if not page.show_in_nav
 )
 PUBLIC_NAV_KEYS = (
+    "home",
     "leaderboards",
-    "league_results",
-    "weekly_recap",
     "tournament_registration",
-    "tournament_partner_board",
-    "match_explorer",
     "players",
-    "badge_codex",
-    "jupr_live",
-    "challenge_ladder",
+    "weekly_recap",
     "faqs",
 )
 

--- a/jupr_app/ui/pages/home.py
+++ b/jupr_app/ui/pages/home.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import streamlit as st
+
+
+def render(ctx) -> None:  # noqa: ARG001
+    st.markdown(
+        """
+        <section class="jupr-public-shell">
+          <div class="jupr-hero jupr-card">
+            <div class="jupr-hero-eyebrow">JUPR</div>
+            <h1 class="jupr-hero-title">The official player rating and event system for Tres Palapas.</h1>
+            <p class="jupr-hero-subtitle">
+              Track ratings, standings, player profiles, events, match history, badges, and weekly updates
+              from Tres Palapas pickleball.
+            </p>
+            <div class="jupr-hero-actions">
+              <a class="jupr-link-button" href="?page=leaderboards">View Leaderboards</a>
+              <a class="jupr-link-button" href="?page=players">Find Your Player Profile</a>
+              <a class="jupr-link-button" href="?page=tournament_registration">See Upcoming Events</a>
+              <a class="jupr-link-button" href="?page=verified_updates_request">Subscribe to Player Updates</a>
+              <a class="jupr-link-button" href="?admin=1&page=admin_login">Admin Login</a>
+            </div>
+          </div>
+
+          <div class="jupr-home-grid">
+            <article class="jupr-home-card jupr-card jupr-card--hover">
+              <h3 class="jupr-home-card-title">Ratings &amp; Standings</h3>
+              <p class="jupr-home-card-body">Live player ratings, league results, match history, and verified event tracking.</p>
+            </article>
+            <article class="jupr-home-card jupr-card jupr-card--hover">
+              <h3 class="jupr-home-card-title">Player Profiles</h3>
+              <p class="jupr-home-card-body">Search players, view rating history, badges, trophies, and recent match results.</p>
+            </article>
+            <article class="jupr-home-card jupr-card jupr-card--hover">
+              <h3 class="jupr-home-card-title">Events &amp; Updates</h3>
+              <p class="jupr-home-card-body">View public event registration, weekly recaps, partner boards, and player update subscriptions.</p>
+            </article>
+            <article class="jupr-home-card jupr-callout">
+              <h3 class="jupr-home-card-title">Built for Tres Palapas</h3>
+              <p class="jupr-home-card-body">A public-facing rating and event hub for the Tres Palapas pickleball community.</p>
+            </article>
+          </div>
+        </section>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/jupr_app/ui/public_nav.py
+++ b/jupr_app/ui/public_nav.py
@@ -2,49 +2,54 @@ from __future__ import annotations
 
 import streamlit as st
 
-from jupr_app.ui.page_registry import PAGE_KEY_TO_LABEL, PUBLIC_NAV_KEYS
+from jupr_app.ui.page_registry import PAGE_KEY_TO_LABEL
 from jupr_app.ui.url import qp_get
 
 
 def render_public_top_nav(
     *,
-    labels_in_order: list[str] | None = None,
-    current_label: str | None = None,
-    default_page: str = "leaderboards",
+    labels_in_order: list[str] | None = None,  # noqa: ARG001
+    current_label: str | None = None,  # noqa: ARG001
+    default_page: str = "home",
 ) -> str:
-    """
-    Render the horizontal public navigation and return the selected label.
+    """Render the public website-style top nav and return the active page label."""
 
-    If callers do not provide a label list, the shared public-page registry drives the nav.
-    """
-    if labels_in_order is None:
-        labels_in_order = [
-            PAGE_KEY_TO_LABEL[key]
-            for key in PUBLIC_NAV_KEYS
-            if key in PAGE_KEY_TO_LABEL
-        ]
+    current_page = (qp_get("page", "") or "").strip().lower() or default_page
+    if current_page not in PAGE_KEY_TO_LABEL:
+        current_page = default_page
 
-    if not labels_in_order:
-        return PAGE_KEY_TO_LABEL.get(default_page, default_page)
+    links: list[tuple[str, str, str]] = [
+        ("Home", "./", "home"),
+        ("Leaderboards", "?page=leaderboards", "leaderboards"),
+        ("Players", "?page=players", "players"),
+        ("Events", "?page=tournament_registration", "tournament_registration"),
+        ("Updates", "?page=verified_updates_request", "verified_updates_request"),
+        ("Admin Login", "?admin=1&page=admin_login", "admin_login"),
+    ]
 
-    if current_label is None:
-        current_page = (qp_get("page", "") or "").strip() or default_page
-        current_label = PAGE_KEY_TO_LABEL.get(current_page, labels_in_order[0])
-
-    st.markdown("**Go to:**")
-
-    try:
-        idx = labels_in_order.index(current_label)
-    except ValueError:
-        idx = 0
-
-    selected_label = st.radio(
-        label="public_nav",
-        options=labels_in_order,
-        index=idx,
-        horizontal=True,
-        label_visibility="collapsed",
-        key="public_top_nav_radio",
+    nav_links_html = "".join(
+        (
+            f'<a class="jupr-public-nav-link {"active" if key == current_page else ""}" '
+            f'href="{href}">{label}</a>'
+        )
+        for label, href, key in links
     )
 
-    return selected_label
+    st.markdown(
+        f"""
+        <div class="jupr-public-shell">
+          <header class="jupr-public-nav">
+            <a class="jupr-public-brand" href="./">
+              <span>JUPR</span>
+              <small>Tres Palapas Rating System</small>
+            </a>
+            <nav class="jupr-public-nav-links" aria-label="Public navigation">
+              {nav_links_html}
+            </nav>
+          </header>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    return PAGE_KEY_TO_LABEL.get(current_page, PAGE_KEY_TO_LABEL[default_page])

--- a/jupr_app/ui/theme_clean.py
+++ b/jupr_app/ui/theme_clean.py
@@ -245,6 +245,114 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         outline-offset: 2px;
       }}
 
+      /* Public website shell */
+      .jupr-public-shell {{
+        width: 100%;
+      }}
+      .jupr-public-nav {{
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.9rem;
+        margin-bottom: 1.15rem;
+        padding: 0.85rem 1rem;
+        border-radius: var(--radius);
+        border: 1px solid var(--border);
+        background: color-mix(in srgb, var(--panel) 90%, transparent);
+        box-shadow: var(--shadow);
+        backdrop-filter: blur(8px);
+      }}
+      .jupr-public-brand {{
+        display: inline-flex;
+        flex-direction: column;
+        text-decoration: none;
+        color: var(--text-primary);
+        font-weight: 800;
+        letter-spacing: 0.02em;
+      }}
+      .jupr-public-brand small {{
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        font-weight: 600;
+      }}
+      .jupr-public-nav-links {{
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+      }}
+      .jupr-public-nav-link {{
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        padding: 0.34rem 0.76rem;
+        color: var(--text-secondary);
+        background: transparent;
+        text-decoration: none;
+        font-size: 0.84rem;
+        font-weight: 700;
+        transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+      }}
+      .jupr-public-nav-link:hover {{
+        border-color: var(--accent-border);
+        background: var(--accent-soft);
+        color: var(--text-primary);
+        transform: translateY(-1px);
+      }}
+      .jupr-public-nav-link.active {{
+        border-color: var(--accent-border);
+        background: var(--accent-soft);
+        color: var(--text-primary);
+      }}
+      .jupr-hero {{
+        margin-bottom: 1rem;
+        padding: 1.35rem;
+      }}
+      .jupr-hero-eyebrow {{
+        font-size: 0.8rem;
+        font-weight: 800;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--accent);
+        margin-bottom: 0.45rem;
+      }}
+      .jupr-hero-title {{
+        margin: 0 0 0.45rem 0;
+        font-size: clamp(1.5rem, 3vw, 2.3rem);
+        line-height: 1.15;
+      }}
+      .jupr-hero-subtitle {{
+        margin: 0;
+        max-width: 70ch;
+        color: var(--text-secondary);
+      }}
+      .jupr-hero-actions {{
+        margin-top: 1rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.55rem;
+      }}
+      .jupr-home-grid {{
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.8rem;
+      }}
+      .jupr-home-card {{
+        height: 100%;
+      }}
+      .jupr-home-card-title {{
+        margin: 0 0 0.35rem 0;
+        font-size: 1.02rem;
+        color: var(--text-primary);
+      }}
+      .jupr-home-card-body {{
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 0.95rem;
+      }}
+
       /* Cards + sections */
       .jupr-card {{
         border: 1px solid var(--border);
@@ -398,37 +506,6 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
       }}
       .stTabs [data-baseweb="tab-border"] {{
         display: none;
-      }}
-
-      /* Radio navigation (public top nav) */
-      div[data-testid="stRadio"] div[role="radiogroup"] {{
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.35rem;
-        align-items: center;
-      }}
-      div[data-testid="stRadio"] label[data-baseweb="radio"] {{
-        margin: 0 !important;
-        gap: 0 !important;
-        padding-left: 0 !important;
-      }}
-      div[data-testid="stRadio"] label[data-baseweb="radio"] > div {{
-        border-radius: 999px;
-        border: 1px solid var(--border);
-        padding: 0.35rem 0.85rem;
-        background: var(--panel);
-        color: var(--muted);
-        font-weight: 650;
-        transition: border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
-      }}
-      div[data-testid="stRadio"] div[role="radiogroup"] label > div:first-child {{
-        display: none !important;
-      }}
-      div[data-testid="stRadio"] label[data-baseweb="radio"] input:checked + div {{
-        border-color: var(--accent-border);
-        color: var(--text);
-        background: var(--accent-soft);
-        box-shadow: 0 0 0 1px var(--accent-soft);
       }}
 
       /* Expanders */
@@ -591,27 +668,47 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
 
       /* Public link button fallback */
       .jupr-link-button {{
-        text-decoration: none;
-      }}
-      .jupr-link-button__btn {{
-        padding: 0.5rem 1rem;
-        font-size: 1rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.35rem;
+        min-height: 2.2rem;
+        padding: 0.5rem 0.95rem;
         border-radius: 0.75rem;
-        cursor: pointer;
         border: 1px solid var(--border);
         background: var(--panel);
         color: var(--text);
+        text-decoration: none;
         font-weight: 650;
         box-shadow: 0 1px 1px rgba(0,0,0,0.04);
         transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
       }}
-      .jupr-link-button__btn:hover {{
+      .jupr-link-button:hover {{
         border-color: var(--border-strong);
         transform: translateY(-1px);
       }}
-      .jupr-link-button__btn:focus-visible {{
+      .jupr-link-button:focus-visible {{
         outline: 3px solid var(--focus);
         outline-offset: 2px;
+      }}
+      .jupr-link-button__btn {{
+        all: unset;
+        cursor: pointer;
+      }}
+
+      @media (max-width: 760px) {{
+        .jupr-public-nav {{
+          align-items: flex-start;
+        }}
+        .jupr-public-nav-links {{
+          width: 100%;
+        }}
+        .jupr-home-grid {{
+          grid-template-columns: 1fr;
+        }}
+        .jupr-hero {{
+          padding: 1rem;
+        }}
       }}
     </style>
     """

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -367,6 +367,7 @@ def main():
             challenge_ladder,
             challenge_ladder_admin,
             faqs,
+            home,
             jupr_live,
             jupr_live_admin,
             leaderboards,
@@ -396,6 +397,7 @@ def main():
 
         # ---- Router ----
         PAGES = {
+            "Home": home,
             "🏆 Leaderboards": leaderboards,
             "📊 League Results": league_results,
             "🖨️ League Night Printout": league_printout,
@@ -451,6 +453,8 @@ def main():
         deep_page_key = incoming_page_param
         if not deep_page_key and recovery_flow:
             deep_page_key = "reset_password"
+        elif PUBLIC_MODE and not deep_page_key:
+            deep_page_key = "home"
 
         deep_label = PAGE_KEY_TO_LABEL.get(deep_page_key, "")
 
@@ -534,22 +538,19 @@ def main():
         # Keep URL synced (canonical deep links)
         # -------------------------
         try:
-            target_page = LABEL_TO_PAGE_KEY.get(sel, "leaderboards")
+            target_page = LABEL_TO_PAGE_KEY.get(sel, "home")
             current_page = qp_get("page", "").strip()
-            last_rendered_nav = st.session_state.get("_last_rendered_nav")
-            nav_changed = sel != last_rendered_nav
-
-            if nav_changed and current_page != target_page:
-                st.query_params["page"] = target_page
 
             if PUBLIC_MODE:
-                if target_page == "leaderboards":
-                    _set_query_params_idempotent(removals={"admin", "page"})
+                if target_page == "home":
+                    _set_query_params_idempotent(removals={"admin", "public", "page"})
                 elif current_page != target_page:
                     _set_query_params_idempotent(
                         updates={"page": target_page},
-                        removals={"admin"},
+                        removals={"admin", "public"},
                     )
+                else:
+                    _set_query_params_idempotent(removals={"admin", "public"})
             else:
                 _set_query_params_idempotent(
                     updates={"admin": "1"},

--- a/tests/test_page_registry.py
+++ b/tests/test_page_registry.py
@@ -9,13 +9,13 @@ from jupr_app.ui.page_registry import (
 def test_jupr_live_is_registered_as_public_page():
     public_labels = labels_for_keys(PUBLIC_NAV_KEYS)
 
-    assert "jupr_live" in PUBLIC_NAV_KEYS
-    assert "jupr_live_admin" not in PUBLIC_NAV_KEYS
+    assert "jupr_live" in PAGE_KEY_TO_LABEL
+    assert "jupr_live_admin" in PAGE_KEY_TO_LABEL
     assert PAGE_KEY_TO_LABEL["jupr_live"] == "🔴 JUPR Live"
     assert PAGE_KEY_TO_LABEL["jupr_live_admin"] == "🔴 JUPR Live Admin"
     assert LABEL_TO_PAGE_KEY["🔴 JUPR Live"] == "jupr_live"
     assert LABEL_TO_PAGE_KEY["🔴 JUPR Live Admin"] == "jupr_live_admin"
-    assert "🔴 JUPR Live" in public_labels
+    assert "🔴 JUPR Live" not in public_labels
     assert "🔴 JUPR Live Admin" not in public_labels
     assert "jupr_live_social" not in PAGE_KEY_TO_LABEL
     assert "🟢 JUPR Live Social" not in LABEL_TO_PAGE_KEY
@@ -26,16 +26,11 @@ def test_existing_public_pages_remain_in_shared_public_nav():
     public_labels = labels_for_keys(PUBLIC_NAV_KEYS)
 
     assert public_labels == [
+        "Home",
         "🏆 Leaderboards",
-        "📊 League Results",
-        "🗞️ Weekly Recap",
         "📝 Tournament Registration",
-        "🤝 Partner Board",
-        "🎯 Match Explorer",
         "🔍 Player Search",
-        "📼 Badge Codex",
-        "🔴 JUPR Live",
-        "🪜 Challenge Ladder",
+        "🗞️ Weekly Recap",
         "❓ FAQs",
     ]
 

--- a/tests/test_public_nav_shell.py
+++ b/tests/test_public_nav_shell.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_public_nav_uses_html_anchors_instead_of_streamlit_radio():
+    contents = Path("jupr_app/ui/public_nav.py").read_text(encoding="utf-8")
+
+    assert "st.radio" not in contents
+    assert "jupr-public-nav" in contents
+    assert '"./"' in contents
+    assert '"?page=leaderboards"' in contents
+    assert '"?admin=1&page=admin_login"' in contents
+    assert 'default_page: str = "home"' in contents


### PR DESCRIPTION
### Motivation
- Make the public base URL render a polished JUPR homepage instead of landing directly on leaderboards. 
- Replace the Streamlit `st.radio()` public nav with an anchor-based website header so the public UI behaves like a traditional site. 
- Preserve existing deep links and admin-entry semantics while keeping the public surface safe (no admin pages exposed, no DB writes).

### Description
- Added a new public page module `jupr_app/ui/pages/home.py` exposing `render(ctx)` with hero text, CTAs linking to `?page=leaderboards`, `?page=players`, `?page=tournament_registration`, `?page=verified_updates_request`, and `?admin=1&page=admin_login`, and secondary feature cards using existing theme classes. 
- Updated `jupr_app/ui/page_registry.py` to register `home` as a public page and place it first in `PUBLIC_NAV_KEYS` so home becomes the public root. 
- Replaced the radio nav in `jupr_app/ui/public_nav.py` with a custom anchor-based shell that renders brand + nav links and returns the resolved label for the existing router; the Admin Login anchor intentionally targets `?admin=1&page=admin_login`. 
- Adjusted `streamlit_app.py` lazy imports and `PAGES` to include `home`, defaulted public requests with no `page` to `home`, and updated canonical query-param sync so `home` is the root (removes `page`, `admin`, `public`) while other public pages keep `?page=<key>`; deep-link behavior is preserved. 
- Added scoped CSS in `jupr_app/ui/theme_clean.py` for durable classes (`.jupr-public-shell`, `.jupr-public-nav`, `.jupr-hero`, `.jupr-home-grid`, `.jupr-home-card`, `.jupr-link-button`, etc.) with responsive and dark/light token support. 
- Tests: updated `tests/test_page_registry.py` expectations and added `tests/test_public_nav_shell.py` to assert anchors are used instead of `st.radio`.

### Testing
- Ran `pytest -q tests/test_page_registry.py tests/test_public_nav_shell.py` and the tests passed: `4 passed`. 
- Verified unit-test assertions for registry ordering, hidden/public labels, and that `jupr_app/ui/public_nav.py` no longer contains `st.radio` and contains the expected anchor targets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd6360fe883269d55daaaec5409fe)