### PR TITLE
Refactor public nav to registry-driven sticky navbar

### DIFF
--- a/jupr_app/ui/public_nav.py
+++ b/jupr_app/ui/public_nav.py
@@ -1,40 +1,87 @@
 from __future__ import annotations
 
+from urllib.parse import urlencode
+
 import streamlit as st
 
-from jupr_app.ui.page_registry import PAGE_KEY_TO_LABEL
-from jupr_app.ui.url import qp_get
+from jupr_app.ui.page_registry import LABEL_TO_PAGE_KEY, PAGE_KEY_TO_LABEL
+
+PUBLIC_LABEL_BY_KEY: dict[str, str] = {
+    "home": "Home",
+    "leaderboards": "Leaderboards",
+    "players": "Players",
+    "tournament_registration": "Events",
+    "weekly_recap": "Weekly Recap",
+    "rating_rules": "Rating Rules",
+    "faqs": "FAQs",
+}
+
+
+def _current_query_params() -> dict[str, str]:
+    params: dict[str, str] = {}
+    for key in st.query_params.keys():
+        value = st.query_params.get(key, "")
+        if isinstance(value, list):
+            value = value[0] if value else ""
+        value_text = str(value or "")
+        if value_text:
+            params[key] = value_text
+    return params
+
+
+def _href_for_page(page_key: str, *, base_params: dict[str, str]) -> str:
+    params = dict(base_params)
+    params.pop("admin", None)
+    params.pop("public", None)
+    params.pop("next", None)
+    if page_key == "home":
+        params.pop("page", None)
+    else:
+        params["page"] = page_key
+
+    if not params:
+        return "./"
+
+    return f"?{urlencode(sorted(params.items()))}"
 
 
 def render_public_top_nav(
     *,
-    labels_in_order: list[str] | None = None,  # noqa: ARG001
-    current_label: str | None = None,  # noqa: ARG001
+    labels_in_order: list[str] | None = None,
+    current_label: str | None = None,
     default_page: str = "home",
 ) -> str:
     """Render the public website-style top nav and return the active page label."""
 
-    current_page = (qp_get("page", "") or "").strip().lower() or default_page
-    if current_page not in PAGE_KEY_TO_LABEL:
-        current_page = default_page
+    labels_in_order = labels_in_order or []
+    nav_page_keys: list[str] = []
+    for label in labels_in_order:
+        page_key = LABEL_TO_PAGE_KEY.get(label)
+        if not page_key:
+            continue
+        if page_key not in PUBLIC_LABEL_BY_KEY:
+            continue
+        if page_key not in nav_page_keys:
+            nav_page_keys.append(page_key)
 
-    links: list[tuple[str, str, str]] = [
-        ("Home", "./", "home"),
-        ("Leaderboards", "?page=leaderboards", "leaderboards"),
-        ("Players", "?page=players", "players"),
-        ("Events", "?page=tournament_registration", "tournament_registration"),
-        ("Rating Rules", "?page=rating_rules", "rating_rules"),
-        ("Updates", "?page=verified_updates_request", "verified_updates_request"),
-        ("Admin Login", "?admin=1&page=admin_login", "admin_login"),
-    ]
+    if not nav_page_keys:
+        nav_page_keys = list(PUBLIC_LABEL_BY_KEY.keys())
+
+    current_page_key = LABEL_TO_PAGE_KEY.get(current_label or "")
+    if current_page_key not in nav_page_keys:
+        current_page_key = default_page if default_page in nav_page_keys else nav_page_keys[0]
+
+    base_params = _current_query_params()
 
     nav_links_html = "".join(
         (
-            f'<a class="jupr-public-nav-link {"active" if key == current_page else ""}" '
-            f'href="{href}">{label}</a>'
+            f'<a class="jupr-public-nav-link {"active" if page_key == current_page_key else ""}" '
+            f'href="{_href_for_page(page_key, base_params=base_params)}">{PUBLIC_LABEL_BY_KEY[page_key]}</a>'
         )
-        for label, href, key in links
+        for page_key in nav_page_keys
     )
+
+    admin_href = "?admin=1&page=admin_login"
 
     st.markdown(
         f"""
@@ -47,10 +94,11 @@ def render_public_top_nav(
             <nav class="jupr-public-nav-links" aria-label="Public navigation">
               {nav_links_html}
             </nav>
+            <a class="jupr-public-admin-action" href="{admin_href}">Admin Login</a>
           </header>
         </div>
         """,
         unsafe_allow_html=True,
     )
 
-    return PAGE_KEY_TO_LABEL.get(current_page, PAGE_KEY_TO_LABEL[default_page])
+    return PAGE_KEY_TO_LABEL.get(current_page_key, PAGE_KEY_TO_LABEL[default_page])

--- a/jupr_app/ui/theme_clean.py
+++ b/jupr_app/ui/theme_clean.py
@@ -254,14 +254,17 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         flex-wrap: wrap;
         align-items: center;
         justify-content: space-between;
-        gap: 0.9rem;
+        gap: 0.8rem 1rem;
+        position: sticky;
+        top: 0.5rem;
+        z-index: 120;
         margin-bottom: 1.15rem;
-        padding: 0.85rem 1rem;
+        padding: 0.7rem 0.9rem;
         border-radius: var(--radius);
-        border: 1px solid var(--border);
-        background: color-mix(in srgb, var(--panel) 90%, transparent);
-        box-shadow: var(--shadow);
-        backdrop-filter: blur(8px);
+        border: 1px solid var(--border-strong);
+        background: color-mix(in srgb, var(--panel) 94%, transparent);
+        box-shadow: var(--shadow-lg);
+        backdrop-filter: blur(10px);
       }}
       .jupr-public-brand {{
         display: inline-flex;
@@ -279,32 +282,78 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
       .jupr-public-nav-links {{
         display: flex;
         align-items: center;
+        flex: 1 1 420px;
         flex-wrap: wrap;
         gap: 0.45rem;
+        min-width: 0;
       }}
       .jupr-public-nav-link {{
         display: inline-flex;
         align-items: center;
         border-radius: 999px;
-        border: 1px solid var(--border);
-        padding: 0.34rem 0.76rem;
-        color: var(--text-secondary);
-        background: transparent;
+        border: 1px solid color-mix(in srgb, var(--border-strong) 72%, transparent);
+        padding: 0.34rem 0.72rem;
+        color: var(--text-primary);
+        background: color-mix(in srgb, var(--panel) 86%, transparent);
         text-decoration: none;
         font-size: 0.84rem;
         font-weight: 700;
         transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+        white-space: nowrap;
       }}
       .jupr-public-nav-link:hover {{
-        border-color: var(--accent-border);
+        border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
         background: var(--accent-soft);
         color: var(--text-primary);
         transform: translateY(-1px);
       }}
       .jupr-public-nav-link.active {{
-        border-color: var(--accent-border);
-        background: var(--accent-soft);
+        border-color: color-mix(in srgb, var(--accent) 52%, var(--border));
+        background: color-mix(in srgb, var(--accent-soft) 85%, var(--panel));
         color: var(--text-primary);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent);
+      }}
+      .jupr-public-admin-action {{
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.38rem 0.72rem;
+        border-radius: 10px;
+        border: 1px solid color-mix(in srgb, var(--accent) 36%, var(--border-strong));
+        background: color-mix(in srgb, var(--accent-soft) 45%, var(--panel));
+        color: var(--text-primary);
+        text-decoration: none;
+        white-space: nowrap;
+        font-size: 0.8rem;
+        font-weight: 800;
+      }}
+      .jupr-public-admin-action:hover {{
+        color: var(--text-primary);
+        border-color: color-mix(in srgb, var(--accent) 55%, var(--border-strong));
+        background: color-mix(in srgb, var(--accent-soft) 65%, var(--panel));
+      }}
+      .jupr-public-admin-action:focus-visible,
+      .jupr-public-nav-link:focus-visible {{
+        outline: 3px solid var(--focus);
+        outline-offset: 2px;
+      }}
+      @media (max-width: 720px) {{
+        .jupr-public-nav {{
+          gap: 0.65rem;
+          padding: 0.64rem 0.72rem;
+        }}
+        .jupr-public-brand {{
+          min-width: 100%;
+        }}
+        .jupr-public-nav-links {{
+          flex-wrap: nowrap;
+          overflow-x: auto;
+          padding-bottom: 0.15rem;
+          scrollbar-width: thin;
+        }}
+        .jupr-public-admin-action {{
+          margin-left: auto;
+        }}
       }}
       .jupr-hero {{
         margin-bottom: 1rem;


### PR DESCRIPTION
### Motivation
- Public pages need a clear, persistent, website-style navigation bar driven by the existing page registry so the public site feels connected and deep-link context is preserved.
- The previous public nav was hardcoded and ignored the page registry (`labels_in_order` / `current_label`), risking drift and missing public pages or exposing admin-only items.

### Description
- Reworked `render_public_top_nav` in `jupr_app/ui/public_nav.py` to actually use `labels_in_order` and `current_label`, mapping labels back to page keys via `LABEL_TO_PAGE_KEY` and returning the active label from `PAGE_KEY_TO_LABEL`.
- Introduced a clean `PUBLIC_LABEL_BY_KEY` map for friendly display names (`Home`, `Leaderboards`, `Players`, `Events`, `Weekly Recap`, `Rating Rules`, `FAQs`) and filtered nav rendering to only those public keys.
- Implemented query-preserving link generation with `_current_query_params` and `_href_for_page` so non-routing deep-link params (e.g. `league`, `player`, `pid`, `club_id`) are preserved while normalizing routing params and keeping the home URL canonical.
- Strengthened presentation in `jupr_app/ui/theme_clean.py` to make the nav sticky, full-width within the content container, visually prominent with clear active state, and mobile-friendly (wrap or horizontal scroll), and added a separate `Admin Login` action.

### Testing
- Ran `python -m compileall jupr_app/ui/public_nav.py jupr_app/ui/theme_clean.py streamlit_app.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed188b07448326995abb09cf054ba5)