### PR TITLE
Polish public branding and tournament-focused navigation

### DIFF
--- a/jupr_app/ui/branding.py
+++ b/jupr_app/ui/branding.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+PRODUCT_NAME = "JUPR"
+CLUB_NAME = "Tres Palapas"
+CLUB_ID = "tres_palapas"
+TAGLINE = "Official player ratings and events for Tres Palapas"
+SUPPORT_EMAIL = "joe@juprleagues.com"
+PUBLIC_BASE_URL_FALLBACK = "https://juprtrespalapas.streamlit.app"
+
+
+__all__ = [
+    "PRODUCT_NAME",
+    "CLUB_NAME",
+    "CLUB_ID",
+    "TAGLINE",
+    "SUPPORT_EMAIL",
+    "PUBLIC_BASE_URL_FALLBACK",
+]

--- a/jupr_app/ui/pages/home.py
+++ b/jupr_app/ui/pages/home.py
@@ -2,21 +2,24 @@ from __future__ import annotations
 
 import streamlit as st
 
+from jupr_app.ui.branding import CLUB_NAME, PRODUCT_NAME, TAGLINE
+
 
 def render(ctx) -> None:  # noqa: ARG001
     st.markdown(
-        """
+        f"""
         <section class="jupr-public-shell">
           <div class="jupr-hero jupr-card">
-            <div class="jupr-hero-eyebrow">JUPR</div>
-            <h1 class="jupr-hero-title">Tres Palapas ratings, profiles, and events.</h1>
+            <div class="jupr-hero-eyebrow">{PRODUCT_NAME} at {CLUB_NAME}</div>
+            <h1 class="jupr-hero-title">Official player ratings and events for {CLUB_NAME}.</h1>
             <p class="jupr-hero-subtitle">
-              Find current standings, player profiles, upcoming events, and player update subscriptions.
+              Find current ratings, player profiles, tournament registration, and player update subscriptions.
             </p>
+            <p class="jupr-hero-subtitle">{TAGLINE}</p>
             <div class="jupr-hero-actions">
               <a class="jupr-link-button" href="?page=leaderboards">Leaderboards</a>
               <a class="jupr-link-button" href="?page=players">Player Profiles</a>
-              <a class="jupr-link-button" href="?page=tournament_registration">Events</a>
+              <a class="jupr-link-button" href="?page=tournament_registration">Tournaments</a>
               <a class="jupr-link-button" href="?page=verified_updates_request">Player Updates</a>
             </div>
           </div>
@@ -56,10 +59,10 @@ def render(ctx) -> None:  # noqa: ARG001
               <p class="jupr-home-card-body">Profiles, recent results, badges, trophies, and update subscriptions.</p>
               <div class="jupr-home-card-cta">Find players →</div>
             </a>
-            <a class="jupr-home-card jupr-card jupr-card--hover jupr-home-card-link" href="?page=tournament_registration" aria-label="View event registration and updates">
-              <h3 class="jupr-home-card-title">Events &amp; Updates</h3>
-              <p class="jupr-home-card-body">Event registration, weekly recaps, partner boards, and player notifications.</p>
-              <div class="jupr-home-card-cta">See events →</div>
+            <a class="jupr-home-card jupr-card jupr-card--hover jupr-home-card-link" href="?page=tournament_registration" aria-label="View tournament registration and updates">
+              <h3 class="jupr-home-card-title">Tournaments &amp; Updates</h3>
+              <p class="jupr-home-card-body">Tournament registration, weekly recaps, partner boards, and player notifications.</p>
+              <div class="jupr-home-card-cta">See tournaments →</div>
             </a>
             <a class="jupr-home-card jupr-card jupr-card--hover jupr-home-card-link" href="?page=rating_rules" aria-label="Read the rating rules">
               <h3 class="jupr-home-card-title">Rating Rules</h3>

--- a/jupr_app/ui/public_nav.py
+++ b/jupr_app/ui/public_nav.py
@@ -4,6 +4,7 @@ import inspect
 
 import streamlit as st
 
+from jupr_app.ui.branding import CLUB_NAME, PRODUCT_NAME, TAGLINE
 from jupr_app.ui.page_registry import LABEL_TO_PAGE_KEY, PAGE_KEY_TO_LABEL
 from jupr_app.ui.public_links import navigate_same_tab
 
@@ -16,7 +17,7 @@ PUBLIC_LABEL_BY_KEY: dict[str, str] = {
     "badge_codex": "Badges",
     "challenge_ladder": "Challenge Ladder",
     "jupr_live": "JUPR Live",
-    "tournament_registration": "Events",
+    "tournament_registration": "Tournaments",
     "tournament_partner_board": "Partner Board",
     "rating_rules": "Rating Rules",
     "weekly_recap": "Weekly Recap",
@@ -79,7 +80,25 @@ def _render_public_nav_styles() -> None:
           }
           .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-brand {
             flex: 0 1 auto;
-            min-width: 10rem;
+            min-width: 14rem;
+          }
+          .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-brand-row {
+            display: flex;
+            align-items: center;
+            gap: 0.55rem;
+          }
+          .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-logo-slot {
+            width: 1.9rem;
+            height: 1.9rem;
+            border-radius: 999px;
+            border: 1px solid color-mix(in srgb, var(--border-strong) 55%, transparent);
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.8rem;
+            font-weight: 700;
+            color: var(--text-muted);
+            background: color-mix(in srgb, var(--panel) 88%, transparent);
           }
           .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-brand .stButton > button {
             all: unset;
@@ -116,25 +135,22 @@ def _render_public_nav_styles() -> None:
             gap: 0.35rem;
             flex-wrap: wrap;
           }
-          .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-admin {
-            flex: 0 1 auto;
-            margin-left: auto;
+          .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-footer-links {
+            margin-top: 0.55rem;
+            font-size: 0.76rem;
+            color: var(--text-muted);
+            display: flex;
+            gap: 0.5rem;
+            align-items: center;
+            justify-content: flex-end;
           }
-          .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-admin .stButton {
-            display: inline-flex;
-          }
-          .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-admin .stButton > button {
-            border-radius: 10px;
-            font-size: 0.8rem;
-            font-weight: 800;
-            padding: 0.35rem 0.65rem;
-            white-space: nowrap;
-            width: fit-content;
-          }
-          @media (max-width: 1080px) {
-            .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-admin {
-              margin-left: 0;
-            }
+          .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-footer-links .stButton > button {
+            all: unset;
+            cursor: pointer;
+            color: var(--text-muted);
+            text-decoration: underline;
+            font-size: 0.76rem;
+            font-weight: 600;
           }
         </style>
         """,
@@ -205,16 +221,15 @@ def render_public_app_header(
         unsafe_allow_html=True,
     )
 
-    st.markdown('<div class="jupr-public-brand">', unsafe_allow_html=True)
-    if st.button("JUPR", key="public_header_brand_home"):
+    st.markdown('<div class="jupr-public-brand"><div class="jupr-public-brand-row"><div class="jupr-public-logo-slot" aria-hidden="true">Logo</div>', unsafe_allow_html=True)
+    if st.button(f"{PRODUCT_NAME} at {CLUB_NAME}", key="public_header_brand_home"):
         navigate_same_tab(
             page="home",
             params=_safe_context_params("home", current_params),
             public_mode=True,
             source="public_header:home",
         )
-    st.markdown('<div class="jupr-public-brand-subtitle">Tres Palapas Rating System</div>', unsafe_allow_html=True)
-    st.markdown("</div>", unsafe_allow_html=True)
+    st.markdown('</div><div class="jupr-public-brand-subtitle">' + TAGLINE + '</div></div>', unsafe_allow_html=True)
 
     st.markdown('<div class="jupr-public-nav-control">', unsafe_allow_html=True)
     nav_labels = [PUBLIC_LABEL_BY_KEY[key] for key in nav_page_keys]
@@ -234,26 +249,26 @@ def render_public_app_header(
         )
     st.markdown("</div>", unsafe_allow_html=True)
 
-    st.markdown('<div class="jupr-public-admin">', unsafe_allow_html=True)
+    st.markdown("</div></div>", unsafe_allow_html=True)
+
     admin_authenticated = bool(st.session_state.get("jupr_admin_authenticated", False))
+    st.markdown('<div class="jupr-public-footer-links">', unsafe_allow_html=True)
     admin_label = "Admin Dashboard" if admin_authenticated else "Admin Login"
-    if st.button(admin_label, key="public_header_admin_primary"):
+    if st.button(admin_label, key="public_footer_admin_link"):
         navigate_same_tab(
             page="league_manager" if admin_authenticated else "admin_login",
             public_mode=False,
-            source="public_header:admin_dashboard" if admin_authenticated else "public_header:admin_login",
+            source="public_footer:admin_dashboard" if admin_authenticated else "public_footer:admin_login",
         )
 
-    if admin_authenticated and st.button("Logout", key="public_header_logout"):
+    if admin_authenticated and st.button("Logout", key="public_footer_logout"):
         navigate_same_tab(
             page=current_page_key or default_page,
             params={"logout": "1", **_safe_context_params(current_page_key or default_page, current_params)},
             public_mode=True,
-            source="public_header:logout",
+            source="public_footer:logout",
         )
-    st.markdown("</div>", unsafe_allow_html=True)
-
-    st.markdown("</div></div></div>", unsafe_allow_html=True)
+    st.markdown("</div></div>", unsafe_allow_html=True)
 
     return PAGE_KEY_TO_LABEL.get(current_page_key, PAGE_KEY_TO_LABEL[default_page])
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -33,6 +33,7 @@ from jupr_app.ui.page_registry import (
     PUBLIC_NAV_KEYS,
     labels_for_keys,
 )
+from jupr_app.ui.branding import CLUB_ID, PUBLIC_BASE_URL_FALLBACK
 from jupr_app.ui.public_nav import render_public_app_header
 from jupr_app.ui.theme_clean import apply_clean_theme
 from jupr_app.ui.url import qp_get
@@ -56,10 +57,6 @@ def _debug_exceptions_enabled() -> bool:
 # -------------------------
 # CONFIG
 # -------------------------
-CLUB_ID = "tres_palapas"
-
-# Public base URL used for share links + link buttons (Streamlit Cloud)
-PUBLIC_BASE_URL = "https://juprtrespalapas.streamlit.app"
 
 
 # -------------------------
@@ -83,6 +80,30 @@ def get_secret(path: list[str], default=None):
         cur = cur[k]
 
     return cur
+
+
+
+
+def get_public_base_url() -> str:
+    """Resolve public base URL from env/secrets with stable fallback."""
+    env_value = str(os.getenv("JUPR_PUBLIC_BASE_URL", "") or "").strip().rstrip("/")
+    if env_value:
+        return env_value
+
+    secret_candidates = (
+        get_secret(["JUPR_PUBLIC_BASE_URL"], ""),
+        get_secret(["PUBLIC_BASE_URL"], ""),
+        get_secret(["public", "base_url"], ""),
+    )
+    for candidate in secret_candidates:
+        secret_value = str(candidate or "").strip().rstrip("/")
+        if secret_value:
+            return secret_value
+
+    return PUBLIC_BASE_URL_FALLBACK
+
+
+PUBLIC_BASE_URL = get_public_base_url()
 
 
 # -------------------------

--- a/tests/test_public_nav_shell.py
+++ b/tests/test_public_nav_shell.py
@@ -20,8 +20,9 @@ def test_public_nav_uses_same_tab_routing_buttons():
     assert '"rating_rules": "public_header:rating_rules"' in contents
     assert '"weekly_recap": "public_header:weekly_recap"' in contents
     assert '"faqs": "public_header:faqs"' in contents
-    assert '"public_header:admin_dashboard" if admin_authenticated else "public_header:admin_login"' in contents
-    assert 'source="public_header:logout"' in contents
+    assert '"public_footer:admin_dashboard" if admin_authenticated else "public_footer:admin_login"' in contents
+    assert 'source="public_footer:logout"' in contents
+    assert '"tournament_registration": "Tournaments"' in contents
     assert "default_page: str = \"home\"" in contents
 
 

--- a/tests/test_streamlit_base_url.py
+++ b/tests/test_streamlit_base_url.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_public_base_url_prefers_env_with_fallback():
+    contents = Path("streamlit_app.py").read_text(encoding="utf-8")
+
+    assert 'os.getenv("JUPR_PUBLIC_BASE_URL", "")' in contents
+    assert 'PUBLIC_BASE_URL = get_public_base_url()' in contents
+    assert 'return PUBLIC_BASE_URL_FALLBACK' in contents


### PR DESCRIPTION
### Motivation
- Make the public JUPR site read and feel like a polished, club-first product for Tres Palapas instead of a generic Streamlit tool. 
- Centralize club/product branding values so copy and configuration are consistent across public UI and app config. 
- Surface tournament-focused language in the public nav and home CTAs while de-emphasizing the header admin CTA. 

### Description
- Add `jupr_app/ui/branding.py` to centralize `PRODUCT_NAME`, `CLUB_NAME`, `CLUB_ID`, `TAGLINE`, `SUPPORT_EMAIL`, and `PUBLIC_BASE_URL_FALLBACK`. 
- Update `streamlit_app.py` to resolve `PUBLIC_BASE_URL` from the environment variable `JUPR_PUBLIC_BASE_URL` first, then safe secret keys, and finally fall back to the branded Streamlit URL, ensuring missing secrets do not crash local/test runs. 
- Modify `jupr_app/ui/public_nav.py` to show club-facing branding (`{PRODUCT_NAME} at {CLUB_NAME}`), add a small placeholder logo/avatar slot, change the `tournament_registration` label from "Events" to "Tournaments", preserve same-tab navigation behavior, and move the Admin Login/Admin Dashboard (and Logout) to a compact footer-level link area with updated source tags. 
- Update `jupr_app/ui/pages/home.py` hero and CTAs to emphasize ratings, players, tournaments, and player updates, include the tagline, and replace generic "Events" copy with tournament-specific wording while preserving the existing Rating Rules trust card. 
- Adjust tests by updating `tests/test_public_nav_shell.py` expectations and adding `tests/test_streamlit_base_url.py` to assert the new PUBLIC_BASE_URL resolution approach. 
- No database schema changes and no changes to admin authentication behavior. 

### Testing
- Ran `pytest -q tests/test_public_nav_shell.py tests/test_streamlit_base_url.py tests/test_page_registry.py` and all tests passed (`10 passed`). 
- Verified that the new PUBLIC_BASE_URL resolution uses `os.getenv("JUPR_PUBLIC_BASE_URL", "")`, falls back to safe secret keys, and ultimately returns `PUBLIC_BASE_URL_FALLBACK` when no override is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f003a06ebc8326be1cdd9aee7c0e04)