### PR TITLE
Add admin auth debug events and session continuity diagnostics

### DIFF
--- a/jupr_app/ui/admin_auth.py
+++ b/jupr_app/ui/admin_auth.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Mapping
+from datetime import datetime, timezone
 
 import streamlit as st
 import streamlit.components.v1 as components
 from supabase import create_client
+
+from jupr_app.ui.public_links import redact_query_params
 
 
 logger = logging.getLogger(__name__)
@@ -21,6 +24,8 @@ _BROWSER_SYNC_PAYLOAD_KEY = "_admin_browser_sync_payload"
 _BROWSER_CLEAR_PENDING_KEY = "_admin_browser_clear_pending"
 _BROWSER_RESTORE_INFLIGHT_SESSION_KEY = "jupr_admin_restore_inflight_at"
 _ADMIN_RESTORE_FAILED_THIS_RUN_KEY = "_admin_restore_failed_this_run"
+_AUTH_DEBUG_EVENTS_KEY = "jupr_auth_debug_events"
+_AUTH_DEBUG_EVENTS_MAX = 50
 
 
 class AdminAuthError(RuntimeError):
@@ -29,6 +34,54 @@ class AdminAuthError(RuntimeError):
 
 class AdminAuthConfigError(AdminAuthError):
     """Raised when required auth config is missing."""
+
+
+def _safe_route_snapshot() -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    for key in st.query_params.keys():
+        value = st.query_params.get(key, "")
+        if isinstance(value, list):
+            value = value[0] if value else ""
+        text_value = str(value or "").strip()
+        if text_value:
+            snapshot[str(key)] = text_value
+    return redact_query_params(snapshot)
+
+
+def _sanitize_debug_text(value: object) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    lowered = text.lower()
+    sensitive_terms = (
+        "access_token",
+        "refresh_token",
+        "password",
+        "auth code",
+        "auth_code",
+        "token hash",
+        "token_hash",
+        "supabase",
+        "anon_key",
+        "service_role",
+    )
+    if any(term in lowered for term in sensitive_terms):
+        return "[REDACTED]"
+    return text
+
+
+def _append_auth_debug_event(event_type: str, *, success: bool, reason: str = "") -> None:
+    events = list(st.session_state.get(_AUTH_DEBUG_EVENTS_KEY, []))
+    events.append(
+        {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "event_type": str(event_type or "").strip() or "unknown",
+            "success": bool(success),
+            "reason": _sanitize_debug_text(reason),
+            "route_query_params": _safe_route_snapshot(),
+        }
+    )
+    st.session_state[_AUTH_DEBUG_EVENTS_KEY] = events[-_AUTH_DEBUG_EVENTS_MAX:]
 
 
 def _get_secret(path: list[str], default=None):
@@ -434,6 +487,11 @@ def restore_admin_browser_session() -> dict[str, str] | None:
 def clear_admin_browser_session() -> None:
     st.session_state[_BROWSER_CLEAR_PENDING_KEY] = True
     st.session_state.pop(_BROWSER_SYNC_PAYLOAD_KEY, None)
+    _append_auth_debug_event(
+        "clear_browser_tokens_queued",
+        success=True,
+        reason="Queued browser token clear for logout/session cleanup.",
+    )
     logger.info("Browser token clear queued")
 
 
@@ -454,6 +512,11 @@ def render_admin_browser_session_clear_now() -> None:
     )
     st.session_state.pop(_BROWSER_SYNC_PAYLOAD_KEY, None)
     st.session_state.pop(_BROWSER_CLEAR_PENDING_KEY, None)
+    _append_auth_debug_event(
+        "clear_browser_tokens_now",
+        success=True,
+        reason="Cleared browser auth tokens immediately in current tab.",
+    )
     logger.info("Browser token clear rendered immediately")
 
 
@@ -465,17 +528,37 @@ def maybe_restore_admin_login_from_browser() -> bool:
     if existing_user is not None:
         existing_email = str(getattr(existing_user, "email", "") or "").strip().lower()
         logger.info("Browser restore skipped: user already present in session state")
+        _append_auth_debug_event(
+            "restore_skipped_already_authenticated",
+            success=True,
+            reason="Existing admin user already present in this Streamlit session.",
+        )
         return bool(
             existing_email and is_allowed_admin_email(existing_email, load_admin_allowlist())
         )
     if bool(st.session_state.get(_ADMIN_RESTORE_FAILED_THIS_RUN_KEY, False)):
         logger.info("Browser restore skipped: this run already recorded a restore failure")
+        _append_auth_debug_event(
+            "restore_skipped_after_failure",
+            success=False,
+            reason="Restore already failed earlier in this app run.",
+        )
         return False
 
     logger.info("Browser token restore attempt started")
+    _append_auth_debug_event(
+        "restore_attempt_started",
+        success=True,
+        reason="Attempting to restore admin auth from browser storage handshake.",
+    )
     stored_tokens = restore_admin_browser_session()
     if not stored_tokens:
         logger.info("Browser token restore skipped: no handshake tokens available yet")
+        _append_auth_debug_event(
+            "restore_skipped_no_handshake_tokens",
+            success=False,
+            reason="No restore handshake tokens available in query params yet.",
+        )
         return False
 
     try:
@@ -502,6 +585,11 @@ def maybe_restore_admin_login_from_browser() -> bool:
         ):
             clear_local_admin_auth_state()
             logger.info("Browser token restore failed: invalid session/user or disallowed email")
+            _append_auth_debug_event(
+                "restore_failed",
+                success=False,
+                reason="Invalid restore session/user or user not in admin allowlist.",
+            )
             return False
 
         st.session_state[_AUTH_USER_KEY] = user
@@ -512,9 +600,19 @@ def maybe_restore_admin_login_from_browser() -> bool:
             persist_admin_browser_session(access_token, refresh_token)
         st.session_state.pop(_ADMIN_RESTORE_FAILED_THIS_RUN_KEY, None)
         logger.info("Browser token restore succeeded")
+        _append_auth_debug_event(
+            "restore_succeeded",
+            success=True,
+            reason="Browser token restore completed for allowlisted admin user.",
+        )
         return True
     except Exception as exc:
         logger.warning("Browser token restore failed: %r", exc)
+        _append_auth_debug_event(
+            "restore_failed",
+            success=False,
+            reason=f"Exception during restore: {exc}",
+        )
         clear_local_admin_auth_state()
         render_admin_browser_session_clear_now()
         _clear_sensitive_query_params()
@@ -551,10 +649,17 @@ def login_admin(email: str, password: str) -> dict:
 
     st.session_state[_AUTH_USER_KEY] = user
     st.session_state[_AUTH_SESSION_KEY] = session
+    # A failed automatic restore should not remain visible after a successful manual login.
+    st.session_state.pop(_ADMIN_RESTORE_FAILED_THIS_RUN_KEY, None)
     access_token = str(getattr(session, "access_token", "") or "").strip()
     refresh_token = str(getattr(session, "refresh_token", "") or "").strip()
     if access_token and refresh_token:
         persist_admin_browser_session(access_token, refresh_token)
+    _append_auth_debug_event(
+        "login_succeeded",
+        success=True,
+        reason="Manual admin login succeeded.",
+    )
     return {"user": user, "session": session}
 
 

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -3,6 +3,7 @@ import pandas as pd
 import time
 import json
 from datetime import datetime, timezone
+from uuid import uuid4
 from jupr_app.domain.replay_history import replay_history
 
 from postgrest.exceptions import APIError
@@ -146,9 +147,20 @@ def render(ctx):
 
     with st.expander("🧰 System Debug Panel", expanded=False):
         nav_events = list(st.session_state.get("jupr_nav_debug_events", []))
+        auth_events = list(st.session_state.get("jupr_auth_debug_events", []))
         current_query_params = redact_query_params(_query_params_snapshot())
+        debug_session_id = str(st.session_state.setdefault("debug_session_id", str(uuid4())))
 
         st.caption("Admin-only diagnostics for navigation, auth, and session restoration state.")
+        st.write("Session continuity diagnostics")
+        st.json(
+            {
+                "debug_session_id": debug_session_id,
+                "navigation_events_present": bool(nav_events),
+                "navigation_event_count": len(nav_events),
+                "auth_event_count": len(auth_events),
+            }
+        )
 
         st.markdown("#### Phase 1 — Navigation diagnostics")
         st.write("Current query params")
@@ -193,11 +205,23 @@ def render(ctx):
             "admin_user": _admin_user_debug_snapshot(),
             "admin_session": _admin_session_debug_snapshot(),
             "allowlist_size": len(st.session_state.get("admin_allowlist", set()) or set()),
+            "auth_events": auth_events,
         }
         st.json(auth_debug)
+        if st.button("Clear auth debug events", key="clear_auth_debug_events"):
+            st.session_state["jupr_auth_debug_events"] = []
+            st.success("Auth debug events cleared.")
+            auth_events = []
+            auth_debug["auth_events"] = auth_events
 
         debug_report = {
             "generated_at": datetime.now(timezone.utc).isoformat(),
+            "debug_session_id": debug_session_id,
+            "session_continuity": {
+                "navigation_events_present": bool(nav_events),
+                "navigation_event_count": len(nav_events),
+                "auth_event_count": len(auth_events),
+            },
             "navigation": {
                 "query_params": current_query_params,
                 "runtime": nav_runtime,

--- a/tests/test_admin_auth_browser_restore.py
+++ b/tests/test_admin_auth_browser_restore.py
@@ -118,3 +118,44 @@ def test_streamlit_app_only_restores_browser_tokens_for_admin_entry():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")
 
     assert "if admin_entry_requested:\n            maybe_restore_admin_login_from_browser()" in app
+
+
+def test_append_auth_debug_event_redacts_sensitive_reason_and_query_params(monkeypatch):
+    fake_st = _FakeSt()
+    fake_st.query_params.update(
+        {
+            "page": "admin_tools",
+            "jupr_admin_access_token": "secret-token",
+            "jupr_admin_refresh_token": "refresh-token",
+            "public": "1",
+        }
+    )
+    monkeypatch.setattr(admin_auth, "st", fake_st)
+
+    admin_auth._append_auth_debug_event(
+        "restore_failed",
+        success=False,
+        reason="Exception while validating access_token value",
+    )
+
+    events = fake_st.session_state.get("jupr_auth_debug_events", [])
+    assert len(events) == 1
+    event = events[0]
+    assert event["event_type"] == "restore_failed"
+    assert event["success"] is False
+    assert event["reason"] == "[REDACTED]"
+    assert event["route_query_params"]["jupr_admin_access_token"] == "[REDACTED]"
+    assert event["route_query_params"]["jupr_admin_refresh_token"] == "[REDACTED]"
+
+
+def test_append_auth_debug_event_keeps_only_latest_50(monkeypatch):
+    fake_st = _FakeSt()
+    monkeypatch.setattr(admin_auth, "st", fake_st)
+
+    for idx in range(60):
+        admin_auth._append_auth_debug_event(f"event_{idx}", success=True, reason="")
+
+    events = fake_st.session_state.get("jupr_auth_debug_events", [])
+    assert len(events) == 50
+    assert events[0]["event_type"] == "event_10"
+    assert events[-1]["event_type"] == "event_59"


### PR DESCRIPTION
### Motivation
- Prior restore failures remained visible after a later successful manual admin login and navigation debug events were empty, making it hard to diagnose session continuity issues.
- We need richer, safe diagnostics for auth lifecycle activity and a way to tell if Streamlit session changes are dropping navigation events.

### Description
- Add a bounded auth debug event pipeline (`jupr_auth_debug_events`, max 50) with timestamp, `event_type`, `success`, sanitized `reason`, and a redacted snapshot of current route/query params, using existing `redact_query_params` utilities and never storing raw tokens/secrets.  
- Instrument admin auth flows to record events for restore attempts, restore skips (already authenticated / prior failure / no handshake), restore failures/successes, manual login success, and browser-token clear actions.  
- Clear the stale `_admin_restore_failed_this_run` flag after a successful manual login so a prior automatic-restore failure does not persist in diagnostics.  
- Extend the System Debug Panel to surface `auth_events`, include them in the copyable debug report, add a dedicated "Clear auth debug events" button, and add session continuity diagnostics with a stable `debug_session_id`, nav-events presence/count, and auth-event count.

### Testing
- Ran targeted unit tests: `pytest -q tests/test_public_links.py tests/test_admin_auth_browser_restore.py` and all tests passed (`9 passed`).
- Verified runtime sanity by compiling modified modules with `python -m py_compile jupr_app/ui/admin_auth.py jupr_app/ui/pages/admin_tools.py` with no errors.
- Added lightweight tests to verify auth-event redaction and retention trimming (new tests in `tests/test_admin_auth_browser_restore.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee8d3ed67c8326851b8426bd933f66)