### PR TITLE
Fix public tournament selection to avoid stale query lock on registration and partner board

### DIFF
--- a/jupr_app/ui/pages/tournament_partner_board.py
+++ b/jupr_app/ui/pages/tournament_partner_board.py
@@ -19,22 +19,80 @@ def _safe_text(value: Any) -> str:
     return str(value or "").strip()
 
 
-def _pick_tournament(ctx, supabase):
+def _public_tournament_label(choice: dict[str, Any]) -> str:
+    tournament = choice.get("tournament") or {}
+    settings = choice.get("settings") or {}
+    name = _safe_text(tournament.get("name") or f"Tournament #{tournament.get('id')}")
+    start_date = _safe_text(tournament.get("start_date"))
+    slug = _safe_text(settings.get("registration_slug"))
+    details = " • ".join(part for part in [start_date, slug] if part)
+    return f"{name} ({details})" if details else name
+
+
+def _resolve_public_tournament_id(choices: list[dict[str, Any]], *, qp_tournament_id: str, qp_slug: str) -> str:
+    by_id = {str((row.get("tournament") or {}).get("id")): row for row in choices}
+    by_slug = {
+        _safe_text((row.get("settings") or {}).get("registration_slug")): row
+        for row in choices
+        if _safe_text((row.get("settings") or {}).get("registration_slug"))
+    }
+    if qp_tournament_id and qp_tournament_id in by_id:
+        return qp_tournament_id
+    if qp_slug and qp_slug in by_slug:
+        return str((by_slug[qp_slug].get("tournament") or {}).get("id"))
+    first = choices[0] if choices else {}
+    return str((first.get("tournament") or {}).get("id") or "")
+
+
+def _set_public_tournament_query_params(*, page_key: str, registration_slug: str | None) -> None:
+    st.query_params["page"] = page_key
+    if registration_slug:
+        st.query_params["tournament"] = registration_slug
+    else:
+        st.query_params.pop("tournament", None)
+    st.query_params.pop("tournament_id", None)
+
+
+def _select_public_tournament(ctx, supabase, *, page_key: str):
     club_id = _safe_text(getattr(ctx, "club_id", ""))
     choices = list_open_public_tournaments(supabase, club_id)
     if not choices:
         return None, None, [], []
-    labels = [f"{row['tournament'].get('name')}" for row in choices]
-    selected_label = st.selectbox("Choose a tournament", labels)
-    idx = labels.index(selected_label)
-    selected = choices[idx]
-    tournament = selected["tournament"]
-    settings = selected["settings"]
+
+    qp_tournament_id = _safe_text(st.query_params.get("tournament_id"))
+    qp_slug = _safe_text(st.query_params.get("tournament"))
+    selected_id = _resolve_public_tournament_id(choices, qp_tournament_id=qp_tournament_id, qp_slug=qp_slug)
+
+    by_id = {str((row.get("tournament") or {}).get("id")): row for row in choices}
+    selected_choice = by_id.get(selected_id) or choices[0]
+    selected_id = str((selected_choice.get("tournament") or {}).get("id") or "")
+
+    if len(choices) > 1:
+        selected_id = st.selectbox(
+            "Choose a tournament",
+            options=[str((row.get("tournament") or {}).get("id")) for row in choices],
+            index=max(0, [str((row.get("tournament") or {}).get("id")) for row in choices].index(selected_id)),
+            format_func=lambda tid: _public_tournament_label(by_id[tid]),
+        )
+        selected_choice = by_id[selected_id]
+
+    selected_settings = selected_choice.get("settings") or {}
+    selected_slug = _safe_text(selected_settings.get("registration_slug"))
+
+    should_update_qp = (
+        _safe_text(st.query_params.get("page")) != page_key
+        or _safe_text(st.query_params.get("tournament")) != selected_slug
+        or bool(_safe_text(st.query_params.get("tournament_id")))
+    )
+    if should_update_qp:
+        _set_public_tournament_query_params(page_key=page_key, registration_slug=selected_slug or None)
+        st.rerun()
+
     return get_public_tournament_bundle(
         supabase,
         club_id=club_id,
-        tournament_id=str(tournament.get("id")),
-        registration_slug=settings.get("registration_slug"),
+        tournament_id=selected_id or None,
+        registration_slug=selected_slug or None,
     )
 
 
@@ -61,17 +119,18 @@ def render(ctx):
 
     qp_tournament_id = _safe_text(st.query_params.get("tournament_id"))
     qp_slug = _safe_text(st.query_params.get("tournament"))
-    tournament, settings, days, event_options = get_public_tournament_bundle(
+    tournament, settings, days, event_options = _select_public_tournament(
+        ctx,
         supabase,
-        club_id=club_id,
-        tournament_id=qp_tournament_id or None,
-        registration_slug=qp_slug or None,
+        page_key="tournament_partner_board",
     )
     if not tournament:
-        tournament, settings, days, event_options = _pick_tournament(ctx, supabase)
-        if not tournament:
-            st.info("No open tournaments are currently using the partner board.")
-            st.stop()
+        st.info("No open tournaments are currently using the partner board.")
+        st.stop()
+    if qp_tournament_id and str(tournament.get("id")) != qp_tournament_id:
+        st.warning("The requested tournament_id is unavailable. Showing the selected open tournament instead.")
+    elif qp_slug and _safe_text(settings.get("registration_slug")) != qp_slug:
+        st.warning("The requested tournament link is unavailable. Showing the selected open tournament instead.")
 
     state = build_registration_state(supabase, tournament, settings, days, event_options)
     board = state.get("partner_board", [])

--- a/jupr_app/ui/pages/tournament_registration.py
+++ b/jupr_app/ui/pages/tournament_registration.py
@@ -49,25 +49,82 @@ def _coerce_int(value: str) -> int | None:
         return None
 
 
-def _show_tournament_picker(ctx, supabase) -> tuple[dict[str, Any] | None, dict[str, Any] | None, list[dict[str, Any]], list[dict[str, Any]]]:
+def _public_tournament_label(choice: dict[str, Any]) -> str:
+    tournament = choice.get("tournament") or {}
+    settings = choice.get("settings") or {}
+    name = _safe_text(tournament.get("name") or f"Tournament #{tournament.get('id')}")
+    start_date = _safe_text(tournament.get("start_date"))
+    slug = _safe_text(settings.get("registration_slug"))
+    details = " • ".join(part for part in [start_date, slug] if part)
+    return f"{name} ({details})" if details else name
+
+
+def _resolve_public_tournament_id(choices: list[dict[str, Any]], *, qp_tournament_id: str, qp_slug: str) -> str:
+    by_id = {str((row.get("tournament") or {}).get("id")): row for row in choices}
+    by_slug = {
+        _safe_text((row.get("settings") or {}).get("registration_slug")): row
+        for row in choices
+        if _safe_text((row.get("settings") or {}).get("registration_slug"))
+    }
+    if qp_tournament_id and qp_tournament_id in by_id:
+        return qp_tournament_id
+    if qp_slug and qp_slug in by_slug:
+        return str((by_slug[qp_slug].get("tournament") or {}).get("id"))
+    first = choices[0] if choices else {}
+    return str((first.get("tournament") or {}).get("id") or "")
+
+
+def _set_public_tournament_query_params(*, page_key: str, registration_slug: str | None) -> None:
+    st.query_params["page"] = page_key
+    if registration_slug:
+        st.query_params["tournament"] = registration_slug
+    else:
+        st.query_params.pop("tournament", None)
+    st.query_params.pop("tournament_id", None)
+
+
+def _select_public_tournament(ctx, supabase, *, page_key: str) -> tuple[dict[str, Any] | None, dict[str, Any] | None, list[dict[str, Any]], list[dict[str, Any]]]:
     club_id = _safe_text(getattr(ctx, "club_id", ""))
     choices = list_open_public_tournaments(supabase, club_id)
     if not choices:
         st.info("No open tournament registrations are currently published.")
         return None, None, [], []
 
-    labels = [f"{row['tournament'].get('name')}" for row in choices]
-    selected_label = st.selectbox("Choose a tournament", labels)
-    idx = labels.index(selected_label)
-    selected = choices[idx]
-    tournament = selected["tournament"]
-    settings = selected["settings"]
-    st.query_params["tournament"] = settings.get("registration_slug") or ""
+    qp_tournament_id = _safe_text(st.query_params.get("tournament_id"))
+    qp_slug = _safe_text(st.query_params.get("tournament"))
+    selected_id = _resolve_public_tournament_id(choices, qp_tournament_id=qp_tournament_id, qp_slug=qp_slug)
+
+    by_id = {str((row.get("tournament") or {}).get("id")): row for row in choices}
+    selected_choice = by_id.get(selected_id) or choices[0]
+    selected_id = str((selected_choice.get("tournament") or {}).get("id") or "")
+
+    show_selector = len(choices) > 1
+    if show_selector:
+        selected_id = st.selectbox(
+            "Choose a tournament",
+            options=[str((row.get("tournament") or {}).get("id")) for row in choices],
+            index=max(0, [str((row.get("tournament") or {}).get("id")) for row in choices].index(selected_id)),
+            format_func=lambda tid: _public_tournament_label(by_id[tid]),
+        )
+        selected_choice = by_id[selected_id]
+
+    selected_settings = selected_choice.get("settings") or {}
+    selected_slug = _safe_text(selected_settings.get("registration_slug"))
+
+    should_update_qp = (
+        _safe_text(st.query_params.get("page")) != page_key
+        or _safe_text(st.query_params.get("tournament")) != selected_slug
+        or bool(_safe_text(st.query_params.get("tournament_id")))
+    )
+    if should_update_qp:
+        _set_public_tournament_query_params(page_key=page_key, registration_slug=selected_slug or None)
+        st.rerun()
+
     return get_public_tournament_bundle(
         supabase,
         club_id=club_id,
-        tournament_id=str(tournament.get("id")),
-        registration_slug=settings.get("registration_slug"),
+        tournament_id=selected_id or None,
+        registration_slug=selected_slug or None,
     )
 
 
@@ -483,19 +540,17 @@ def render(ctx):
 
     qp_tournament_id = _safe_text(st.query_params.get("tournament_id"))
     qp_slug = _safe_text(st.query_params.get("tournament"))
-    tournament, settings, days, event_options = get_public_tournament_bundle(
+    tournament, settings, days, event_options = _select_public_tournament(
+        ctx,
         supabase,
-        club_id=club_id,
-        tournament_id=qp_tournament_id or None,
-        registration_slug=qp_slug or None,
+        page_key="tournament_registration",
     )
-
     if not tournament:
-        if qp_tournament_id or qp_slug:
-            st.warning("This tournament is unavailable for public registration.")
-        tournament, settings, days, event_options = _show_tournament_picker(ctx, supabase)
-        if not tournament:
-            st.stop()
+        st.stop()
+    if qp_tournament_id and str(tournament.get("id")) != qp_tournament_id:
+        st.warning("The requested tournament_id is unavailable. Showing the selected open tournament instead.")
+    elif qp_slug and _safe_text(settings.get("registration_slug")) != qp_slug:
+        st.warning("The requested tournament link is unavailable. Showing the selected open tournament instead.")
 
     public_urls = build_public_urls(
         base_url=_safe_text(st.session_state.get("base_url")),

--- a/tests/test_public_tournament_selection.py
+++ b/tests/test_public_tournament_selection.py
@@ -1,0 +1,49 @@
+from jupr_app.ui.pages import tournament_partner_board as partner_board
+from jupr_app.ui.pages import tournament_registration as registration
+
+
+def _choices():
+    return [
+        {
+            "tournament": {"id": "111", "name": "Tournament A", "start_date": "2026-02-01"},
+            "settings": {"registration_slug": "a-open"},
+        },
+        {
+            "tournament": {"id": "222", "name": "Tournament B", "start_date": "2026-03-01"},
+            "settings": {"registration_slug": "b-open"},
+        },
+    ]
+
+
+def test_registration_resolve_public_tournament_id_prefers_valid_tournament_id():
+    selected = registration._resolve_public_tournament_id(
+        _choices(),
+        qp_tournament_id="222",
+        qp_slug="a-open",
+    )
+    assert selected == "222"
+
+
+def test_registration_resolve_public_tournament_id_falls_back_to_slug_then_first():
+    from_slug = registration._resolve_public_tournament_id(
+        _choices(),
+        qp_tournament_id="999",
+        qp_slug="b-open",
+    )
+    assert from_slug == "222"
+
+    from_first = registration._resolve_public_tournament_id(
+        _choices(),
+        qp_tournament_id="999",
+        qp_slug="missing",
+    )
+    assert from_first == "111"
+
+
+def test_partner_board_resolve_public_tournament_id_matches_rules():
+    selected = partner_board._resolve_public_tournament_id(
+        _choices(),
+        qp_tournament_id="",
+        qp_slug="b-open",
+    )
+    assert selected == "222"


### PR DESCRIPTION
### Motivation
- The public registration and partner-board pages could become locked to a tournament when stale `tournament_id` or `tournament` query params were present, preventing users from switching tournaments via the UI. 
- The goal is to always allow switching among currently open/public tournaments and canonicalize the URL to the selected tournament slug while preserving per-tournament wizard state. 
- Selector behavior must prefer a valid `tournament_id` then slug then the first open tournament, and clear stale `tournament_id` when canonicalizing to a slug.

### Description
- Replaced the fallback-only pickers with a selector-first helper `_select_public_tournament` and added `_public_tournament_label`, `_resolve_public_tournament_id`, and `_set_public_tournament_query_params` to both `tournament_registration.py` and `tournament_partner_board.py`. 
- The selectbox now uses tournament IDs as option values and `format_func` for human labels, initializes selection from query params (prefer `tournament_id`, then slug, then first open), clears stale `tournament_id`, sets `tournament=<slug>`, preserves `page=<page_key>`, and calls `st.rerun()` when params are updated. 
- The pages still load per-tournament wizard state keyed by tournament id and show warnings when a requested `tournament_id`/slug is unavailable, and identical selection/query-param behavior was applied to the partner board. 
- Added unit tests `tests/test_public_tournament_selection.py` that assert the selection-resolution precedence and fallback behavior.

### Testing
- Ran `python -m py_compile jupr_app/ui/pages/tournament_registration.py jupr_app/ui/pages/tournament_partner_board.py` and compilation succeeded. 
- Ran `pytest -q tests/test_public_tournament_selection.py` and the tests passed (`3 passed`). 
- Verified the selector logic and query-param canonicalization by unit tests covering `._resolve_public_tournament_id` behavior for both pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6dbb86308326a43b454d06dc33aa)