### PR TITLE
Improve tournament registration publish readiness and public empty states

### DIFF
--- a/jupr_app/ui/pages/tournament_manager.py
+++ b/jupr_app/ui/pages/tournament_manager.py
@@ -2122,7 +2122,10 @@ def render(ctx):
             )
         zero_selectable = readiness["total"] > 0 and readiness["selectable"] == 0
         if zero_selectable:
-            st.error("This publish would leave the public registration form with 0 selectable divisions.")
+            st.warning(
+                "This publish has no open public divisions. Public registration will show: "
+                "'Registration coming soon. Divisions are being finalized.'"
+            )
         elif readiness["hidden"] > 0:
             st.warning("Some divisions are hidden from public registration (draft/disabled).")
 

--- a/jupr_app/ui/pages/tournament_registration.py
+++ b/jupr_app/ui/pages/tournament_registration.py
@@ -155,6 +155,54 @@ def _group_events(days: list[dict[str, Any]], event_options: list[dict[str, Any]
     return grouped
 
 
+def _build_public_division_status_rows(
+    *,
+    days: list[dict[str, Any]],
+    event_options: list[dict[str, Any]],
+    event_rosters: list[dict[str, Any]] | None = None,
+) -> list[dict[str, str]]:
+    day_lookup = {str(day.get("id")): day for day in days}
+    roster_lookup = {str(row.get("event_option_id")): row for row in (event_rosters or [])}
+    rows: list[dict[str, str]] = []
+    for event in event_options:
+        if not is_day_enabled(day_lookup.get(str(event.get("registration_day_id")), {})):
+            continue
+        visibility = public_event_option_visibility(event)
+        if visibility == "hidden":
+            continue
+        status = _safe_text(event.get("status") or "draft").lower()
+        status_label = status.replace("_", " ").title()
+        roster = roster_lookup.get(str(event.get("id"))) or {}
+        capacity = _coerce_int(event.get("capacity_teams"))
+        entries = roster.get("entries") or []
+        if capacity and len(entries) >= capacity and visibility == "selectable":
+            status_label = "Full"
+        rows.append(
+            {
+                "day": _safe_text((day_lookup.get(str(event.get("registration_day_id"))) or {}).get("label") or "Day"),
+                "event": _safe_text(event.get("event_family_label") or event.get("label") or "Event"),
+                "division": _safe_text(event.get("division_name") or event.get("label") or "Division"),
+                "status": status_label,
+            }
+        )
+    return rows
+
+
+def _public_empty_state_message(
+    *,
+    registration_open: bool,
+    selectable_count: int,
+    hidden_draft_count: int,
+) -> str | None:
+    if not registration_open:
+        return "Registration is closed."
+    if selectable_count > 0:
+        return None
+    if hidden_draft_count > 0:
+        return "Registration coming soon. Divisions are being finalized."
+    return "No open divisions are available right now."
+
+
 def _division_choice_label(event: dict[str, Any], *, eligible: bool = True) -> str:
     name = _safe_text(event.get("division_name") or event.get("label") or "Division")
     parts: list[str] = []
@@ -862,17 +910,41 @@ def render(ctx):
         with st.expander("Refund policy", expanded=False):
             st.markdown(_safe_text(settings.get("refund_policy_markdown")))
 
-    is_open, message = registration_is_open(settings)
-    if not is_open:
-        st.warning(message or "Registration is not open.")
-        st.stop()
-
     days = [row for row in days if is_day_enabled(row)]
     selectable_event_options = [row for row in event_options if public_event_option_visibility(row) == "selectable"]
     blocked_visible_options = [row for row in event_options if public_event_option_visibility(row) == "visible_blocked"]
+    hidden_draft_options = [row for row in event_options if _safe_text(row.get("status") or "draft").lower() == "draft"]
 
+    state = build_registration_state(
+        supabase,
+        tournament=tournament,
+        settings=settings,
+        days=days,
+        event_options=event_options,
+    )
+    public_status_rows = _build_public_division_status_rows(
+        days=days,
+        event_options=event_options,
+        event_rosters=state.get("event_rosters") or [],
+    )
+    if public_status_rows:
+        with st.expander("Division status", expanded=True):
+            for row in public_status_rows:
+                st.caption(
+                    f"{row['day']} · {row['event']} · {row['division']} — **{row['status']}**"
+                )
+
+    is_open, _ = registration_is_open(settings)
+    empty_message = _public_empty_state_message(
+        registration_open=is_open,
+        selectable_count=len(selectable_event_options),
+        hidden_draft_count=len(hidden_draft_options),
+    )
+    if empty_message:
+        st.warning(empty_message)
+        st.stop()
     if not days or not selectable_event_options:
-        st.warning("This tournament does not have a registration form configured yet.")
+        st.warning("No open divisions are available right now.")
         st.stop()
 
     grouped_events = _group_events(days, selectable_event_options)

--- a/tests/test_tournament_registration_public_status.py
+++ b/tests/test_tournament_registration_public_status.py
@@ -1,0 +1,97 @@
+from jupr_app.ui.pages import tournament_registration as registration
+
+
+def test_public_empty_state_message_variants():
+    assert (
+        registration._public_empty_state_message(
+            registration_open=False,
+            selectable_count=3,
+            hidden_draft_count=0,
+        )
+        == "Registration is closed."
+    )
+
+    assert (
+        registration._public_empty_state_message(
+            registration_open=True,
+            selectable_count=0,
+            hidden_draft_count=2,
+        )
+        == "Registration coming soon. Divisions are being finalized."
+    )
+
+    assert (
+        registration._public_empty_state_message(
+            registration_open=True,
+            selectable_count=0,
+            hidden_draft_count=0,
+        )
+        == "No open divisions are available right now."
+    )
+
+    assert (
+        registration._public_empty_state_message(
+            registration_open=True,
+            selectable_count=1,
+            hidden_draft_count=0,
+        )
+        is None
+    )
+
+
+def test_build_public_division_status_rows_shows_open_closed_and_full():
+    days = [{"id": "day-1", "label": "Day 1", "enabled": True}]
+    event_options = [
+        {
+            "id": "evt-open",
+            "registration_day_id": "day-1",
+            "event_family_label": "Mixed Doubles",
+            "division_name": "4.0",
+            "status": "open",
+            "enabled": True,
+            "capacity_teams": 2,
+        },
+        {
+            "id": "evt-closed",
+            "registration_day_id": "day-1",
+            "event_family_label": "Mixed Doubles",
+            "division_name": "4.5",
+            "status": "closed",
+            "enabled": True,
+        },
+        {
+            "id": "evt-draft",
+            "registration_day_id": "day-1",
+            "event_family_label": "Mixed Doubles",
+            "division_name": "5.0",
+            "status": "draft",
+            "enabled": True,
+        },
+    ]
+    event_rosters = [
+        {
+            "event_option_id": "evt-open",
+            "entries": [{"team": 1}, {"team": 2}],
+        }
+    ]
+
+    rows = registration._build_public_division_status_rows(
+        days=days,
+        event_options=event_options,
+        event_rosters=event_rosters,
+    )
+
+    assert rows == [
+        {
+            "day": "Day 1",
+            "event": "Mixed Doubles",
+            "division": "4.0",
+            "status": "Full",
+        },
+        {
+            "day": "Day 1",
+            "event": "Mixed Doubles",
+            "division": "4.5",
+            "status": "Closed",
+        },
+    ]


### PR DESCRIPTION
### Motivation
- Prevent public registration pages from rendering an empty/broken form when a tournament shell is published but all divisions remain in draft.  
- Allow tournament shells to be published before divisions are opened while making the public UX explicit and credible.  
- Make division-level open/closed/full visibility available to public users so status is clear on the public page.

### Description
- Added `_public_empty_state_message()` to centralize public empty-state text options and used it to gate public rendering with clear messages such as `Registration coming soon. Divisions are being finalized.`, `Registration is closed.`, and `No open divisions are available right now.` (file: `jupr_app/ui/pages/tournament_registration.py`).
- Added `_build_public_division_status_rows()` and a public `Division status` expander that lists day → event → division with a status label (Open/Closed/Full) derived from capacity/roster info (file: `jupr_app/ui/pages/tournament_registration.py`).
- Reworked public gating in the registration render flow to stop before the registration wizard whenever registration is closed or there are no selectable divisions, ensuring the public page never shows an empty form (file: `jupr_app/ui/pages/tournament_registration.py`).
- Updated the Tournament Manager `Publish & QA` UI text to warn admins that publishing a shell with zero open public divisions will cause the public page to show the coming-soon message (file: `jupr_app/ui/pages/tournament_manager.py`).
- Added focused unit tests `tests/test_tournament_registration_public_status.py` that validate empty-state selection and public division-status row generation.

### Testing
- Ran the new focused tests with `pytest -q tests/test_tournament_registration_public_status.py` and they passed (2 tests).  
- Ran a combined test command including existing public tournament selection tests and observed an unrelated pre-existing failure in `test_partner_board_resolve_public_tournament_id_matches_rules` (module `tournament_partner_board` missing `_resolve_public_tournament_id`), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f02b7b612c8326a77dd03df6154d86)