### PR TITLE
Add durable admin activity log with safe fallbacks and admin UI

### DIFF
--- a/jupr_app/domain/admin_activity_log.py
+++ b/jupr_app/domain/admin_activity_log.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from postgrest.exceptions import APIError
+
+from jupr_app.domain.admin.roles import ROLE_CLUB_OWNER, ROLE_SUPER_ADMIN, normalize_role
+
+RETENTION_DAYS = 365
+
+
+@dataclass(frozen=True)
+class ActivityLogWriteResult:
+    ok: bool
+    warning: str | None = None
+
+
+def can_view_admin_activity(role: str) -> bool:
+    normalized = normalize_role(role)
+    return normalized in {ROLE_SUPER_ADMIN, ROLE_CLUB_OWNER}
+
+
+def retention_cutoff_iso(*, now: datetime | None = None) -> str:
+    anchor = now or datetime.now(timezone.utc)
+    return (anchor - timedelta(days=RETENTION_DAYS)).isoformat()
+
+
+def build_activity_payload(
+    *,
+    club_id: str,
+    actor_email: str,
+    actor_role: str,
+    action_type: str,
+    entity_type: str,
+    entity_id: str,
+    before_json: Any = None,
+    after_json: Any = None,
+    note: str | None = None,
+    source_page: str | None = None,
+    flagged_for_review: bool = False,
+) -> dict[str, Any]:
+    return {
+        "club_id": str(club_id),
+        "actor_email": str(actor_email or "").strip().lower() or "unknown",
+        "actor_role": normalize_role(actor_role),
+        "action_type": str(action_type or "").strip(),
+        "entity_type": str(entity_type or "").strip(),
+        "entity_id": str(entity_id or "").strip(),
+        "before_json": before_json,
+        "after_json": after_json,
+        "note": str(note or "").strip() or None,
+        "source_page": str(source_page or "").strip() or None,
+        "flagged_for_review": bool(flagged_for_review),
+    }
+
+
+def write_admin_activity_log(supabase, payload: dict[str, Any]) -> ActivityLogWriteResult:
+    try:
+        supabase.table("admin_activity_log").insert(payload).execute()
+        return ActivityLogWriteResult(ok=True)
+    except Exception as exc:  # noqa: BLE001 - intentionally degrade gracefully
+        warning = "Admin activity log write failed."
+        if isinstance(exc, APIError):
+            code = getattr(exc, "code", None) or ((exc.args[0].get("code")) if exc.args and isinstance(exc.args[0], dict) else None)
+            if code in {"42P01", "PGRST205"}:
+                warning = "Admin activity log table is not available yet. Apply migrations to enable audit visibility."
+        return ActivityLogWriteResult(ok=False, warning=warning)
+
+
+def list_recent_admin_activity_logs(
+    supabase,
+    *,
+    club_id: str,
+    include_flagged_only: bool = False,
+    limit: int = 200,
+) -> tuple[list[dict[str, Any]], str | None]:
+    try:
+        query = (
+            supabase.table("admin_activity_log")
+            .select(
+                "id,club_id,actor_email,actor_role,action_type,entity_type,entity_id,before_json,after_json,note,source_page,flagged_for_review,created_at"
+            )
+            .eq("club_id", str(club_id))
+            .order("created_at", desc=True)
+            .limit(int(limit))
+        )
+        if include_flagged_only:
+            query = query.eq("flagged_for_review", True)
+        result = query.execute()
+        return list(result.data or []), None
+    except Exception as exc:  # noqa: BLE001
+        if isinstance(exc, APIError):
+            code = getattr(exc, "code", None) or ((exc.args[0].get("code")) if exc.args and isinstance(exc.args[0], dict) else None)
+            if code in {"42P01", "PGRST205"}:
+                return [], "Admin activity migration is not applied yet."
+        return [], "Unable to load admin activity logs right now."

--- a/jupr_app/domain/bulk_match_editor.py
+++ b/jupr_app/domain/bulk_match_editor.py
@@ -9,6 +9,7 @@ import pandas as pd
 from jupr_app.domain.gamification.badge_queue import enqueue_badge_eval
 from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue
 from jupr_app.domain.gamification.live_awards import run_live_badge_awards
+from jupr_app.domain.admin_activity_log import build_activity_payload, write_admin_activity_log
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,9 @@ def apply_bulk_match_edits(
     actor: str,
     source: str = "match_log.bulk_match_editor",
     correction_note: str | None = None,
+    actor_email: str | None = None,
+    actor_role: str | None = None,
+    flagged_for_review: bool = False,
 ) -> Dict[str, Any]:
     """
     Apply per-match patches safely.
@@ -319,6 +323,24 @@ def apply_bulk_match_edits(
             "warnings": warnings,
         },
     )
+    log_result = write_admin_activity_log(
+        supabase,
+        build_activity_payload(
+            club_id=str(club_id),
+            actor_email=actor_email or actor,
+            actor_role=actor_role or "",
+            action_type="match_edit",
+            entity_type="match",
+            entity_id="bulk",
+            before_json=audit_before,
+            after_json=audit_after,
+            note=correction_note,
+            source_page=source,
+            flagged_for_review=flagged_for_review,
+        ),
+    )
+    if log_result.warning:
+        warnings.append(log_result.warning)
 
     # Recompute last_game_at for affected players (best effort)
     try:

--- a/jupr_app/domain/match_delete.py
+++ b/jupr_app/domain/match_delete.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from jupr_app.domain.player_activity import recompute_last_game_at_for_players
 from jupr_app.domain.replay_history import FULL_RESET_LABEL, replay_history
+from jupr_app.domain.admin_activity_log import build_activity_payload, write_admin_activity_log
 
 
 def delete_rated_matches_with_replay(
@@ -17,8 +18,10 @@ def delete_rated_matches_with_replay(
     df_meta: Optional[pd.DataFrame],
     progress_cb: Optional[Callable[[float], None]] = None,
     actor: Optional[str] = None,
+    actor_role: Optional[str] = None,
     source: Optional[str] = None,
     note: Optional[str] = None,
+    flagged_for_review: bool = False,
 ) -> Dict[str, Any]:
     """Soft-delete rated matches, recompute player activity, then run FULL replay."""
     normalized_ids = sorted({int(mid) for mid in (match_ids or []) if mid is not None})
@@ -78,6 +81,24 @@ def delete_rated_matches_with_replay(
             .in_("id", existing_ids)
             .execute()
         )
+        log_result = write_admin_activity_log(
+            supabase,
+            build_activity_payload(
+                club_id=str(club_id),
+                actor_email=actor or "admin",
+                actor_role=actor_role or "",
+                action_type="match_delete",
+                entity_type="match",
+                entity_id=",".join(str(mid) for mid in existing_ids),
+                before_json=before_rows,
+                after_json={"deleted_ids": existing_ids, "deleted_at": now_iso},
+                note=note,
+                source_page=source or "match_log",
+                flagged_for_review=flagged_for_review,
+            ),
+        )
+        if log_result.warning:
+            warning = (f"{warning} " if warning else "") + log_result.warning
 
     if affected_player_ids:
         recompute_last_game_at_for_players(

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -12,6 +12,12 @@ from jupr_app.domain.admin.roles import (
     can_run_replay,
     normalize_role,
 )
+from jupr_app.domain.admin_activity_log import (
+    RETENTION_DAYS,
+    can_view_admin_activity,
+    list_recent_admin_activity_logs,
+    retention_cutoff_iso,
+)
 
 from postgrest.exceptions import APIError
 
@@ -125,9 +131,34 @@ def _format_auth_debug_events(events: list[dict[str, object]]) -> list[dict[str,
     return formatted
 
 
-def _admin_role_context() -> tuple[str, bool, bool]:
+def _admin_role_context() -> tuple[str, bool, bool, bool]:
     role = normalize_role(str(st.session_state.get("admin_role", ROLE_READ_ONLY) or ROLE_READ_ONLY))
-    return role, can_manage_roles(role), can_run_replay(role)
+    return role, can_manage_roles(role), can_run_replay(role), can_view_admin_activity(role)
+
+
+def _render_admin_activity_section(supabase, club_id: str, *, current_role: str, can_view_activity: bool) -> None:
+    st.subheader("🧾 Admin Activity Log")
+    st.caption(f"Current role: **{current_role}**.")
+    st.caption("Retention guidance: keep approximately 1 year of history for trust and operational review.")
+    st.caption(f"Suggested retention cutoff: `{retention_cutoff_iso()[:10]}` (last {RETENTION_DAYS} days).")
+
+    if not can_view_activity:
+        st.info("Only Super Admin and Club Owner can view admin activity.")
+        return
+
+    flagged_only = st.checkbox("Show flagged scorekeeper edits/deletes only", value=False, key="admin_activity_flagged_only")
+    rows, warning = list_recent_admin_activity_logs(
+        supabase,
+        club_id=str(club_id),
+        include_flagged_only=flagged_only,
+        limit=300,
+    )
+    if warning:
+        st.warning(warning)
+    if not rows:
+        st.info("No admin activity rows found yet.")
+        return
+    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
 
 
 def _render_role_assignment_section(supabase, admin_allowlist: set[str], *, current_role: str, can_assign_roles: bool) -> None:
@@ -235,13 +266,20 @@ def render(ctx):
     supabase = ctx.supabase
     club_id = str(ctx.club_id)
     admin_allowlist = set(st.session_state.get("admin_allowlist", set()) or set())
-    admin_role, role_can_manage_roles, role_can_run_replay = _admin_role_context()
+    admin_role, role_can_manage_roles, role_can_run_replay, role_can_view_activity = _admin_role_context()
 
     _render_role_assignment_section(
         supabase,
         admin_allowlist,
         current_role=admin_role,
         can_assign_roles=role_can_manage_roles,
+    )
+    st.divider()
+    _render_admin_activity_section(
+        supabase,
+        club_id=club_id,
+        current_role=admin_role,
+        can_view_activity=role_can_view_activity,
     )
 
     st.divider()

--- a/jupr_app/ui/pages/match_log.py
+++ b/jupr_app/ui/pages/match_log.py
@@ -12,6 +12,7 @@ from jupr_app.domain.live_social import (
 from jupr_app.ui.layout import page_shell
 from jupr_app.domain.replay_history import FULL_RESET_LABEL, replay_history
 from jupr_app.domain.match_delete import delete_rated_matches_with_replay
+from jupr_app.domain.admin.roles import ROLE_SCOREKEEPER, normalize_role
 
 BULK_REPLAY_ERROR_STATE_KEY = "match_log_bulk_replay_error"
 
@@ -32,6 +33,8 @@ def render(ctx):
     if not bool(getattr(ctx, "admin_logged_in", False)):
         st.error("Admin login required.")
         st.stop()
+    admin_role = normalize_role(str(st.session_state.get("admin_role", "") or ""))
+    actor_email = str(getattr(st.session_state.get("admin_auth_user"), "email", "") or st.session_state.get("admin_email") or "admin")
 
     df_matches = getattr(ctx, "df_matches", None)
     if df_matches is None or df_matches.empty:
@@ -680,6 +683,9 @@ def render(ctx):
                     patches=patches,
                     actor=actor.strip() or "admin",
                     correction_note=(correction_note.strip() or None),
+                    actor_email=actor_email,
+                    actor_role=admin_role,
+                    flagged_for_review=(admin_role == ROLE_SCOREKEEPER),
                 )
 
             replay_error = None
@@ -796,8 +802,10 @@ def render(ctx):
                     match_ids=delete_ids,
                     df_meta=getattr(ctx, "df_meta", pd.DataFrame()),
                     progress_cb=lambda x: bar.progress(float(x)),
-                    actor="match_log.bulk_delete",
+                    actor=actor_email,
+                    actor_role=admin_role,
                     source="match_log",
+                    flagged_for_review=(admin_role == ROLE_SCOREKEEPER),
                 )
             if delete_result.get("warning"):
                 st.warning(delete_result["warning"])

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -26,6 +26,8 @@ from jupr_app.domain.notifications.player_update_sender import (
     send_pending_player_update_emails,
 )
 from jupr_app.domain.recaps.player_weekly_digest import compute_player_weekly_digest
+from jupr_app.domain.admin.roles import normalize_role
+from jupr_app.domain.admin_activity_log import build_activity_payload, write_admin_activity_log
 from jupr_app.ui.components.player_digest_layout import render_player_digest
 from jupr_app.ui.components.player_picker import render_player_picker
 from jupr_app.ui.layout import page_shell
@@ -50,6 +52,36 @@ def _player_name(ctx, player_id: int | None) -> str:
     except Exception:
         return ""
     return str(id_to_name.get(pid, ""))
+
+
+def _log_subscription_action(
+    supabase,
+    *,
+    club_id: str,
+    actor_email: str,
+    actor_role: str,
+    action_type: str,
+    row_id: str,
+    before_json: dict | None = None,
+    after_json: dict | None = None,
+    note: str | None = None,
+) -> str | None:
+    result = write_admin_activity_log(
+        supabase,
+        build_activity_payload(
+            club_id=club_id,
+            actor_email=actor_email,
+            actor_role=actor_role,
+            action_type=action_type,
+            entity_type="subscription",
+            entity_id=row_id,
+            before_json=before_json,
+            after_json=after_json,
+            note=note,
+            source_page="player_updates_admin",
+        ),
+    )
+    return result.warning
 
 
 def _pending_table_rows(ctx, rows: list[dict]) -> list[dict]:
@@ -191,6 +223,7 @@ def render(ctx) -> None:
     supabase = ctx.supabase
     club_id = str(ctx.club_id)
     actor = _actor_label(ctx)
+    admin_role = normalize_role(str(st.session_state.get("admin_role", "") or ""))
 
     pending_tab, active_tab, digests_tab, queue_tab = st.tabs(
         [
@@ -242,16 +275,44 @@ def render(ctx) -> None:
 
                 if approve_clicked:
                     try:
+                        before_row = dict(row)
                         approve_request(supabase, row_id, verified_by=actor, admin_note=admin_note)
+                        log_warning = _log_subscription_action(
+                            supabase,
+                            club_id=club_id,
+                            actor_email=actor,
+                            actor_role=admin_role,
+                            action_type="subscription_approve",
+                            row_id=row_id,
+                            before_json=before_row,
+                            after_json={"request_status": "active", "verified_by": actor},
+                            note=admin_note,
+                        )
                         st.success("Request approved.")
+                        if log_warning:
+                            st.warning(log_warning)
                         st.rerun()
                     except Exception as exc:
                         st.error(f"Approve failed: {_friendly_error(exc)}")
 
                 if reject_clicked:
                     try:
+                        before_row = dict(row)
                         reject_request(supabase, row_id, admin_note=admin_note, verified_by=actor)
+                        log_warning = _log_subscription_action(
+                            supabase,
+                            club_id=club_id,
+                            actor_email=actor,
+                            actor_role=admin_role,
+                            action_type="subscription_reject",
+                            row_id=row_id,
+                            before_json=before_row,
+                            after_json={"request_status": "rejected", "verified_by": actor},
+                            note=admin_note,
+                        )
                         st.success("Request rejected.")
+                        if log_warning:
+                            st.warning(log_warning)
                         st.rerun()
                     except Exception as exc:
                         st.error(f"Reject failed: {_friendly_error(exc)}")
@@ -342,8 +403,22 @@ def render(ctx) -> None:
 
                 if unsubscribe_clicked:
                     try:
+                        before_row = dict(row)
                         mark_unsubscribed(supabase, row_id)
+                        log_warning = _log_subscription_action(
+                            supabase,
+                            club_id=club_id,
+                            actor_email=actor,
+                            actor_role=admin_role,
+                            action_type="subscription_unsubscribe",
+                            row_id=row_id,
+                            before_json=before_row,
+                            after_json={"request_status": "unsubscribed"},
+                            note=admin_note,
+                        )
                         st.success("Subscription deactivated.")
+                        if log_warning:
+                            st.warning(log_warning)
                         st.rerun()
                     except Exception as exc:
                         st.error(f"Unsubscribe failed: {_friendly_error(exc)}")

--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -26,6 +26,8 @@ from jupr_app.domain.tournament_registration_repo import (
     save_builder_draft,
     upsert_registration_settings,
 )
+from jupr_app.domain.admin.roles import normalize_role
+from jupr_app.domain.admin_activity_log import build_activity_payload, write_admin_activity_log
 from jupr_app.ui.layout import page_shell
 from jupr_app.ui.public_links import navigate_same_tab
 
@@ -2200,6 +2202,23 @@ def render(ctx):
                         days=days_payload,
                         event_options=event_payload,
                     )
+                    admin_email = str(getattr(st.session_state.get("admin_auth_user"), "email", "") or st.session_state.get("admin_email") or "admin")
+                    admin_role = normalize_role(str(st.session_state.get("admin_role", "") or ""))
+                    log_result = write_admin_activity_log(
+                        supabase,
+                        build_activity_payload(
+                            club_id=str(club_id),
+                            actor_email=admin_email,
+                            actor_role=admin_role,
+                            action_type="tournament_publish",
+                            entity_type="tournament_registration",
+                            entity_id=str(tournament_id),
+                            before_json={"publish_impact_summary": (publish_impact or {}).get("summary", {})},
+                            after_json={"days_count": len(days_payload), "event_options_count": len(event_payload)},
+                            note="Publish registration changes",
+                            source_page="tournament_manager",
+                        ),
+                    )
                 except ValueError as exc:
                     st.error(str(exc))
                     st.stop()
@@ -2214,6 +2233,8 @@ def render(ctx):
                 st.session_state[draft_last_saved_step_key] = _safe_text(saved_payload.get("saved_step"))
                 st.session_state[draft_last_saved_at_key] = _safe_text(saved_payload.get("saved_at"))
                 st.success("Registration changes published.")
+                if not log_result.ok and log_result.warning:
+                    st.warning(log_result.warning)
                 st.rerun()
 
         st.info("Registration review, issue triage, and workbook exports now live on 📋 Tournament Operations.")

--- a/supabase/migrations/20260428_admin_activity_log.sql
+++ b/supabase/migrations/20260428_admin_activity_log.sql
@@ -1,0 +1,27 @@
+create table if not exists public.admin_activity_log (
+  id bigint generated always as identity primary key,
+  club_id text not null,
+  actor_email text not null,
+  actor_role text not null,
+  action_type text not null,
+  entity_type text not null,
+  entity_id text not null,
+  before_json jsonb,
+  after_json jsonb,
+  note text,
+  source_page text,
+  flagged_for_review boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists admin_activity_log_club_created_idx
+  on public.admin_activity_log (club_id, created_at desc);
+
+create index if not exists admin_activity_log_flagged_idx
+  on public.admin_activity_log (club_id, flagged_for_review, created_at desc);
+
+comment on table public.admin_activity_log is
+  'Admin activity audit log. Retain approximately 1 year for trust and operational review.';
+
+comment on column public.admin_activity_log.note is
+  'Optional reason/note captured from operator workflow context.';

--- a/tests/test_admin_activity_log.py
+++ b/tests/test_admin_activity_log.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from jupr_app.domain.admin.roles import (
+    ROLE_CLUB_OWNER,
+    ROLE_READ_ONLY,
+    ROLE_SCOREKEEPER,
+    ROLE_SUPER_ADMIN,
+)
+from jupr_app.domain.admin_activity_log import (
+    build_activity_payload,
+    can_view_admin_activity,
+    write_admin_activity_log,
+)
+
+
+class _InsertProbe:
+    def __init__(self):
+        self.rows: list[dict] = []
+
+    def insert(self, payload):
+        self.rows.append(dict(payload))
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=self.rows)
+
+
+class _SupabaseProbe:
+    def __init__(self):
+        self.probe = _InsertProbe()
+
+    def table(self, _name: str):
+        return self.probe
+
+
+class _FailingSupabase:
+    def table(self, _name: str):
+        raise RuntimeError("missing table")
+
+
+def test_build_activity_payload_sets_expected_shape():
+    payload = build_activity_payload(
+        club_id="club-1",
+        actor_email="Admin@Example.com",
+        actor_role=ROLE_SCOREKEEPER,
+        action_type="match_edit",
+        entity_type="match",
+        entity_id="42",
+        before_json={"score_t1": 11},
+        after_json={"score_t1": 9},
+        note="Corrected entry",
+        source_page="match_log",
+        flagged_for_review=True,
+    )
+
+    assert payload["club_id"] == "club-1"
+    assert payload["actor_email"] == "admin@example.com"
+    assert payload["actor_role"] == ROLE_SCOREKEEPER
+    assert payload["action_type"] == "match_edit"
+    assert payload["entity_type"] == "match"
+    assert payload["entity_id"] == "42"
+    assert payload["flagged_for_review"] is True
+
+
+def test_can_view_admin_activity_is_limited_to_owner_and_super_admin():
+    assert can_view_admin_activity(ROLE_SUPER_ADMIN) is True
+    assert can_view_admin_activity(ROLE_CLUB_OWNER) is True
+    assert can_view_admin_activity(ROLE_SCOREKEEPER) is False
+    assert can_view_admin_activity(ROLE_READ_ONLY) is False
+
+
+def test_write_admin_activity_log_degrades_gracefully():
+    ok_result = write_admin_activity_log(_SupabaseProbe(), {"club_id": "club"})
+    fail_result = write_admin_activity_log(_FailingSupabase(), {"club_id": "club"})
+
+    assert ok_result.ok is True
+    assert fail_result.ok is False
+    assert fail_result.warning is not None


### PR DESCRIPTION
### Motivation
- Provide durable, queryable admin activity logging for trust and operational review with visibility limited to `Super Admin` and `Club Owner` and guidance for ~1 year retention.
- Ensure scorekeeper edits/deletes are allowed but captured and flagged for club-owner review.
- Make logging best-effort so public pages and admin mutations degrade safely if the migration/table is not present.

### Description
- Added a Supabase migration `supabase/migrations/20260428_admin_activity_log.sql` creating `admin_activity_log` with the requested columns, indexes, and retention comment. 
- Added a helper module `jupr_app/domain/admin_activity_log.py` with `build_activity_payload`, `write_admin_activity_log` (best-effort writes that return warnings instead of raising), `list_recent_admin_activity_logs`, `can_view_admin_activity`, and retention helper constants. 
- Integrated logging into high-impact flows: bulk match edits (`match_edit`), rated match deletes (`match_delete`), subscription approve/reject/unsubscribe actions (`subscription_approve|reject|unsubscribe`), and tournament registration publish (`tournament_publish`), including per-action before/after payloads and `flagged_for_review` when actor role is a scorekeeper. 
- Added an Admin Tools section `🧾 Admin Activity Log` that is visible only to `Super Admin` and `Club Owner`, includes retention guidance and a filter for flagged scorekeeper edits/deletes. 
- Kept logging non-blocking: failures to persist logs append warnings to operation warnings or surface a non-fatal UI warning; rating calculations were not changed. 
- Added unit tests `tests/test_admin_activity_log.py` that validate payload shape, permission visibility, and graceful degradation when inserts fail.

### Testing
- Ran `pytest -q tests/test_admin_activity_log.py tests/test_rating_integrity_clashes.py` and both suites passed (`11 passed`).
- Ran `pytest -q tests/test_admin_tools_badge_controls.py tests/test_imports.py` where `tests/test_imports.py` failed in this environment due to missing Streamlit `secrets.toml` (environment-specific), not due to the new logging code.
- New unit tests for activity payloads and write fallback passed; UI/viewer code uses safe fallbacks and surfaces warnings when writes fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0264ab1c483268ee7758d2f99088e)