### PR TITLE
Improve player-selection UX with reusable searchable picker

### DIFF
--- a/jupr_app/ui/components/player_picker.py
+++ b/jupr_app/ui/components/player_picker.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+
+MAX_MATCH_OPTIONS = 50
+
+
+def _base_label_for_row(row: pd.Series) -> str:
+    display_name = str(row.get("display_name") or "").strip()
+    name = str(row.get("name") or "").strip()
+    return display_name or name or f"Player #{int(row['id'])}"
+
+
+def build_player_picker_df(players_df: pd.DataFrame, *, include_inactive: bool = True) -> pd.DataFrame:
+    if players_df is None or players_df.empty or "id" not in players_df.columns:
+        return pd.DataFrame(columns=["id", "display_label", "option_label", "search_text", "sort_label"])
+
+    working = players_df.copy()
+    working = working[working["id"].notna()].copy()
+    if working.empty:
+        return pd.DataFrame(columns=["id", "display_label", "option_label", "search_text", "sort_label"])
+
+    working["id"] = pd.to_numeric(working["id"], errors="coerce")
+    working = working[working["id"].notna()].copy()
+    if working.empty:
+        return pd.DataFrame(columns=["id", "display_label", "option_label", "search_text", "sort_label"])
+    working["id"] = working["id"].astype(int)
+
+    if not include_inactive:
+        if "inactive_at" in working.columns:
+            working = working[working["inactive_at"].isna()].copy()
+        elif "active" in working.columns:
+            working = working[working["active"] == True].copy()
+
+    if working.empty:
+        return pd.DataFrame(columns=["id", "display_label", "option_label", "search_text", "sort_label"])
+
+    working["display_label"] = working.apply(_base_label_for_row, axis=1)
+    working["option_label"] = working["display_label"] + working["id"].map(lambda pid: f" (#{int(pid)})")
+    working["search_text"] = working["display_label"].astype(str).str.lower()
+    working["sort_label"] = working["display_label"].astype(str).str.lower()
+
+    deduped = (
+        working.sort_values(["sort_label", "display_label", "id"])
+        .drop_duplicates(subset=["id"], keep="first")
+        .reset_index(drop=True)
+    )
+    return deduped[["id", "display_label", "option_label", "search_text", "sort_label"]]
+
+
+def filter_player_picker_df(options_df: pd.DataFrame, query: str) -> pd.DataFrame:
+    if options_df is None or options_df.empty:
+        return pd.DataFrame(columns=getattr(options_df, "columns", []))
+
+    clean_query = str(query or "").strip().lower()
+    if not clean_query:
+        return options_df.sort_values(["sort_label", "id"]).reset_index(drop=True)
+
+    tokens = [tok for tok in clean_query.split() if tok]
+    if not tokens:
+        return options_df.sort_values(["sort_label", "id"]).reset_index(drop=True)
+
+    mask = pd.Series([True] * len(options_df), index=options_df.index)
+    haystack = options_df["search_text"].fillna("").astype(str).str.lower()
+    for token in tokens:
+        mask = mask & haystack.str.contains(token, regex=False)
+    return options_df[mask].sort_values(["sort_label", "id"]).reset_index(drop=True)
+
+
+def render_player_picker(
+    players_df,
+    *,
+    label: str = "Player",
+    key: str,
+    default_player_id: int | None = None,
+    include_inactive: bool = True,
+    help: str | None = None,
+    placeholder: str = "Search player by name…",
+) -> int | None:
+    options_df = build_player_picker_df(players_df, include_inactive=include_inactive)
+    if options_df.empty:
+        st.info("No players found.")
+        return None
+
+    search_key = f"{key}__search"
+    select_key = f"{key}__selected"
+
+    if search_key not in st.session_state:
+        st.session_state[search_key] = ""
+
+    valid_ids = set(options_df["id"].astype(int).tolist())
+    if default_player_id is not None and int(default_player_id) in valid_ids and select_key not in st.session_state:
+        st.session_state[select_key] = int(default_player_id)
+
+    st.caption("Start typing a first or last name, then choose the player.")
+    search_cols = st.columns([4, 1])
+    with search_cols[0]:
+        st.text_input(label, key=search_key, placeholder=placeholder, help=help)
+    with search_cols[1]:
+        st.write("")
+        if st.button("Clear Search", key=f"{key}__clear"):
+            st.session_state[search_key] = ""
+            st.rerun()
+
+    query = str(st.session_state.get(search_key, "") or "")
+    filtered = filter_player_picker_df(options_df, query)
+    if filtered.empty:
+        st.info("No players match that search yet. Try a different first or last name.")
+        return None
+
+    option_ids = filtered["id"].astype(int).tolist()
+    if len(option_ids) > MAX_MATCH_OPTIONS:
+        option_ids = option_ids[:MAX_MATCH_OPTIONS]
+        st.caption(f"Showing first {MAX_MATCH_OPTIONS} matches. Keep typing to narrow the list.")
+
+    selected_id = st.session_state.get(select_key)
+    if selected_id not in option_ids:
+        if default_player_id is not None and int(default_player_id) in option_ids:
+            selected_id = int(default_player_id)
+        else:
+            selected_id = option_ids[0]
+        st.session_state[select_key] = selected_id
+
+    selected = st.selectbox(
+        "Matching players",
+        options=option_ids,
+        index=option_ids.index(int(selected_id)) if int(selected_id) in option_ids else 0,
+        key=select_key,
+        format_func=lambda pid: str(filtered.loc[filtered["id"] == int(pid), "option_label"].iloc[0]),
+    )
+    return int(selected) if selected is not None else None

--- a/jupr_app/ui/pages/badge_debug.py
+++ b/jupr_app/ui/pages/badge_debug.py
@@ -7,6 +7,7 @@ import streamlit as st
 
 from jupr_app.domain.gamification.badge_debug import build_badge_debug_report
 from jupr_app.domain.match_filters import apply_match_filters_with_audit
+from jupr_app.ui.components.player_picker import render_player_picker
 from jupr_app.ui.layout import page_shell
 
 
@@ -45,13 +46,15 @@ def render(ctx):
         st.warning("Player data is still loading or unavailable.")
         st.stop()
 
-    player_ids = sorted(df_players["id"].dropna().astype(int).unique().tolist())
-    id_to_name = getattr(ctx, "id_to_name", {})
-    player_id = st.selectbox(
-        "Player",
-        player_ids,
-        format_func=lambda pid: f"{id_to_name.get(int(pid), 'Player')} (#{pid})",
+    player_id = render_player_picker(
+        df_players,
+        label="Search player",
+        key="badge_debug_player",
+        include_inactive=True,
     )
+    if player_id is None:
+        st.info("Choose a player to run badge debug.")
+        return
 
     if df_badges is None or df_badges.empty or "badge_id" not in df_badges.columns:
         st.warning("Badge definitions are unavailable.")

--- a/jupr_app/ui/pages/match_explorer.py
+++ b/jupr_app/ui/pages/match_explorer.py
@@ -6,6 +6,7 @@ import altair as alt
 from jupr_app.ui.helpers import qp_get
 from jupr_app.domain.ratings import calculate_hybrid_elo
 from jupr_app.domain.constants import DEFAULT_K_FACTOR, MIN_WIN_DELTA_ELO, CAP_LOSER_GAIN_ELO
+from jupr_app.ui.components.player_picker import render_player_picker
 from jupr_app.ui.layout import page_shell
 
 
@@ -112,13 +113,6 @@ def render(ctx):
         return
     p["id"] = p["id"].astype(int)
 
-    active_ids = sorted(p["id"].tolist())
-
-    def fmt_pid(x):
-        try:
-            return f"{id_to_name.get(int(x), f'#{int(x)}')}  (#{int(x)})"
-        except Exception:
-            return str(x)
 
     # -------- K factor --------
     def get_k_for_context(context_name: str) -> int:
@@ -151,19 +145,42 @@ def render(ctx):
     # -------- Player selection (ID-safe) --------
     st.subheader("Your matchup (doubles)")
 
-    c1, c2, c3, c4 = st.columns(4)
+    me_id = render_player_picker(
+        p,
+        label="I am",
+        key="mx_me_id",
+        default_player_id=st.session_state.get("mx_me_id"),
+        include_inactive=False,
+    )
 
-    with c1:
-        me_id = st.selectbox("I am", options=[0] + active_ids, format_func=lambda x: "" if x == 0 else fmt_pid(x), key="mx_me_id")
-    with c2:
-        partner_pool = [x for x in active_ids if x != int(me_id)]
-        partner_id = st.selectbox("My partner", options=[0] + partner_pool, format_func=lambda x: "" if x == 0 else fmt_pid(x), key="mx_partner_id")
-    with c3:
-        opp_pool_1 = [x for x in active_ids if x not in (int(me_id), int(partner_id))]
-        opp1_id = st.selectbox("Opponent 1", options=[0] + opp_pool_1, format_func=lambda x: "" if x == 0 else fmt_pid(x), key="mx_opp1_id")
-    with c4:
-        opp_pool_2 = [x for x in active_ids if x not in (int(me_id), int(partner_id), int(opp1_id))]
-        opp2_id = st.selectbox("Opponent 2", options=[0] + opp_pool_2, format_func=lambda x: "" if x == 0 else fmt_pid(x), key="mx_opp2_id")
+    partner_df = p[p["id"].astype(int) != int(me_id)].copy() if me_id else p.copy()
+    partner_id = render_player_picker(
+        partner_df,
+        label="My partner",
+        key="mx_partner_id",
+        default_player_id=st.session_state.get("mx_partner_id"),
+        include_inactive=False,
+    )
+
+    exclude_ids = {int(x) for x in [me_id, partner_id] if x}
+    opp1_df = p[~p["id"].astype(int).isin(exclude_ids)].copy() if exclude_ids else p.copy()
+    opp1_id = render_player_picker(
+        opp1_df,
+        label="Opponent 1",
+        key="mx_opp1_id",
+        default_player_id=st.session_state.get("mx_opp1_id"),
+        include_inactive=False,
+    )
+
+    exclude_ids = {int(x) for x in [me_id, partner_id, opp1_id] if x}
+    opp2_df = p[~p["id"].astype(int).isin(exclude_ids)].copy() if exclude_ids else p.copy()
+    opp2_id = render_player_picker(
+        opp2_df,
+        label="Opponent 2",
+        key="mx_opp2_id",
+        default_player_id=st.session_state.get("mx_opp2_id"),
+        include_inactive=False,
+    )
 
     if not (me_id and partner_id and opp1_id and opp2_id):
         st.info("Select yourself, your partner, and both opponents.")

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -24,6 +24,7 @@ from jupr_app.domain.notifications.player_update_sender import (
 )
 from jupr_app.domain.recaps.player_weekly_digest import compute_player_weekly_digest
 from jupr_app.ui.components.player_digest_layout import render_player_digest
+from jupr_app.ui.components.player_picker import render_player_picker
 from jupr_app.ui.layout import page_shell
 
 
@@ -338,8 +339,6 @@ def render(ctx) -> None:
             return
 
         active_rows = list_active_subscriptions(supabase, club_id, limit=500)
-        labels, label_to_pid = _digest_player_options(ctx, active_rows)
-
         st.markdown("#### Generate for all subscribed players")
         st.caption("Generating digests here also queues them automatically for the Send Queue page.")
         if st.button("Generate + Queue for All Subscribed Players", disabled=not active_rows, use_container_width=True):
@@ -366,8 +365,23 @@ def render(ctx) -> None:
         st.divider()
         with st.expander("Single player options", expanded=False):
             st.caption("Use this only when you want to preview or regenerate one player manually.")
-            selected_label = st.selectbox("Player", options=labels, index=0 if labels else None)
-            selected_pid = label_to_pid.get(selected_label) if selected_label else None
+            active_player_ids = []
+            for row in active_rows:
+                try:
+                    active_player_ids.append(int(row.get("player_id")))
+                except Exception:
+                    continue
+            active_player_ids = sorted(set(active_player_ids))
+            active_df = getattr(ctx, "df_players_all", pd.DataFrame())
+            active_df = active_df.copy() if isinstance(active_df, pd.DataFrame) else pd.DataFrame()
+            if not active_df.empty and "id" in active_df.columns:
+                active_df = active_df[active_df["id"].astype(int).isin(active_player_ids)].copy()
+            selected_pid = render_player_picker(
+                active_df,
+                label="Search player",
+                key="player_updates_digest_single_player",
+                include_inactive=True,
+            )
 
             c1, c2 = st.columns(2)
             with c1:

--- a/jupr_app/ui/pages/player_updates_subscribe.py
+++ b/jupr_app/ui/pages/player_updates_subscribe.py
@@ -12,6 +12,7 @@ from jupr_app.domain.notifications.player_profile_update_repo import (
     get_open_or_active_subscription,
 )
 from jupr_app.ui.helpers import qp_get
+from jupr_app.ui.components.player_picker import build_player_picker_df, render_player_picker
 from jupr_app.ui.layout import page_shell
 
 
@@ -39,38 +40,6 @@ def requested_player_id_from_query(*, player_id_q: str, pid_q: str) -> int | Non
     if fallback.isdigit():
         return int(fallback)
     return None
-
-
-def build_player_picker_df(df_players: pd.DataFrame) -> pd.DataFrame:
-    if df_players is None or df_players.empty or "id" not in df_players.columns:
-        return pd.DataFrame(columns=["id", "option_label", "sort_label"])
-
-    working = df_players.copy()
-    working = working[working["id"].notna()].copy()
-    if working.empty:
-        return pd.DataFrame(columns=["id", "option_label", "sort_label"])
-
-    working["id"] = pd.to_numeric(working["id"], errors="coerce")
-    working = working[working["id"].notna()].copy()
-    if working.empty:
-        return pd.DataFrame(columns=["id", "option_label", "sort_label"])
-
-    working["id"] = working["id"].astype(int)
-    if "display_name" in working.columns:
-        display = working["display_name"].fillna("").astype(str).str.strip()
-    else:
-        display = pd.Series([""] * len(working), index=working.index)
-    base_name = working.get("name", pd.Series([""] * len(working), index=working.index)).fillna("").astype(str).str.strip()
-    working["display_label"] = display.where(display != "", base_name).fillna("").astype(str).str.strip()
-    working["display_label"] = working["display_label"].where(working["display_label"] != "", working["id"].map(lambda x: f"Player #{x}"))
-    working["sort_label"] = working["display_label"].str.lower()
-    deduped = (
-        working.sort_values(["sort_label", "display_label", "id"])
-        .drop_duplicates(subset=["id"], keep="first")
-        .copy()
-    )
-    deduped["option_label"] = deduped["display_label"] + deduped["id"].map(lambda x: f"  (#{x})")
-    return deduped[["id", "option_label", "sort_label"]].sort_values(["sort_label", "id"]).reset_index(drop=True)
 
 
 def resolve_prefill_player_id(
@@ -105,7 +74,7 @@ def render(ctx) -> None:
     df_players_all = getattr(ctx, "df_players_all", None)
     df_players_active = getattr(ctx, "df_players_active", None)
     source_df = df_players_all if df_players_all is not None and not df_players_all.empty else df_players_active
-    options_df = build_player_picker_df(source_df if source_df is not None else pd.DataFrame())
+    options_df = build_player_picker_df(source_df if source_df is not None else pd.DataFrame(), include_inactive=True)
 
     if options_df.empty:
         st.info("No players found.")
@@ -121,19 +90,15 @@ def render(ctx) -> None:
     elif (player_id_q or pid_q) and prefill_player_id is None:
         st.caption("The requested player was not found. Please choose a player below.")
 
-    option_ids = options_df["id"].astype(int).tolist()
-    selected_index = 0
-    if prefill_player_id in set(option_ids):
-        selected_index = option_ids.index(int(prefill_player_id))
-    selected_player_id = st.selectbox(
-        "Player",
-        options=option_ids,
-        index=selected_index,
-        format_func=lambda pid: str(
-            options_df.loc[options_df["id"] == int(pid), "option_label"].iloc[0]
-        ),
+    selected_player_id = render_player_picker(
+        source_df if source_df is not None else pd.DataFrame(),
+        label="Search player",
         key="verified_updates_player_picker",
+        default_player_id=prefill_player_id,
+        include_inactive=True,
     )
+    if selected_player_id is None:
+        return
 
     open_or_active = get_open_or_active_subscription(
         ctx.supabase,

--- a/jupr_app/ui/pages/players.py
+++ b/jupr_app/ui/pages/players.py
@@ -18,6 +18,7 @@ from jupr_app.ui.helpers import (
     qp_get,
     display_requirement_text,
 )
+from jupr_app.ui.components.player_picker import render_player_picker
 from jupr_app.ui.layout import page_shell
 from jupr_app.domain.gamification.profile import (
     build_gamification_summary,
@@ -1410,33 +1411,26 @@ def render(ctx):
             st.session_state["player_search_id"] = int(hit.iloc[0]["id"])
         st.session_state["player_pid_sig_applied"] = pid_sig
 
-    players_df = players_df.sort_values("name").copy()
-    options = [""] + players_df["id"].tolist()
+    current_pick = st.session_state.get("player_search_id")
+    if current_pick is not None:
+        try:
+            current_pick = int(current_pick)
+        except Exception:
+            current_pick = None
 
-    def _fmt(x):
-        if x == "":
-            return ""
-        r = players_df[players_df["id"] == int(x)]
-        if r.empty:
-            return f"#{x}"
-        return f"{str(r.iloc[0]['name'])}  (#{int(x)})"
-
-    current_pick = st.session_state.get("player_search_id", "")
-    if current_pick not in options:
-        st.session_state["player_search_id"] = ""
-
-    pick_id = st.selectbox(
-        "Select a player",
-        options=options,
-        format_func=_fmt,
-        key="player_search_id",
+    pid = render_player_picker(
+        players_df,
+        label="Search player",
+        key="player_search",
+        default_player_id=current_pick,
+        include_inactive=False,
     )
 
-    if pick_id == "":
+    if pid is None:
         st.info("Select a player to view details.")
         return
 
-    pid = int(pick_id)
+    st.session_state["player_search_id"] = int(pid)
     if PUBLIC_MODE:
         try:
             st.query_params["pid"] = str(pid)

--- a/tests/test_player_picker.py
+++ b/tests/test_player_picker.py
@@ -1,0 +1,46 @@
+import pandas as pd
+
+from jupr_app.ui.components.player_picker import build_player_picker_df, filter_player_picker_df
+
+
+def test_build_player_picker_df_alphabetized_and_display_name_preferred():
+    df = pd.DataFrame(
+        [
+            {"id": 2, "name": "zoe alpha", "display_name": ""},
+            {"id": 1, "name": "robert novotny", "display_name": "Rob Novotny"},
+            {"id": 3, "name": "amy bee"},
+        ]
+    )
+    out = build_player_picker_df(df)
+    assert out["id"].tolist() == [3, 1, 2]
+    assert out.loc[out["id"] == 1, "option_label"].iloc[0] == "Rob Novotny (#1)"
+
+
+def test_filter_player_picker_df_case_insensitive_and_multi_token():
+    df = pd.DataFrame(
+        [
+            {"id": 1, "display_label": "Rob Novotny", "option_label": "Rob Novotny (#1)", "search_text": "rob novotny", "sort_label": "rob novotny"},
+            {"id": 2, "display_label": "Robin Smith", "option_label": "Robin Smith (#2)", "search_text": "robin smith", "sort_label": "robin smith"},
+        ]
+    )
+    out = filter_player_picker_df(df, "ROB nov")
+    assert out["id"].tolist() == [1]
+
+
+def test_duplicate_names_distinguished_by_id():
+    df = pd.DataFrame(
+        [
+            {"id": 1, "name": "Alex Kim"},
+            {"id": 2, "name": "Alex Kim"},
+        ]
+    )
+    out = build_player_picker_df(df)
+    assert "Alex Kim (#1)" in out["option_label"].tolist()
+    assert "Alex Kim (#2)" in out["option_label"].tolist()
+
+
+def test_blank_query_returns_all_rows():
+    df = pd.DataFrame([{"id": 1, "name": "A"}, {"id": 2, "name": "B"}])
+    built = build_player_picker_df(df)
+    out = filter_player_picker_df(built, "")
+    assert out["id"].tolist() == [1, 2]


### PR DESCRIPTION
### Motivation
- Users reported the built-in `st.selectbox` typeahead felt hidden, sticky, and inconsistent for finding players by name.  
- The goal was to provide a single reusable picker that gives a clear search field, stable behavior across pages, and predictable alphabetized labels without changing any player data or schemas.

### Description
- Add a new component at `jupr_app/ui/components/player_picker.py` exposing `render_player_picker(...)` and `build_player_picker_df(...)` that prefer `display_name` → `name` → `Player #id`, always append `(#id)`, sort case-insensitively, and prepare search text and labels.  
- The picker provides an explicit `st.text_input` for search, case-insensitive multi-token matching, a one-click `Clear Search` that resets and `st.rerun()`, and caps visible matches at 50 with a caption hint.  
- Replace ad-hoc player `st.selectbox` usage with `render_player_picker` in core pages: `players.py`, `player_updates_subscribe.py`, `player_updates_admin.py`, `badge_debug.py`, and `match_explorer.py` (participant selectors), preserving query-param prefill behavior and session-state defaults.  
- Add unit tests `tests/test_player_picker.py` for alphabetization, `display_name` preference, case-insensitive search, multi-token matching, duplicate-name disambiguation by id, and blank-query behavior, and avoid any DB/schema/rating/auth changes.

### Testing
- Compiled updated modules via `python -m py_compile jupr_app/ui/components/player_picker.py jupr_app/ui/pages/player_updates_subscribe.py jupr_app/ui/pages/players.py jupr_app/ui/pages/player_updates_admin.py jupr_app/ui/pages/badge_debug.py jupr_app/ui/pages/match_explorer.py tests/test_player_picker.py` which succeeded.  
- Ran unit tests with `pytest -q tests/test_player_picker.py` which passed (`4 passed`).  
- All changes are limited to UI picker logic and page wiring; no automated integration UI rendering tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee8f94f8e883268b9228e8f9b39614)