### PR TITLE
Stabilize admin browser auth restoration and stale token cleanup

### DIFF
--- a/jupr_app/ui/admin_auth.py
+++ b/jupr_app/ui/admin_auth.py
@@ -20,6 +20,7 @@ _BROWSER_RESTORE_FLAG_KEY = "jupr_admin_restore_from_storage"
 _BROWSER_SYNC_PAYLOAD_KEY = "_admin_browser_sync_payload"
 _BROWSER_CLEAR_PENDING_KEY = "_admin_browser_clear_pending"
 _BROWSER_RESTORE_INFLIGHT_SESSION_KEY = "jupr_admin_restore_inflight_at"
+_ADMIN_RESTORE_FAILED_THIS_RUN_KEY = "_admin_restore_failed_this_run"
 
 
 class AdminAuthError(RuntimeError):
@@ -120,10 +121,7 @@ def _set_auth_session(client, access_token: str, refresh_token: str):
         raise AttributeError("Supabase client is missing auth")
 
     attempts = (
-        (
-            "set_session(access_token, refresh_token)",
-            lambda: auth.set_session(access_token, refresh_token),
-        ),
+        ("set_session(access_token, refresh_token)", lambda: auth.set_session(access_token, refresh_token)),
         (
             "set_session({access_token, refresh_token})",
             lambda: auth.set_session(
@@ -145,16 +143,39 @@ def _set_auth_session(client, access_token: str, refresh_token: str):
     )
 
     last_exc: Exception | None = None
-    for label, attempt in attempts:
+    for idx, (label, attempt) in enumerate(attempts):
         try:
             return attempt()
-        except Exception as exc:
+        except TypeError as exc:
+            # Only TypeError from early attempts should trigger compatibility fallbacks.
+            # Invalid refresh token failures can occasionally surface as TypeError wrappers.
+            if _is_invalid_refresh_token_error(exc):
+                logger.warning("Supabase auth %s failed with invalid refresh token: %r", label, exc)
+                raise
             last_exc = exc
             logger.warning("Supabase auth %s failed: %r", label, exc)
+            if idx == len(attempts) - 1:
+                raise
+        except Exception as exc:
+            # Preserve real auth failures (AuthApiError, invalid refresh token, etc.).
+            logger.warning("Supabase auth %s failed: %r", label, exc)
+            raise
 
     if last_exc is not None:
         raise last_exc
     raise RuntimeError("Unable to set auth session")
+
+
+def _is_invalid_refresh_token_error(exc: Exception) -> bool:
+    text = str(exc or "").strip().lower()
+    if not text:
+        return False
+    needles = (
+        "invalid refresh token",
+        "already used",
+        "refresh token",
+    )
+    return any(needle in text for needle in needles)
 
 
 def _exchange_auth_code_for_session(client, auth_code: str):
@@ -345,6 +366,16 @@ def restore_admin_browser_session() -> dict[str, str] | None:
     access = _query_param_text("jupr_admin_access_token")
     refresh = _query_param_text("jupr_admin_refresh_token")
     restore_flag = _query_param_text(_BROWSER_RESTORE_FLAG_KEY)
+    if bool(st.session_state.get(_ADMIN_RESTORE_FAILED_THIS_RUN_KEY, False)):
+        logger.info("Admin restore handshake skipped: restore already failed in this run")
+        return None
+
+    existing_user = get_current_admin_user()
+    if existing_user is not None:
+        existing_email = str(getattr(existing_user, "email", "") or "").strip().lower()
+        if existing_email and is_allowed_admin_email(existing_email, load_admin_allowlist()):
+            logger.info("Admin restore handshake skipped: already authenticated admin user in session")
+            return None
 
     if access and refresh and restore_flag == "1":
         logger.info(
@@ -366,6 +397,7 @@ def restore_admin_browser_session() -> dict[str, str] | None:
 
     if restore_flag == "1":
         logger.info("Admin restore skipped: handshake flag present but token query params missing")
+        return None
 
     components.html(
         f"""
@@ -405,6 +437,26 @@ def clear_admin_browser_session() -> None:
     logger.info("Browser token clear queued")
 
 
+def render_admin_browser_session_clear_now() -> None:
+    """Immediately clear browser auth token state for this tab."""
+    components.html(
+        f"""
+        <script>
+        try {{
+          const appWindow = window.parent || window;
+          appWindow.localStorage.removeItem("{_BROWSER_ACCESS_TOKEN_KEY}");
+          appWindow.localStorage.removeItem("{_BROWSER_REFRESH_TOKEN_KEY}");
+          appWindow.sessionStorage.removeItem("{_BROWSER_RESTORE_INFLIGHT_SESSION_KEY}");
+        }} catch (e) {{}}
+        </script>
+        """,
+        height=0,
+    )
+    st.session_state.pop(_BROWSER_SYNC_PAYLOAD_KEY, None)
+    st.session_state.pop(_BROWSER_CLEAR_PENDING_KEY, None)
+    logger.info("Browser token clear rendered immediately")
+
+
 def maybe_restore_admin_login_from_browser() -> bool:
     """Try to restore allowlisted admin auth from browser storage when needed."""
     bootstrap_admin_auth()
@@ -416,6 +468,9 @@ def maybe_restore_admin_login_from_browser() -> bool:
         return bool(
             existing_email and is_allowed_admin_email(existing_email, load_admin_allowlist())
         )
+    if bool(st.session_state.get(_ADMIN_RESTORE_FAILED_THIS_RUN_KEY, False)):
+        logger.info("Browser restore skipped: this run already recorded a restore failure")
+        return False
 
     logger.info("Browser token restore attempt started")
     stored_tokens = restore_admin_browser_session()
@@ -451,11 +506,19 @@ def maybe_restore_admin_login_from_browser() -> bool:
 
         st.session_state[_AUTH_USER_KEY] = user
         st.session_state[_AUTH_SESSION_KEY] = session
+        access_token = str(getattr(session, "access_token", "") or "").strip()
+        refresh_token = str(getattr(session, "refresh_token", "") or "").strip()
+        if access_token and refresh_token:
+            persist_admin_browser_session(access_token, refresh_token)
+        st.session_state.pop(_ADMIN_RESTORE_FAILED_THIS_RUN_KEY, None)
         logger.info("Browser token restore succeeded")
         return True
     except Exception as exc:
         logger.warning("Browser token restore failed: %r", exc)
         clear_local_admin_auth_state()
+        render_admin_browser_session_clear_now()
+        _clear_sensitive_query_params()
+        st.session_state[_ADMIN_RESTORE_FAILED_THIS_RUN_KEY] = True
         return False
 
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -280,9 +280,19 @@ def main():
                 if st.sidebar.button("Log Out", key="admin_logout_btn"):
                     logout_admin()
                     st.session_state.pop("post_login_admin_page_key", None)
-                    st.query_params.pop("admin", None)
-                    st.query_params.pop("public", None)
-                    st.query_params.pop("page", None)
+                    _set_query_params_idempotent(
+                        updates={
+                            "public": "1",
+                            "page": "home",
+                        },
+                        removals={
+                            "admin",
+                            "next",
+                            "jupr_admin_access_token",
+                            "jupr_admin_refresh_token",
+                            "jupr_admin_restore_from_storage",
+                        },
+                    )
                     st.rerun()
 
         # Optional: allow pages to request a refresh of cached data

--- a/tests/test_admin_auth_browser_restore.py
+++ b/tests/test_admin_auth_browser_restore.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from jupr_app.ui import admin_auth
+
+
+class _FakeAuthApiError(Exception):
+    pass
+
+
+class _FakeQueryParams(dict):
+    pass
+
+
+class _FakeSt:
+    def __init__(self):
+        self.session_state = {}
+        self.query_params = _FakeQueryParams()
+
+
+class _InvalidRefreshAuth:
+    def set_session(self, *_args, **_kwargs):
+        raise _FakeAuthApiError("Invalid Refresh Token: Already Used")
+
+
+class _SuccessAuth:
+    def __init__(self, response):
+        self._response = response
+
+    def set_session(self, *_args, **_kwargs):
+        return self._response
+
+
+def test_maybe_restore_invalid_refresh_clears_browser_tokens_now(monkeypatch):
+    fake_st = _FakeSt()
+    fake_st.session_state["admin_auth_session"] = SimpleNamespace(
+        access_token="stale-a", refresh_token="stale-r"
+    )
+    fake_st.query_params.update(
+        {
+            "jupr_admin_access_token": "stale-a",
+            "jupr_admin_refresh_token": "stale-r",
+            "jupr_admin_restore_from_storage": "1",
+            "page": "admin_login",
+        }
+    )
+
+    clear_now_calls = []
+
+    monkeypatch.setattr(admin_auth, "st", fake_st)
+    monkeypatch.setattr(
+        admin_auth,
+        "restore_admin_browser_session",
+        lambda: {"access_token": "stale-a", "refresh_token": "stale-r"},
+    )
+    monkeypatch.setattr(
+        admin_auth,
+        "make_supabase_auth_client",
+        lambda: SimpleNamespace(auth=_InvalidRefreshAuth()),
+    )
+    monkeypatch.setattr(
+        admin_auth,
+        "render_admin_browser_session_clear_now",
+        lambda: clear_now_calls.append("called"),
+    )
+
+    restored = admin_auth.maybe_restore_admin_login_from_browser()
+
+    assert restored is False
+    assert clear_now_calls == ["called"]
+    assert fake_st.session_state.get("_admin_restore_failed_this_run") is True
+    assert fake_st.session_state.get("admin_auth_user") is None
+    assert fake_st.session_state.get("admin_auth_session") is None
+    assert "jupr_admin_access_token" not in fake_st.query_params
+    assert "jupr_admin_refresh_token" not in fake_st.query_params
+    assert "jupr_admin_restore_from_storage" not in fake_st.query_params
+
+
+def test_maybe_restore_success_persists_rotated_tokens(monkeypatch):
+    fake_st = _FakeSt()
+    persisted_tokens = []
+
+    rotated_session = SimpleNamespace(access_token="rotated-a", refresh_token="rotated-r")
+    response = SimpleNamespace(
+        session=rotated_session,
+        user=SimpleNamespace(email="admin@example.com"),
+    )
+
+    monkeypatch.setattr(admin_auth, "st", fake_st)
+    monkeypatch.setattr(
+        admin_auth,
+        "restore_admin_browser_session",
+        lambda: {"access_token": "old-a", "refresh_token": "old-r"},
+    )
+    monkeypatch.setattr(
+        admin_auth,
+        "make_supabase_auth_client",
+        lambda: SimpleNamespace(auth=_SuccessAuth(response)),
+    )
+    monkeypatch.setattr(admin_auth, "load_admin_allowlist", lambda: {"admin@example.com"})
+    monkeypatch.setattr(
+        admin_auth,
+        "persist_admin_browser_session",
+        lambda access, refresh: persisted_tokens.append((access, refresh)),
+    )
+
+    restored = admin_auth.maybe_restore_admin_login_from_browser()
+
+    assert restored is True
+    assert persisted_tokens == [("rotated-a", "rotated-r")]
+    assert fake_st.session_state["admin_auth_user"].email == "admin@example.com"
+    assert fake_st.session_state["admin_auth_session"].refresh_token == "rotated-r"
+
+
+def test_streamlit_app_only_restores_browser_tokens_for_admin_entry():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+
+    assert "if admin_entry_requested:\n            maybe_restore_admin_login_from_browser()" in app

--- a/tests/test_admin_auth_session_helpers.py
+++ b/tests/test_admin_auth_session_helpers.py
@@ -3,7 +3,11 @@ from types import SimpleNamespace
 import pytest
 
 from jupr_app.ui import admin_auth
-from jupr_app.ui.admin_auth import _exchange_auth_code_for_session, _set_auth_session
+from jupr_app.ui.admin_auth import (
+    _exchange_auth_code_for_session,
+    _is_invalid_refresh_token_error,
+    _set_auth_session,
+)
 
 
 class _SetSessionAuth:
@@ -16,6 +20,10 @@ class _SetSessionAuth:
         if len(self.calls) < self._succeed_on:
             raise TypeError(f"attempt {len(self.calls)} failed")
         return {"ok": True, "attempt": len(self.calls)}
+
+
+class _AuthApiError(Exception):
+    pass
 
 
 class _ExchangeCodeAuth:
@@ -68,6 +76,37 @@ def test_set_auth_session_raises_last_exception_if_all_attempts_fail():
         _set_auth_session(client, "a-token", "r-token")
 
     assert len(auth.calls) == 3
+
+
+def test_set_auth_session_preserves_auth_api_error_and_does_not_fallback():
+    class _InvalidRefreshAuth:
+        def __init__(self):
+            self.calls = []
+
+        def set_session(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            raise _AuthApiError("Invalid Refresh Token: Already Used")
+
+    auth = _InvalidRefreshAuth()
+    client = SimpleNamespace(auth=auth)
+
+    with pytest.raises(_AuthApiError, match="Invalid Refresh Token"):
+        _set_auth_session(client, "a-token", "r-token")
+
+    assert auth.calls == [(("a-token", "r-token"), {})]
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        ("Invalid Refresh Token: Already Used", True),
+        ("refresh token expired", True),
+        ("Already Used", True),
+        ("some unrelated error", False),
+    ],
+)
+def test_is_invalid_refresh_token_error(message, expected):
+    assert _is_invalid_refresh_token_error(Exception(message)) is expected
 
 
 def test_exchange_auth_code_for_session_falls_back_in_order():


### PR DESCRIPTION
### Motivation

- Browser-driven admin token restore was triggering full-page `location.replace` reloads and reusing stale/invalid refresh tokens, producing reload loops and confusing UX.
- Supabase `set_session` AuthApiError for invalid/already-used refresh tokens was being masked by later fallback `TypeError` attempts, hiding the real error and preventing decisive token clearing.

### Description

- Added `_is_invalid_refresh_token_error(exc)` to detect invalid/expired/"already used" refresh-token errors by inspecting exception text. 
- Updated `_set_auth_session(client, access_token, refresh_token)` to prefer the real `auth.set_session(access_token, refresh_token)` call and to re-raise real auth failures (including invalid-refresh errors) immediately while only falling back on other signatures for genuine `TypeError` compatibility mismatches. 
- Introduced `render_admin_browser_session_clear_now()` which injects immediate JS to remove `jupr_admin_access_token`, `jupr_admin_refresh_token`, and `jupr_admin_restore_inflight_at` from browser storage and wired it into restore-failure handling so stale tokens are cleared in the same render. 
- Hardened restore flow: `restore_admin_browser_session()` now skips the URL-handshake if a restore already failed this run or when a valid admin session already exists, and treats a handshake-flag-without-tokens as a no-op; `maybe_restore_admin_login_from_browser()` sets a per-run guard ( `_admin_restore_failed_this_run`) on failure, clears Streamlit auth/session keys, removes sensitive query params, and avoids additional reloads. 
- After successful restore, the rotated/updated session tokens are persisted back to browser storage via `persist_admin_browser_session(...)` in the same render so future refreshes do not reuse stale tokens. 
- Adjusted logout routing in `streamlit_app.py` to use `_set_query_params_idempotent(...)` to return cleanly to public home and to strip admin/handshake params.
- Tests added/updated: new `tests/test_admin_auth_browser_restore.py` and updates to `tests/test_admin_auth_session_helpers.py` to exercise the new behavior and invalid-refresh preservation.

### Testing

- Ran unit tests: `pytest -q tests/test_admin_auth_session_helpers.py tests/test_admin_auth_browser_restore.py tests/test_admin_auth_recovery_fallbacks.py`, all tests passed (`22 passed`).
- Added automated tests that verify `_set_auth_session` preserves invalid-refresh AuthApiError, invalid-refresh restore triggers immediate clear path, successful restore persists rotated tokens, and browser restore is only attempted when admin entry is requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3885c2148326b477e1c32146e4db)