### PR TITLE
Add Recent/All match scope toggle to player profile with lazy full-load

### DIFF
--- a/jupr_app/domain/player_rating_series.py
+++ b/jupr_app/domain/player_rating_series.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, time, timezone
+from typing import Optional
 from zoneinfo import ZoneInfo
 
 import pandas as pd
@@ -88,7 +89,7 @@ def _signed_delta_from_elo_delta(r: dict, player_id: int) -> float | None:
     return abs(float(raw)) if winner_team == my_team else -abs(float(raw))
 
 
-def _load_player_matches(supabase, club_id: str, player_id: int, limit: int = 600) -> pd.DataFrame:
+def _load_player_matches(supabase, club_id: str, player_id: int, limit: Optional[int] = 600) -> pd.DataFrame:
     base_select = (
         "id,date,league,match_type,score_t1,score_t2,"
         "t1_p1,t1_p2,t2_p1,t2_p2,"
@@ -101,17 +102,32 @@ def _load_player_matches(supabase, club_id: str, player_id: int, limit: int = 60
     )
 
     def _run(cols: str) -> pd.DataFrame:
-        resp = (
+        base_query = (
             supabase.table("matches")
             .select(cols)
             .eq("club_id", str(club_id))
             .or_(f"t1_p1.eq.{player_id},t1_p2.eq.{player_id},t2_p1.eq.{player_id},t2_p2.eq.{player_id}")
             .order("date", desc=True)
             .order("id", desc=True)
-            .limit(int(limit))
-            .execute()
         )
-        return pd.DataFrame(resp.data or [])
+        if limit is not None:
+            resp = base_query.limit(int(limit)).execute()
+            return pd.DataFrame(resp.data or [])
+
+        # Supabase can enforce per-query row limits; fetch all rows in pages.
+        all_rows: list[dict] = []
+        page_size = 1000
+        offset = 0
+        while True:
+            resp = base_query.range(offset, offset + page_size - 1).execute()
+            batch = resp.data or []
+            if not batch:
+                break
+            all_rows.extend(batch)
+            if len(batch) < page_size:
+                break
+            offset += page_size
+        return pd.DataFrame(all_rows)
 
     try:
         return _run(snap_select)
@@ -119,7 +135,7 @@ def _load_player_matches(supabase, club_id: str, player_id: int, limit: int = 60
         return _run(base_select)
 
 
-def build_player_overall_rating_series(supabase, club_id: str, player_id: int, limit: int = 600) -> pd.DataFrame:
+def build_player_overall_rating_series(supabase, club_id: str, player_id: int, limit: Optional[int] = 600) -> pd.DataFrame:
     matches = _load_player_matches(supabase, club_id, int(player_id), limit=limit)
     if matches.empty:
         return pd.DataFrame(columns=["id", "Date", "League", "Score", "Result", "Overall Δ", "Overall After"])

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -120,6 +120,24 @@ def fetch_player_matches(_supabase, club_id: str, pid: int, limit: int = 600) ->
         return _hash_safe_cached_df(_run(base_select))
 
 
+@st.cache_data(ttl=120)
+def fetch_player_match_count(_supabase, club_id: str, pid: int, league_name: str | None = None) -> int:
+    try:
+        query = (
+            _supabase.table("matches")
+            .select("id", count="exact", head=True)
+            .eq("club_id", str(club_id))
+            .or_(f"t1_p1.eq.{pid},t1_p2.eq.{pid},t2_p1.eq.{pid},t2_p2.eq.{pid}")
+        )
+        if league_name:
+            query = query.eq("league", str(league_name).strip())
+        resp = query.execute()
+        return int(getattr(resp, "count", 0) or 0)
+    except Exception:
+        logger.exception("Failed to fetch player match count")
+        return 0
+
+
 @st.cache_data(ttl=60)
 def fetch_player_badges(_supabase, club_id: str, pid: int) -> pd.DataFrame:
     try:
@@ -2048,7 +2066,14 @@ def render(ctx):
 
         st.divider()
 
-        df = build_player_overall_rating_series(_supabase, club_id, pid, limit=600)
+        df = build_player_overall_rating_series(_supabase, club_id, pid, limit=60)
+        df_all: pd.DataFrame | None = None
+
+        def get_all_matches_df() -> pd.DataFrame:
+            nonlocal df_all
+            if df_all is None:
+                df_all = build_player_overall_rating_series(_supabase, club_id, pid, limit=None)
+            return df_all.copy()
 
         if df.empty:
             st.info("No matches recorded for this player.")
@@ -2113,19 +2138,57 @@ def render(ctx):
         tab_labels = ["Overall"] + [f"League: {lg}" for lg in leagues_in_matches]
         tabs = st.tabs(tab_labels)
 
-        def render_chart_and_table(view_df: pd.DataFrame, title_prefix: str, *, league_trend: bool = False, league_name: str = ""):
+        def render_chart_and_table(
+            view_df_recent: pd.DataFrame,
+            title_prefix: str,
+            *,
+            league_trend: bool = False,
+            league_name: str = "",
+            all_matches_loader=None,
+        ):
             st.subheader(f"{title_prefix} JUPR Trend")
+
+            selected_scope = st.radio(
+                "Display:",
+                options=["Recent 60", "All matches"],
+                horizontal=True,
+                key=f"profile-display-scope-{title_prefix}",
+                label_visibility="collapsed",
+            )
+            show_all = selected_scope == "All matches"
+            if show_all and all_matches_loader is not None:
+                view_df = all_matches_loader()
+            else:
+                view_df = view_df_recent.copy()
+
+            total_matches = fetch_player_match_count(
+                _supabase,
+                club_id,
+                pid,
+                league_name if (league_name and title_prefix != "Overall") else None,
+            )
+            shown_matches = int(len(view_df))
+            if show_all:
+                st.caption(f"Showing all {shown_matches} matches.")
+            else:
+                st.caption(
+                    f"Showing recent {shown_matches} matches for faster loading."
+                    + (f" ({total_matches} total)" if total_matches > shown_matches else "")
+                )
 
             chart_df = view_df.copy().dropna(subset=["Overall After"]).sort_values(["Date", "id"]).reset_index(drop=True)
             if chart_df.empty:
                 st.info("No chartable rating data in this view.")
             else:
-                chart_df["Match #"] = range(1, len(chart_df) + 1)
+                if show_all or total_matches <= len(chart_df):
+                    chart_df["Match #"] = range(1, len(chart_df) + 1)
+                else:
+                    start_match_number = max(total_matches - len(chart_df) + 1, 1)
+                    chart_df["Match #"] = range(start_match_number, start_match_number + len(chart_df))
                 chart_df["DateStr"] = pd.to_datetime(chart_df["Date"], utc=True, errors="coerce").dt.strftime("%Y-%m-%d")
                 chart_df["DeltaStr"] = chart_df["Overall Δ"].map(lambda x: f"{float(x):+.4f}" if pd.notna(x) else "")
                 chart_df["AfterStr"] = chart_df["Overall After"].map(lambda x: f"{float(x):.3f}" if pd.notna(x) else "")
-
-                tail = chart_df.tail(60).copy()
+                chart_scope = chart_df.copy()
 
                 # Optional full restore: show league replay trend (if available)
                 if league_trend and league_name and _LEAGUE_REPLAY_AVAILABLE:
@@ -2148,10 +2211,13 @@ def render(ctx):
                         tmp2 = tmp.dropna(subset=["League After"]).sort_values(["Date", "id"]).reset_index(drop=True)
                         if not tmp2.empty:
                             tmp2["Match #"] = range(1, len(tmp2) + 1)
+                            if not show_all and total_matches > len(tmp2):
+                                start_match_number = max(total_matches - len(tmp2) + 1, 1)
+                                tmp2["Match #"] = range(start_match_number, start_match_number + len(tmp2))
                             tmp2["DateStr"] = pd.to_datetime(tmp2["Date"], utc=True, errors="coerce").dt.strftime("%Y-%m-%d")
                             tmp2["DeltaStr"] = tmp2["League Δ"].map(lambda x: f"{float(x):+.4f}" if pd.notna(x) else "")
                             tmp2["AfterStr"] = tmp2["League After"].map(lambda x: f"{float(x):.3f}" if pd.notna(x) else "")
-                            tail = tmp2.tail(60).copy()
+                            chart_scope = tmp2.copy()
                             y_col = "League After"
                             y_title = "League JUPR After Match"
                         else:
@@ -2166,7 +2232,7 @@ def render(ctx):
 
                 if alt is not None:
                     line = (
-                        alt.Chart(tail)
+                        alt.Chart(chart_scope)
                         .mark_line(point=True)
                         .encode(
                             x=alt.X("Match #:Q", axis=alt.Axis(tickMinStep=1), title="Match Order"),
@@ -2188,7 +2254,7 @@ def render(ctx):
                     )
                     st.altair_chart(line, use_container_width=True)
                 else:
-                    st.line_chart(tail.set_index("Match #")[y_col])
+                    st.line_chart(chart_scope.set_index("Match #")[y_col])
 
             st.divider()
             st.subheader(f"{title_prefix} Match History")
@@ -2258,13 +2324,22 @@ def render(ctx):
             )
 
         with tabs[0]:
-            render_chart_and_table(df, "Overall", league_trend=False)
+            render_chart_and_table(df, "Overall", league_trend=False, all_matches_loader=get_all_matches_df)
 
         for i, lg in enumerate(leagues_in_matches, start=1):
             with tabs[i]:
                 df_lg = df[df["League"].astype(str).str.strip() == lg].copy()
+                def _load_all_lg_matches(league_name: str = lg) -> pd.DataFrame:
+                    all_df = get_all_matches_df()
+                    return all_df[all_df["League"].astype(str).str.strip() == league_name].copy()
                 # Show league replay trend if available; otherwise overall trend filtered to that league’s matches.
-                render_chart_and_table(df_lg, f"League: {lg}", league_trend=True, league_name=lg)
+                render_chart_and_table(
+                    df_lg,
+                    f"League: {lg}",
+                    league_trend=True,
+                    league_name=lg,
+                    all_matches_loader=_load_all_lg_matches,
+                )
 
     def render_social_tab():
         st.markdown("### Social / Community")

--- a/tests/test_player_profile_match_scope.py
+++ b/tests/test_player_profile_match_scope.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+from jupr_app.domain import player_rating_series as prs
+
+
+class _DummyResp:
+    def __init__(self, data):
+        self.data = data
+
+
+class _DummyQuery:
+    def __init__(self, rows):
+        self._rows = rows
+        self._start = 0
+        self._end = None
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, *_args, **_kwargs):
+        return self
+
+    def or_(self, *_args, **_kwargs):
+        return self
+
+    def order(self, *_args, **_kwargs):
+        return self
+
+    def limit(self, n):
+        self._start = 0
+        self._end = int(n) - 1
+        return self
+
+    def range(self, start, end):
+        self._start = int(start)
+        self._end = int(end)
+        return self
+
+    def execute(self):
+        if self._end is None:
+            data = self._rows[self._start :]
+        else:
+            data = self._rows[self._start : self._end + 1]
+        return _DummyResp(data)
+
+
+class _DummySupabase:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def table(self, _name):
+        return _DummyQuery(self._rows)
+
+
+def test_build_player_overall_rating_series_supports_paginated_all_matches():
+    rows = []
+    for idx in range(2505, 0, -1):
+        rows.append(
+            {
+                "id": idx,
+                "date": f"2026-01-{(idx % 28) + 1:02d}T12:00:00Z",
+                "league": "Overall",
+                "match_type": "league",
+                "score_t1": 11,
+                "score_t2": 7,
+                "t1_p1": 1,
+                "t1_p2": 2,
+                "t2_p1": 3,
+                "t2_p2": 4,
+                "elo_delta": 4,
+                "t1_p1_r": 400.0 + idx,
+                "t1_p1_r_end": 404.0 + idx,
+            }
+        )
+
+    supabase = _DummySupabase(rows)
+
+    df_all = prs.build_player_overall_rating_series(supabase, "club-1", 1, limit=None)
+    assert len(df_all) == 2505
+
+    df_recent = prs.build_player_overall_rating_series(supabase, "club-1", 1, limit=60)
+    assert len(df_recent) == 60
+
+
+def test_players_page_has_profile_match_scope_controls_and_default_recent_limit():
+    contents = Path("jupr_app/ui/pages/players.py").read_text(encoding="utf-8")
+
+    assert 'options=["Recent 60", "All matches"]' in contents
+    assert 'selected_scope == "All matches"' in contents
+    assert 'build_player_overall_rating_series(_supabase, club_id, pid, limit=60)' in contents
+    assert 'build_player_overall_rating_series(_supabase, club_id, pid, limit=None)' in contents
+    assert 'Showing recent {shown_matches} matches for faster loading.' in contents
+    assert 'Showing all {shown_matches} matches.' in contents


### PR DESCRIPTION
### Motivation

- Allow players to expand the rating graph and match history to include all their matches while keeping the default profile load light and fast.
- Preserve real match order and consistent chart/table behavior so the recent view still reflects true ordinal positions (e.g., 166–225) and the all view shows full history from earliest to latest.

### Description

- Added a display scope control (`Recent 60` / `All matches`) to the player profile trend and history sections and defaulted it to `Recent 60` so the default view remains unchanged (file: `jupr_app/ui/pages/players.py`).
- Implemented a cached match-count helper `fetch_player_match_count(...)` to show captions and compute x-axis numbering without fetching full history (file: `jupr_app/ui/pages/players.py`).
- Made the rating-series loader support `limit=None` and added paginated fetching when `limit=None` to retrieve all rows safely (file: `jupr_app/domain/player_rating_series.py`).
- Wired the UI so the chart and history table use the same selected scope, preserved the original recent-limit behavior (`60`), and reused the same pattern for league tabs that share the chart/table code (file: `jupr_app/ui/pages/players.py`).
- Added automated tests to validate paginated all-match loading and the presence of the recent/all control and default-limit wiring (file: `tests/test_player_profile_match_scope.py`).

### Testing

- Ran `pytest -q tests/test_player_profile_match_scope.py` and the new tests passed (2 passed).
- Running a broader subset surfaced an unrelated pre-existing assertion in `tests/test_verified_updates_public_routing.py` about `streamlit_app.py`; that failure is not caused by these changes and is external to the player-profile behavior.
- Local checks confirmed default behavior uses 60 recent matches and that selecting `All matches` triggers the lazy full-history load and updates captions and chart/table counts accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3619b3c48326bc786d757aee0727)