### PR TITLE
Make homepage feature cards fully clickable

### DIFF
--- a/jupr_app/ui/pages/home.py
+++ b/jupr_app/ui/pages/home.py
@@ -24,22 +24,26 @@ def render(ctx) -> None:  # noqa: ARG001
           </div>
 
           <div class="jupr-home-grid">
-            <article class="jupr-home-card jupr-card jupr-card--hover">
+            <a class="jupr-home-card jupr-card jupr-card--hover jupr-home-card-link" href="?page=leaderboards" aria-label="View leaderboards">
               <h3 class="jupr-home-card-title">Ratings &amp; Standings</h3>
               <p class="jupr-home-card-body">Live player ratings, league results, match history, and verified event tracking.</p>
-            </article>
-            <article class="jupr-home-card jupr-card jupr-card--hover">
+              <div class="jupr-home-card-cta">View leaderboards →</div>
+            </a>
+            <a class="jupr-home-card jupr-card jupr-card--hover jupr-home-card-link" href="?page=players" aria-label="Find player profiles">
               <h3 class="jupr-home-card-title">Player Profiles</h3>
               <p class="jupr-home-card-body">Search players, view rating history, badges, trophies, and recent match results.</p>
-            </article>
-            <article class="jupr-home-card jupr-card jupr-card--hover">
+              <div class="jupr-home-card-cta">Find players →</div>
+            </a>
+            <a class="jupr-home-card jupr-card jupr-card--hover jupr-home-card-link" href="?page=tournament_registration" aria-label="View event registration and updates">
               <h3 class="jupr-home-card-title">Events &amp; Updates</h3>
               <p class="jupr-home-card-body">View public event registration, weekly recaps, partner boards, and player update subscriptions.</p>
-            </article>
-            <article class="jupr-home-card jupr-callout">
+              <div class="jupr-home-card-cta">See events →</div>
+            </a>
+            <a class="jupr-home-card jupr-card jupr-card--hover jupr-home-card-link" href="?page=faqs" aria-label="Read frequently asked questions">
               <h3 class="jupr-home-card-title">Built for Tres Palapas</h3>
               <p class="jupr-home-card-body">A public-facing rating and event hub for the Tres Palapas pickleball community.</p>
-            </article>
+              <div class="jupr-home-card-cta">Read FAQs →</div>
+            </a>
           </div>
         </section>
         """,

--- a/jupr_app/ui/theme_clean.py
+++ b/jupr_app/ui/theme_clean.py
@@ -352,6 +352,30 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         color: var(--text-secondary);
         font-size: 0.95rem;
       }}
+      .jupr-home-card-link {{
+        display: block;
+        color: inherit;
+        text-decoration: none;
+      }}
+      .jupr-home-card-link:hover {{
+        color: inherit;
+        text-decoration: none;
+      }}
+      .jupr-home-card-link:focus-visible {{
+        outline: 3px solid var(--focus);
+        outline-offset: 3px;
+      }}
+      .jupr-home-card-cta {{
+        margin-top: 0.75rem;
+        font-weight: 700;
+        color: var(--link);
+      }}
+      .jupr-home-card-link:hover .jupr-home-card-cta,
+      .jupr-home-card-link:focus-visible .jupr-home-card-cta {{
+        color: var(--link-hover);
+        text-decoration: underline;
+        text-underline-offset: 0.15em;
+      }}
 
       /* Cards + sections */
       .jupr-card {{


### PR DESCRIPTION
### Motivation
- The homepage feature tiles were visually interactive but implemented as non-link `<article>` elements, creating a confusing UX where only small CTA buttons were actionable.
- The goal is to make the entire card area navigate to the appropriate pages while preserving the existing visual design and accessibility.

### Description
- Replaced the four homepage card wrappers in `jupr_app/ui/pages/home.py` from `<article>` elements to anchor tags with `href` targets and `aria-label`s so each full card navigates to its destination (`?page=leaderboards`, `?page=players`, `?page=tournament_registration`, `?page=faqs`).
- Added subtle per-card CTA lines inside each linked card (e.g. `View leaderboards →`) to retain an action affordance while keeping existing titles and bodies.
- Added CSS in `jupr_app/ui/theme_clean.py` to support `.jupr-home-card-link`, including `display: block`, `color: inherit`, no underline, a visible `:focus-visible` outline for keyboard users, and `.jupr-home-card-cta` styling with hover/focus treatments that work in light and dark themes.
- Kept hero CTAs, admin routing, and routing logic unchanged to avoid exposing admin pages or altering navigation behavior.

### Testing
- Compiled the modified modules with `python -m compileall jupr_app/ui/pages/home.py jupr_app/ui/theme_clean.py` and the compilation succeeded.
- Verified the new templates and CSS were applied in the updated source files (`jupr_app/ui/pages/home.py` and `jupr_app/ui/theme_clean.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd88dea1883269c622cf5730a86a6)