### PR TITLE
Simplify public header and move legal/support links to subtle footer

### DIFF
--- a/jupr_app/ui/public_nav.py
+++ b/jupr_app/ui/public_nav.py
@@ -42,8 +42,6 @@ PUBLIC_SOURCE_BY_PAGE: dict[str, str] = {
 
 _SAFE_CONTEXT_KEYS = {"club_id"}
 PUBLIC_FOOTER_LINKS: tuple[tuple[str, str], ...] = (
-    ("Rating Rules", "rating_rules"),
-    ("FAQ", "faqs"),
     ("Privacy", "privacy_policy"),
     ("Terms", "terms_of_use"),
     ("Contact", "contact_support"),
@@ -140,18 +138,35 @@ def _render_public_nav_styles() -> None:
             flex: 1 1 34rem;
             min-width: min(32rem, 100%);
           }
+          .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-admin-link {
+            flex: 0 0 auto;
+          }
+          .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-admin-link .stButton > button {
+            all: unset;
+            cursor: pointer;
+            color: var(--text-muted);
+            font-size: 0.78rem;
+            font-weight: 600;
+            text-decoration: underline;
+            white-space: nowrap;
+          }
           .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-nav-control [role="radiogroup"] {
             gap: 0.35rem;
             flex-wrap: wrap;
           }
+          .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-footer {
+            margin-top: 1.2rem;
+            padding-top: 0.65rem;
+            border-top: 1px solid color-mix(in srgb, var(--border-strong) 38%, transparent);
+          }
           .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-footer-links {
-            margin-top: 0.55rem;
             font-size: 0.76rem;
             color: var(--text-muted);
             display: flex;
             gap: 0.5rem;
             align-items: center;
-            justify-content: flex-end;
+            flex-wrap: wrap;
+            justify-content: center;
           }
           .jupr-public-shell.jupr-public-nav-streamlit .jupr-public-footer-links .stButton > button {
             all: unset;
@@ -258,10 +273,26 @@ def render_public_app_header(
         )
     st.markdown("</div>", unsafe_allow_html=True)
 
-    st.markdown("</div></div>", unsafe_allow_html=True)
-
     admin_authenticated = bool(st.session_state.get("jupr_admin_authenticated", False))
-    st.markdown('<div class="jupr-public-footer-links">', unsafe_allow_html=True)
+    admin_label = "Admin Dashboard" if admin_authenticated else "Admin Login"
+    st.markdown('<div class="jupr-public-admin-link">', unsafe_allow_html=True)
+    if st.button(admin_label, key="public_header_admin_link"):
+        navigate_same_tab(
+            page="league_manager" if admin_authenticated else "admin_login",
+            public_mode=False,
+            source="public_header:admin_dashboard" if admin_authenticated else "public_header:admin_login",
+        )
+    st.markdown("</div></div></div>", unsafe_allow_html=True)
+
+    return PAGE_KEY_TO_LABEL.get(current_page_key, PAGE_KEY_TO_LABEL[default_page])
+
+
+def render_public_footer(*, current_label: str | None = None, default_page: str = "home") -> None:
+    current_params = _current_query_params()
+    current_page_key = LABEL_TO_PAGE_KEY.get(current_label or "") or default_page
+    admin_authenticated = bool(st.session_state.get("jupr_admin_authenticated", False))
+
+    st.markdown('<div class="jupr-public-shell jupr-public-nav-streamlit"><div class="jupr-public-footer"><div class="jupr-public-footer-links">', unsafe_allow_html=True)
     for link_label, page_key in PUBLIC_FOOTER_LINKS:
         if st.button(link_label, key=f"public_footer_link_{page_key}"):
             navigate_same_tab(
@@ -270,13 +301,6 @@ def render_public_app_header(
                 public_mode=True,
                 source=f"public_footer:{page_key}",
             )
-    admin_label = "Admin Dashboard" if admin_authenticated else "Admin Login"
-    if st.button(admin_label, key="public_footer_admin_link"):
-        navigate_same_tab(
-            page="league_manager" if admin_authenticated else "admin_login",
-            public_mode=False,
-            source="public_footer:admin_dashboard" if admin_authenticated else "public_footer:admin_login",
-        )
 
     if admin_authenticated and st.button("Logout", key="public_footer_logout"):
         navigate_same_tab(
@@ -285,9 +309,7 @@ def render_public_app_header(
             public_mode=True,
             source="public_footer:logout",
         )
-    st.markdown("</div></div>", unsafe_allow_html=True)
-
-    return PAGE_KEY_TO_LABEL.get(current_page_key, PAGE_KEY_TO_LABEL[default_page])
+    st.markdown("</div></div></div>", unsafe_allow_html=True)
 
 
 def render_public_top_nav(

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -35,7 +35,7 @@ from jupr_app.ui.page_registry import (
     labels_for_keys,
 )
 from jupr_app.ui.branding import CLUB_ID, PUBLIC_BASE_URL_FALLBACK
-from jupr_app.ui.public_nav import render_public_app_header
+from jupr_app.ui.public_nav import render_public_app_header, render_public_footer
 from jupr_app.ui.theme_clean import apply_clean_theme
 from jupr_app.ui.url import qp_get
 
@@ -685,6 +685,8 @@ def main():
 
         try:
             render_fn(ctx)
+            if PUBLIC_MODE:
+                render_public_footer(current_label=sel)
         except Exception as exc:
             requested_page_key = qp_get("page", "").strip().lower()
             route_info = {

--- a/tests/test_public_nav_shell.py
+++ b/tests/test_public_nav_shell.py
@@ -20,7 +20,9 @@ def test_public_nav_uses_same_tab_routing_buttons():
     assert '"rating_rules": "public_header:rating_rules"' in contents
     assert '"weekly_recap": "public_header:weekly_recap"' in contents
     assert '"faqs": "public_header:faqs"' in contents
-    assert '"public_footer:admin_dashboard" if admin_authenticated else "public_footer:admin_login"' in contents
+    assert '"public_header:admin_dashboard" if admin_authenticated else "public_header:admin_login"' in contents
+    assert '("Rating Rules", "rating_rules")' not in contents
+    assert '("FAQ", "faqs")' not in contents
     assert '("Privacy", "privacy_policy")' in contents
     assert '("Terms", "terms_of_use")' in contents
     assert '("Contact", "contact_support")' in contents
@@ -44,3 +46,9 @@ def test_public_mode_hides_only_streamlit_header():
 
     assert "header{visibility:hidden;}" not in contents
     assert 'header[data-testid="stHeader"]{visibility:hidden;}' in contents
+
+def test_public_footer_renders_after_public_page_content():
+    contents = Path("streamlit_app.py").read_text(encoding="utf-8")
+
+    assert "from jupr_app.ui.public_nav import render_public_app_header, render_public_footer" in contents
+    assert "render_fn(ctx)\n            if PUBLIC_MODE:\n                render_public_footer(current_label=sel)" in contents


### PR DESCRIPTION
### Motivation
- The public header was visually busy and duplicated legal/support items directly under the top nav, competing with primary site navigation.
- Legal/support links should be reachable but rendered subtly in a footer so the header focuses on brand and primary public pages.

### Description
- Refactored `jupr_app/ui/public_nav.py` to remove `Rating Rules` and `FAQ(s)` from the footer link list and keep them only in the primary public nav mapping (`PUBLIC_LABEL_BY_KEY`).
- Introduced `render_public_footer()` in `jupr_app/ui/public_nav.py` to render legal/support links (`Privacy`, `Terms`, `Contact`, `Data Corrections`, `Email Preferences`) as muted inline-style links and to preserve same-tab navigation and safe context params.
- Simplified the header to include a compact brand/logo area, the primary public navigation, and a visually de-emphasized admin link (small inline control) while avoiding large button-card styling for footer links.
- Updated `streamlit_app.py` to call `render_public_footer()` after page content rendering so public pages render as: public header -> page content -> public footer.

### Testing
- Ran `pytest tests/test_public_nav_shell.py tests/test_streamlit_base_url.py tests/test_page_registry.py` and all tests passed (11 passed).
- Added/updated tests to assert that `Rating Rules` and `FAQ` are not present in the footer link list and that `render_public_footer()` is invoked after public page content rendering.
- Existing routing assertions were preserved to ensure same-tab navigation sources and admin/public routing behavior remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f61ded798883268d70f2fbf43d7ad4)