### PR TITLE
Fix rating-integrity schema fallbacks, bulk-edit player activity, and persistent replay errors

### DIFF
--- a/jupr_app/domain/bulk_match_editor.py
+++ b/jupr_app/domain/bulk_match_editor.py
@@ -260,6 +260,13 @@ def apply_bulk_match_edits(
             "t2_p1": int(update.get("t2_p1", before.get("t2_p1"))),
             "t2_p2": int(update.get("t2_p2", before.get("t2_p2"))),
         }
+        for pid in candidate_players.values():
+            affected_players.add(int(pid))
+        match_type_after = str(update.get("match_type", before.get("match_type")) or "")
+        is_popup_after = bool(before.get("is_popup", False)) or (match_type_after == "PopUp")
+        if not is_popup_after:
+            for pid in candidate_players.values():
+                badge_eligible_players.add(int(pid))
         if len(set(candidate_players.values())) != 4:
             raise ValueError(f"Match {mid}: duplicate player detected in one rated doubles match.")
 

--- a/jupr_app/domain/match_processing.py
+++ b/jupr_app/domain/match_processing.py
@@ -65,6 +65,7 @@ def process_matches(
     skipped_empty = 0
     skipped_unrated = 0
     has_badge_eligible_match = False
+    supports_rating_scope_column: bool | None = None
 
     def as_pid(x):
         """Accept int IDs OR numeric strings OR exact names. Returns int player_id or None."""
@@ -336,6 +337,7 @@ def process_matches(
                 "context_id": m.get("context_id"),
                 "tournament_id": m.get("tournament_id"),
                 "tournament_game_id": m.get("tournament_game_id"),
+                "rating_scope": rating_scope,
             }
         )
         match_payloads.append({"league": league_name, "date": dt_val, "score_t1": s1, "score_t2": s2})
@@ -346,10 +348,35 @@ def process_matches(
     # -------------------------
     badge_summary: dict[str, Any] = {"mode": "skipped", "awarded_count": 0, "candidate_count": 0, "badge_ids": []}
     if db_matches:
+        def _insert_match_chunk(chunk: list[dict[str, Any]]):
+            nonlocal supports_rating_scope_column
+            if supports_rating_scope_column is False:
+                legacy_chunk = [{k: v for k, v in row.items() if k != "rating_scope"} for row in chunk]
+                return sb_retry(lambda legacy_chunk=legacy_chunk: supabase.table("matches").insert(legacy_chunk).execute())
+
+            try:
+                insert_result = sb_retry(lambda chunk=chunk: supabase.table("matches").insert(chunk).execute())
+            except Exception as exc:
+                exc_text = str(exc).lower()
+                if "rating_scope" in exc_text and "column" in exc_text:
+                    supports_rating_scope_column = False
+                    legacy_chunk = [{k: v for k, v in row.items() if k != "rating_scope"} for row in chunk]
+                    return sb_retry(lambda legacy_chunk=legacy_chunk: supabase.table("matches").insert(legacy_chunk).execute())
+                raise
+            error_obj = getattr(insert_result, "error", None) if insert_result is not None else None
+            error_text = str(error_obj or "").lower()
+            if ("rating_scope" in error_text and "column" in error_text) or "matches_rating_scope_check" in error_text:
+                supports_rating_scope_column = False
+                legacy_chunk = [{k: v for k, v in row.items() if k != "rating_scope"} for row in chunk]
+                return sb_retry(lambda legacy_chunk=legacy_chunk: supabase.table("matches").insert(legacy_chunk).execute())
+
+            supports_rating_scope_column = True
+            return insert_result
+
         CHUNK_M = 300
         for i in range(0, len(db_matches), CHUNK_M):
             chunk = db_matches[i : i + CHUNK_M]
-            insert_result = sb_retry(lambda chunk=chunk: supabase.table("matches").insert(chunk).execute())
+            insert_result = _insert_match_chunk(chunk)
             inserted_rows = getattr(insert_result, "data", None) if insert_result is not None else None
             if not inserted_rows:
                 error_obj = getattr(insert_result, "error", None) if insert_result is not None else None

--- a/jupr_app/domain/replay_history.py
+++ b/jupr_app/domain/replay_history.py
@@ -179,25 +179,37 @@ def replay_history(
     skipped_incomplete_scope = 0
     matches_scanned_total = 0
 
+    match_query_mode = "with_deleted_and_scope"
     offset = 0
     while True:
         start = offset
         end = offset + READ_PAGE_SIZE - 1
 
-        def _load_page_with_filters():
+        def _load_page_with_deleted_and_scope():
             return (
                 supabase.table("matches")
                 .select(match_cols)
                 .eq("club_id", club_id)
                 .is_("deleted_at", None)
-                .neq("rating_scope", "unrated")
                 .order("date", desc=False)
                 .order("id", desc=False)
                 .range(start, end)
                 .execute()
             )
 
-        def _load_page_fallback():
+        def _load_page_with_deleted_only():
+            return (
+                supabase.table("matches")
+                .select("id,date,league,match_type,t1_p1,t1_p2,t2_p1,t2_p2,score_t1,score_t2,deleted_at")
+                .eq("club_id", club_id)
+                .is_("deleted_at", None)
+                .order("date", desc=False)
+                .order("id", desc=False)
+                .range(start, end)
+                .execute()
+            )
+
+        def _load_page_legacy_fallback():
             return (
                 supabase.table("matches")
                 .select("id,date,league,match_type,t1_p1,t1_p2,t2_p1,t2_p2,score_t1,score_t2")
@@ -209,10 +221,22 @@ def replay_history(
             )
 
         try:
-            page_resp = _retry(_load_page_with_filters, label=f"select_matches_{start}_{end}")
+            if match_query_mode == "with_deleted_and_scope":
+                page_resp = _retry(_load_page_with_deleted_and_scope, label=f"select_matches_{start}_{end}")
+            elif match_query_mode == "with_deleted_only":
+                page_resp = _retry(_load_page_with_deleted_only, label=f"select_matches_deleted_only_{start}_{end}")
+            else:
+                page_resp = _retry(_load_page_legacy_fallback, label=f"select_matches_legacy_{start}_{end}")
         except Exception:
-            # Backward-compat fallback for deployments that have not yet applied the soft-delete/rating_scope columns.
-            page_resp = _retry(_load_page_fallback, label=f"select_matches_fallback_{start}_{end}")
+            # Backward-compat fallback for deployments with partial schema rollout.
+            if match_query_mode == "with_deleted_and_scope":
+                match_query_mode = "with_deleted_only"
+                page_resp = _retry(_load_page_with_deleted_only, label=f"select_matches_deleted_only_{start}_{end}")
+            elif match_query_mode == "with_deleted_only":
+                match_query_mode = "legacy"
+                page_resp = _retry(_load_page_legacy_fallback, label=f"select_matches_legacy_{start}_{end}")
+            else:
+                raise
 
         page = page_resp.data or []
         if not page:
@@ -223,7 +247,7 @@ def replay_history(
         for m in page:
             if m.get("deleted_at") is not None:
                 continue
-            if str(m.get("rating_scope", "") or "").strip().lower() == "unrated":
+            if "rating_scope" in m and str(m.get("rating_scope", "") or "").strip().lower() == "unrated":
                 continue
             lg = _norm_league(m.get("league", "") or "")
             in_scope = full_reset or (lg == target_league_norm)

--- a/jupr_app/ui/pages/match_log.py
+++ b/jupr_app/ui/pages/match_log.py
@@ -13,6 +13,16 @@ from jupr_app.ui.layout import page_shell
 from jupr_app.domain.replay_history import FULL_RESET_LABEL, replay_history
 from jupr_app.domain.match_delete import delete_rated_matches_with_replay
 
+BULK_REPLAY_ERROR_STATE_KEY = "match_log_bulk_replay_error"
+
+
+def _set_bulk_replay_error(message: str) -> None:
+    st.session_state[BULK_REPLAY_ERROR_STATE_KEY] = str(message)
+
+
+def _clear_bulk_replay_error() -> None:
+    st.session_state.pop(BULK_REPLAY_ERROR_STATE_KEY, None)
+
 
 
 def render(ctx):
@@ -27,6 +37,11 @@ def render(ctx):
     if df_matches is None or df_matches.empty:
         st.info("No matches loaded.")
         st.stop()
+    if st.session_state.get(BULK_REPLAY_ERROR_STATE_KEY):
+        st.warning(
+            "⚠️ Previous automatic Replay ALL failed after bulk edit. "
+            f"{st.session_state[BULK_REPLAY_ERROR_STATE_KEY]}"
+        )
 
     df = df_matches.copy()
     df["source_type"] = "rated"
@@ -682,14 +697,19 @@ def render(ctx):
                     replay_error = str(exc)
 
             if replay_error:
-                st.error(
+                _set_bulk_replay_error(
                     "Edits were saved, but Replay ALL failed. Ratings may be stale. "
                     "Run Admin Tools → Replay History → ALL immediately. "
                     f"Error: {replay_error}"
                 )
+                st.error(
+                    st.session_state[BULK_REPLAY_ERROR_STATE_KEY]
+                )
             elif result["recompute_scope"]["ratings"]:
+                _clear_bulk_replay_error()
                 st.success(f"Updated {result['updated_count']} match(es). Ratings were rebuilt automatically via Replay ALL.")
             else:
+                _clear_bulk_replay_error()
                 st.success(
                     f"Updated {result['updated_count']} match(es). "
                     f"Affected leagues: {', '.join(result.get('affected_leagues', [])) or '(unknown)'}"
@@ -706,7 +726,8 @@ def render(ctx):
             st.session_state["bulk_match_baseline"] = view.copy(deep=True)
             st.session_state["bulk_match_editor_version"] += 1
             st.session_state["force_data_refresh"] = True
-            st.rerun()
+            if replay_error is None:
+                st.rerun()
 
         except Exception as exc:
             st.error(f"Unable to apply bulk edits: {exc}")
@@ -733,6 +754,7 @@ def render(ctx):
                     target_reset=str(target_reset_quick),
                     progress_cb=lambda x: bar.progress(float(x)),
                 )
+            _clear_bulk_replay_error()
             st.success("Replay complete.")
             st.info(f"Skipped incomplete doubles rows: {result['skipped_incomplete']}")
             st.info(f"Matches rewritten: {result['matches_rewritten']}")

--- a/supabase/migrations/20260424_matches_soft_delete.sql
+++ b/supabase/migrations/20260424_matches_soft_delete.sql
@@ -4,6 +4,19 @@ alter table if exists public.matches
   add column if not exists deleted_by text,
   add column if not exists deleted_source text,
   add column if not exists delete_note text,
+  add column if not exists rating_scope text,
   add column if not exists updated_at timestamptz,
   add column if not exists updated_by text,
   add column if not exists correction_note text;
+
+alter table if exists public.matches
+  drop constraint if exists matches_rating_scope_check;
+
+alter table if exists public.matches
+  add constraint matches_rating_scope_check
+  check (
+    rating_scope is null
+    or rating_scope = ''
+    or rating_scope = 'overall_only'
+    or rating_scope = 'unrated'
+  );

--- a/tests/test_jupr_live_rating_scope.py
+++ b/tests/test_jupr_live_rating_scope.py
@@ -55,6 +55,7 @@ class _Supabase:
             "players": [],
             "league_ratings": [],
         }
+        self.fail_on_rating_scope_insert = False
 
     def table(self, name):
         return _Query(self, name)
@@ -71,6 +72,9 @@ class _Supabase:
             return SimpleNamespace(data=data)
         if q._op == "insert":
             payload = q._payload if isinstance(q._payload, list) else [q._payload]
+            if q.table == "matches" and self.fail_on_rating_scope_insert:
+                if any("rating_scope" in row for row in payload):
+                    raise RuntimeError("column \"rating_scope\" of relation \"matches\" does not exist")
             for row in payload:
                 rows.append(dict(row))
             return SimpleNamespace(data=payload)
@@ -267,3 +271,31 @@ def test_process_matches_without_rating_scope_keeps_legacy_league_updates(monkey
         df_meta=pd.DataFrame(),
     )
     assert len(sb.tables["league_ratings"]) == 4
+
+
+def test_process_matches_insert_falls_back_when_rating_scope_column_missing(monkeypatch):
+    _patch_side_effects(monkeypatch)
+    sb = _Supabase()
+    sb.fail_on_rating_scope_insert = True
+    sb.tables["players"] = _players_df().to_dict("records")
+    result = process_matches(
+        [{
+            "league": "JUPR Live",
+            "t1_p1": 1,
+            "t1_p2": 2,
+            "t2_p1": 3,
+            "t2_p2": 4,
+            "s1": 11,
+            "s2": 9,
+            "rating_scope": "overall_only",
+        }],
+        supabase=sb,
+        club_id="club",
+        name_to_id={},
+        df_players_all=_players_df(),
+        df_leagues=pd.DataFrame(),
+        df_meta=pd.DataFrame(),
+    )
+    assert result["inserted"] == 1
+    assert len(sb.tables["matches"]) == 1
+    assert "rating_scope" not in sb.tables["matches"][0]

--- a/tests/test_match_log_replay_error_state.py
+++ b/tests/test_match_log_replay_error_state.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from jupr_app.ui.pages import match_log
+
+
+def test_bulk_replay_error_state_persists_until_cleared(monkeypatch):
+    fake_st = SimpleNamespace(session_state={})
+    monkeypatch.setattr(match_log, "st", fake_st)
+
+    match_log._set_bulk_replay_error("Replay failed")
+    assert fake_st.session_state[match_log.BULK_REPLAY_ERROR_STATE_KEY] == "Replay failed"
+
+    match_log._clear_bulk_replay_error()
+    assert match_log.BULK_REPLAY_ERROR_STATE_KEY not in fake_st.session_state

--- a/tests/test_rating_integrity_clashes.py
+++ b/tests/test_rating_integrity_clashes.py
@@ -17,6 +17,7 @@ class _Query:
         self.table = table
         self._op = "select"
         self._payload = None
+        self._select_cols = None
         self._filters = []
         self._order = []
         self._range = None
@@ -24,6 +25,7 @@ class _Query:
 
     def select(self, _cols):
         self._op = "select"
+        self._select_cols = _cols
         return self
 
     def insert(self, payload, returning=None):
@@ -152,6 +154,20 @@ class _Supabase:
         return SimpleNamespace(data=[])
 
 
+class _StrictSchemaSupabase(_Supabase):
+    def __init__(self, missing_match_columns: set[str]):
+        super().__init__()
+        self.missing_match_columns = set(missing_match_columns)
+
+    def execute(self, q: _Query):
+        if q._op == "select" and q.table == "matches" and q._select_cols:
+            requested = {c.strip() for c in str(q._select_cols).split(",")}
+            missing = requested.intersection(self.missing_match_columns)
+            if missing:
+                raise RuntimeError(f"column does not exist: {sorted(missing)}")
+        return super().execute(q)
+
+
 def _seed_players():
     return [
         {"id": 1, "club_id": "club", "name": "A", "rating": 1200, "starting_rating": 1200, "wins": 0, "losses": 0, "matches_played": 0},
@@ -167,6 +183,42 @@ def test_replay_history_ignores_soft_deleted_matches():
     sb.tables["matches"] = [
         {"id": 1, "club_id": "club", "date": "2024-01-01T00:00:00Z", "league": "Main", "match_type": "League", "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 5, "deleted_at": None},
         {"id": 2, "club_id": "club", "date": "2024-01-02T00:00:00Z", "league": "Main", "match_type": "League", "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 0, "deleted_at": "2026-01-01T00:00:00Z"},
+    ]
+
+    result = replay_history(
+        supabase=sb,
+        club_id="club",
+        df_meta=pd.DataFrame(),
+        target_reset=FULL_RESET_LABEL,
+    )
+
+    assert result["matches_rewritten"] == 1
+
+
+def test_replay_history_missing_rating_scope_still_excludes_soft_deleted():
+    sb = _StrictSchemaSupabase(missing_match_columns={"rating_scope"})
+    sb.tables["players"] = _seed_players()
+    sb.tables["matches"] = [
+        {"id": 1, "club_id": "club", "date": "2024-01-01T00:00:00Z", "league": "Main", "match_type": "League", "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 5, "deleted_at": None},
+        {"id": 2, "club_id": "club", "date": "2024-01-02T00:00:00Z", "league": "Main", "match_type": "League", "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 0, "deleted_at": "2026-01-01T00:00:00Z"},
+    ]
+
+    result = replay_history(
+        supabase=sb,
+        club_id="club",
+        df_meta=pd.DataFrame(),
+        target_reset=FULL_RESET_LABEL,
+    )
+
+    assert result["matches_rewritten"] == 1
+
+
+def test_replay_history_includes_null_rating_scope_but_skips_unrated():
+    sb = _Supabase()
+    sb.tables["players"] = _seed_players()
+    sb.tables["matches"] = [
+        {"id": 1, "club_id": "club", "date": "2024-01-01T00:00:00Z", "league": "Main", "match_type": "League", "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 5, "deleted_at": None, "rating_scope": None},
+        {"id": 2, "club_id": "club", "date": "2024-01-02T00:00:00Z", "league": "Main", "match_type": "League", "t1_p1": 1, "t1_p2": 2, "t2_p1": 3, "t2_p2": 4, "score_t1": 11, "score_t2": 7, "deleted_at": None, "rating_scope": "unrated"},
     ]
 
     result = replay_history(
@@ -241,6 +293,43 @@ def test_bulk_editor_validates_duplicate_players_and_negative_scores(monkeypatch
 
     with pytest.raises(ValueError, match="not in this club"):
         apply_bulk_match_edits(sb, "club", [{"id": 1, "t2_p2": 999}], actor="admin")
+
+
+def test_bulk_editor_recomputes_last_game_for_removed_and_added_players(monkeypatch):
+    sb = _Supabase()
+    sb.tables["players"] = _seed_players() + [
+        {"id": 5, "club_id": "club", "name": "E", "rating": 1200, "starting_rating": 1200, "wins": 0, "losses": 0, "matches_played": 0},
+    ]
+    sb.tables["matches"] = [
+        {
+            "id": 1,
+            "club_id": "club",
+            "league": "Main",
+            "date": "2024-01-01T00:00:00Z",
+            "week_tag": "Week 1",
+            "match_type": "League",
+            "t1_p1": 1,
+            "t1_p2": 2,
+            "t2_p1": 3,
+            "t2_p2": 4,
+            "score_t1": 11,
+            "score_t2": 7,
+        }
+    ]
+    seen = {}
+
+    monkeypatch.setattr("jupr_app.domain.bulk_match_editor.enqueue_badge_eval", lambda *a, **k: {"queued": False})
+    monkeypatch.setattr("jupr_app.domain.bulk_match_editor.run_live_badge_awards", lambda *a, **k: {"mode": "inline"})
+
+    def _capture_recompute(**kwargs):
+        seen["player_ids"] = set(kwargs["player_ids"])
+
+    monkeypatch.setattr("jupr_app.domain.player_activity.recompute_last_game_at_for_players", _capture_recompute)
+
+    result = apply_bulk_match_edits(sb, "club", [{"id": 1, "t1_p1": 5}], actor="admin")
+
+    assert result["updated_count"] == 1
+    assert seen["player_ids"] == {1, 2, 3, 4, 5}
 
 
 class _LoadSpyQuery(_Query):


### PR DESCRIPTION
### Motivation

- Ensure Replay History never includes soft-deleted matches even on deployments where `rating_scope` hasn't been added yet. 
- Preserve counting of older rated matches that have `rating_scope = NULL` while still excluding legacy `rating_scope = 'unrated'` rows. 
- Make match insertion tolerant to mixed-schema deployments so new `rating_scope` writes do not break older DBs. 
- Ensure bulk player corrections update activity for both removed and newly added players and keep replay failures visible to admins.

### Description

- Hardened match loading in `jupr_app/domain/replay_history.py` to use progressive query modes (with `deleted_at`+`rating_scope`, then `deleted_at` only, then legacy) and moved the `unrated` exclusion to a Python-only check that only runs when the `rating_scope` key is present. 
- Updated migration `supabase/migrations/20260424_matches_soft_delete.sql` to add `rating_scope text` if missing and to add a permissive check constraint allowing `NULL`, `''`, `'overall_only'`, and `'unrated'` without introducing a default. 
- Changed `jupr_app/domain/match_processing.py` to include `rating_scope` when inserting matches and added a safe insert fallback that retries the insert without the `rating_scope` column if the target schema rejects it. 
- Adjusted `jupr_app/domain/bulk_match_editor.py` to add both before- and after-player IDs into `affected_players` (and into badge-eligible players when appropriate) so `last_game_at` is recomputed for removed and added players. 
- Updated `jupr_app/ui/pages/match_log.py` to persist automatic Replay ALL failures in `st.session_state` via helpers (`_set_bulk_replay_error`/`_clear_bulk_replay_error`), show a persistent admin warning, and avoid immediately wiping the error by calling `st.rerun()` only when replay succeeded. 
- Added and updated tests covering missing `rating_scope` column handling, `NULL` vs `'unrated'` behavior, insert fallback when `rating_scope` is missing, bulk edit player activity recompute for removed/added players, and persistent replay-error session-state helper (`tests/test_rating_integrity_clashes.py`, `tests/test_jupr_live_rating_scope.py`, `tests/test_match_log_replay_error_state.py`).

### Testing

- Ran `pytest -q tests/test_rating_integrity_clashes.py tests/test_jupr_live_rating_scope.py tests/test_match_log_replay_error_state.py` and all tests passed (16 passed). 
- New/updated unit tests exercise: missing `rating_scope` with `deleted_at` present, `rating_scope = NULL` inclusion, `rating_scope = 'unrated'` exclusion, `process_matches` insert fallback when `rating_scope` missing, bulk editor recompute for removed and added players, and persistent replay error state. 
- No UI/browser screenshots were taken; changes to `match_log` error visibility are covered by unit tests for the session-state helpers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec03b922a083269e5b408ff3dc29c9)