### PR TITLE
Harden Club Social player resolution and enforce unrated social-only flow

### DIFF
--- a/jupr_app/domain/live_social_submit.py
+++ b/jupr_app/domain/live_social_submit.py
@@ -20,9 +20,7 @@ from jupr_app.domain.live_social import (
     social_league_match_rows_from_event,
     social_round_robin_match_rows_from_event,
 )
-from jupr_app.domain.player_ops import safe_add_player
 
-DEFAULT_PROVISIONAL_SEED_ELO = 1400.0
 STRONG_DUPLICATE_THRESHOLD = 0.94
 
 
@@ -82,84 +80,7 @@ def _players_frame(ctx) -> pd.DataFrame:
     frame = frame.dropna(subset=["id"]).copy()
     frame["id"] = frame["id"].astype(int)
     frame["name"] = frame.get("name", "").fillna("").astype(str).map(normalize_name)
-    if "rating" in frame.columns:
-        frame["rating"] = pd.to_numeric(frame.get("rating"), errors="coerce")
-    else:
-        frame["rating"] = float(DEFAULT_PROVISIONAL_SEED_ELO)
     return frame
-
-
-def _provisional_seed_elo(ctx, participants: list[dict]) -> float:
-    explicit_ids: list[int] = []
-    for participant in participants or []:
-        raw_pid = participant.get("player_id")
-        if raw_pid is None:
-            continue
-        text = str(raw_pid).strip()
-        if not text:
-            continue
-        try:
-            explicit_ids.append(int(text))
-        except Exception:
-            continue
-    explicit_ids = sorted(set(explicit_ids))
-    if not explicit_ids:
-        return float(DEFAULT_PROVISIONAL_SEED_ELO)
-    players_df = _players_frame(ctx)
-    if players_df.empty:
-        return float(DEFAULT_PROVISIONAL_SEED_ELO)
-    seeded = players_df[players_df["id"].isin(explicit_ids)].dropna(subset=["rating"]).copy()
-    if seeded.empty:
-        return float(DEFAULT_PROVISIONAL_SEED_ELO)
-    return float(seeded["rating"].mean())
-
-
-def _fetch_player_by_exact_name(supabase, *, club_id: str, display_name: str) -> dict | None:
-    rows = (
-        supabase.table("players")
-        .select("id,name,rating,starting_rating")
-        .eq("club_id", str(club_id))
-        .eq("name", normalize_name(display_name))
-        .limit(2)
-        .execute()
-        .data
-        or []
-    )
-    if not rows:
-        return None
-    return dict(rows[0])
-
-
-def _ensure_rated_player_from_social(
-    ctx,
-    *,
-    club_id: str,
-    display_name: str,
-    provisional_seed_elo: float,
-) -> tuple[dict, bool]:
-    existing = _fetch_player_by_exact_name(
-        ctx.supabase,
-        club_id=club_id,
-        display_name=display_name,
-    )
-    if existing is not None:
-        return existing, False
-    ok, err = safe_add_player(
-        supabase=ctx.supabase,
-        club_id=club_id,
-        name=normalize_name(display_name),
-        rating_jupr=float(provisional_seed_elo) / 400.0,
-    )
-    if not ok:
-        raise RuntimeError(err or f"Unable to create rated player for {display_name}.")
-    created = _fetch_player_by_exact_name(
-        ctx.supabase,
-        club_id=club_id,
-        display_name=display_name,
-    )
-    if created is None:
-        raise RuntimeError(f"Unable to resolve created rated player for {display_name}.")
-    return created, True
 
 
 def _normalized_name(value: object) -> str:
@@ -246,13 +167,9 @@ def save_resolved_social_live_event(
     event_date = str(event.get("eventDate") or "").strip() or datetime.now(timezone.utc).date().isoformat()
     source_event_uid = _event_uid(event)
     participants = list(event.get("participants") or [])
-    admin_logged_in = bool(getattr(ctx, "admin_logged_in", False))
-    provisional_seed_elo = _provisional_seed_elo(ctx, participants)
-
     created_people_count = 0
     linked_existing_players_count = 0
-    created_rated_players_count = 0
-    created_rated_player_names: list[str] = []
+    duplicate_confirmation_count = 0
     participant_rows: list[dict] = []
 
     try:
@@ -265,37 +182,24 @@ def save_resolved_social_live_event(
             else:
                 explicit_player_id = None
 
-            if (
-                explicit_player_id is None
-                and admin_logged_in
-                and match_status in {"create_rated", "create rated"}
-            ):
+            duplicate_candidates = []
+            duplicate_confirmed = bool(participant.get("duplicate_confirmed", False))
+            duplicate_note = str(participant.get("duplicate_note") or "").strip()
+            if explicit_player_id is None:
                 duplicate_candidates = _find_strong_duplicate_candidates(
                     ctx,
                     display_name=display_name,
                 )
                 if duplicate_candidates:
-                    top = duplicate_candidates[0]
-                    if _normalized_name(top.get("name")) != _normalized_name(display_name):
+                    has_explicit_duplicate_confirmation = duplicate_confirmed and bool(duplicate_note)
+                    if not has_explicit_duplicate_confirmation:
+                        top = duplicate_candidates[0]
                         raise ValueError(
                             "Duplicate warning: "
                             f"'{display_name}' is very close to existing rated player '{top.get('name')}'. "
-                            "Select the existing player in roster confirmation to continue."
+                            "Select an existing profile or confirm duplicate social-only creation with a note."
                         )
-                rated_player, created_rated = _ensure_rated_player_from_social(
-                    ctx,
-                    club_id=club_id,
-                    display_name=display_name,
-                    provisional_seed_elo=provisional_seed_elo,
-                )
-                explicit_player_id = int(rated_player["id"])
-                participant["player_id"] = explicit_player_id
-                participant["name"] = normalize_name(rated_player.get("name") or display_name)
-                participant["match_status"] = "created_rated"
-                display_name = str(participant.get("name") or display_name)
-                if created_rated:
-                    created_rated_players_count += 1
-                    created_rated_player_names.append(display_name)
+                    duplicate_confirmation_count += 1
 
             auto_link_enabled = match_status not in {"new_social", "new social person"} or explicit_player_id is not None
             club_person, created_new, matched_player = resolve_or_create_club_person(
@@ -423,9 +327,10 @@ def save_resolved_social_live_event(
             "match_count": len(match_rows),
             "created_people_count": created_people_count,
             "linked_existing_players_count": linked_existing_players_count,
-            "created_rated_players_count": created_rated_players_count,
-            "created_rated_player_names": created_rated_player_names,
-            "provisional_seed_elo": provisional_seed_elo,
+            "created_rated_players_count": 0,
+            "created_rated_player_names": [],
+            "duplicate_confirmation_count": duplicate_confirmation_count,
+            "unmatched_requires_admin_review_count": max(0, int(created_people_count) - int(linked_existing_players_count)),
         }
     except Exception as exc:
         if is_missing_social_tables_error(exc):

--- a/jupr_app/ui/live/shared.py
+++ b/jupr_app/ui/live/shared.py
@@ -316,28 +316,27 @@ def _build_roster_candidate_rows(
         elif candidate_names:
             status = "suggested match"
         else:
-            status = "create rated"
+            status = "new social-only"
 
-        create_rated_token = f"create_rated::{normalized_pasted or pasted_name}"
+        create_social_token = f"new::{normalized_pasted or pasted_name}"
         options: list[dict[str, str | int | None]] = [
             {"token": f"player::{int(player_name_to_id[name])}", "label": str(name)}
             for name in candidate_names
         ]
         options.append(
             {
-                "token": create_rated_token,
-                "label": f"Create new rated player: {normalize_name(pasted_name)}",
+                "token": create_social_token,
+                "label": f"Create new social-only player: {normalize_name(pasted_name)}",
             }
         )
-        default_token = create_rated_token
+        default_token = create_social_token
         if exact_names:
             default_token = f"player::{int(player_name_to_id[exact_names[0]])}"
-        elif candidate_names and top_score >= 0.86:
-            default_token = f"player::{int(player_name_to_id[candidate_names[0]])}"
         duplicate_warning = ""
         if (not exact_names) and candidate_names and top_score >= 0.9:
             duplicate_warning = (
-                "Possible duplicate: this name is very close to an existing rated player."
+                "Possible duplicate: this name is very close to an existing rated player. "
+                "If you still need a separate social-only profile, provide a confirmation note."
             )
         rows.append(
             {
@@ -378,19 +377,6 @@ def _resolved_participants_from_confirmation(
                     }
                 )
             continue
-        if selected_token.startswith("create_rated::"):
-            create_name = original
-            if create_name:
-                names.append(create_name)
-                resolved_rows.append(
-                    {
-                        "name": create_name,
-                        "player_id": None,
-                        "source_name": original,
-                        "match_status": "create_rated",
-                    }
-                )
-            continue
         social_name = original
         if social_name:
             names.append(social_name)
@@ -400,6 +386,8 @@ def _resolved_participants_from_confirmation(
                     "player_id": None,
                     "source_name": original,
                     "match_status": "new_social",
+                    "duplicate_confirmed": bool(row.get("duplicate_confirmed", False)),
+                    "duplicate_note": str(row.get("duplicate_note") or "").strip(),
                 }
             )
     return names, resolved_ids, resolved_rows
@@ -1047,8 +1035,7 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
         roster_candidates = list(state.get("roster_candidates") or [])
         st.markdown("#### Step 1: Review roster matches")
         st.caption(
-            "Confirm each pasted name once. Exact or suggested matches use canonical current-player names; "
-            "or choose explicit rated-player creation."
+            "Confirm each pasted name once. Choose an existing rated profile or create a social-only profile."
         )
         with st.form(f"{config.state_key}_roster_resolution_form"):
             confirmed_rows: list[dict] = []
@@ -1072,15 +1059,47 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
                     label_visibility="collapsed",
                 )
                 selected_token = tokens[labels.index(selected_label)] if selected_label in labels else default_token
+                duplicate_confirmed = False
+                duplicate_note = ""
+                if duplicate_warning and selected_token.startswith("new::"):
+                    duplicate_confirmed = selector_col.checkbox(
+                        "I intentionally want a separate social-only profile for this similar name.",
+                        value=False,
+                        key=f"{config.state_key}_dup_confirm_{idx}",
+                    )
+                    duplicate_note = selector_col.text_input(
+                        "Duplicate confirmation note (required)",
+                        value="",
+                        key=f"{config.state_key}_dup_note_{idx}",
+                    ).strip()
                 confirmed_rows.append(
                     {
                         "original": str(row.get("original") or ""),
                         "selection": selected_token,
                         "status": str(row.get("status") or ""),
+                        "duplicate_confirmed": duplicate_confirmed,
+                        "duplicate_note": duplicate_note,
                     }
                 )
             confirmed = st.form_submit_button("Confirm roster", type="primary")
         if confirmed:
+            duplicate_errors: list[str] = []
+            for row in confirmed_rows:
+                if not str(row.get("selection") or "").startswith("new::"):
+                    continue
+                if row.get("duplicate_confirmed") and str(row.get("duplicate_note") or "").strip():
+                    continue
+                for source_row in roster_candidates:
+                    if str(source_row.get("original") or "") == str(row.get("original") or "") and str(
+                        source_row.get("duplicate_warning") or ""
+                    ).strip():
+                        duplicate_errors.append(
+                            f"{row.get('original')}: check duplicate confirmation and add a note to create a separate social-only profile."
+                        )
+                        break
+            if duplicate_errors:
+                st.error("\n".join(duplicate_errors))
+                st.stop()
             canonical_names, resolved_ids, resolved_rows = _resolved_participants_from_confirmation(
                 confirmed_rows,
                 player_name_to_id,
@@ -1099,18 +1118,13 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
         if state.get("roster_confirmed"):
             confirmed_rows = list(state.get("confirmed_roster_rows") or [])
             matched_rows = [row for row in confirmed_rows if row.get("player_id") is not None]
-            new_rows = [row for row in confirmed_rows if row.get("match_status") == "create_rated"]
-            social_only_rows = [
-                row for row in confirmed_rows if row.get("player_id") is None and row.get("match_status") != "create_rated"
-            ]
+            social_only_rows = [row for row in confirmed_rows if row.get("player_id") is None]
             st.caption(
                 f"Confirmed roster: {len(matched_rows)} matched existing rated players, "
-                f"{len(new_rows)} create-new rated players."
+                f"{len(social_only_rows)} social-only players for admin review."
             )
             if matched_rows:
                 st.caption("Matched: " + ", ".join(str(row.get("name") or "") for row in matched_rows))
-            if new_rows:
-                st.caption("Create rated: " + ", ".join(str(row.get("name") or "") for row in new_rows))
             if social_only_rows:
                 st.caption("Social-only fallback: " + ", ".join(str(row.get("name") or "") for row in social_only_rows))
 
@@ -1154,12 +1168,10 @@ def render_setup(ctx, state: dict, config: LivePageConfig) -> None:
                             "selection": (
                                 f"player::{int(row.get('player_id'))}"
                                 if row.get("player_id") is not None
-                                else (
-                                    f"create_rated::{_normalized_person_key(row.get('name'))}"
-                                    if str(row.get("match_status") or "") == "create_rated"
-                                    else f"new::{_normalized_person_key(row.get('name'))}"
-                                )
+                                else f"new::{_normalized_person_key(row.get('name'))}"
                             ),
+                            "duplicate_confirmed": bool(row.get("duplicate_confirmed", False)),
+                            "duplicate_note": str(row.get("duplicate_note") or "").strip(),
                         }
                         for row in confirmed_roster_rows
                     ],

--- a/tests/test_jupr_live_modes.py
+++ b/tests/test_jupr_live_modes.py
@@ -60,7 +60,7 @@ def test_club_social_save_handles_missing_tables_gracefully(monkeypatch):
     monkeypatch.setattr(jupr_live, "st", fake_st)
     monkeypatch.setattr(
         jupr_live,
-        "save_social_live_event",
+        "save_resolved_social_live_event",
         lambda *args, **kwargs: (_ for _ in ()).throw(_TablesMissing("missing")),
     )
 

--- a/tests/test_live_social.py
+++ b/tests/test_live_social.py
@@ -459,7 +459,7 @@ def test_resolved_save_preserves_explicit_existing_player_linkage():
     assert linked_row["linked_player_id"] == 77
 
 
-def test_resolved_save_creates_new_rated_player_and_links_participant():
+def test_resolved_save_creates_new_social_only_person_without_creating_rated_player():
     supabase = _FakeSupabase()
     supabase.store["players"] = [
         {"id": 101, "club_id": "club-1", "name": "Alice", "rating": 1600.0, "starting_rating": 1600.0},
@@ -481,7 +481,7 @@ def test_resolved_save_creates_new_rated_player_and_links_participant():
     event["participants"] = [
         {"id": "p-1", "name": "Alice", "player_id": 101, "seed": 1, "match_status": "matched_existing"},
         {"id": "p-2", "name": "Bob", "player_id": 102, "seed": 2, "match_status": "matched_existing"},
-        {"id": "p-3", "name": "New Rated", "player_id": None, "seed": 3, "match_status": "create_rated"},
+        {"id": "p-3", "name": "New Social", "player_id": None, "seed": 3, "match_status": "new_social"},
         {"id": "p-4", "name": "Drew", "player_id": None, "seed": 4, "match_status": "new_social"},
     ]
     result = save_resolved_social_live_event(
@@ -491,30 +491,27 @@ def test_resolved_save_creates_new_rated_player_and_links_participant():
         submission_mode="admin",
         host_name="admin",
     )
-    assert result["created_rated_players_count"] == 1
-    created_players = [row for row in supabase.store["players"] if row["name"] == "New Rated"]
-    assert len(created_players) == 1
-    created = created_players[0]
-    assert created["rating"] == 1400.0
+    assert result["created_rated_players_count"] == 0
+    created_players = [row for row in supabase.store["players"] if row["name"] == "New Social"]
+    assert len(created_players) == 0
     unchanged_alice = [row for row in supabase.store["players"] if row["id"] == 101][0]
     unchanged_bob = [row for row in supabase.store["players"] if row["id"] == 102][0]
     assert unchanged_alice["rating"] == 1600.0
     assert unchanged_bob["rating"] == 1200.0
     participants = supabase.store["live_event_participants"]
     created_participant = [row for row in participants if row["participant_key"] == "p-3"][0]
-    assert created_participant["linked_player_id"] == created["id"]
+    assert created_participant["linked_player_id"] is None
 
 
-def test_resolved_save_falls_back_to_default_provisional_seed_without_other_rated_players():
+def test_resolved_save_never_creates_players_even_without_any_rated_players():
     supabase = _FakeSupabase()
     supabase.store["players"] = []
     ctx = _Ctx(supabase=supabase, club_id="club-1", name_to_id={})
-    ctx.admin_logged_in = True
     ctx.df_players_all = pd.DataFrame()
     event = _sample_event()
     for participant in event["participants"]:
         participant["player_id"] = None
-        participant["match_status"] = "create_rated"
+        participant["match_status"] = "new_social"
     save_resolved_social_live_event(
         ctx,
         event,
@@ -523,7 +520,7 @@ def test_resolved_save_falls_back_to_default_provisional_seed_without_other_rate
         host_name="admin",
     )
     created = [row for row in supabase.store["players"] if row["club_id"] == "club-1"]
-    assert all(float(row["rating"]) == 1400.0 for row in created)
+    assert created == []
 
 
 def test_resolved_save_detects_strong_duplicate_and_blocks_creation():
@@ -532,12 +529,11 @@ def test_resolved_save_detects_strong_duplicate_and_blocks_creation():
         {"id": 55, "club_id": "club-1", "name": "Jon Snow", "rating": 1500.0, "starting_rating": 1500.0}
     ]
     ctx = _Ctx(supabase=supabase, club_id="club-1", name_to_id={})
-    ctx.admin_logged_in = True
     ctx.df_players_all = pd.DataFrame([{"id": 55, "name": "Jon Snow", "rating": 1500.0}])
     event = _sample_event()
     event["participants"][0]["name"] = "John Snow"
     event["participants"][0]["player_id"] = None
-    event["participants"][0]["match_status"] = "create_rated"
+    event["participants"][0]["match_status"] = "new_social"
     try:
         save_resolved_social_live_event(
             ctx,
@@ -550,6 +546,32 @@ def test_resolved_save_detects_strong_duplicate_and_blocks_creation():
         assert "Duplicate warning" in str(exc)
     else:
         raise AssertionError("Expected duplicate warning ValueError")
+
+
+def test_resolved_save_allows_duplicate_when_admin_confirms_with_note():
+    supabase = _FakeSupabase()
+    supabase.store["players"] = [
+        {"id": 55, "club_id": "club-1", "name": "Jon Snow", "rating": 1500.0, "starting_rating": 1500.0}
+    ]
+    ctx = _Ctx(supabase=supabase, club_id="club-1", name_to_id={})
+    ctx.df_players_all = pd.DataFrame([{"id": 55, "name": "Jon Snow", "rating": 1500.0}])
+    event = _sample_event()
+    event["participants"][0]["name"] = "John Snow"
+    event["participants"][0]["player_id"] = None
+    event["participants"][0]["match_status"] = "new_social"
+    event["participants"][0]["duplicate_confirmed"] = True
+    event["participants"][0]["duplicate_note"] = "Different member, verified at desk."
+    result = save_resolved_social_live_event(
+        ctx,
+        event,
+        target_club_id="club-1",
+        submission_mode="admin",
+        host_name="admin",
+    )
+    assert result["duplicate_confirmation_count"] == 1
+    saved = supabase.store["live_event_participants"]
+    created_row = [row for row in saved if row["participant_key"] == "p-1"][0]
+    assert created_row["linked_player_id"] is None
 
 
 def test_social_history_falls_back_to_legacy_submitted_by_column():


### PR DESCRIPTION
### Motivation
- Prevent Club Social saves from accidentally creating or seeding rated players and avoid unintended rating effects from social results.
- Provide an explicit social-only workflow so admins can confirm unmatched players and intentionally create duplicate-named social identities.
- Add safeguards so duplicate-like names require explicit admin confirmation + note before creating separate social-only profiles.

### Description
- Roster UI: replace the implicit "create rated" option with an explicit "Create new social-only player" path and surface duplicate warnings with a confirmation checkbox and required note when a close match exists (changes in `jupr_app/ui/live/shared.py`).
- Submit logic: social submission persistence now never auto-creates rated players from Club Social saves, enforces duplicate-name confirmation (requires note), and carries duplicate metadata through resolution (changes in `jupr_app/domain/live_social_submit.py`).
- Result payload: keep `result_mode` as `social_unrated` and return admin-review counters including `duplicate_confirmation_count` and `unmatched_requires_admin_review_count`; created-rated counters are always zero for social flows.
- Tests: updated and added tests to validate existing-player linking, social-only creation (no rated players created), duplicate blocking, and allowed duplicate creation when confirmed with a note (changes in `tests/test_live_social.py` and `tests/test_jupr_live_modes.py`).

### Testing
- Ran `pytest -q tests/test_live_social.py` and all tests passed (`27 passed`).
- Ran `pytest -q tests/test_jupr_live_modes.py` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f02e75d9cc8326a6e78012c2633a93)