### PR TITLE
Add bulk pending digest deletion in Player Updates Send Queue

### DIFF
--- a/jupr_app/domain/notifications/player_profile_update_repo.py
+++ b/jupr_app/domain/notifications/player_profile_update_repo.py
@@ -585,6 +585,60 @@ def delete_pending_outbox_row(
     return deleted[0]
 
 
+def bulk_delete_pending_outbox_rows(
+    supabase,
+    *,
+    club_id: str,
+    outbox_ids: list[str],
+) -> dict[str, int]:
+    club_id = _require_nonempty(club_id, "club_id")
+    normalized_ids = []
+    for raw in outbox_ids or []:
+        outbox_id = str(raw or "").strip()
+        if outbox_id:
+            normalized_ids.append(outbox_id)
+    if not normalized_ids:
+        raise ValueError("At least one outbox_id is required")
+
+    unique_ids = list(dict.fromkeys(normalized_ids))
+    requested = len(unique_ids)
+
+    matched_rows = _safe_data(
+        supabase.table("player_profile_update_outbox")
+        .select("id")
+        .eq("club_id", club_id)
+        .eq("send_status", SEND_STATUS_PENDING)
+        .in_("id", unique_ids)
+        .execute()
+    )
+    matched_ids = [str(row.get("id") or "").strip() for row in matched_rows if str(row.get("id") or "").strip()]
+    matched_pending = len(matched_ids)
+    if not matched_ids:
+        return {
+            "requested": requested,
+            "matched_pending": 0,
+            "deleted": 0,
+            "skipped": requested,
+        }
+
+    deleted_rows = _safe_data(
+        supabase.table("player_profile_update_outbox")
+        .delete()
+        .eq("club_id", club_id)
+        .eq("send_status", SEND_STATUS_PENDING)
+        .in_("id", matched_ids)
+        .execute()
+    )
+    deleted = len(deleted_rows)
+    skipped = max(0, requested - deleted)
+    return {
+        "requested": requested,
+        "matched_pending": matched_pending,
+        "deleted": deleted,
+        "skipped": skipped,
+    }
+
+
 def list_outbox_rows(
     supabase,
     club_id: str,

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -7,6 +7,7 @@ import streamlit as st
 
 from jupr_app.domain.notifications.player_profile_update_repo import (
     approve_request,
+    bulk_delete_pending_outbox_rows,
     delete_pending_outbox_row,
     list_active_subscriptions,
     list_digests_for_range,
@@ -150,6 +151,10 @@ def _outbox_display_rows(ctx, rows: list[dict]) -> list[dict]:
             }
         )
     return display_rows
+
+
+def _normalized_text_filter(value: str) -> str:
+    return str(value or "").strip().lower()
 
 
 def render(ctx) -> None:
@@ -501,8 +506,141 @@ def render(ctx) -> None:
         st.markdown("#### Pending to send")
         if pending_rows:
             st.dataframe(pd.DataFrame(_outbox_display_rows(ctx, pending_rows)), use_container_width=True, hide_index=True)
-            st.markdown("#### Remove pending queued digest")
-            st.caption("Only pending rows can be removed. This does not delete sent history.")
+            st.markdown("#### Bulk remove pending queued digests")
+            st.caption(
+                "This only removes pending queued emails. Saved digest previews and sent email history are not affected."
+            )
+
+            bulk_rows: list[dict] = []
+            for row in pending_rows:
+                outbox_id = str(row.get("id") or "").strip()
+                if not outbox_id:
+                    continue
+                bulk_rows.append(
+                    {
+                        "outbox_id": outbox_id,
+                        "player_name": _player_name(ctx, row.get("player_id")),
+                        "player_id": row.get("player_id"),
+                        "email": row.get("email"),
+                        "week_start": row.get("week_start"),
+                        "week_end": row.get("week_end"),
+                        "created_at": row.get("created_at"),
+                    }
+                )
+
+            fs1, fs2, fs3 = st.columns(3)
+            with fs1:
+                filter_week_start = st.text_input(
+                    "Filter week_start",
+                    key="bulk_delete_filter_week_start",
+                    placeholder="YYYY-MM-DD",
+                ).strip()
+            with fs2:
+                filter_week_end = st.text_input(
+                    "Filter week_end",
+                    key="bulk_delete_filter_week_end",
+                    placeholder="YYYY-MM-DD",
+                ).strip()
+            with fs3:
+                filter_text = _normalized_text_filter(
+                    st.text_input(
+                        "Filter player/email",
+                        key="bulk_delete_filter_text",
+                        placeholder="Name or email",
+                    )
+                )
+
+            filtered_rows: list[dict] = []
+            for row in bulk_rows:
+                row_week_start = str(row.get("week_start") or "").strip()
+                row_week_end = str(row.get("week_end") or "").strip()
+                row_name = _normalized_text_filter(row.get("player_name") or "")
+                row_email = _normalized_text_filter(row.get("email") or "")
+                if filter_week_start and row_week_start != filter_week_start:
+                    continue
+                if filter_week_end and row_week_end != filter_week_end:
+                    continue
+                if filter_text and filter_text not in row_name and filter_text not in row_email:
+                    continue
+                filtered_rows.append(row)
+
+            selection_key = "player_updates_bulk_selected_outbox_ids"
+            selected_ids = set(st.session_state.get(selection_key, []))
+            visible_ids = [str(row.get("outbox_id") or "").strip() for row in filtered_rows if str(row.get("outbox_id") or "").strip()]
+
+            b1, b2 = st.columns(2)
+            with b1:
+                if st.button("Select all pending", use_container_width=True, disabled=not visible_ids):
+                    selected_ids.update(visible_ids)
+                    st.session_state[selection_key] = sorted(selected_ids)
+                    st.rerun()
+            with b2:
+                if st.button("Clear selection", use_container_width=True, disabled=not selected_ids):
+                    st.session_state[selection_key] = []
+                    st.rerun()
+
+            if filtered_rows:
+                editor_rows = []
+                for row in filtered_rows:
+                    outbox_id = str(row.get("outbox_id") or "").strip()
+                    editor_rows.append(
+                        {
+                            "selected": outbox_id in selected_ids,
+                            "player_name": row.get("player_name"),
+                            "player_id": row.get("player_id"),
+                            "email": row.get("email"),
+                            "week_start": row.get("week_start"),
+                            "week_end": row.get("week_end"),
+                            "created_at": row.get("created_at"),
+                            "_outbox_id": outbox_id,
+                        }
+                    )
+                editor_df = pd.DataFrame(editor_rows)
+                edited_df = st.data_editor(
+                    editor_df,
+                    use_container_width=True,
+                    hide_index=True,
+                    disabled=["player_name", "player_id", "email", "week_start", "week_end", "created_at", "_outbox_id"],
+                    column_order=["selected", "player_name", "player_id", "email", "week_start", "week_end", "created_at"],
+                    key="bulk_delete_pending_editor",
+                )
+                edited_selected_ids = {
+                    str(row.get("_outbox_id") or "").strip()
+                    for _, row in edited_df.iterrows()
+                    if bool(row.get("selected")) and str(row.get("_outbox_id") or "").strip()
+                }
+                selected_ids = (selected_ids - set(visible_ids)) | edited_selected_ids
+                st.session_state[selection_key] = sorted(selected_ids)
+            else:
+                st.caption("No pending rows match the current filters.")
+
+            selected_count = len(selected_ids)
+            st.caption(f"Selected pending rows: {selected_count}")
+            confirm_bulk_delete = st.checkbox(
+                "I understand this will remove the selected pending digests from the send queue. Sent history will not be deleted.",
+                key="confirm_bulk_delete_pending",
+            )
+            if st.button(
+                "Delete selected pending digests",
+                use_container_width=True,
+                disabled=(selected_count == 0 or not confirm_bulk_delete),
+            ):
+                try:
+                    result = bulk_delete_pending_outbox_rows(
+                        supabase,
+                        club_id=club_id,
+                        outbox_ids=sorted(selected_ids),
+                    )
+                    st.session_state[selection_key] = []
+                    st.success(f"Deleted {result['deleted']} pending queued digests.")
+                    st.rerun()
+                except Exception as exc:
+                    st.error(f"Bulk delete failed: {_friendly_error(exc)}")
+
+            st.markdown("#### Remove one pending queued digest")
+            st.caption(
+                "This only removes pending queued emails. Saved digest previews and sent email history are not affected."
+            )
             for row in pending_rows:
                 outbox_id = str(row.get("id") or "").strip()
                 player_name = _player_name(ctx, row.get("player_id")) or f"Player #{row.get('player_id')}"

--- a/tests/test_player_update_queueing.py
+++ b/tests/test_player_update_queueing.py
@@ -8,6 +8,7 @@ import pandas as pd
 from jupr_app.domain.match_processing import process_matches
 from jupr_app.domain.notifications.player_profile_update_repo import (
     REQUEST_STATUS_ACTIVE,
+    bulk_delete_pending_outbox_rows,
     delete_pending_outbox_row,
     queue_player_updates_for_affected_subscribers,
 )
@@ -317,3 +318,37 @@ def test_delete_pending_outbox_row_allows_pending_and_blocks_sent():
         assert False, "Expected sent rows to be protected"
     except ValueError as exc:
         assert "Only pending queued digests can be deleted." in str(exc)
+
+
+def test_bulk_delete_pending_outbox_rows_only_deletes_pending_for_club():
+    sb = _Supabase()
+    sb.tables["player_profile_update_outbox"] = [
+        {"id": "o1", "club_id": "club", "send_status": "pending"},
+        {"id": "o2", "club_id": "club", "send_status": "sent"},
+        {"id": "o3", "club_id": "club", "send_status": "error"},
+        {"id": "o4", "club_id": "club", "send_status": "pending"},
+        {"id": "o5", "club_id": "other", "send_status": "pending"},
+    ]
+
+    result = bulk_delete_pending_outbox_rows(
+        sb,
+        club_id="club",
+        outbox_ids=["o1", "o2", "o3", "o4", "o5"],
+    )
+
+    assert result == {
+        "requested": 5,
+        "matched_pending": 2,
+        "deleted": 2,
+        "skipped": 3,
+    }
+    assert [row["id"] for row in sb.tables["player_profile_update_outbox"]] == ["o2", "o3", "o5"]
+
+
+def test_bulk_delete_pending_outbox_rows_requires_ids():
+    sb = _Supabase()
+    try:
+        bulk_delete_pending_outbox_rows(sb, club_id="club", outbox_ids=[])
+        assert False, "Expected empty outbox IDs to fail"
+    except ValueError as exc:
+        assert "At least one outbox_id is required" in str(exc)


### PR DESCRIPTION
### Motivation
- Admins need a safe, one-action way to remove many accidentally queued pending player update digests instead of deleting them one-by-one. 
- The bulk flow must strictly protect sent/errored/skipped history and only affect pending rows scoped to a club.

### Description
- Added `bulk_delete_pending_outbox_rows(...)` to `jupr_app/domain/notifications/player_profile_update_repo.py` that requires `club_id` and at least one `outbox_id`, only targets `player_profile_update_outbox`, filters by `club_id` and `send_status = "pending"`, and returns counts `{requested, matched_pending, deleted, skipped}`.
- Extended the Send Queue UI in `jupr_app/ui/pages/player_updates_admin.py` with a new "Bulk remove pending queued digests" section above the single-row fallback, including optional filters (`week_start`, `week_end`, player/email text), a selectable table via `st.data_editor`, buttons for `Select all pending` and `Clear selection`, a required confirmation checkbox, and a `Delete selected pending digests` action that calls `bulk_delete_pending_outbox_rows` and runs `st.rerun()` after success.
- Kept and renamed the existing one-by-one flow to "Remove one pending queued digest" and preserved its behavior as a fallback, and added copy clarifying pending-only behavior.
- Added a small UI helper `_normalized_text_filter` and tests for the new helper behavior and validations in `tests/test_player_update_queueing.py`.

### Testing
- Ran `pytest -q tests/test_player_update_queueing.py`, which completed successfully with all tests passing (`9 passed`).
- New tests cover that `bulk_delete_pending_outbox_rows` only deletes pending rows for the given club and rejects empty `outbox_ids` inputs (both passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee9c3cdb2883268226b33e39b9ea4c)