### PR TITLE
Refactor public navigation chrome and lightweight page headers

### DIFF
--- a/jupr_app/ui/layout.py
+++ b/jupr_app/ui/layout.py
@@ -1,19 +1,9 @@
 from __future__ import annotations
 
 import html
-from urllib.parse import urlencode
-
 import streamlit as st
 
-from jupr_app.ui.theme_clean import topbar
-
-
-def build_admin_entry_url() -> str:
-    """
-    Build a deterministic URL that explicitly enters the admin login landing page.
-    """
-    params: dict[str, str] = {"admin": "1", "page": "admin_login"}
-    return f"/?{urlencode(params)}"
+from jupr_app.ui.theme_clean import page_header, topbar
 
 
 def page_shell(
@@ -32,16 +22,11 @@ def page_shell(
         if mode_label:
             chips.append(f'<span class="jupr-pill neutral">{html.escape(mode_label)}</span>')
 
-        in_public_shell = bool(st.session_state.get("jupr_public_mode", False))
-        in_admin_entry = bool(st.session_state.get("jupr_admin_entry_active", False))
-        if in_public_shell and not in_admin_entry:
-            admin_href = html.escape(build_admin_entry_url(), quote=True)
-            chips.append(
-                f'<a class="jupr-topbar-action" href="{admin_href}" '
-                'aria-label="Open admin login">Admin Login</a>'
-            )
-
         resolved_right_html = "".join(chips)
 
-    topbar(title, subtitle, right_html=resolved_right_html)
+    in_public_shell = bool(st.session_state.get("jupr_public_mode", False))
+    if in_public_shell:
+        page_header(title, subtitle, right_html=resolved_right_html)
+    else:
+        topbar(title, subtitle, right_html=resolved_right_html)
     st.markdown("<div style='height:6px'></div>", unsafe_allow_html=True)

--- a/jupr_app/ui/pages/home.py
+++ b/jupr_app/ui/pages/home.py
@@ -18,7 +18,6 @@ def render(ctx) -> None:  # noqa: ARG001
               <a class="jupr-link-button" href="?page=players">Player Profiles</a>
               <a class="jupr-link-button" href="?page=tournament_registration">Events</a>
               <a class="jupr-link-button" href="?page=verified_updates_request">Player Updates</a>
-              <a class="jupr-link-button" href="?admin=1&page=admin_login">Admin Login</a>
             </div>
           </div>
 

--- a/jupr_app/ui/public_nav.py
+++ b/jupr_app/ui/public_nav.py
@@ -45,7 +45,7 @@ def _href_for_page(page_key: str, *, base_params: dict[str, str]) -> str:
     return f"?{urlencode(sorted(params.items()))}"
 
 
-def render_public_top_nav(
+def render_public_app_header(
     *,
     labels_in_order: list[str] | None = None,
     current_label: str | None = None,
@@ -81,7 +81,17 @@ def render_public_top_nav(
         for page_key in nav_page_keys
     )
 
-    admin_href = "?admin=1&page=admin_login"
+    admin_authenticated = bool(st.session_state.get("jupr_admin_authenticated", False))
+    admin_href = "?admin=1&page=league_manager"
+    logout_href = "?logout=1"
+    admin_action_html = (
+        '<div class="jupr-public-admin-actions">'
+        f'<a class="jupr-public-admin-action" href="{admin_href}">Admin Dashboard</a>'
+        f'<a class="jupr-public-admin-action jupr-public-admin-action--secondary" href="{logout_href}">Logout</a>'
+        "</div>"
+        if admin_authenticated
+        else f'<a class="jupr-public-admin-action" href="?admin=1&page=admin_login">Admin Login</a>'
+    )
 
     st.markdown(
         f"""
@@ -94,7 +104,7 @@ def render_public_top_nav(
             <nav class="jupr-public-nav-links" aria-label="Public navigation">
               {nav_links_html}
             </nav>
-            <a class="jupr-public-admin-action" href="{admin_href}">Admin Login</a>
+            {admin_action_html}
           </div>
         </div>
         """,
@@ -102,3 +112,17 @@ def render_public_top_nav(
     )
 
     return PAGE_KEY_TO_LABEL.get(current_page_key, PAGE_KEY_TO_LABEL[default_page])
+
+
+def render_public_top_nav(
+    *,
+    labels_in_order: list[str] | None = None,
+    current_label: str | None = None,
+    default_page: str = "home",
+) -> str:
+    """Backward-compatible alias for the public app header renderer."""
+    return render_public_app_header(
+        labels_in_order=labels_in_order,
+        current_label=current_label,
+        default_page=default_page,
+    )

--- a/jupr_app/ui/theme_clean.py
+++ b/jupr_app/ui/theme_clean.py
@@ -258,12 +258,12 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         position: sticky;
         top: 0.5rem;
         z-index: 120;
-        margin-bottom: 1.15rem;
-        padding: 0.7rem 0.9rem;
+        margin-bottom: 0.8rem;
+        padding: 0.52rem 0.72rem;
         border-radius: var(--radius);
         border: 1px solid var(--border-strong);
         background: color-mix(in srgb, var(--panel) 94%, transparent);
-        box-shadow: var(--shadow-lg);
+        box-shadow: 0 8px 18px rgba(2, 6, 23, 0.06);
         backdrop-filter: blur(10px);
       }}
       .jupr-public-brand {{
@@ -327,6 +327,17 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         font-size: 0.8rem;
         font-weight: 800;
       }}
+      .jupr-public-admin-actions {{
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }}
+      .jupr-public-admin-action--secondary {{
+        border-color: var(--border);
+        background: var(--panel);
+      }}
       .jupr-public-admin-action:hover {{
         color: var(--text-primary);
         border-color: color-mix(in srgb, var(--accent) 55%, var(--border-strong));
@@ -354,6 +365,34 @@ def apply_clean_theme(*, accent_hex: str = "#2F6FED") -> None:
         .jupr-public-admin-action {{
           margin-left: auto;
         }}
+        .jupr-public-admin-actions {{
+          margin-left: auto;
+        }}
+      }}
+      .jupr-page-header {{
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 0.8rem 1rem;
+        flex-wrap: wrap;
+        margin-bottom: 0.75rem;
+        padding: 0.6rem 0.1rem 0.4rem;
+      }}
+      .jupr-page-header__title {{
+        font-size: clamp(1.25rem, 2.1vw, 1.55rem);
+        font-weight: 750;
+        line-height: 1.2;
+        color: var(--text-primary);
+      }}
+      .jupr-page-header__subtitle {{
+        margin-top: 0.2rem;
+        font-size: 0.9rem;
+        color: var(--text-muted);
+      }}
+      .jupr-page-header__right {{
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
       }}
       .jupr-hero {{
         margin-bottom: 1rem;
@@ -879,6 +918,25 @@ def topbar(title: str, subtitle: str = "", *, right_html: str = "") -> None:
             <div class="jupr-topbar__subtitle">{subtitle_html}</div>
           </div>
           <div class="jupr-topbar__right">{right_html}</div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def page_header(title: str, subtitle: str = "", *, right_html: str = "") -> None:
+    """Render a lightweight page header intended for public pages under global nav."""
+    title_html = html.escape(title)
+    subtitle_html = html.escape(subtitle)
+
+    st.markdown(
+        f"""
+        <div class="jupr-page-header">
+          <div class="jupr-page-header__left">
+            <div class="jupr-page-header__title">{title_html}</div>
+            <div class="jupr-page-header__subtitle">{subtitle_html}</div>
+          </div>
+          <div class="jupr-page-header__right">{right_html}</div>
         </div>
         """,
         unsafe_allow_html=True,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -33,7 +33,7 @@ from jupr_app.ui.page_registry import (
     PUBLIC_NAV_KEYS,
     labels_for_keys,
 )
-from jupr_app.ui.public_nav import render_public_top_nav
+from jupr_app.ui.public_nav import render_public_app_header
 from jupr_app.ui.theme_clean import apply_clean_theme
 from jupr_app.ui.url import qp_get
 
@@ -188,6 +188,7 @@ def main():
         public_requested = _is_truthy(qp_get("public", "0"))
         admin_requested = _is_truthy(qp_get("admin", "0"))
         incoming_page_param = qp_get("page", "").strip().lower()
+        logout_requested = _is_truthy(qp_get("logout", "0"))
         admin_login_requested = incoming_page_param == "admin_login"
         requested_admin_page = incoming_page_param in ADMIN_ONLY_PAGE_KEYS
         recovery_flow = is_recovery_flow_query()
@@ -225,6 +226,25 @@ def main():
             authorized = False
 
         admin_authenticated = authenticated and authorized
+        st.session_state["jupr_admin_authenticated"] = bool(admin_authenticated)
+
+        if logout_requested:
+            if authenticated:
+                logout_admin()
+                st.session_state.pop("post_login_admin_page_key", None)
+            params_changed = _set_query_params_idempotent(
+                updates={"public": "1", "page": "home"},
+                removals={
+                    "admin",
+                    "next",
+                    "logout",
+                    "jupr_admin_access_token",
+                    "jupr_admin_refresh_token",
+                    "jupr_admin_restore_from_storage",
+                },
+            )
+            if params_changed:
+                st.rerun()
 
         if admin_login_requested and admin_authenticated:
             post_login_target = str(
@@ -495,7 +515,7 @@ def main():
                     if deep_label in public_labels_in_order
                     else public_labels_in_order[0]
                 )
-                sel = render_public_top_nav(
+                sel = render_public_app_header(
                     labels_in_order=public_labels_in_order,
                     current_label=current_label,
                 )


### PR DESCRIPTION
### Motivation
- Remove redundant public-facing navigation and large page-level hero/title cards that duplicated actions like `Admin Login` and created visual clutter.
- Provide a clear two-level header structure: a slim, consistent global public header and a lighter page header for per-page titles/subtitles.
- Preserve existing public routing/query-param behavior and admin auth flow while reducing duplicated UI elements.

### Description
- Introduces a reusable global public header renderer `render_public_app_header` (keeps `render_public_top_nav` as a backward-compatible alias) in `jupr_app/ui/public_nav.py` and uses it from `streamlit_app.py` for public routing.
- Makes the global public header auth-aware so unauthenticated visitors see `Admin Login` and authenticated admins see `Admin Dashboard` + `Logout`, with logout handled via `?logout=1` in `streamlit_app.py`.
- Adds a lightweight `page_header` (in `jupr_app/ui/theme_clean.py`) and updates `page_shell` (in `jupr_app/ui/layout.py`) to render the `page_header` for public mode while preserving the existing `topbar` for admin pages.
- Removes the duplicate `Admin Login` CTA from the Home hero and tightens the public nav visual styling (reduced padding, softer shadow, responsive wrapping) and adds CSS for the page header in `jupr_app/ui/theme_clean.py`.

### Testing
- Compiled modified modules with `python -m compileall streamlit_app.py jupr_app/ui/public_nav.py jupr_app/ui/layout.py jupr_app/ui/theme_clean.py jupr_app/ui/pages/home.py` and observed no syntax errors.
- Verified the new `?logout=1` query handling path compiles and that the public header rendering functions compile cleanly, with no automated test failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee34d7ae7c8326893346d2d878dd09)