### PR TITLE
Add verified player updates foundation Supabase migration

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -15,6 +15,7 @@ Inventory below reflects files currently present in this repository.
 
 ### `supabase/migrations/` (canonical)
 
+- `20260420000000_verified_player_updates_foundation.sql`
 - `20260424_matches_soft_delete.sql`
 - `20260428090000_add_unsubscribe_token_to_player_profile_update_subscriptions.sql`
 - `20260428100000_admin_role_assignments.sql`

--- a/supabase/migrations/20260420000000_verified_player_updates_foundation.sql
+++ b/supabase/migrations/20260420000000_verified_player_updates_foundation.sql
@@ -1,0 +1,93 @@
+create table if not exists public.player_profile_update_subscriptions (
+    id uuid primary key default gen_random_uuid(),
+    club_id text not null,
+    player_id bigint not null,
+    email text not null,
+    email_normalized text not null,
+    request_status text not null default 'pending_admin_review',
+    request_note text null,
+    admin_note text null,
+    verified_at timestamptz null,
+    verified_by text null,
+    unsubscribed_at timestamptz null,
+    preferences_json jsonb not null default '{"frequency":"weekly","send_only_if_changed":true}'::jsonb,
+    last_digest_week_start date null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint player_profile_update_subscriptions_status_check
+        check (request_status in ('pending_admin_review', 'active', 'rejected', 'unsubscribed'))
+);
+
+create index if not exists player_profile_update_subscriptions_club_player_idx
+    on public.player_profile_update_subscriptions (club_id, player_id);
+
+create index if not exists player_profile_update_subscriptions_status_created_idx
+    on public.player_profile_update_subscriptions (request_status, created_at desc);
+
+create index if not exists player_profile_update_subscriptions_email_norm_idx
+    on public.player_profile_update_subscriptions (email_normalized);
+
+create unique index if not exists player_profile_update_subscriptions_open_uidx
+    on public.player_profile_update_subscriptions (club_id, player_id)
+    where request_status in ('pending_admin_review', 'active');
+
+create table if not exists public.player_weekly_profile_digests (
+    id uuid primary key default gen_random_uuid(),
+    club_id text not null,
+    player_id bigint not null,
+    week_start date not null,
+    week_end date not null,
+    generated_json jsonb not null default '{}'::jsonb,
+    final_json jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    unique (club_id, player_id, week_start)
+);
+
+create table if not exists public.player_profile_update_outbox (
+    id uuid primary key default gen_random_uuid(),
+    subscription_id uuid not null references public.player_profile_update_subscriptions(id) on delete cascade,
+    club_id text not null,
+    player_id bigint not null,
+    week_start date not null,
+    week_end date not null,
+    email text not null,
+    send_status text not null default 'pending',
+    provider_message_id text null,
+    sent_at timestamptz null,
+    error_text text null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint player_profile_update_outbox_status_check
+        check (send_status in ('pending', 'sent', 'skipped', 'error')),
+    unique (subscription_id, week_start)
+);
+
+create index if not exists player_profile_update_outbox_subscription_week_idx
+    on public.player_profile_update_outbox (subscription_id, week_start);
+
+create or replace function public.set_updated_at_timestamp()
+returns trigger as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists player_profile_update_subscriptions_set_updated_at on public.player_profile_update_subscriptions;
+create trigger player_profile_update_subscriptions_set_updated_at
+before update on public.player_profile_update_subscriptions
+for each row
+execute function public.set_updated_at_timestamp();
+
+drop trigger if exists player_weekly_profile_digests_set_updated_at on public.player_weekly_profile_digests;
+create trigger player_weekly_profile_digests_set_updated_at
+before update on public.player_weekly_profile_digests
+for each row
+execute function public.set_updated_at_timestamp();
+
+drop trigger if exists player_profile_update_outbox_set_updated_at on public.player_profile_update_outbox;
+create trigger player_profile_update_outbox_set_updated_at
+before update on public.player_profile_update_outbox
+for each row
+execute function public.set_updated_at_timestamp();


### PR DESCRIPTION
### Motivation
- Ensure Supabase Preview no longer fails when the unsubscribe migration references `public.player_profile_update_subscriptions` before that relation exists by adding the missing foundation migration from the earlier work.

### Description
- Add `supabase/migrations/20260420000000_verified_player_updates_foundation.sql` containing the full, idempotent SQL from the foundation migration to create/patch `public.player_profile_update_subscriptions`, `public.player_weekly_profile_digests`, and `public.player_profile_update_outbox` including indexes, constraints, and `updated_at` trigger wiring.
- Update `docs/migrations.md` to include `20260420000000_verified_player_updates_foundation.sql` so the canonical migration ordering is: `20260420000000_verified_player_updates_foundation.sql`, `20260424_matches_soft_delete.sql`, `20260428090000_add_unsubscribe_token_to_player_profile_update_subscriptions.sql`, `20260428100000_admin_role_assignments.sql`, and `20260428101000_admin_activity_log.sql`.
- Use the SQL prepared in the prior foundation migration (no minimal or altered table shapes were invented), and avoid any changes to production data or manual writes to `supabase_migrations.schema_migrations`.

### Testing
- Ran `python scripts/check_supabase_migration_versions.py` and it passed, confirming unique migration version prefixes.
- Ran `python scripts/check_migration_sources.py` but it could not complete validation in this environment due to a missing local `Test` ref (`fatal: ambiguous argument 'Test...HEAD'`), so cross-branch source checks were not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2669d926083269bd36017a6f2a488)