### PR TITLE
Backfill verified player updates foundation into supabase/migrations

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -13,9 +13,15 @@ Inventory below reflects files currently present in this repository.
 
 ### `supabase/migrations/` (canonical)
 
+- `20260420000000_verified_player_updates_foundation.sql`
 - `20260424_matches_soft_delete.sql`
 - `20260428_add_unsubscribe_token_to_player_profile_update_subscriptions.sql`
 - `2026XX_backport_tournament_engine.sql`
+
+Note (2026-04-28):
+
+- Verified player update schema migrations originally lived only in `migrations/` (`20260420_verified_player_updates.sql`, `20260421_verified_player_updates_date_window_uniqueness.sql`, and `20260421_player_update_outbox_allow_repeat_queue_rows.sql`).
+- Supabase migration runs only read `supabase/migrations/`, so we backfilled their schema intent into `supabase/migrations/20260420000000_verified_player_updates_foundation.sql` to guarantee the base tables exist before later unsubscribe/update migrations run.
 
 ### `migrations/` (legacy/archive)
 
@@ -102,6 +108,7 @@ Use the guard script:
 
 ```bash
 python scripts/check_migration_sources.py
+python scripts/check_player_update_migration_foundation.py
 ```
 
 Behavior:

--- a/scripts/check_player_update_migration_foundation.py
+++ b/scripts/check_player_update_migration_foundation.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Guardrail: player update migrations must create subscriptions before updates.
+
+Ensures any Supabase migration that runs an UPDATE against
+public.player_profile_update_subscriptions has an earlier Supabase migration that
+creates that table.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SUPABASE_MIGRATIONS = ROOT / "supabase" / "migrations"
+
+UPDATE_PATTERN = re.compile(r"\bupdate\s+public\.player_profile_update_subscriptions\b", re.IGNORECASE)
+CREATE_PATTERN = re.compile(
+    r"\bcreate\s+table\s+(if\s+not\s+exists\s+)?public\.player_profile_update_subscriptions\b",
+    re.IGNORECASE,
+)
+
+
+def main() -> int:
+    sql_files = sorted(SUPABASE_MIGRATIONS.glob("*.sql"), key=lambda p: p.name)
+    if not sql_files:
+        print("[player-update-foundation] No supabase migrations found.", file=sys.stderr)
+        return 1
+
+    creators: list[str] = []
+    failures: list[str] = []
+
+    for path in sql_files:
+        text = path.read_text(encoding="utf-8")
+        if CREATE_PATTERN.search(text):
+            creators.append(path.name)
+
+        if UPDATE_PATTERN.search(text) and not creators:
+            failures.append(path.name)
+
+    if failures:
+        print(
+            "[player-update-foundation] Found UPDATE migration(s) that run before table creation:",
+            file=sys.stderr,
+        )
+        for name in failures:
+            print(f"  - {name}", file=sys.stderr)
+        print(
+            "Add an earlier supabase migration that creates public.player_profile_update_subscriptions.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("[player-update-foundation] OK: creation migration exists before any UPDATE.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supabase/migrations/20260420000000_verified_player_updates_foundation.sql
+++ b/supabase/migrations/20260420000000_verified_player_updates_foundation.sql
@@ -1,0 +1,220 @@
+-- Backfill foundation for verified player update tables into Supabase-managed migrations.
+-- Root migrations existed under migrations/ but Supabase applies only supabase/migrations/.
+
+create table if not exists public.player_profile_update_subscriptions (
+    id uuid primary key default gen_random_uuid(),
+    club_id text not null,
+    player_id bigint not null,
+    email text not null,
+    email_normalized text not null,
+    request_status text not null default 'pending_admin_review',
+    request_note text null,
+    admin_note text null,
+    verified_at timestamptz null,
+    verified_by text null,
+    unsubscribed_at timestamptz null,
+    preferences_json jsonb not null default '{"frequency":"weekly","send_only_if_changed":true}'::jsonb,
+    last_digest_week_start date null,
+    unsubscribe_token text null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+alter table if exists public.player_profile_update_subscriptions add column if not exists id uuid default gen_random_uuid();
+alter table if exists public.player_profile_update_subscriptions add column if not exists club_id text;
+alter table if exists public.player_profile_update_subscriptions add column if not exists player_id bigint;
+alter table if exists public.player_profile_update_subscriptions add column if not exists email text;
+alter table if exists public.player_profile_update_subscriptions add column if not exists email_normalized text;
+alter table if exists public.player_profile_update_subscriptions add column if not exists request_status text default 'pending_admin_review';
+alter table if exists public.player_profile_update_subscriptions add column if not exists request_note text;
+alter table if exists public.player_profile_update_subscriptions add column if not exists admin_note text;
+alter table if exists public.player_profile_update_subscriptions add column if not exists verified_at timestamptz;
+alter table if exists public.player_profile_update_subscriptions add column if not exists verified_by text;
+alter table if exists public.player_profile_update_subscriptions add column if not exists unsubscribed_at timestamptz;
+alter table if exists public.player_profile_update_subscriptions add column if not exists preferences_json jsonb default '{"frequency":"weekly","send_only_if_changed":true}'::jsonb;
+alter table if exists public.player_profile_update_subscriptions add column if not exists last_digest_week_start date;
+alter table if exists public.player_profile_update_subscriptions add column if not exists unsubscribe_token text;
+alter table if exists public.player_profile_update_subscriptions add column if not exists created_at timestamptz default now();
+alter table if exists public.player_profile_update_subscriptions add column if not exists updated_at timestamptz default now();
+
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'player_profile_update_subscriptions_pkey'
+          and conrelid = 'public.player_profile_update_subscriptions'::regclass
+    ) then
+        alter table public.player_profile_update_subscriptions
+            add constraint player_profile_update_subscriptions_pkey primary key (id);
+    end if;
+end $$;
+
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'player_profile_update_subscriptions_status_check'
+          and conrelid = 'public.player_profile_update_subscriptions'::regclass
+    ) then
+        alter table public.player_profile_update_subscriptions
+            add constraint player_profile_update_subscriptions_status_check
+            check (request_status in ('pending_admin_review', 'active', 'rejected', 'unsubscribed'));
+    end if;
+end $$;
+
+create index if not exists player_profile_update_subscriptions_club_player_idx
+    on public.player_profile_update_subscriptions (club_id, player_id);
+
+create index if not exists player_profile_update_subscriptions_status_created_idx
+    on public.player_profile_update_subscriptions (request_status, created_at desc);
+
+create index if not exists player_profile_update_subscriptions_email_norm_idx
+    on public.player_profile_update_subscriptions (email_normalized);
+
+create unique index if not exists player_profile_update_subscriptions_open_uidx
+    on public.player_profile_update_subscriptions (club_id, player_id)
+    where request_status in ('pending_admin_review', 'active');
+
+create unique index if not exists player_profile_update_subscriptions_unsubscribe_token_key
+    on public.player_profile_update_subscriptions (unsubscribe_token)
+    where unsubscribe_token is not null;
+
+create table if not exists public.player_weekly_profile_digests (
+    id uuid primary key default gen_random_uuid(),
+    club_id text not null,
+    player_id bigint not null,
+    week_start date not null,
+    week_end date not null,
+    generated_json jsonb not null default '{}'::jsonb,
+    final_json jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint player_weekly_profile_digests_club_player_window_key
+        unique (club_id, player_id, week_start, week_end)
+);
+
+alter table if exists public.player_weekly_profile_digests add column if not exists id uuid default gen_random_uuid();
+alter table if exists public.player_weekly_profile_digests add column if not exists club_id text;
+alter table if exists public.player_weekly_profile_digests add column if not exists player_id bigint;
+alter table if exists public.player_weekly_profile_digests add column if not exists week_start date;
+alter table if exists public.player_weekly_profile_digests add column if not exists week_end date;
+alter table if exists public.player_weekly_profile_digests add column if not exists generated_json jsonb default '{}'::jsonb;
+alter table if exists public.player_weekly_profile_digests add column if not exists final_json jsonb default '{}'::jsonb;
+alter table if exists public.player_weekly_profile_digests add column if not exists created_at timestamptz default now();
+alter table if exists public.player_weekly_profile_digests add column if not exists updated_at timestamptz default now();
+
+alter table if exists public.player_weekly_profile_digests
+    drop constraint if exists player_weekly_profile_digests_club_id_player_id_week_start_key;
+
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'player_weekly_profile_digests_club_player_window_key'
+          and conrelid = 'public.player_weekly_profile_digests'::regclass
+    ) then
+        alter table public.player_weekly_profile_digests
+            add constraint player_weekly_profile_digests_club_player_window_key
+            unique (club_id, player_id, week_start, week_end);
+    end if;
+end $$;
+
+create table if not exists public.player_profile_update_outbox (
+    id uuid primary key default gen_random_uuid(),
+    subscription_id uuid not null references public.player_profile_update_subscriptions(id) on delete cascade,
+    club_id text not null,
+    player_id bigint not null,
+    week_start date not null,
+    week_end date not null,
+    email text not null,
+    send_status text not null default 'pending',
+    provider_message_id text null,
+    sent_at timestamptz null,
+    error_text text null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint player_profile_update_outbox_status_check
+        check (send_status in ('pending', 'sent', 'skipped', 'error'))
+);
+
+alter table if exists public.player_profile_update_outbox add column if not exists id uuid default gen_random_uuid();
+alter table if exists public.player_profile_update_outbox add column if not exists subscription_id uuid;
+alter table if exists public.player_profile_update_outbox add column if not exists club_id text;
+alter table if exists public.player_profile_update_outbox add column if not exists player_id bigint;
+alter table if exists public.player_profile_update_outbox add column if not exists week_start date;
+alter table if exists public.player_profile_update_outbox add column if not exists week_end date;
+alter table if exists public.player_profile_update_outbox add column if not exists email text;
+alter table if exists public.player_profile_update_outbox add column if not exists send_status text default 'pending';
+alter table if exists public.player_profile_update_outbox add column if not exists provider_message_id text;
+alter table if exists public.player_profile_update_outbox add column if not exists sent_at timestamptz;
+alter table if exists public.player_profile_update_outbox add column if not exists error_text text;
+alter table if exists public.player_profile_update_outbox add column if not exists created_at timestamptz default now();
+alter table if exists public.player_profile_update_outbox add column if not exists updated_at timestamptz default now();
+
+alter table if exists public.player_profile_update_outbox
+    drop constraint if exists player_profile_update_outbox_subscription_window_key;
+alter table if exists public.player_profile_update_outbox
+    drop constraint if exists player_profile_update_outbox_subscription_id_week_start_key;
+
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'player_profile_update_outbox_subscription_id_fkey'
+          and conrelid = 'public.player_profile_update_outbox'::regclass
+    ) then
+        alter table public.player_profile_update_outbox
+            add constraint player_profile_update_outbox_subscription_id_fkey
+            foreign key (subscription_id)
+            references public.player_profile_update_subscriptions(id)
+            on delete cascade;
+    end if;
+end $$;
+
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'player_profile_update_outbox_status_check'
+          and conrelid = 'public.player_profile_update_outbox'::regclass
+    ) then
+        alter table public.player_profile_update_outbox
+            add constraint player_profile_update_outbox_status_check
+            check (send_status in ('pending', 'sent', 'skipped', 'error'));
+    end if;
+end $$;
+
+drop index if exists public.player_profile_update_outbox_subscription_week_idx;
+create index if not exists player_profile_update_outbox_subscription_week_window_idx
+    on public.player_profile_update_outbox (subscription_id, week_start, week_end);
+
+create or replace function public.set_updated_at_timestamp()
+returns trigger as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists player_profile_update_subscriptions_set_updated_at on public.player_profile_update_subscriptions;
+create trigger player_profile_update_subscriptions_set_updated_at
+before update on public.player_profile_update_subscriptions
+for each row
+execute function public.set_updated_at_timestamp();
+
+drop trigger if exists player_weekly_profile_digests_set_updated_at on public.player_weekly_profile_digests;
+create trigger player_weekly_profile_digests_set_updated_at
+before update on public.player_weekly_profile_digests
+for each row
+execute function public.set_updated_at_timestamp();
+
+drop trigger if exists player_profile_update_outbox_set_updated_at on public.player_profile_update_outbox;
+create trigger player_profile_update_outbox_set_updated_at
+before update on public.player_profile_update_outbox
+for each row
+execute function public.set_updated_at_timestamp();

--- a/supabase/migrations/20260428_add_unsubscribe_token_to_player_profile_update_subscriptions.sql
+++ b/supabase/migrations/20260428_add_unsubscribe_token_to_player_profile_update_subscriptions.sql
@@ -1,10 +1,14 @@
 alter table if exists public.player_profile_update_subscriptions
     add column if not exists unsubscribe_token text;
 
-update public.player_profile_update_subscriptions
-set unsubscribe_token = md5(random()::text || clock_timestamp()::text || coalesce(id::text, ''))
-where unsubscribe_token is null;
-
+do $$
+begin
+    if to_regclass('public.player_profile_update_subscriptions') is not null then
+        update public.player_profile_update_subscriptions
+        set unsubscribe_token = md5(random()::text || clock_timestamp()::text || coalesce(id::text, ''))
+        where unsubscribe_token is null;
+    end if;
+end $$;
 create unique index if not exists player_profile_update_subscriptions_unsubscribe_token_key
     on public.player_profile_update_subscriptions (unsubscribe_token)
     where unsubscribe_token is not null;


### PR DESCRIPTION
### Motivation
- Supabase applies only `supabase/migrations/`, but the verified-player-update schema lived in the legacy `migrations/` folder, causing a later Supabase migration that runs `UPDATE public.player_profile_update_subscriptions` to fail when the table did not exist.
- The change ensures base tables for the player-update/unsubscribe flows exist before any migration that updates them runs.

### Description
- Add `supabase/migrations/20260420000000_verified_player_updates_foundation.sql` which idempotently creates or patches `public.player_profile_update_subscriptions`, `public.player_weekly_profile_digests`, and `public.player_profile_update_outbox`, preserving constraints, indexes, and triggers where possible with `IF NOT EXISTS`/guarded `ALTER`/`DO $$` checks.
- Make the unsubscribe-token migration safe by guarding the `UPDATE` with `to_regclass(...)` so it runs only if the table exists and then create the unique index as before (`supabase/migrations/20260428_add_unsubscribe_token_to_player_profile_update_subscriptions.sql`).
- Add a small static guard script `scripts/check_player_update_migration_foundation.py` that verifies any supabase migration that updates `player_profile_update_subscriptions` has an earlier supabase migration creating it, and add a documentation note to `docs/migrations.md` explaining why the verified-player-update schema was backfilled.
- Keep all changes additive and idempotent and avoid any destructive operations or schema simplifications that would drop or lose existing production data.

### Testing
- Ran `python scripts/check_player_update_migration_foundation.py` which returned `OK: creation migration exists before any UPDATE.` (success).
- Type-checked the guard script with `python -m py_compile scripts/check_player_update_migration_foundation.py` which succeeded.
- Verified migration ordering and presence with `rg -n "update public\.player_profile_update_subscriptions|create table if not exists public\.player_profile_update_subscriptions" supabase/migrations/*.sql` and `ls -1 supabase/migrations | sort` which showed the foundation migration lexically before the unsubscribe migration (success).
- `python scripts/check_migration_sources.py --base-ref Test --warn-only` failed in this environment due to the local clone not having a `Test` ref (environment warning, not a change failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f033d95b448326815b808f2ce9d0bf)