### PR TITLE
Use `league_ratings` as canonical source for Current Standings

### DIFF
--- a/jupr_app/ui/pages/league_results.py
+++ b/jupr_app/ui/pages/league_results.py
@@ -294,6 +294,81 @@ def _build_scoped_league_standings(
     return standings
 
 
+def _build_current_standings_from_league_ratings(
+    df_leagues: pd.DataFrame | None,
+    df_players_all: pd.DataFrame | None,
+    df_players_active: pd.DataFrame | None,
+    league_name: str,
+    active_only: bool = True,
+) -> pd.DataFrame:
+    if df_leagues is None or df_leagues.empty:
+        return pd.DataFrame()
+
+    normalized_league = str(league_name or "").strip()
+    if not normalized_league:
+        return pd.DataFrame()
+
+    data = df_leagues.copy()
+    required = {"player_id", "league_name", "rating"}
+    if not required.issubset(set(data.columns)):
+        return pd.DataFrame()
+
+    data["league_name"] = data["league_name"].fillna("").astype(str).str.strip()
+    data = data[data["league_name"] == normalized_league].copy()
+    if data.empty:
+        return pd.DataFrame()
+
+    if df_players_all is not None and not df_players_all.empty and {"id", "name"}.issubset(set(df_players_all.columns)):
+        players = df_players_all[["id", "name"]].copy().rename(columns={"id": "player_id", "name": "player_name"})
+        data = data.merge(players, on="player_id", how="left")
+    else:
+        data["player_name"] = pd.NA
+
+    if active_only and df_players_active is not None and not df_players_active.empty and "id" in df_players_active.columns:
+        active_ids = set(pd.to_numeric(df_players_active["id"], errors="coerce").dropna().astype(int).tolist())
+        data = data[pd.to_numeric(data["player_id"], errors="coerce").fillna(-1).astype(int).isin(active_ids)].copy()
+        if data.empty:
+            return pd.DataFrame()
+
+    data["player_id"] = pd.to_numeric(data["player_id"], errors="coerce").fillna(-1).astype(int)
+    data["rating"] = pd.to_numeric(data.get("rating"), errors="coerce")
+    data["starting_rating"] = pd.to_numeric(data.get("starting_rating"), errors="coerce")
+    data["wins"] = pd.to_numeric(data.get("wins"), errors="coerce").fillna(0).astype(int)
+    data["losses"] = pd.to_numeric(data.get("losses"), errors="coerce").fillna(0).astype(int)
+    data["matches_played"] = pd.to_numeric(data.get("matches_played"), errors="coerce").fillna(0).astype(int)
+    data["games"] = data["matches_played"]
+    data["player_name"] = data["player_name"].where(
+        data["player_name"].notna() & (data["player_name"].astype(str).str.strip() != ""),
+        data["player_id"].map(lambda pid: f"#{int(pid)}"),
+    )
+    data["win_pct"] = data.apply(
+        lambda r: (float(r["wins"]) / float(r["games"]) * 100.0) if int(r["games"]) > 0 else pd.NA,
+        axis=1,
+    )
+    data["JUPR"] = data["rating"].astype(float) / 400.0
+    data["rating_delta"] = (data["rating"] - data["starting_rating"]).astype(float) / 400.0
+    data = data.sort_values(
+        ["rating", "games", "wins", "player_name"],
+        ascending=[False, False, False, True],
+    ).copy()
+    data["rank"] = range(1, len(data) + 1)
+    return data[
+        [
+            "player_id",
+            "player_name",
+            "rating",
+            "starting_rating",
+            "games",
+            "wins",
+            "losses",
+            "win_pct",
+            "JUPR",
+            "rating_delta",
+            "rank",
+        ]
+    ]
+
+
 def _render_html_table(headers: list[str], rows: list[list[str]], table_class: str = "") -> None:
     table_class_attr = f"lb-table {table_class}".strip()
     header_html = "".join(f"<th>{html.escape(str(h))}</th>" for h in headers)
@@ -670,7 +745,38 @@ def render(ctx):
     if not replay_df.empty and scoped_player_ids:
         replay_df = replay_df[replay_df["player_id"].astype(int).isin(scoped_player_ids)].copy()
     weekly_rating = _weekly_rating_summary(replay_df)
-    standings = _build_scoped_league_standings(overall_stats, replay_df, getattr(ctx, "id_to_name", {}))
+    standings_from_league_ratings = _build_current_standings_from_league_ratings(
+        getattr(ctx, "df_leagues", None),
+        df_players_all,
+        df_players_active,
+        league_name,
+        active_only=True,
+    )
+    standings = standings_from_league_ratings.copy()
+    standings_source = "league_ratings"
+    replay_standings = _build_scoped_league_standings(overall_stats, replay_df, getattr(ctx, "id_to_name", {}))
+    if standings.empty:
+        standings = replay_standings.copy()
+        standings_source = "match replay fallback"
+
+    mismatch_df = pd.DataFrame()
+    if not standings_from_league_ratings.empty and not replay_standings.empty:
+        replay_cmp = replay_standings[["player_id", "player_name", "JUPR"]].rename(
+            columns={"JUPR": "replay_JUPR", "player_name": "replay_player_name"}
+        )
+        league_cmp = standings_from_league_ratings[["player_id", "player_name", "JUPR"]].rename(
+            columns={"JUPR": "league_ratings_JUPR"}
+        )
+        mismatch_df = league_cmp.merge(replay_cmp, on="player_id", how="inner")
+        if not mismatch_df.empty:
+            mismatch_df["player_name"] = mismatch_df["player_name"].where(
+                mismatch_df["player_name"].notna() & (mismatch_df["player_name"].astype(str).str.strip() != ""),
+                mismatch_df["replay_player_name"],
+            )
+            mismatch_df["difference"] = (mismatch_df["replay_JUPR"] - mismatch_df["league_ratings_JUPR"]).abs()
+            mismatch_df = mismatch_df[mismatch_df["difference"] > 0.001].copy()
+            mismatch_df = mismatch_df.sort_values("difference", ascending=False)
+
     weeks_df = _build_league_weeks(df_meta, league_name, league_matches)
     league_week_nums = weeks_df["week_num"].tolist() if not weeks_df.empty else []
     league_matches_ui = _sanitize_dataframe_for_ui(league_matches)
@@ -690,6 +796,29 @@ def render(ctx):
 
     if section == "Overall":
         st.subheader("Current Standings")
+        st.caption(f"Rating source: {standings_source}")
+        if bool(getattr(ctx, "admin_logged_in", False)) and not bool(getattr(ctx, "public_mode", False)) and not mismatch_df.empty:
+            st.warning(
+                f"Replay standings differ from league_ratings for {len(mismatch_df)} players. "
+                "Current standings are using league_ratings."
+            )
+            with st.expander("View replay vs league_ratings mismatches"):
+                mismatch_view = mismatch_df[["player_name", "league_ratings_JUPR", "replay_JUPR", "difference"]].copy()
+                mismatch_view["league_ratings_JUPR"] = mismatch_view["league_ratings_JUPR"].map(lambda v: f"{float(v):.3f}")
+                mismatch_view["replay_JUPR"] = mismatch_view["replay_JUPR"].map(lambda v: f"{float(v):.3f}")
+                mismatch_view["difference"] = mismatch_view["difference"].map(lambda v: f"{float(v):.3f}")
+                st.dataframe(
+                    mismatch_view.rename(
+                        columns={
+                            "player_name": "Player",
+                            "league_ratings_JUPR": "league_ratings JUPR",
+                            "replay_JUPR": "Replay JUPR",
+                            "difference": "Difference",
+                        }
+                    ),
+                    hide_index=True,
+                    width="stretch",
+                )
         if standings_ui.empty:
             st.info("No league rating data found yet.")
         else:

--- a/tests/test_league_results_current_standings.py
+++ b/tests/test_league_results_current_standings.py
@@ -1,0 +1,128 @@
+import math
+from types import SimpleNamespace
+
+import pandas as pd
+
+from jupr_app.domain.player_ratings_source import build_seed_rating_maps, current_seed_rating
+from jupr_app.ui.pages.league_results import (
+    _build_current_standings_from_league_ratings,
+    _build_scoped_league_standings,
+)
+
+
+class FailingSupabase:
+    def table(self, _name):
+        raise RuntimeError("db unavailable")
+
+
+def _fixture_frames():
+    league_name = "2026 Spring Ladder"
+    df_players_all = pd.DataFrame(
+        [
+            {"id": 1, "name": "Joe Baumann", "rating": 2066.0},
+            {"id": 2, "name": "Toby McElravey", "rating": 1900.0},
+        ]
+    )
+    df_players_active = pd.DataFrame([{"id": 1}, {"id": 2}])
+    df_leagues = pd.DataFrame(
+        [
+            {
+                "league_name": league_name,
+                "player_id": 1,
+                "rating": 2056.8,
+                "starting_rating": 2083.2,
+                "wins": 9,
+                "losses": 3,
+                "matches_played": 12,
+            },
+            {
+                "league_name": league_name,
+                "player_id": 2,
+                "rating": 1866.0,
+                "starting_rating": 1878.0,
+                "wins": 7,
+                "losses": 5,
+                "matches_played": 12,
+            },
+        ]
+    )
+    return SimpleNamespace(
+        league_name=league_name,
+        df_players_all=df_players_all,
+        df_players_active=df_players_active,
+        df_leagues=df_leagues,
+    )
+
+
+def test_current_standings_use_league_ratings_values():
+    fx = _fixture_frames()
+    standings = _build_current_standings_from_league_ratings(
+        fx.df_leagues, fx.df_players_all, fx.df_players_active, fx.league_name
+    )
+
+    joe = standings[standings["player_name"] == "Joe Baumann"].iloc[0]
+    toby = standings[standings["player_name"] == "Toby McElravey"].iloc[0]
+
+    assert math.isclose(float(joe["JUPR"]), 5.142, abs_tol=1e-9)
+    assert math.isclose(float(toby["JUPR"]), 4.665, abs_tol=1e-9)
+
+
+def test_current_standings_prefer_league_ratings_over_replay_values():
+    fx = _fixture_frames()
+    overall_stats = pd.DataFrame(
+        [
+            {"player_id": 1, "player_name": "Joe Baumann", "games": 12, "wins": 9, "losses": 3},
+            {"player_id": 2, "player_name": "Toby McElravey", "games": 12, "wins": 7, "losses": 5},
+        ]
+    )
+    replay_df = pd.DataFrame(
+        [
+            {"player_id": 1, "start_rating": 2083.2, "end_rating": 2076.4},  # 5.191 replay JUPR
+            {"player_id": 2, "start_rating": 1878.0, "end_rating": 1866.0},
+        ]
+    )
+
+    replay_standings = _build_scoped_league_standings(overall_stats, replay_df, {1: "Joe Baumann", 2: "Toby McElravey"})
+    league_standings = _build_current_standings_from_league_ratings(
+        fx.df_leagues, fx.df_players_all, fx.df_players_active, fx.league_name
+    )
+
+    joe_replay = replay_standings[replay_standings["player_id"] == 1].iloc[0]
+    joe_league = league_standings[league_standings["player_id"] == 1].iloc[0]
+    assert math.isclose(float(joe_replay["JUPR"]), 5.191, abs_tol=1e-9)
+    assert math.isclose(float(joe_league["JUPR"]), 5.142, abs_tol=1e-9)
+    assert float(joe_league["JUPR"]) != float(joe_replay["JUPR"])
+
+
+def test_league_results_and_league_manager_seed_rating_agree():
+    fx = _fixture_frames()
+    standings = _build_current_standings_from_league_ratings(
+        fx.df_leagues, fx.df_players_all, fx.df_players_active, fx.league_name
+    )
+    overall_map, league_map, from_live = build_seed_rating_maps(
+        supabase=FailingSupabase(),
+        club_id="club-1",
+        player_ids={1, 2},
+        league_names={fx.league_name},
+        df_players_all=fx.df_players_all,
+        df_leagues=fx.df_leagues,
+    )
+    assert from_live is False
+
+    joe_seed = current_seed_rating(
+        player_id=1,
+        league_name=fx.league_name,
+        overall_map=overall_map,
+        league_map=league_map,
+    )
+    toby_seed = current_seed_rating(
+        player_id=2,
+        league_name=fx.league_name,
+        overall_map=overall_map,
+        league_map=league_map,
+    )
+    joe_row = standings[standings["player_id"] == 1].iloc[0]
+    toby_row = standings[standings["player_id"] == 2].iloc[0]
+
+    assert math.isclose(joe_seed / 400.0, float(joe_row["JUPR"]), abs_tol=1e-9)
+    assert math.isclose(toby_seed / 400.0, float(toby_row["JUPR"]), abs_tol=1e-9)


### PR DESCRIPTION
### Motivation
- Fix a bug where Current Standings in League Results were rebuilt from match-replay calculations instead of using `league_ratings` (causing mismatches such as Joe showing 5.191 instead of 5.142). 
- Ensure League Results and League Manager seeding use the same canonical per-league rating source so UI and seeding agree.

### Description
- Added `_build_current_standings_from_league_ratings(...)` in `jupr_app/ui/pages/league_results.py` to build current standings directly from `df_leagues` (`league_ratings`), normalizing `league_name`, joining player names, optionally filtering active players, coercing numeric fields, computing `JUPR` and `rating_delta`, ranking, and sorting by `rating` desc / `games` desc / `wins` desc / `player_name` asc. 
- Updated `render()` in `league_results.py` to use the new helper as the default source for Current Standings and only fall back to replay-based standings when the `league_ratings`-derived dataframe is empty, while still keeping replay data for weekly rating history/graphs. 
- Added a small caption under Current Standings showing the rating source (`Rating source: league_ratings` or `Rating source: match replay fallback`).
- Added an admin-only mismatch warning (threshold > 0.001) when both replay and `league_ratings` standings exist, with an expander that shows player, `league_ratings` JUPR, replay JUPR, and the absolute difference. 
- Added regression tests `tests/test_league_results_current_standings.py` validating the Joe/Toby fixtures and the preference for `league_ratings` over replay and verifying agreement with League Manager seeding fallback logic via `build_seed_rating_maps` / `current_seed_rating`.

### Testing
- Ran `pytest -q tests/test_league_results_current_standings.py`, and all tests passed (`3 passed`).
- New tests cover: `Joe Baumann` showing `5.142` (from `league_ratings`), `Toby McElravey` showing `4.665`, replay-vs-league mismatch case, and agreement between League Results and League Manager seeding maps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1b18449c83269deb8fd627a78591)