### PR TITLE
Add match-filtered bulk digest queueing option

### DIFF
--- a/jupr_app/domain/notifications/player_update_sender.py
+++ b/jupr_app/domain/notifications/player_update_sender.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import urlencode
 
@@ -134,6 +134,58 @@ def _find_active_subscription_for_player(active_rows: list[dict[str, Any]], play
     return None
 
 
+def _coerce_match_day(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).date()
+    if isinstance(value, date):
+        return value
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(timezone.utc).date()
+    except Exception:
+        try:
+            return date.fromisoformat(text[:10])
+        except Exception:
+            return None
+
+
+def _coerce_optional_player_id(value: Any) -> int | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return int(text)
+    except Exception:
+        return None
+
+
+def get_player_ids_with_matches_in_range(ctx, *, start_date: date, end_date: date) -> set[int]:
+    supabase = ctx.supabase
+    club_id = str(ctx.club_id)
+    query_end = end_date + timedelta(days=1)
+    rows = (
+        supabase.table("matches")
+        .select("date,t1_p1,t1_p2,t2_p1,t2_p2")
+        .eq("club_id", club_id)
+        .gte("date", start_date.isoformat())
+        .lte("date", query_end.isoformat())
+        .execute()
+    ).data or []
+
+    player_ids: set[int] = set()
+    for row in rows:
+        match_day = _coerce_match_day((row or {}).get("date"))
+        if match_day is None or match_day < start_date or match_day > end_date:
+            continue
+        for key in ("t1_p1", "t1_p2", "t2_p1", "t2_p2"):
+            pid = _coerce_optional_player_id((row or {}).get(key))
+            if pid is not None:
+                player_ids.add(pid)
+    return player_ids
+
+
 def _save_digest_for_subscription(ctx, *, subscription: dict[str, Any], start_date: date, end_date: date) -> dict[str, Any]:
     supabase = ctx.supabase
     club_id = str(ctx.club_id)
@@ -195,16 +247,36 @@ def generate_digests_for_active_subscriptions(ctx, *, start_date: date, end_date
     }
 
 
-def generate_and_queue_digests_for_active_subscriptions(ctx, *, start_date: date, end_date: date) -> dict[str, int]:
+def generate_and_queue_digests_for_active_subscriptions(
+    ctx,
+    *,
+    start_date: date,
+    end_date: date,
+    only_players_with_matches: bool = False,
+) -> dict[str, int]:
     supabase = ctx.supabase
     club_id = str(ctx.club_id)
 
     active_rows = list_active_subscriptions(supabase, club_id, limit=2000)
+    player_ids_with_matches = (
+        get_player_ids_with_matches_in_range(ctx, start_date=start_date, end_date=end_date)
+        if only_players_with_matches
+        else set()
+    )
+    eligible_rows = (
+        [
+            row
+            for row in active_rows
+            if _coerce_optional_player_id(row.get("player_id")) in player_ids_with_matches
+        ]
+        if only_players_with_matches
+        else list(active_rows)
+    )
     saved = 0
     queued = 0
     failed = 0
 
-    for sub in active_rows:
+    for sub in eligible_rows:
         try:
             _save_digest_for_subscription(ctx, subscription=sub, start_date=start_date, end_date=end_date)
             saved += 1
@@ -215,8 +287,11 @@ def generate_and_queue_digests_for_active_subscriptions(ctx, *, start_date: date
 
     return {
         "active_subscriptions": len(active_rows),
+        "players_with_matches": len(player_ids_with_matches),
+        "eligible_subscriptions": len(eligible_rows),
         "saved": saved,
         "queued": queued,
+        "skipped_no_matches": max(0, len(active_rows) - len(eligible_rows)),
         "failed": failed,
     }
 

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -346,20 +346,45 @@ def render(ctx) -> None:
         active_rows = list_active_subscriptions(supabase, club_id, limit=500)
         st.markdown("#### Generate for all subscribed players")
         st.caption("Generating digests here also queues them automatically for the Send Queue page.")
-        if st.button("Generate + Queue for All Subscribed Players", disabled=not active_rows, use_container_width=True):
+        only_players_with_matches = st.checkbox(
+            "Only generate for players with matches during selected dates",
+            value=True,
+            key="player_updates_only_players_with_matches",
+            help="Recommended. This prevents creating queued emails for players who did not play during this date window.",
+        )
+        bulk_button_text = (
+            "Generate + Queue for Active Players With Matches"
+            if only_players_with_matches
+            else "Generate + Queue for All Subscribed Players"
+        )
+        if st.button(bulk_button_text, disabled=not active_rows, use_container_width=True):
             try:
                 result = generate_and_queue_digests_for_active_subscriptions(
                     ctx,
                     start_date=start_date,
                     end_date=end_date,
+                    only_players_with_matches=only_players_with_matches,
                 )
-                st.success(
-                    "Bulk generation complete: "
-                    f"active={result['active_subscriptions']} · "
-                    f"saved={result['saved']} · "
-                    f"queued={result['queued']} · "
-                    f"failed={result['failed']}"
-                )
+                if only_players_with_matches:
+                    st.success(
+                        "Bulk generation complete: "
+                        f"active={result['active_subscriptions']} · "
+                        f"players with matches={result['players_with_matches']} · "
+                        f"eligible={result['eligible_subscriptions']} · "
+                        f"saved={result['saved']} · "
+                        f"queued={result['queued']} · "
+                        f"skipped no matches={result['skipped_no_matches']} · "
+                        f"failed={result['failed']}"
+                    )
+                else:
+                    st.success(
+                        "Bulk generation complete: "
+                        f"active={result['active_subscriptions']} · "
+                        f"eligible={result['eligible_subscriptions']} · "
+                        f"saved={result['saved']} · "
+                        f"queued={result['queued']} · "
+                        f"failed={result['failed']}"
+                    )
             except Exception as exc:
                 st.error(f"Bulk digest generation failed: {_friendly_error(exc)}")
 

--- a/tests/test_player_update_sender_bulk_generation.py
+++ b/tests/test_player_update_sender_bulk_generation.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+from jupr_app.domain.notifications import player_update_sender as sender
+
+
+class _Query:
+    def __init__(self, sb, table):
+        self.sb = sb
+        self.table = table
+        self.filters: list[tuple[str, str, object]] = []
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, column: str, value: object):
+        self.filters.append(("eq", column, value))
+        return self
+
+    def gte(self, column: str, value: object):
+        self.filters.append(("gte", column, value))
+        return self
+
+    def lte(self, column: str, value: object):
+        self.filters.append(("lte", column, value))
+        return self
+
+    def execute(self):
+        return self.sb.execute(self)
+
+
+class _Supabase:
+    def __init__(self):
+        self.tables = {"matches": []}
+
+    def table(self, name: str):
+        return _Query(self, name)
+
+    def execute(self, query: _Query):
+        rows = list(self.tables.get(query.table, []))
+        for op, column, value in query.filters:
+            if op == "eq":
+                rows = [row for row in rows if str(row.get(column)) == str(value)]
+            elif op == "gte":
+                rows = [row for row in rows if str(row.get(column) or "") >= str(value)]
+            elif op == "lte":
+                rows = [row for row in rows if str(row.get(column) or "") <= str(value)]
+        return SimpleNamespace(data=rows)
+
+
+def test_generate_and_queue_filters_to_subscribers_with_matches(monkeypatch):
+    ctx = SimpleNamespace(supabase=object(), club_id="club")
+    active_rows = [
+        {"id": "s1", "player_id": 1},
+        {"id": "s2", "player_id": 2},
+        {"id": "s3", "player_id": 3},
+    ]
+
+    saved_players: list[int] = []
+    queued_players: list[int] = []
+
+    monkeypatch.setattr(sender, "list_active_subscriptions", lambda *_args, **_kwargs: active_rows)
+    monkeypatch.setattr(sender, "get_player_ids_with_matches_in_range", lambda *_args, **_kwargs: {1, 3})
+    monkeypatch.setattr(
+        sender,
+        "_save_digest_for_subscription",
+        lambda _ctx, *, subscription, start_date, end_date: saved_players.append(int(subscription["player_id"])),
+    )
+    monkeypatch.setattr(
+        sender,
+        "_queue_outbox_for_subscription",
+        lambda _ctx, *, subscription, start_date, end_date: queued_players.append(int(subscription["player_id"])),
+    )
+
+    result = sender.generate_and_queue_digests_for_active_subscriptions(
+        ctx,
+        start_date=date(2026, 2, 1),
+        end_date=date(2026, 2, 28),
+        only_players_with_matches=True,
+    )
+
+    assert saved_players == [1, 3]
+    assert queued_players == [1, 3]
+    assert result == {
+        "active_subscriptions": 3,
+        "players_with_matches": 2,
+        "eligible_subscriptions": 2,
+        "saved": 2,
+        "queued": 2,
+        "skipped_no_matches": 1,
+        "failed": 0,
+    }
+
+
+def test_generate_and_queue_unfiltered_queues_all_subscribers(monkeypatch):
+    ctx = SimpleNamespace(supabase=object(), club_id="club")
+    active_rows = [{"id": "s1", "player_id": 1}, {"id": "s2", "player_id": 2}]
+    queued_players: list[int] = []
+
+    monkeypatch.setattr(sender, "list_active_subscriptions", lambda *_args, **_kwargs: active_rows)
+    monkeypatch.setattr(
+        sender,
+        "_save_digest_for_subscription",
+        lambda _ctx, *, subscription, start_date, end_date: None,
+    )
+    monkeypatch.setattr(
+        sender,
+        "_queue_outbox_for_subscription",
+        lambda _ctx, *, subscription, start_date, end_date: queued_players.append(int(subscription["player_id"])),
+    )
+
+    result = sender.generate_and_queue_digests_for_active_subscriptions(
+        ctx,
+        start_date=date(2026, 2, 1),
+        end_date=date(2026, 2, 28),
+        only_players_with_matches=False,
+    )
+
+    assert queued_players == [1, 2]
+    assert result["active_subscriptions"] == 2
+    assert result["eligible_subscriptions"] == 2
+    assert result["players_with_matches"] == 0
+    assert result["skipped_no_matches"] == 0
+
+
+def test_get_player_ids_with_matches_in_range_includes_range_bounds_and_ignores_invalid_ids():
+    sb = _Supabase()
+    sb.tables["matches"] = [
+        {"club_id": "club", "date": "2026-02-10", "t1_p1": 1, "t1_p2": None, "t2_p1": "", "t2_p2": "abc"},
+        {"club_id": "club", "date": "2026-02-11T20:15:00Z", "t1_p1": "3", "t1_p2": 4, "t2_p1": None, "t2_p2": " "},
+        {"club_id": "club", "date": "2026-02-12T09:00:00Z", "t1_p1": 9, "t1_p2": 9, "t2_p1": 9, "t2_p2": 9},
+    ]
+    ctx = SimpleNamespace(supabase=sb, club_id="club")
+
+    player_ids = sender.get_player_ids_with_matches_in_range(
+        ctx,
+        start_date=date(2026, 2, 10),
+        end_date=date(2026, 2, 11),
+    )
+
+    assert player_ids == {1, 3, 4}


### PR DESCRIPTION
### Motivation
- Prevent creating saved digests and queued outbox rows for subscribers who had no matches in the selected date range to avoid unnecessary pending emails and cleanup work.
- Provide admins a clear, safe opt-in UI to only generate/queue digests for players who actually played during the chosen window while preserving the existing all-subscribers flow.

### Description
- Added `get_player_ids_with_matches_in_range(ctx, *, start_date, end_date) -> set[int]` in `jupr_app/domain/notifications/player_update_sender.py` that queries `matches`, parses date/timestamp values safely, treats the end date as inclusive, extracts `t1_p1/t1_p2/t2_p1/t2_p2`, ignores invalid/null ids, and returns a set of player ids.
- Updated `generate_and_queue_digests_for_active_subscriptions(...)` to accept `only_players_with_matches: bool = False`, filter active subscriptions when enabled, iterate only eligible subscriptions, and return richer summary counts (`active_subscriptions`, `players_with_matches`, `eligible_subscriptions`, `saved`, `queued`, `skipped_no_matches`, `failed`).
- Updated UI in `jupr_app/ui/pages/player_updates_admin.py` to add a default-checked checkbox labeled “Only generate for players with matches during selected dates” with help text, dynamic bulk button text, and mode-specific success summary messages.
- Added focused unit tests in `tests/test_player_update_sender_bulk_generation.py` validating filtered vs unfiltered behavior, inclusive date boundaries, and robustness against null/blank/non-integer player ids.
- No changes to actual email sending, outbox deletion, subscriptions, ratings, badges, or match mutation logic.

### Testing
- Added unit tests and ran the new and related suites with `pytest -q tests/test_player_update_sender_bulk_generation.py tests/test_player_update_queueing.py`.
- All tests passed: the run completed successfully (`12 passed`, with warnings only).
- Tests cover filtered generation (queues only subscribed players with matches), unfiltered generation (queues all active subscribers), inclusive date handling, and ignoring invalid partner ids.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee9dd09e3483268ac210672949d005)