### PR TITLE
Replace patch-note README with private operator README for Joe

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,15 +1,116 @@
-Apply these replacements on branch rollback-feb8:
+# JUPR Private Operator README (Joe)
 
-1. Replace streamlit_app.py with the file in this bundle.
-2. Add jupr_app/ui/admin_auth.py.
-3. Update requirements.txt to include extra-streamlit-components>=0.1.71.
-4. Redeploy.
+This README is for operating JUPR at Tres Palapas.
+It is **not** written as a public contributor guide.
 
-What this patch does:
-- Persists signed admin sessions to a browser cookie.
-- Restores admin login on hard page loads and direct ?page=... navigation.
-- Keeps the existing HMAC-signed TTL model.
+> Security rule: never paste secret values into this repo, commit history, issues, PRs, or ChatGPT.
 
-Notes:
-- This patch fixes the sitewide “looks logged out after internal navigation or reload” pattern.
-- It does not yet refactor internal admin link buttons to in-app navigation, but with cookie-backed restore those links should no longer boot the user out.
+## 1) What JUPR is
+
+- JUPR is the player ratings and event operations app used at Tres Palapas.
+- It tracks official player ratings and supports official Tres Palapas events.
+- It is the source of truth for player-facing ratings and core tournament/admin workflows.
+
+## 2) Branch model
+
+Use this model consistently:
+
+- `rollback-feb8` = **production** branch
+- `Test` = **staging** branch
+- `professional/*` = **work branches** that open PRs into `Test`
+
+Typical flow:
+
+1. Create/update a `professional/*` branch.
+2. Open PR into `Test`.
+3. Validate in staging.
+4. Promote to production branch (`rollback-feb8`) only after staging is stable.
+
+## 3) Streamlit deployment
+
+- The **production Streamlit app** deploys from `rollback-feb8`.
+- The **test/staging Streamlit app** deploys from `Test`.
+- Secrets are stored in **Streamlit Community Cloud** secrets settings.
+- Never put secrets in repo files, commit messages, PR comments, or ChatGPT prompts.
+
+## 4) Supabase
+
+- There is currently **one production Supabase project**.
+- There is **no staging Supabase project yet**.
+- SQL migrations are often manually pasted into the Supabase SQL editor.
+- Preferred canonical location for migration files is: `supabase/migrations/`.
+
+## 5) MailerSend / email
+
+- Sender name: **JUPR Notifications**
+- Reply-to address: **joe@juprleagues.com**
+- Unsubscribe behavior must be enforced by the **JUPR database/state** (not only MailerSend provider state).
+
+## 6) Local setup (minimal)
+
+If you do not run locally, **skip this section**.
+
+1. Install Python (use the same major/minor version configured in Streamlit settings; record that version here when confirmed).
+2. Create and activate a virtual environment.
+3. Install dependencies from `requirements.txt`.
+4. Run the app locally with Streamlit for quick checks before pushing.
+
+Example commands:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+streamlit run streamlit_app.py
+```
+
+## 7) Testing checklist before deploy
+
+Before deploying any branch, smoke test these pages/flows:
+
+- Public home page
+- Leaderboards
+- Player profile + player search
+- Tournament registration page
+- Admin login
+- Match log/admin page (basic smoke test)
+
+## 8) Migration checklist
+
+When applying DB changes:
+
+1. Review SQL carefully.
+2. Apply SQL in Supabase SQL editor.
+3. Verify expected tables/columns/indexes exist.
+4. Deploy the correct app branch.
+5. Run smoke tests in app after migration.
+
+## 9) Rollback checklist
+
+If a release causes issues:
+
+1. Stop and document the issue briefly.
+2. Re-deploy known-good branch (`rollback-feb8`) to production.
+3. Confirm core user flows (home, leaderboards, login, registration).
+4. If DB changes were part of incident, assess whether a DB rollback is safe before executing anything destructive.
+5. Log what happened and what needs to be fixed before next release.
+
+## 10) Making repo private
+
+Order of operations:
+
+1. Stabilize `Test` first.
+2. Confirm Streamlit/GitHub integration has access to the private repository.
+3. Then switch repo visibility to private.
+
+## 11) What not to commit
+
+Never commit any of the following:
+
+- Supabase keys
+- Streamlit secrets
+- MailerSend API keys
+- Private player exports
+- Production DB dumps
+
+If a secret is accidentally exposed, rotate it immediately and remove exposure from history where possible.


### PR DESCRIPTION
### Motivation
- Replace a one-off patch-note README with a clear, operator-focused guide for Joe to run JUPR at Tres Palapas without exposing secrets. 
- Provide simple operational rules (branch model, deploy mapping, DB/migration workflow, email policy, local run notes) so a non-developer operator can run day-to-day tasks and releases. 

### Description
- Overwrote `README.txt` with a private operator README that includes the 11 required sections: What JUPR is, Branch model, Streamlit deployment, Supabase, MailerSend/email, Local setup, Testing checklist, Migration checklist, Rollback checklist, Making repo private, and What not to commit. 
- Explicitly documents branch mapping (`rollback-feb8` = production, `Test` = staging, `professional/*` = PR branches), Streamlit secret storage guidance, and the preferred `supabase/migrations/` folder without including any secret values. 
- Adds concise, minimal local setup steps using `requirements.txt` and instructs recording the Python version from Streamlit settings, plus practical operator-focused checklists for testing, migration, and rollback. 

### Testing
- The new `README.txt` file was written and its contents were programmatically inspected to confirm all required sections and phrasing were included, and inspection succeeded. 
- Repository tooling was used to create the PR targeting the `Test` branch and reported success. 
- No automated unit or integration tests were applicable to this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01e959a008326a36c01ffd49c4bf9)