### PR TITLE
Define supabase/migrations as canonical and add migration-source guard

### DIFF
--- a/.github/workflows/migration-source-guard.yml
+++ b/.github/workflows/migration-source-guard.yml
@@ -1,0 +1,27 @@
+name: Migration Source Guard
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Check migration source policy
+        run: |
+          if git show-ref --verify --quiet refs/remotes/origin/Test; then
+            python scripts/check_migration_sources.py --base-ref origin/Test
+          else
+            python scripts/check_migration_sources.py --base-ref Test
+          fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: db-migrate
+.PHONY: db-migrate check-migration-sources
 
 db-migrate: ## Apply pending SQL migrations (requires DATABASE_URL)
 	@bash scripts/db_migrate.sh
+
+check-migration-sources: ## Guard: block undocumented new root migrations
+	@python scripts/check_migration_sources.py

--- a/README.txt
+++ b/README.txt
@@ -76,11 +76,19 @@ Before any deploy, smoke test:
 
 ## 8) Migration checklist
 
+Detailed policy: see `docs/migrations.md`.
+
 1. Review SQL.
 2. Apply SQL in Supabase SQL editor.
 3. Verify expected columns/tables.
 4. Deploy app branch.
 5. Smoke test.
+
+Guardrail command:
+
+```bash
+make check-migration-sources
+```
 
 ## 9) Rollback checklist
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,101 @@
+# Migration source of truth
+
+## Canonical location
+
+`supabase/migrations/` is the **canonical location** for schema migrations that must exist in Supabase.
+
+- If a migration changes Supabase schema (tables, columns, constraints, indexes, functions, grants, triggers, policies), the SQL must be captured in `supabase/migrations/`.
+- Do **not** rely on `migrations/` alone for Supabase schema changes.
+
+## Current inventory (as of 2026-04-28)
+
+### `supabase/migrations/` (canonical)
+
+- `20260424_matches_soft_delete.sql`
+- `20260428_add_unsubscribe_token_to_player_profile_update_subscriptions.sql`
+- `2026XX_backport_tournament_engine.sql`
+
+### `migrations/` (legacy/archive)
+
+The repository still contains a historical `migrations/` folder with many SQL files.
+Treat this folder as **legacy/archive** unless a file is explicitly documented for non-Supabase usage.
+
+Current files in `migrations/`:
+
+- `20250220_badges_v1.sql`
+- `20250301_player_inactivity.sql`
+- `20250320_gamification_v2.sql`
+- `20250325_player_badges_dedupe.sql`
+- `20250410_badges_copy_pack.sql`
+- `20250415_gamification_story_badges.sql`
+- `20250420_badge_definitions_seed.sql`
+- `20250425_tournaments.sql`
+- `20250505_tournament_podium.sql`
+- `20260130_unique_leagues_metadata.sql`
+- `20260207_weekly_recaps.sql`
+- `20260215_end_league_top_performers.sql`
+- `20260301_bulk_replay_rpcs.sql`
+- `20260301_premium_league_editor.sql`
+- `20260309_tournament_registration.sql`
+- `20260310_tournament_event_draws.sql`
+- `20260329_live_social_events.sql`
+- `20260330_live_social_moderation_columns.sql`
+- `20260417_live_events_submitted_by_name_canonical.sql`
+- `20260417_live_events_submitted_by_name_canonical_rollback.sql`
+- `20260417_tournament_builder_draft_snapshot.sql`
+- `20260420_verified_player_updates.sql`
+- `20260421_player_update_outbox_allow_repeat_queue_rows.sql`
+- `20260421_verified_player_updates_date_window_uniqueness.sql`
+- `20260615_player_badges_unique_contract.sql`
+- `20260620_badge_state.sql`
+- `20260625_badge_recompute_runs.sql`
+- `20260630_player_badges_revocation.sql`
+- `20260705_badge_eval_queue.sql`
+- `20260712_badge_eval_triggers.sql`
+- `20260715_perf_indexes.sql`
+- `20260720_badge_eval_queue_backfill.sql`
+- `20260720_player_badges_provenance_grants.sql`
+- `20260725_events.sql`
+- `20260801_badge_queue_and_facts_grants.sql`
+- `20260805_player_badges_awarded_by_text.sql`
+- `20260810_player_badges_awarded_by_text.sql`
+- `20261010_tournament_builder_refactor.sql`
+- `20261011_tournament_dates.sql`
+- `20261018_tournament_registration_schema_contract.sql`
+
+## Handling duplicates or overlaps
+
+We are intentionally **not** deleting or moving old SQL files aggressively in this change.
+
+Potential overlap area currently observed:
+
+- `supabase/migrations/2026XX_backport_tournament_engine.sql`
+- Multiple legacy tournament-related files in `migrations/` (for example `20250425_tournaments.sql`, `20260309_tournament_registration.sql`, `20261010_tournament_builder_refactor.sql`).
+
+If you discover clear duplicates, document them first in this file (or PR notes) before any cleanup.
+
+## Manual SQL apply checklist (production Supabase)
+
+There is currently no staging Supabase. Do not auto-apply SQL from this repo.
+
+For schema changes:
+
+1. Review SQL in the PR.
+2. Paste and run SQL in **Supabase SQL editor** (production project).
+3. Confirm expected table/column/constraint exists.
+4. Deploy the `Test` branch application.
+5. Run smoke tests on key flows.
+
+## Guardrail for future changes
+
+Use the guard script:
+
+```bash
+python scripts/check_migration_sources.py
+```
+
+Behavior:
+
+- Detects newly-added `migrations/*.sql` files in the current branch (compared to `Test` by default).
+- Fails unless each new root migration is documented in `docs/migrations_root_explanations.md`.
+- This keeps contributors from accidentally treating `migrations/` as the primary Supabase source.

--- a/docs/migrations_root_explanations.md
+++ b/docs/migrations_root_explanations.md
@@ -1,0 +1,16 @@
+# Root migration explanations (legacy)
+
+This file is an allowlist for **new** SQL files added under `migrations/`.
+
+Policy:
+
+- `supabase/migrations/` is canonical for Supabase schema migrations.
+- New `migrations/*.sql` files should be rare and must include a justification below.
+
+Entry format:
+
+- `migrations/<filename>.sql`: <why this must live in root migrations and not only in supabase/migrations/>.
+
+Current entries:
+
+- _None yet._

--- a/scripts/check_migration_sources.py
+++ b/scripts/check_migration_sources.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Guardrail: prevent undocumented new root migrations.
+
+Fails when new files are added under migrations/*.sql unless explicitly documented
+in docs/migrations_root_explanations.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+EXPLANATIONS_FILE = ROOT / "docs" / "migrations_root_explanations.md"
+
+
+def run_git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def added_root_migrations(base_ref: str) -> list[str]:
+    diff = run_git("diff", "--name-status", "--diff-filter=A", f"{base_ref}...HEAD")
+    added: list[str] = []
+    for line in diff.splitlines():
+        parts = line.strip().split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+        status, path = parts
+        if status != "A":
+            continue
+        if re.fullmatch(r"migrations/.+\.sql", path):
+            added.append(path)
+    return sorted(set(added))
+
+
+def documented_entries() -> set[str]:
+    if not EXPLANATIONS_FILE.exists():
+        return set()
+    text = EXPLANATIONS_FILE.read_text(encoding="utf-8")
+    # Matches bullets like:
+    # - `migrations/example.sql`: reason
+    matches = re.findall(r"-\s+`(migrations/[^`]+\.sql)`\s*:", text)
+    return set(matches)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base-ref",
+        default="Test",
+        help="Git base ref to compare with current HEAD (default: Test)",
+    )
+    parser.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="Warn instead of exiting non-zero.",
+    )
+    args = parser.parse_args()
+
+    try:
+        added = added_root_migrations(args.base_ref)
+    except subprocess.CalledProcessError as exc:
+        print("[migration-guard] Could not evaluate git diff.", file=sys.stderr)
+        print(exc.stderr, file=sys.stderr)
+        return 2
+
+    if not added:
+        print("[migration-guard] No new root migrations detected.")
+        return 0
+
+    documented = documented_entries()
+    undocumented = [path for path in added if path not in documented]
+
+    if not undocumented:
+        print("[migration-guard] New root migrations are documented.")
+        return 0
+
+    print("[migration-guard] Undocumented root migrations detected:", file=sys.stderr)
+    for path in undocumented:
+        print(f"  - {path}", file=sys.stderr)
+
+    print(
+        "Add entries to docs/migrations_root_explanations.md "
+        "or move schema migrations into supabase/migrations/.",
+        file=sys.stderr,
+    )
+
+    if args.warn_only:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Prevent schema drift by making `supabase/migrations/` the canonical source for Supabase schema changes and documenting the manual Supabase SQL workflow. 
- Avoid any automatic or accidental execution of SQL from the repo and ensure contributors know where to place migrations. 
- Provide a small, automated guard so future contributors do not accidentally treat the root `migrations/` folder as the authoritative Supabase source. 

### Description

- Add `docs/migrations.md` documenting that `supabase/migrations/` is the canonical location, include a current inventory of `supabase/migrations/` and legacy `migrations/`, document overlap policy, and add a manual SQL apply checklist. 
- Add `docs/migrations_root_explanations.md` as an allowlist / justification file for any new `migrations/*.sql` added at the repo root. 
- Add an executable guard script `scripts/check_migration_sources.py` that fails when new `migrations/*.sql` files are added without an entry in `docs/migrations_root_explanations.md`. 
- Wire the guard into developer tooling by adding a `check-migration-sources` Makefile target and a GitHub Actions workflow `.github/workflows/migration-source-guard.yml` that runs the guard on push and PRs. 
- Update `README.txt` migration guidance to point to `docs/migrations.md` and show the guard command (`make check-migration-sources`). 
- Do not move or delete any existing SQL files and do not add any runtime or auto-apply SQL logic. 

### Testing

- Successfully compiled the guard script with `python -m py_compile scripts/check_migration_sources.py`. 
- Ran the guard locally with `python scripts/check_migration_sources.py --base-ref HEAD~1` which returned no new root migrations. 
- Attempting `python scripts/check_migration_sources.py --base-ref Test` or `--base-ref origin/Test` failed locally when those refs were not present, which is expected for a shallow/local clone and is handled by the workflow which uses `origin/Test` when available. 
- The GitHub Actions workflow was added to run the guard on push/PR (will validate behavior in CI on open PRs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01fe704588326ac466c12c5be3535)