### PR TITLE
Fix player profile crash resilience and canonical route sync

### DIFF
--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -344,6 +344,43 @@ def _safe_float(value, default: float | None = None) -> float | None:
         return default
 
 
+def _ensure_rating_series_frame(df: pd.DataFrame | None) -> pd.DataFrame:
+    required_cols: dict[str, object] = {
+        "id": pd.NA,
+        "Date": pd.NaT,
+        "League": "",
+        "Score": "",
+        "Result": "",
+        "Overall Δ": pd.NA,
+        "Overall After": pd.NA,
+        "match_type": "",
+        "context": "",
+        "tournament_id": pd.NA,
+        "t1_p1": pd.NA,
+        "t1_p2": pd.NA,
+        "t2_p1": pd.NA,
+        "t2_p2": pd.NA,
+        "t1_p1_r": pd.NA,
+        "t1_p2_r": pd.NA,
+        "t2_p1_r": pd.NA,
+        "t2_p2_r": pd.NA,
+    }
+
+    if df is None or not isinstance(df, pd.DataFrame):
+        return pd.DataFrame(columns=list(required_cols.keys()))
+
+    safe_df = df.copy()
+    for col, default in required_cols.items():
+        if col not in safe_df.columns:
+            safe_df[col] = default
+
+    safe_df["Date"] = pd.to_datetime(safe_df.get("Date"), utc=True, errors="coerce")
+    safe_df["id"] = pd.to_numeric(safe_df.get("id"), errors="coerce")
+    safe_df["Overall Δ"] = pd.to_numeric(safe_df.get("Overall Δ"), errors="coerce")
+    safe_df["Overall After"] = pd.to_numeric(safe_df.get("Overall After"), errors="coerce")
+    return safe_df
+
+
 def _month_day(value) -> str:
     dt = pd.to_datetime(value, utc=True, errors="coerce")
     if pd.isna(dt):
@@ -442,8 +479,7 @@ def _aggregate_repeating_badges(unlocked_badges: list[dict]) -> list[dict]:
 
 
 def _build_profile_snapshot(df: pd.DataFrame, row: pd.Series, pid: int) -> dict:
-    if df is None:
-        df = pd.DataFrame()
+    df = _ensure_rating_series_frame(df)
     out = {"stats": [], "wins": 0, "losses": 0, "matches": 0}
     if df.empty:
         current_jupr = (_safe_float(row.get("rating"), 1200.0) or 1200.0) / 400.0
@@ -1464,7 +1500,21 @@ def render(ctx):
     pick_name = str(row["name"])
     claimed_or_verified_profile = _player_is_claimed_or_verified(row)
 
-    df_rating_all = build_player_overall_rating_series(_supabase, club_id, pid, limit=None)
+    try:
+        logger.info(
+            "Rendering selected player profile: pid=%s name=%s page=%s public_mode=%s query=%s",
+            int(pid),
+            str(row.get("name") or "").strip(),
+            current_page_key or "(none)",
+            PUBLIC_MODE,
+            dict(st.query_params),
+        )
+    except Exception:
+        logger.info("Rendering selected player profile: pid=%s", int(pid))
+
+    df_rating_all = _ensure_rating_series_frame(
+        build_player_overall_rating_series(_supabase, club_id, pid, limit=None)
+    )
     snapshot = _build_profile_snapshot(df_rating_all, row, pid)
     c1 = st.container()
     verified_updates_manage_url = ""
@@ -2210,16 +2260,17 @@ def render(ctx):
                                     },
                                 )
     def render_ratings_tab():
-        df_recent = build_player_overall_rating_series(_supabase, club_id, pid, limit=60)
-        df = build_player_overall_rating_series(_supabase, club_id, pid, limit=None)
+        df_recent = _ensure_rating_series_frame(
+            build_player_overall_rating_series(_supabase, club_id, pid, limit=60)
+        )
+        df = _ensure_rating_series_frame(
+            build_player_overall_rating_series(_supabase, club_id, pid, limit=None)
+        )
         if df.empty:
             st.info("No rated match data yet for this player.")
             return
 
         df = df.copy().sort_values(["Date", "id"], ascending=[True, True]).reset_index(drop=True)
-        df["Date"] = pd.to_datetime(df.get("Date"), utc=True, errors="coerce")
-        df["Overall Δ"] = pd.to_numeric(df.get("Overall Δ"), errors="coerce")
-        df["Overall After"] = pd.to_numeric(df.get("Overall After"), errors="coerce")
 
         snapshot_local = _build_profile_snapshot(df, row, pid)
         wins = int(snapshot_local.get("wins", 0) or 0)
@@ -2439,7 +2490,11 @@ def render(ctx):
                     "Opponents": ", ".join(_lookup_player_name(players_df, x) for x in ctx_match.get("opponent_ids", []) if x is not None),
                     "Score": str(match.get("Score") or "—"),
                     "Result": "W" if str(match.get("Result", "")).upper() == "WIN" else ("L" if str(match.get("Result", "")).upper() == "LOSS" else "D"),
-                    "Overall rating delta": f"{float(match.get('Overall Δ')):+.4f}" if pd.notna(match.get("Overall Δ")) else "",
+                    "Overall rating delta": (
+                        f"{delta_val:+.4f}"
+                        if (delta_val := _safe_float(match.get("Overall Δ"))) is not None and pd.notna(delta_val)
+                        else ""
+                    ),
                     "Explain": explain_link(match),
                 }
             )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -551,25 +551,46 @@ def main():
         # -------------------------
         try:
             target_page = LABEL_TO_PAGE_KEY.get(sel, "home")
-            current_page = qp_get("page", "").strip()
+            current_page = qp_get("page", "").strip().lower()
+            canonical_updates: dict[str, str] = {}
+            canonical_removals: set[str] = set()
 
             if PUBLIC_MODE:
-                if target_page == "home":
-                    _set_query_params_idempotent(removals={"admin", "public", "page"})
-                elif current_page != target_page:
-                    _set_query_params_idempotent(
-                        updates={"page": target_page},
-                        removals={"admin", "public"},
-                    )
-                else:
-                    _set_query_params_idempotent(removals={"admin", "public"})
-            else:
-                _set_query_params_idempotent(
-                    updates={"admin": "1"},
-                    removals={"public"},
+                canonical_removals.update(
+                    {
+                        "admin",
+                        "next",
+                        "jupr_admin_access_token",
+                        "jupr_admin_refresh_token",
+                        "jupr_admin_restore_from_storage",
+                    }
                 )
+                if target_page == "home":
+                    canonical_removals.update({"public", "page"})
+                else:
+                    canonical_removals.add("public")
+                    canonical_updates["page"] = target_page
+            else:
+                canonical_updates["admin"] = "1"
+                canonical_removals.add("public")
+                if target_page:
+                    canonical_updates["page"] = target_page
+
+            params_changed = _set_query_params_idempotent(
+                updates=canonical_updates,
+                removals=canonical_removals,
+            )
 
             st.session_state["_last_rendered_nav"] = sel
+
+            if params_changed and current_page != (target_page or ""):
+                logger.info(
+                    "Canonical route sync updated page query param: requested=%s resolved=%s public_mode=%s",
+                    current_page,
+                    target_page,
+                    PUBLIC_MODE,
+                )
+                st.rerun()
         except Exception:
             logger.exception("Failed to sync canonical query params for page selection.")
             if debug_exceptions:


### PR DESCRIPTION
### Motivation
- Selecting a player (e.g., Joe Baumann) caused the Players page to crash when rating-series or related match/context fields were missing or partial, and the URL sometimes retained a stale `page` query param (e.g., `league_manager`) while the UI resolved to `players`.
- Improve diagnostics and non-failing behavior so profile sections render clean empty states instead of throwing, while keeping the global error wrapper and debug behavior intact.

### Description
- Add a normalization helper ` _ensure_rating_series_frame` that guarantees expected rating-series schema and coerces dates/numerics so downstream snapshot, trend, breakdown, and history logic can operate safely.
- Use the normalization helper before building the snapshot and in ratings rendering (`trend`, `breakdown`, `history`) so missing or malformed rating data produces clean empty frames rather than exceptions.
- Add structured pre-render logging for the selected player context (pid, name, page key, public/admin mode and current query params) to improve diagnostics when profile rendering fails.
- Harden match-delta formatting to use `_safe_float` to avoid `float(...)` crashes on non-numeric/partial values.
- Make canonical route/query-param synchronization deterministic in `streamlit_app.main()` by computing `canonical_updates`/`canonical_removals`, stripping stale admin-only tokens on public routes, reconciling `page` to the resolved nav target, and rerunning when a canonical correction changed the URL.

### Testing
- Compiled the modified modules with `python -m py_compile streamlit_app.py jupr_app/ui/pages/players.py` and the files compiled without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed139e81d48326b97125b8b973bf02)