### PR TITLE
Unify internal JUPR navigation to same-tab query-param routing

### DIFF
--- a/jupr_app/ui/nav.py
+++ b/jupr_app/ui/nav.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-import streamlit as st
+from jupr_app.ui.public_links import navigate_same_tab
 
 
 logger = logging.getLogger(__name__)
@@ -31,12 +31,15 @@ def navigate_to_player_profile(
         if text_value:
             next_params[str(key)] = text_value
 
-    st.query_params.clear()
-    st.query_params.update(next_params)
     logger.info(
         "Internal navigation to player profile via query-param mutation (full_reload=False): pid=%s public_mode=%s extra_keys=%s",
         player_id,
         public_mode,
         sorted((extra_params or {}).keys()),
     )
-    st.rerun()
+    navigate_same_tab(
+        page=next_params["page"],
+        params={k: v for k, v in next_params.items() if k != "page"},
+        public_mode=public_mode,
+        clear_existing=True,
+    )

--- a/jupr_app/ui/pages/leaderboards.py
+++ b/jupr_app/ui/pages/leaderboards.py
@@ -7,7 +7,7 @@ import pandas as pd
 from jupr_app.domain.awards import build_top_performer_entries
 from jupr_app.ui.nav import navigate_to_player_profile
 from jupr_app.ui.url import qp_get
-from jupr_app.ui.public_links import build_public_url, public_link_button
+from jupr_app.ui.public_links import build_public_url, public_nav_button
 from jupr_app.ui.layout import page_shell
 from jupr_app.ui.theme_clean import callout
 from jupr_app.ui.badge_data import normalize_player_badges_frame, normalize_player_ids
@@ -1082,7 +1082,11 @@ def render(ctx):
             st.markdown("#### Public standings")
             st.caption("Share this link with players.")
             st.text_input("Public share URL", value=public_url, label_visibility="collapsed")
-            public_link_button("Open Public Standings", public_url)
+            public_nav_button(
+                "Open Public Standings",
+                page="leaderboards",
+                params={"league": target_league},
+            )
     if inactive_notice and not PUBLIC_MODE:
         callout("info", "Heads up", inactive_notice)
 

--- a/jupr_app/ui/pages/reset_password.py
+++ b/jupr_app/ui/pages/reset_password.py
@@ -15,6 +15,7 @@ from jupr_app.ui.admin_auth import (
     make_supabase_auth_client,
     update_recovered_user_password,
 )
+from jupr_app.ui.public_links import navigate_same_tab
 from jupr_app.ui.layout import page_shell
 
 
@@ -158,4 +159,5 @@ def render(ctx):
 
         clear_local_admin_auth_state()
         st.success("Password updated successfully. Return to login and sign in with your new password.")
-        st.link_button("Return to login", "/?page=admin_login&admin=1")
+        if st.button("Return to login"):
+            navigate_same_tab(page="admin_login", public_mode=False)

--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -27,6 +27,7 @@ from jupr_app.domain.tournament_registration_repo import (
     upsert_registration_settings,
 )
 from jupr_app.ui.layout import page_shell
+from jupr_app.ui.public_links import navigate_same_tab
 
 COMPETITION_FORMATS = ["ROUND_ROBIN", "SINGLE_ELIM", "DOUBLE_ELIM", "ROUND_ROBIN_PLUS_PLAYOFF"]
 SCORING_OPTIONS = ["GAME_TO_11", "GAME_TO_15", "GAME_TO_21", "BEST_2_OF_3"]
@@ -2090,8 +2091,14 @@ def render(ctx):
             tournament_id=tournament_id,
             registration_slug=settings.get("registration_slug"),
         )
-        st.link_button("Public registration form", public_urls["registration"])
-        st.link_button("Public partner board", public_urls["partner_board"])
+        nav_params = {"tournament_id": tournament_id}
+        slug = _safe_text(settings.get("registration_slug"))
+        if slug:
+            nav_params["tournament"] = slug
+        if st.button("Public registration form"):
+            navigate_same_tab(page="tournament_registration", params=nav_params, public_mode=True)
+        if st.button("Public partner board"):
+            navigate_same_tab(page="tournament_partner_board", params=nav_params, public_mode=True)
         st.caption("Publish registration changes before sharing links when days, events, or divisions have changed.")
 
         validation_errors = _validate_builder(days_df, events_df, divisions_df)

--- a/jupr_app/ui/pages/tournament_registration.py
+++ b/jupr_app/ui/pages/tournament_registration.py
@@ -33,6 +33,7 @@ from jupr_app.domain.tournament_registration_repo import (
     update_admin_registration_selection,
 )
 from jupr_app.ui.layout import page_shell
+from jupr_app.ui.public_links import navigate_same_tab
 
 
 def _uid(prefix: str) -> str:
@@ -783,7 +784,12 @@ def render(ctx):
                 window_bits.append(f"Closes: {_safe_text(settings.get('registration_close_at'))}")
             st.caption(" • ".join(window_bits))
     with top_cols[1]:
-        st.link_button("View Tournament Roster", public_urls["roster"])
+        if st.button("View Tournament Roster", key=f"view_tournament_roster_{tournament.get('id')}"):
+            nav_params = {"tournament_id": str(tournament.get("id"))}
+            slug = _safe_text(settings.get("registration_slug"))
+            if slug:
+                nav_params["tournament"] = slug
+            navigate_same_tab(page="tournament_roster", params=nav_params, public_mode=True)
 
     if admin_mode:
         roster_tab, add_tab, links_tab = st.tabs(["Registration Roster", "Add Registration", "Public Form Preview / Links"])
@@ -833,8 +839,18 @@ def render(ctx):
         with links_tab:
             st.code(public_urls["registration"])
             st.code(public_urls["roster"])
-            st.link_button("Open Public Registration Form", public_urls["registration"])
-            st.link_button("Open Public Roster", public_urls["roster"])
+            if st.button("Open Public Registration Form", key=f"open_public_registration_{tournament.get('id')}"):
+                nav_params = {"tournament_id": str(tournament.get("id"))}
+                slug = _safe_text(settings.get("registration_slug"))
+                if slug:
+                    nav_params["tournament"] = slug
+                navigate_same_tab(page="tournament_registration", params=nav_params, public_mode=True)
+            if st.button("Open Public Roster", key=f"open_public_roster_{tournament.get('id')}"):
+                nav_params = {"tournament_id": str(tournament.get("id"))}
+                slug = _safe_text(settings.get("registration_slug"))
+                if slug:
+                    nav_params["tournament"] = slug
+                navigate_same_tab(page="tournament_roster", params=nav_params, public_mode=True)
         return
 
     if settings.get("sponsor_markdown"):
@@ -1471,7 +1487,12 @@ def render(ctx):
                 st.success(
                     f"Registration saved. Confirmation record: {result.get('registration_id')}. Submitting again with the same email updates your registration. Final placement may still change after partner matching and waitlist review."
                 )
-                st.link_button("View Tournament Roster", public_urls["roster"])
+                if st.button("View Tournament Roster", key=f"view_tournament_roster_post_save_{tournament.get('id')}"):
+                    nav_params = {"tournament_id": str(tournament.get("id"))}
+                    slug = _safe_text(settings.get("registration_slug"))
+                    if slug:
+                        nav_params["tournament"] = slug
+                    navigate_same_tab(page="tournament_roster", params=nav_params, public_mode=True)
                 wizard["current_step"] = 1
                 wizard["step3"] = {"selected_event_ids": []}
                 wizard["step4"] = {"partner_details": {}}

--- a/jupr_app/ui/pages/tournament_roster.py
+++ b/jupr_app/ui/pages/tournament_roster.py
@@ -13,6 +13,7 @@ from jupr_app.domain.tournament_registration_repo import (
     registration_feature_available,
 )
 from jupr_app.ui.layout import page_shell
+from jupr_app.ui.public_links import navigate_same_tab
 
 
 def _safe_text(value: Any) -> str:
@@ -149,7 +150,12 @@ def render(ctx, *, focus_partners: bool = False, legacy_partner_board: bool = Fa
                 window_bits.append(f"Closes: {_safe_text(settings.get('registration_close_at'))}")
             st.caption(" • ".join(window_bits))
     with top_cols[1]:
-        st.link_button("Register", public_urls["registration"])
+        if st.button("Register", key=f"register_from_roster_{tournament.get('id')}"):
+            nav_params = {"tournament_id": str(tournament.get("id"))}
+            slug = _safe_text(settings.get("registration_slug"))
+            if slug:
+                nav_params["tournament"] = slug
+            navigate_same_tab(page="tournament_registration", params=nav_params, public_mode=True)
 
     summary = state.get("summary") or {}
     registrations = state.get("registrations_by_event") or []
@@ -234,4 +240,3 @@ def render(ctx, *, focus_partners: bool = False, legacy_partner_board: bool = Fa
                         if skills:
                             details.append("Skill " + " / ".join(str(skill) for skill in skills))
                         st.markdown(f"- {names}" + (f" — {' • '.join(details)}" if details else ""))
-

--- a/jupr_app/ui/pages/tournaments.py
+++ b/jupr_app/ui/pages/tournaments.py
@@ -8,7 +8,6 @@ import streamlit as st
 from jupr_app.domain.event_tags import derive_default_date_tags, normalize_event_tags
 from jupr_app.domain.tournament_registration_repo import (
     archive_tournament,
-    build_public_urls,
     delete_unused_draft_tournament,
     get_registration_settings,
     list_existing_tournaments,
@@ -17,6 +16,7 @@ from jupr_app.domain.tournament_registration_repo import (
     upsert_registration_settings,
 )
 from jupr_app.ui.layout import page_shell
+from jupr_app.ui.public_links import navigate_same_tab
 
 LEGACY_DEFAULT_TEAM_COUNT = 4
 TOURNAMENT_STATUS_OPTIONS = ["DRAFT", "REGISTRATION", "REGISTRATION_OPEN", "REGISTRATION_CLOSED", "ARCHIVED"]
@@ -182,13 +182,23 @@ def render(ctx):
     if launch[2].button("🔴 Open Tournament Live"):
         _go_to_page("tournament_live", tournament_id)
 
-    links = build_public_urls(
-        base_url=_safe_text(st.session_state.get("base_url")),
-        tournament_id=str(tournament_id),
-        registration_slug=settings.get("registration_slug"),
-    )
-    launch[3].link_button("📝 Public Registration", links["registration"])
-    launch[4].link_button("🤝 Partner Board", links["partner_board"])
+    slug = _safe_text(settings.get("registration_slug"))
+    tournament_nav_params = {"tournament_id": str(tournament_id)}
+    if slug:
+        tournament_nav_params["tournament"] = slug
+
+    if launch[3].button("📝 Public Registration"):
+        navigate_same_tab(
+            page="tournament_registration",
+            params=tournament_nav_params,
+            public_mode=True,
+        )
+    if launch[4].button("🤝 Partner Board"):
+        navigate_same_tab(
+            page="tournament_partner_board",
+            params=tournament_nav_params,
+            public_mode=True,
+        )
 
     st.markdown("#### Admin Actions")
     action_cols = st.columns(2)

--- a/jupr_app/ui/pages/weekly_recap.py
+++ b/jupr_app/ui/pages/weekly_recap.py
@@ -5,6 +5,7 @@ from postgrest.exceptions import APIError
 
 from jupr_app.ui.components.weekly_recap_layout import render_weekly_recap
 from jupr_app.ui.layout import page_shell
+from jupr_app.ui.public_links import navigate_same_tab
 from jupr_app.ui.url import qp_get
 
 
@@ -136,10 +137,12 @@ def render(ctx):
 
     if not print_mode:
         st.caption("Tip: use your browser print dialog for a bulletin-board-ready PDF.")
-        base_url = st.session_state.get("base_url", "")
-        if base_url:
-            print_url = f"{base_url}/?page=weekly_recap&public=1&print=1"
-            st.link_button("Open Print-Friendly View", print_url)
+        if st.button("Open Print-Friendly View"):
+            navigate_same_tab(
+                page="weekly_recap",
+                params={"print": "1"},
+                public_mode=True,
+            )
         pdf_bytes = _build_recap_pdf(
             recap,
             str(selected_row.get("week_start") or ""),

--- a/jupr_app/ui/public_links.py
+++ b/jupr_app/ui/public_links.py
@@ -1,8 +1,10 @@
 # jupr_app/ui/public_links.py
 from __future__ import annotations
 
-import streamlit as st
 import urllib.parse
+from collections.abc import Mapping
+
+import streamlit as st
 
 
 def get_base_url() -> str:
@@ -28,15 +30,104 @@ def build_public_url(*, page: str, params: dict[str, str] | None = None) -> str:
     return f"{base}/?{urllib.parse.urlencode(q)}"
 
 
-def public_link_button(label: str, url: str):
-    """
-    A link-button with safe fallback for older Streamlit versions.
-    """
-    try:
-        st.link_button(label, url)
-    except Exception:
-        st.markdown(
-            f'<a class="jupr-link-button" href="{url}" target="_blank" rel="noopener noreferrer">'
-            f'<button class="jupr-link-button__btn">{label}</button></a>',
-            unsafe_allow_html=True,
-        )
+def _clean_param_values(params: Mapping[str, object] | None = None) -> dict[str, str]:
+    cleaned: dict[str, str] = {}
+    for key, value in (params or {}).items():
+        if value is None:
+            continue
+        text_value = str(value).strip()
+        if text_value:
+            cleaned[str(key)] = text_value
+    return cleaned
+
+
+def build_public_params(page: str, params: dict[str, str] | None = None) -> dict[str, str]:
+    public_params = {"page": str(page).strip(), "public": "1"}
+    public_params.update(_clean_param_values(params))
+    return public_params
+
+
+def build_route_params(
+    *,
+    page: str,
+    params: Mapping[str, object] | None = None,
+    public_mode: bool = True,
+) -> dict[str, str]:
+    route_params = {"page": str(page).strip()}
+    route_params.update(_clean_param_values(params))
+    if public_mode:
+        route_params["public"] = "1"
+        route_params.pop("admin", None)
+    else:
+        route_params["admin"] = "1"
+        route_params.pop("public", None)
+    return route_params
+
+
+def navigate_same_tab(
+    page: str,
+    params: dict[str, str] | None = None,
+    public_mode: bool = True,
+    clear_existing: bool = True,
+) -> None:
+    next_params = build_route_params(page=page, params=params, public_mode=public_mode)
+    if clear_existing:
+        st.query_params.clear()
+    st.query_params.update(next_params)
+    st.rerun()
+
+
+def public_nav_button(
+    label: str,
+    page: str,
+    params: dict[str, str] | None = None,
+    key: str | None = None,
+    use_container_width: bool = False,
+) -> bool:
+    clicked = st.button(label, key=key, use_container_width=use_container_width)
+    if clicked:
+        navigate_same_tab(page=page, params=params, public_mode=True)
+    return clicked
+
+
+def _same_app_query_params_from_url(url: str) -> dict[str, str] | None:
+    parsed = urllib.parse.urlparse(str(url or "").strip())
+    if not parsed.scheme and not parsed.netloc:
+        query = urllib.parse.parse_qs(parsed.query, keep_blank_values=False)
+        return {k: v[-1] for k, v in query.items() if v and str(v[-1]).strip()}
+
+    base = urllib.parse.urlparse(get_base_url())
+    if parsed.scheme in {"http", "https"} and base.netloc and parsed.netloc == base.netloc:
+        query = urllib.parse.parse_qs(parsed.query, keep_blank_values=False)
+        return {k: v[-1] for k, v in query.items() if v and str(v[-1]).strip()}
+    return None
+
+
+def external_link_button(label: str, url: str, use_container_width: bool = False) -> None:
+    st.link_button(label, url, use_container_width=use_container_width)
+
+
+def public_link_button(
+    label: str,
+    url: str,
+    *,
+    key: str | None = None,
+    use_container_width: bool = False,
+) -> None:
+    """Backward compatible helper: same-app URLs navigate in-tab; external URLs use link_button."""
+    route_params = _same_app_query_params_from_url(url)
+    if route_params and route_params.get("page"):
+        clicked = st.button(label, key=key, use_container_width=use_container_width)
+        if clicked:
+            next_page = route_params.get("page", "home")
+            raw_public = str(route_params.get("public", "")).strip().lower()
+            public_mode = raw_public in {"1", "true", "yes", "y", "on"}
+            nav_params = {k: v for k, v in route_params.items() if k != "page"}
+            navigate_same_tab(
+                page=next_page,
+                params=nav_params,
+                public_mode=public_mode,
+                clear_existing=True,
+            )
+        return
+    external_link_button(label, url, use_container_width=use_container_width)

--- a/tests/test_public_links.py
+++ b/tests/test_public_links.py
@@ -1,0 +1,56 @@
+from jupr_app.ui.public_links import build_public_params, build_route_params
+
+
+def test_build_public_params_skips_none_and_preserves_common_route_keys():
+    params = build_public_params(
+        "players",
+        {
+            "pid": "42",
+            "league": "OVERALL",
+            "club_id": "tres_palapas",
+            "tournament_id": "100",
+            "event_id": "200",
+            "player": None,
+        },
+    )
+
+    assert params == {
+        "page": "players",
+        "public": "1",
+        "pid": "42",
+        "league": "OVERALL",
+        "club_id": "tres_palapas",
+        "tournament_id": "100",
+        "event_id": "200",
+    }
+
+
+def test_build_route_params_public_mode_never_includes_admin_flag():
+    params = build_route_params(
+        page="leaderboards",
+        params={"league": "OVERALL", "admin": "1", "pid": None},
+        public_mode=True,
+    )
+
+    assert params == {
+        "page": "leaderboards",
+        "league": "OVERALL",
+        "public": "1",
+    }
+    assert "admin" not in params
+
+
+def test_build_route_params_admin_mode_never_includes_public_flag():
+    params = build_route_params(
+        page="tournament_manager",
+        params={"tournament_id": "abc", "public": "1", "club_id": "tres_palapas"},
+        public_mode=False,
+    )
+
+    assert params == {
+        "page": "tournament_manager",
+        "tournament_id": "abc",
+        "club_id": "tres_palapas",
+        "admin": "1",
+    }
+    assert "public" not in params


### PR DESCRIPTION
### Motivation
- Internal links were inconsistently opening new browser tabs because some code used absolute public URLs + `st.link_button`/anchor fallbacks instead of in-app query-param navigation. This created an app-like UX mismatch between public and admin flows.
- Create a small, opinionated navigation layer so same-app routes always update `st.query_params` and call `st.rerun()` (stay in the same tab), while preserving true external link behavior and existing shareable deep links.

### Description
- Added a same-tab navigation layer in `jupr_app/ui/public_links.py` including `build_public_params`, `build_route_params`, `navigate_same_tab`, `public_nav_button`, `public_link_button`, and `external_link_button`, and a small helper `_same_app_query_params_from_url`. `build_public_url` was kept for generating shareable absolute URLs.
- Rewired canonical player navigation in `jupr_app/ui/nav.py` to call `navigate_same_tab(...)` (preserves `pid`, `club_id` and public/admin semantics) instead of mutating `st.query_params` directly.
- Replaced same-app `st.link_button` / absolute-URL patterns with same-tab navigation buttons in key pages: `jupr_app/ui/pages/leaderboards.py`, `tournaments.py`, `tournament_registration.py`, `tournament_roster.py`, `tournament_manager.py`, `weekly_recap.py`, and `reset_password.py` so internal CTAs and pins route in-tab.
- Added unit tests `tests/test_public_links.py` for `build_public_params` and `build_route_params` to validate skipping `None` values, preserving common route keys, and ensuring `public=1` and `admin=1` are mutually exclusive per mode.

### Testing
- Ran Python syntax check: `python -m py_compile jupr_app/ui/public_links.py jupr_app/ui/nav.py jupr_app/ui/pages/...` and the modified modules compiled successfully.
- Ran unit tests: `pytest -q tests/test_public_links.py tests/test_verified_updates_public_routing.py` which passed (11 tests passed in the run executed here).
- Performed repo checks to ensure remaining `st.link_button` usage is intentional (isolated to `external_link_button` and non-app examples) and `target="_blank"` occurrences are limited to explicit external examples. All checks passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee36c066fc8326bfc6a1e83d064a3d)