### PR TITLE
Use exact match-date digest windows, include all digest matches in emails, and add pending-outbox removal

### DIFF
--- a/jupr_app/domain/notifications/player_profile_update_repo.py
+++ b/jupr_app/domain/notifications/player_profile_update_repo.py
@@ -72,6 +72,10 @@ def _week_window_for_day(day: date) -> tuple[date, date]:
     return week_start, week_end
 
 
+def _digest_window_for_match_day(day: date) -> tuple[date, date]:
+    return day, day
+
+
 def normalize_email(email: str) -> str:
     return str(email or "").strip().lower()
 
@@ -506,16 +510,16 @@ def queue_player_updates_for_affected_subscribers(
     if not unique_player_ids:
         return summary
 
-    week_windows: set[tuple[date, date]] = set()
+    digest_windows: set[tuple[date, date]] = set()
     for raw_date in match_dates or []:
         parsed = _coerce_date(raw_date)
         if parsed is None:
             continue
-        week_windows.add(_week_window_for_day(parsed))
-    if not week_windows:
-        week_windows.add(_week_window_for_day(datetime.now(timezone.utc).date()))
+        digest_windows.add(_digest_window_for_match_day(parsed))
+    if not digest_windows:
+        digest_windows.add(_digest_window_for_match_day(datetime.now(timezone.utc).date()))
 
-    summary["week_windows"] = len(week_windows)
+    summary["week_windows"] = len(digest_windows)
 
     active_subs = list_active_subscriptions(supabase, club_id, limit=max(500, len(unique_player_ids) * 5))
     active_by_player: dict[int, dict[str, Any]] = {}
@@ -538,9 +542,9 @@ def queue_player_updates_for_affected_subscribers(
         subscription_id = str(subscription.get("id") or "").strip()
         email = str(subscription.get("email") or "").strip()
         if not subscription_id or not email:
-            summary["failed"] += len(week_windows)
+            summary["failed"] += len(digest_windows)
             continue
-        for week_start, week_end in sorted(week_windows):
+        for week_start, week_end in sorted(digest_windows):
             try:
                 create_outbox_row(
                     supabase,
@@ -558,6 +562,27 @@ def queue_player_updates_for_affected_subscribers(
                     continue
                 summary["failed"] += 1
     return summary
+
+
+def delete_pending_outbox_row(
+    supabase,
+    club_id: str,
+    outbox_id: str,
+) -> dict[str, Any]:
+    club_id = _require_nonempty(club_id, "club_id")
+    outbox_id = _require_nonempty(outbox_id, "outbox_id")
+
+    deleted = _safe_data(
+        supabase.table("player_profile_update_outbox")
+        .delete()
+        .eq("club_id", club_id)
+        .eq("id", outbox_id)
+        .eq("send_status", SEND_STATUS_PENDING)
+        .execute()
+    )
+    if not deleted:
+        raise ValueError("Only pending queued digests can be deleted.")
+    return deleted[0]
 
 
 def list_outbox_rows(

--- a/jupr_app/domain/notifications/player_update_email_template.py
+++ b/jupr_app/domain/notifications/player_update_email_template.py
@@ -89,8 +89,8 @@ def build_player_update_email_html(digest_json: dict, chart_cid: str | None) -> 
             + "</td></tr>"
         )
     match_items = "".join(
-        f"<tr><td style='padding:5px 0;font-size:13px;line-height:1.35;'>{html.escape(_s(item.get('summary')))}</td></tr>"
-        for item in matches[:5]
+        f"<tr><td style='padding:2px 0;font-size:13px;line-height:1.25;'>{html.escape(_s(item.get('summary')))}</td></tr>"
+        for item in matches
         if _s(item.get("summary"))
     )
     recent_matches_block = (
@@ -184,7 +184,7 @@ def build_player_update_email_text(digest_json: dict) -> str:
         f"- {_s(item.get('tournament_name')) or _s(item.get('league_name')) or 'Trophy'}"
         for item in trophies[:3]
     ]
-    match_lines = [f"- {_s(item.get('summary'))}" for item in matches[:5] if _s(item.get("summary"))]
+    match_lines = [f"- {_s(item.get('summary'))}" for item in matches if _s(item.get("summary"))]
 
     return "\n".join(
         [

--- a/jupr_app/domain/recaps/player_weekly_digest.py
+++ b/jupr_app/domain/recaps/player_weekly_digest.py
@@ -501,9 +501,17 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
     start_date, end_date = normalize_date_range(start_date, end_date)
     supabase = getattr(ctx, "supabase", None)
     club_id = str(getattr(ctx, "club_id", "") or "")
+    start_dt_utc, end_dt_utc = get_date_range_bounds(start_date, end_date, tz_name)
 
     overall_series = build_player_overall_rating_series(supabase, club_id, int(player_id), limit=1200)
     window_series = filter_rating_series_for_window(overall_series, start_date, end_date, tz_name=tz_name).copy()
+    if not window_series.empty:
+        window_series["Date"] = pd.to_datetime(window_series.get("Date"), utc=True, errors="coerce")
+        window_series = window_series[
+            window_series["Date"].notna()
+            & (window_series["Date"] >= pd.Timestamp(start_dt_utc))
+            & (window_series["Date"] <= pd.Timestamp(end_dt_utc))
+        ].copy()
     if not window_series.empty:
         window_series["player_id"] = int(player_id)
 
@@ -552,7 +560,6 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
         "record": f"{wins}-{losses}",
     }
 
-    start_dt_utc, end_dt_utc = get_date_range_bounds(start_date, end_date, tz_name)
     points = []
     if before is not None and not window_series.empty:
         points.append(
@@ -609,6 +616,7 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
     )
     notable_results = _build_notable_results(window_series)
     matches_played_rows: list[dict] = []
+    single_day_window = start_date == end_date
     for _, row in window_series.sort_values(["Date", "id"], ascending=[False, False]).iterrows():
         player_on_t1 = _is_player_on_t1(row, int(player_id))
         if player_on_t1 is None:
@@ -628,9 +636,11 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
         date_text = _format_display_date(played_at) if pd.notna(played_at) else "Unknown date"
         partners = " / ".join(_player_name(ctx, int(pid)) for pid in partner_ids) if partner_ids else "No partner listed"
         opponents = " / ".join(_player_name(ctx, int(pid)) for pid in opponent_ids) if opponent_ids else "Unknown opponents"
-        summary_line = f"{date_text} — with {partners} vs {opponents} — {result_short}"
-        if score:
-            summary_line = f"{summary_line} {score}"
+        result_score = f"{result_short} {score}" if score else f"{result_short}"
+        if single_day_window:
+            summary_line = f"{result_score} — with {partners} vs {opponents}"
+        else:
+            summary_line = f"{result_score} — {date_text} — with {partners} vs {opponents}"
         matches_played_rows.append(
             {
                 "date": played_at.isoformat() if pd.notna(played_at) else None,
@@ -639,6 +649,7 @@ def compute_player_weekly_digest(ctx, player_id: int, start_date: date, end_date
                 "opponents": opponents,
                 "result": result_short,
                 "score": score,
+                "result_score": result_score,
                 "summary": summary_line,
             }
         )

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -7,6 +7,7 @@ import streamlit as st
 
 from jupr_app.domain.notifications.player_profile_update_repo import (
     approve_request,
+    delete_pending_outbox_row,
     list_active_subscriptions,
     list_digests_for_range,
     list_outbox_rows,
@@ -170,7 +171,7 @@ def render(ctx) -> None:
         [
             "Pending Requests",
             "Active Profiles",
-            "Weekly Digests",
+            "Player Digests",
             "Send Queue",
         ]
     )
@@ -317,23 +318,23 @@ def render(ctx) -> None:
                         st.error(f"Unsubscribe failed: {_friendly_error(exc)}")
 
     with digests_tab:
-        st.subheader("Weekly Digests")
+        st.subheader("Player Digests")
         today = date.today()
         start_date = st.date_input(
-            "Start Date",
+            "Digest Start Date",
             value=today - timedelta(days=7),
             key="player_updates_digest_start",
             help="Custom date windows are supported (not Monday–Sunday only).",
         )
         end_date = st.date_input(
-            "End Date",
+            "Digest End Date",
             value=today,
             key="player_updates_digest_end",
-            help="Must be on or after Start Date.",
+            help="Must be on or after Digest Start Date.",
         )
 
         if end_date < start_date:
-            st.error("End Date must be on or after Start Date.")
+            st.error("Digest End Date must be on or after Digest Start Date.")
             return
 
         active_rows = list_active_subscriptions(supabase, club_id, limit=500)
@@ -432,7 +433,7 @@ def render(ctx) -> None:
 
     with queue_tab:
         st.subheader("Send Queue")
-        st.caption("Digests generated on Weekly Digests are queued automatically. Just hit send here.")
+        st.caption("Digests generated on Player Digests are queued automatically. Just hit send here.")
 
         try:
             outbox_rows = list_outbox_rows(supabase, club_id, limit=1000)
@@ -486,6 +487,30 @@ def render(ctx) -> None:
         st.markdown("#### Pending to send")
         if pending_rows:
             st.dataframe(pd.DataFrame(_outbox_display_rows(ctx, pending_rows)), use_container_width=True, hide_index=True)
+            st.markdown("#### Remove pending queued digest")
+            st.caption("Only pending rows can be removed. This does not delete sent history.")
+            for row in pending_rows:
+                outbox_id = str(row.get("id") or "").strip()
+                player_name = _player_name(ctx, row.get("player_id")) or f"Player #{row.get('player_id')}"
+                with st.expander(
+                    f"{player_name} · {row.get('email') or 'no email'} · "
+                    f"{row.get('week_start')} → {row.get('week_end')} · {row.get('created_at') or 'n/a'}"
+                ):
+                    with st.form(f"delete_pending_outbox_{outbox_id}"):
+                        confirm_delete = st.checkbox(
+                            "I understand this will remove this pending digest from the send queue.",
+                            key=f"confirm_delete_outbox_{outbox_id}",
+                        )
+                        delete_clicked = st.form_submit_button("Delete queued digest")
+                    if delete_clicked:
+                        try:
+                            if not confirm_delete:
+                                raise ValueError("Please confirm removal before deleting.")
+                            delete_pending_outbox_row(supabase, club_id=club_id, outbox_id=outbox_id)
+                            st.success("Queued digest removed.")
+                            st.rerun()
+                        except Exception as exc:
+                            st.error(f"Delete failed: {_friendly_error(exc)}")
         else:
             st.caption("No pending emails right now.")
 

--- a/tests/test_player_update_queueing.py
+++ b/tests/test_player_update_queueing.py
@@ -8,6 +8,7 @@ import pandas as pd
 from jupr_app.domain.match_processing import process_matches
 from jupr_app.domain.notifications.player_profile_update_repo import (
     REQUEST_STATUS_ACTIVE,
+    delete_pending_outbox_row,
     queue_player_updates_for_affected_subscribers,
 )
 
@@ -35,6 +36,10 @@ class _Query:
     def update(self, payload):
         self._op = "update"
         self._payload = payload
+        return self
+
+    def delete(self):
+        self._op = "delete"
         return self
 
     def eq(self, col, val):
@@ -125,6 +130,13 @@ class _Supabase:
                 row.update(q._payload)
             return SimpleNamespace(data=data)
 
+        if q._op == "delete":
+            deleted = [dict(row) for row in data]
+            for row in data:
+                if row in rows:
+                    rows.remove(row)
+            return SimpleNamespace(data=deleted)
+
         return SimpleNamespace(data=[])
 
 
@@ -139,7 +151,7 @@ def _players_df():
     )
 
 
-def test_queue_helper_queues_per_subscribed_player_per_week_window():
+def test_queue_helper_queues_per_subscribed_player_per_digest_date_window():
     sb = _Supabase()
     sb.tables["player_profile_update_subscriptions"] = [
         {"id": "sub-1", "club_id": "club", "player_id": 1, "email": "a@example.com", "request_status": REQUEST_STATUS_ACTIVE},
@@ -155,12 +167,18 @@ def test_queue_helper_queues_per_subscribed_player_per_week_window():
 
     assert summary["affected_players"] == 3
     assert summary["active_subscriptions"] == 2
-    assert summary["week_windows"] == 2
-    assert summary["queued"] == 4
+    assert summary["week_windows"] == 3
+    assert summary["queued"] == 6
     assert summary["already_queued"] == 0
     assert summary["no_active_subscription"] == 1
     assert summary["failed"] == 0
-    assert len(sb.tables["player_profile_update_outbox"]) == 4
+    assert len(sb.tables["player_profile_update_outbox"]) == 6
+    windows = {(row["week_start"], row["week_end"]) for row in sb.tables["player_profile_update_outbox"]}
+    assert windows == {
+        ("2026-02-10", "2026-02-10"),
+        ("2026-02-11", "2026-02-11"),
+        ("2026-02-17", "2026-02-17"),
+    }
 
 
 def test_queue_helper_counts_duplicate_outbox_rows_as_already_queued():
@@ -174,8 +192,8 @@ def test_queue_helper_counts_duplicate_outbox_rows_as_already_queued():
             "subscription_id": "sub-1",
             "club_id": "club",
             "player_id": 1,
-            "week_start": "2026-02-09",
-            "week_end": "2026-02-15",
+            "week_start": "2026-02-10",
+            "week_end": "2026-02-10",
             "email": "a@example.com",
             "send_status": "pending",
         }
@@ -260,3 +278,42 @@ def test_process_matches_skips_queue_when_no_matches_inserted(monkeypatch):
     assert result["inserted"] == 0
     assert calls["count"] == 0
     assert result["player_update_queue"]["mode"] == "skipped"
+
+
+def test_queue_helper_queues_multiple_distinct_match_dates():
+    sb = _Supabase()
+    sb.tables["player_profile_update_subscriptions"] = [
+        {"id": "sub-1", "club_id": "club", "player_id": 1, "email": "a@example.com", "request_status": REQUEST_STATUS_ACTIVE},
+    ]
+
+    summary = queue_player_updates_for_affected_subscribers(
+        sb,
+        club_id="club",
+        affected_player_ids=[1],
+        match_dates=[date(2026, 4, 24), date(2026, 4, 25)],
+    )
+
+    assert summary["queued"] == 2
+    windows = {(row["week_start"], row["week_end"]) for row in sb.tables["player_profile_update_outbox"]}
+    assert windows == {
+        ("2026-04-24", "2026-04-24"),
+        ("2026-04-25", "2026-04-25"),
+    }
+
+
+def test_delete_pending_outbox_row_allows_pending_and_blocks_sent():
+    sb = _Supabase()
+    sb.tables["player_profile_update_outbox"] = [
+        {"id": "o1", "club_id": "club", "send_status": "pending"},
+        {"id": "o2", "club_id": "club", "send_status": "sent"},
+    ]
+
+    deleted = delete_pending_outbox_row(sb, "club", "o1")
+    assert deleted["id"] == "o1"
+    assert [row["id"] for row in sb.tables["player_profile_update_outbox"]] == ["o2"]
+
+    try:
+        delete_pending_outbox_row(sb, "club", "o2")
+        assert False, "Expected sent rows to be protected"
+    except ValueError as exc:
+        assert "Only pending queued digests can be deleted." in str(exc)

--- a/tests/test_verified_player_update_pipeline.py
+++ b/tests/test_verified_player_update_pipeline.py
@@ -5,7 +5,10 @@ from datetime import date, datetime, timezone
 import pandas as pd
 
 from jupr_app.domain.notifications.player_update_charts import render_player_digest_chart_png
-from jupr_app.domain.notifications.player_update_email_template import build_player_update_email_html
+from jupr_app.domain.notifications.player_update_email_template import (
+    build_player_update_email_html,
+    build_player_update_email_text,
+)
 from jupr_app.domain.recaps import player_weekly_digest as digest_mod
 
 
@@ -149,8 +152,39 @@ def test_digest_has_chart_points_and_match_rows_when_window_active(monkeypatch):
 
     assert digest["chart"]["points"], "Expected chart points for active span"
     assert digest["chart"]["points"][0]["result"] == "ANCHOR"
+    assert len([p for p in digest["chart"]["points"] if not p.get("is_anchor")]) == 2
     assert digest["matches_played_rows"], "Expected matches list rows"
-    assert digest["matches_played_rows"][0]["summary"].startswith("April")
+    assert digest["matches_played_rows"][0]["summary"].startswith("L 9-11 — April 3rd — with Joel vs Keith / Natasha")
+
+
+def test_digest_summary_formats_multi_day_with_result_score_first(monkeypatch):
+    base_df = pd.DataFrame(
+        [
+            {
+                "id": 11,
+                "Date": pd.Timestamp("2026-04-24T16:00:00Z"),
+                "League": "L1",
+                "Score": "10-12",
+                "Result": "LOSS",
+                "Overall Δ": -0.01,
+                "Overall After": 3.19,
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+                "score_t1": 10,
+                "score_t2": 12,
+            },
+        ]
+    )
+
+    monkeypatch.setattr(digest_mod, "build_player_overall_rating_series", lambda *_args, **_kwargs: base_df)
+    monkeypatch.setattr(digest_mod, "filter_rating_series_for_window", lambda *_args, **_kwargs: base_df)
+    monkeypatch.setattr(digest_mod, "_load_badges_earned", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(digest_mod, "_load_trophies_earned", lambda *_args, **_kwargs: [])
+
+    digest = digest_mod.compute_player_weekly_digest(_Ctx(), 1, date(2026, 4, 20), date(2026, 4, 25))
+    assert digest["matches_played_rows"][0]["summary"] == "L 10-12 — April 24th — with Joel vs Keith / Natasha"
 
 
 def test_chart_renderer_accepts_date_points_without_match_numbers():
@@ -173,7 +207,7 @@ def test_email_html_renders_matches_and_quiet_empty_trophies():
         "display_range": "March 15th – April 22nd",
         "summary": {"overall_jupr_after": 3.2, "overall_delta": 0.02, "record": "2-1", "matches_played": 3},
         "chart": {"points": [{"date": "2026-04-22T00:00:00+00:00", "overall_after": 3.2}]},
-        "badges_grouped": [{"name": "Blowout Artist", "count": 3, "description": "Win by a big margin."}],
+        "badges_grouped": [{"name": "Blowout Artist", "count": 3, "description": "Win by a big margin.", "prestige": 50}],
         "matches_played_rows": [
             {"summary": "April 3rd — with Joel vs Keith / Natasha — W 15-11"},
         ],
@@ -184,6 +218,23 @@ def test_email_html_renders_matches_and_quiet_empty_trophies():
 
     html = build_player_update_email_html(digest, chart_cid="chart-1")
     assert "Chart unavailable for this date range" not in html
-    assert "Matches Played" in html
+    assert "Matches" in html
     assert "Blowout Artist x3" in html
     assert "None this period" not in html
+
+
+def test_email_templates_render_all_recent_matches_without_cap():
+    digest = {
+        "player_name": "Ada",
+        "display_range": "April 24th – April 24th",
+        "summary": {"overall_jupr_after": 3.2, "overall_delta": 0.02, "record": "6-0", "matches_played": 6},
+        "chart": {"points": [{"date": "2026-04-24T00:00:00+00:00", "overall_after": 3.2}]},
+        "matches_played_rows": [{"summary": f"W 11-{i} — with Joel vs Keith / Natasha"} for i in range(1, 7)],
+        "links": {"player_profile": "https://example.com/p", "unsubscribe": "https://example.com/u"},
+    }
+
+    html = build_player_update_email_html(digest, chart_cid="chart-1")
+    text = build_player_update_email_text(digest)
+
+    assert html.count("with Joel vs Keith / Natasha") == 6
+    assert text.count("with Joel vs Keith / Natasha") == 6


### PR DESCRIPTION
### Motivation
- Auto-queued player digests generated during match entry should represent only the exact match dates entered rather than expanding to a full Monday–Sunday week.
- Digest chart and recent-match lists must reflect only matches inside the digest window and be easy to skim; admins need a safe way to remove a queued (pending) digest before it is sent.

### Description
- Change automatic queueing in `queue_player_updates_for_affected_subscribers()` to group by exact match date using a new helper `_digest_window_for_match_day(day)` so queued outbox rows use `week_start == week_end == match_date` instead of `_week_window_for_day()` week windows, preserving DB column names. (`jupr_app/domain/notifications/player_profile_update_repo.py`)
- Add `delete_pending_outbox_row(supabase, club_id, outbox_id)` which only deletes outbox rows with `send_status == "pending"` and raises a friendly error otherwise. (`jupr_app/domain/notifications/player_profile_update_repo.py`) 
- Constrain chart and match data to the selected digest window inside `compute_player_weekly_digest()` so chart points and matches come only from the digest date range, and add `result_score` plus new summary formatting that places result/score first for single-day and multi-day windows. (`jupr_app/domain/recaps/player_weekly_digest.py`)
- Remove the `[:5]` cap for recent matches in both HTML and plain-text templates and tighten HTML line spacing so the email shows every match in the digest. (`jupr_app/domain/notifications/player_update_email_template.py`)
- Update Player Updates Admin UI labels from “Weekly Digests” to “Player Digests” and rename date inputs to “Digest Start Date” / “Digest End Date”, and add a per-row pending-queue removal UI (confirmation checkbox + form) wired to `delete_pending_outbox_row()` with `st.rerun()` after success. (`jupr_app/ui/pages/player_updates_admin.py`)
- Update and add unit tests to cover exact-date queueing, multiple match dates, uncapped recent matches in emails, summary formatting, and pending-vs-sent outbox deletion. (`tests/test_player_update_queueing.py`, `tests/test_verified_player_update_pipeline.py`)

### Testing
- Ran `pytest -q tests/test_player_update_queueing.py tests/test_verified_player_update_pipeline.py` and all tests passed (14 passed, 0 failed).
- Existing duplicate-outbox protection, send flow, and subscription behaviors were preserved as the implementation reuses the existing outbox schema and validation logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec06b2c7fc8326a2f8e79a37586d0c)