### PR TITLE
Fix Super Admin “View As” flow, deny-by-default admin pages, and audit payload compatibility

### DIFF
--- a/jupr_app/domain/admin_activity_log.py
+++ b/jupr_app/domain/admin_activity_log.py
@@ -43,6 +43,21 @@ def build_activity_payload(
     effective_role: str | None = None,
     role_source: str | None = None,
 ) -> dict[str, Any]:
+    normalized_after_json = after_json if isinstance(after_json, dict) else ({"value": after_json} if after_json is not None else None)
+    if effective_role or role_source:
+        audit_context: dict[str, str] = {}
+        if effective_role:
+            audit_context["effective_role"] = normalize_role(effective_role)
+        if role_source:
+            audit_context["role_source"] = str(role_source or "").strip()
+        if normalized_after_json is None:
+            normalized_after_json = {"_audit_context": audit_context}
+        else:
+            normalized_after_json = {
+                **normalized_after_json,
+                "_audit_context": audit_context,
+            }
+
     return {
         "club_id": str(club_id),
         "actor_email": str(actor_email or "").strip().lower() or "unknown",
@@ -51,12 +66,10 @@ def build_activity_payload(
         "entity_type": str(entity_type or "").strip(),
         "entity_id": str(entity_id or "").strip(),
         "before_json": before_json,
-        "after_json": after_json,
+        "after_json": normalized_after_json,
         "note": str(note or "").strip() or None,
         "source_page": str(source_page or "").strip() or None,
         "flagged_for_review": bool(flagged_for_review),
-        "effective_role": normalize_role(effective_role) if effective_role else None,
-        "role_source": str(role_source or "").strip() or None,
     }
 
 

--- a/jupr_app/ui/admin_page_permissions.py
+++ b/jupr_app/ui/admin_page_permissions.py
@@ -12,26 +12,33 @@ from jupr_app.domain.admin.roles import (
 )
 
 ADMIN_PAGE_PERMISSION_MATRIX: dict[str, tuple[str, ...]] = {
-    "league_manager": (PERMISSION_MANAGE_MATCHES, PERMISSION_ENTER_SCORES),
-    "match_uploader": (PERMISSION_ENTER_SCORES,),
-    "match_log": (PERMISSION_MANAGE_MATCHES, PERMISSION_ENTER_SCORES),
-    "player_editor": (PERMISSION_MANAGE_PLAYERS,),
+    "admin_guide": (PERMISSION_VIEW_AUDIT_LOG,),
     "admin_tools": (PERMISSION_VIEW_AUDIT_LOG,),
-    "tournaments": (PERMISSION_MANAGE_TOURNAMENTS, PERMISSION_ENTER_SCORES),
+    "badge_audit": (PERMISSION_RUN_REPLAY,),
+    "badge_debug": (PERMISSION_RUN_REPLAY,),
+    "challenge_ladder_admin": (PERMISSION_MANAGE_TOURNAMENTS, PERMISSION_MANAGE_MATCHES),
+    "jupr_live_admin": (PERMISSION_MANAGE_TOURNAMENTS, PERMISSION_ENTER_SCORES),
+    "league_manager": (PERMISSION_MANAGE_MATCHES, PERMISSION_ENTER_SCORES),
+    "league_printout": (PERMISSION_ENTER_SCORES, PERMISSION_MANAGE_MATCHES),
+    "match_canonical_audit": (PERMISSION_RUN_REPLAY,),
+    "match_log": (PERMISSION_MANAGE_MATCHES, PERMISSION_ENTER_SCORES),
+    "match_uploader": (PERMISSION_ENTER_SCORES,),
+    "moneyball": (PERMISSION_MANAGE_TOURNAMENTS, PERMISSION_ENTER_SCORES),
+    "player_editor": (PERMISSION_MANAGE_PLAYERS,),
+    "player_updates_admin": (PERMISSION_MANAGE_SUBSCRIPTIONS,),
+    "theme_qa": (PERMISSION_RUN_REPLAY,),
+    "top_players_printable": (PERMISSION_RUN_REPLAY,),
+    "tournament_live": (PERMISSION_MANAGE_TOURNAMENTS, PERMISSION_ENTER_SCORES),
     "tournament_manager": (PERMISSION_MANAGE_TOURNAMENTS,),
     "tournament_ops": (PERMISSION_MANAGE_TOURNAMENTS, PERMISSION_ENTER_SCORES),
-    "tournament_live": (PERMISSION_MANAGE_TOURNAMENTS, PERMISSION_ENTER_SCORES),
-    "player_updates_admin": (PERMISSION_MANAGE_SUBSCRIPTIONS,),
+    "tournaments": (PERMISSION_MANAGE_TOURNAMENTS, PERMISSION_ENTER_SCORES),
     "weekly_recap_admin": (PERMISSION_RUN_REPLAY,),
-    "badge_debug": (PERMISSION_RUN_REPLAY,),
-    "badge_audit": (PERMISSION_RUN_REPLAY,),
-    "match_canonical_audit": (PERMISSION_RUN_REPLAY,),
-    "top_players_printable": (PERMISSION_RUN_REPLAY,),
 }
 
 
-def is_admin_page_available_for_role(page_key: str, role: str) -> bool:
-    required_permissions = ADMIN_PAGE_PERMISSION_MATRIX.get(str(page_key or "").strip().lower())
+def is_admin_page_available_for_role(page_key: str, role: str, *, is_admin_only: bool = True) -> bool:
+    normalized_key = str(page_key or "").strip().lower()
+    required_permissions = ADMIN_PAGE_PERMISSION_MATRIX.get(normalized_key)
     if not required_permissions:
-        return True
+        return not is_admin_only
     return any(has_permission(role, permission) for permission in required_permissions)

--- a/jupr_app/ui/admin_view_as.py
+++ b/jupr_app/ui/admin_view_as.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from jupr_app.domain.admin.roles import ROLE_SUPER_ADMIN, normalize_role
+
+_ALLOWED_VIEW_AS_ROLES = frozenset({"club_owner", "organizer", "scorekeeper", "read_only"})
+
+
+def can_use_view_as(real_role: str) -> bool:
+    return normalize_role(real_role) == ROLE_SUPER_ADMIN
+
+
+def sanitize_view_as_role(real_role: str, requested_view_as_role: str | None) -> str | None:
+    if not can_use_view_as(real_role):
+        return None
+    candidate = normalize_role(requested_view_as_role)
+    if candidate in _ALLOWED_VIEW_AS_ROLES:
+        return candidate
+    return None
+
+
+def resolve_effective_admin_role(
+    real_role: str,
+    real_role_source: str,
+    requested_view_as_role: str | None,
+) -> tuple[str, str, str | None]:
+    normalized_real_role = normalize_role(real_role)
+    sanitized_view_as_role = sanitize_view_as_role(normalized_real_role, requested_view_as_role)
+
+    if sanitized_view_as_role:
+        return sanitized_view_as_role, "super_admin_view_as", sanitized_view_as_role
+
+    return normalized_real_role, str(real_role_source or "admin_role_assignments"), None

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -39,6 +39,10 @@ from jupr_app.ui.public_nav import render_public_app_header, render_public_foote
 from jupr_app.ui.theme_clean import apply_clean_theme
 from jupr_app.ui.url import qp_get
 from jupr_app.ui.admin_page_permissions import is_admin_page_available_for_role
+from jupr_app.ui.admin_view_as import (
+    can_use_view_as,
+    resolve_effective_admin_role,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -312,10 +316,36 @@ def main():
         st.session_state["jupr_public_mode"] = bool(PUBLIC_MODE)
         st.session_state["jupr_admin_entry_active"] = bool(admin_entry_requested)
         st.session_state["admin_allowlist"] = admin_allowlist
-        st.session_state["admin_real_role"] = "read_only"
-        st.session_state["admin_real_role_source"] = "not_authenticated"
-        st.session_state["admin_role"] = "read_only"
-        st.session_state["admin_role_source"] = "not_authenticated"
+        st.session_state.setdefault("admin_real_role", "read_only")
+        st.session_state.setdefault("admin_real_role_source", "not_authenticated")
+        st.session_state.setdefault("admin_role", "read_only")
+        st.session_state.setdefault("admin_role_source", "not_authenticated")
+        st.session_state.setdefault("admin_view_as_role", None)
+
+        supabase = get_supabase()
+        if admin_authenticated:
+            role_resolution = resolve_admin_role(
+                supabase=supabase,
+                email=current_admin_email,
+                user_id=str(getattr(current_admin, "id", "") or "").strip() or None,
+                allowlist=admin_allowlist,
+            )
+            st.session_state["admin_real_role"] = role_resolution.role
+            st.session_state["admin_real_role_source"] = role_resolution.source
+            effective_role, effective_role_source, sanitized_view_as_role = resolve_effective_admin_role(
+                role_resolution.role,
+                role_resolution.source,
+                st.session_state.get("admin_view_as_role"),
+            )
+            st.session_state["admin_role"] = effective_role
+            st.session_state["admin_role_source"] = effective_role_source
+            st.session_state["admin_view_as_role"] = sanitized_view_as_role
+        else:
+            st.session_state["admin_real_role"] = "read_only"
+            st.session_state["admin_real_role_source"] = "not_authenticated"
+            st.session_state["admin_role"] = "read_only"
+            st.session_state["admin_role_source"] = "not_authenticated"
+            st.session_state["admin_view_as_role"] = None
 
         # ---- Sidebar / Auth ----
         if PUBLIC_MODE or admin_login_requested:
@@ -342,7 +372,7 @@ def main():
                     )
                     st.rerun()
 
-            if admin_authenticated and st.session_state.get("admin_real_role") == "super_admin":
+            if admin_authenticated and can_use_view_as(st.session_state.get("admin_real_role", "")):
                 st.sidebar.markdown("### Super Admin Tools")
                 view_as_options = {
                     "Actual Super Admin": "",
@@ -355,14 +385,10 @@ def main():
                 selected_label = next((label for label, role in view_as_options.items() if role == current_view_as), "Actual Super Admin")
                 picked_label = st.sidebar.selectbox("View admin as", list(view_as_options.keys()), index=list(view_as_options.keys()).index(selected_label), help="Temporarily preview another role’s permissions. Your real account and audit identity do not change.")
                 picked_role = view_as_options[picked_label]
-                if picked_role:
-                    st.session_state["admin_view_as_role"] = picked_role
-                    st.session_state["admin_role"] = picked_role
-                    st.session_state["admin_role_source"] = "super_admin_view_as"
-                else:
-                    st.session_state.pop("admin_view_as_role", None)
-                    st.session_state["admin_role"] = st.session_state.get("admin_real_role", "super_admin")
-                    st.session_state["admin_role_source"] = st.session_state.get("admin_real_role_source", "admin_role_assignments")
+                current_role = str(st.session_state.get("admin_view_as_role", "") or "")
+                if picked_role != current_role:
+                    st.session_state["admin_view_as_role"] = picked_role or None
+                    st.rerun()
 
         # Optional: allow pages to request a refresh of cached data
         if bool(st.session_state.get("force_data_refresh", False)):
@@ -373,29 +399,7 @@ def main():
             st.session_state["force_data_refresh"] = False
 
         # ---- Load data + ctx ----
-        supabase = get_supabase()
-
-        if admin_authenticated:
-            role_resolution = resolve_admin_role(
-                supabase=supabase,
-                email=current_admin_email,
-                user_id=str(getattr(current_admin, "id", "") or "").strip() or None,
-                allowlist=admin_allowlist,
-            )
-            st.session_state["admin_real_role"] = role_resolution.role
-            st.session_state["admin_real_role_source"] = role_resolution.source
-            view_as_role = str(st.session_state.get("admin_view_as_role", "") or "").strip().lower()
-            real_is_super_admin = role_resolution.role == "super_admin"
-            if not real_is_super_admin:
-                st.session_state.pop("admin_view_as_role", None)
-                st.session_state["admin_role"] = role_resolution.role
-                st.session_state["admin_role_source"] = role_resolution.source
-            elif view_as_role and view_as_role in {"club_owner", "organizer", "scorekeeper", "read_only"}:
-                st.session_state["admin_role"] = view_as_role
-                st.session_state["admin_role_source"] = "super_admin_view_as"
-            else:
-                st.session_state["admin_role"] = role_resolution.role
-                st.session_state["admin_role_source"] = role_resolution.source
+        
         (
             df_players_all,
             df_players_active,
@@ -608,9 +612,7 @@ def main():
             if (admin_logged_in and st.session_state.get("admin_role_source") == "super_admin_view_as" and st.session_state.get("admin_real_role") == "super_admin"):
                 st.sidebar.warning(f"View As mode active: {effective_role}\n\nActions still log under your real super_admin account.")
                 if st.sidebar.button("Return to Super Admin"):
-                    st.session_state.pop("admin_view_as_role", None)
-                    st.session_state["admin_role"] = "super_admin"
-                    st.session_state["admin_role_source"] = st.session_state.get("admin_real_role_source", "admin_role_assignments")
+                    st.session_state["admin_view_as_role"] = None
                     st.rerun()
             visible_labels = [x for x in visible_labels if x not in HIDDEN_PAGE_LABELS]
 

--- a/tests/test_admin_activity_log.py
+++ b/tests/test_admin_activity_log.py
@@ -62,6 +62,42 @@ def test_build_activity_payload_sets_expected_shape():
     assert payload["entity_type"] == "match"
     assert payload["entity_id"] == "42"
     assert payload["flagged_for_review"] is True
+    assert "effective_role" not in payload
+    assert "role_source" not in payload
+
+
+def test_build_activity_payload_nests_effective_role_context():
+    payload = build_activity_payload(
+        club_id="club-1",
+        actor_email="Admin@Example.com",
+        actor_role=ROLE_SUPER_ADMIN,
+        action_type="match_edit",
+        entity_type="match",
+        entity_id="42",
+        after_json={"score_t1": 9},
+        effective_role=ROLE_SCOREKEEPER,
+        role_source="super_admin_view_as",
+    )
+    assert payload["after_json"]["_audit_context"]["effective_role"] == ROLE_SCOREKEEPER
+    assert payload["after_json"]["_audit_context"]["role_source"] == "super_admin_view_as"
+
+
+def test_write_admin_activity_log_avoids_unknown_top_level_view_as_keys():
+    supabase = _SupabaseProbe()
+    payload = build_activity_payload(
+        club_id="club-1",
+        actor_email="Admin@Example.com",
+        actor_role=ROLE_SUPER_ADMIN,
+        action_type="match_edit",
+        entity_type="match",
+        entity_id="42",
+        effective_role=ROLE_SCOREKEEPER,
+        role_source="super_admin_view_as",
+    )
+    write_admin_activity_log(supabase, payload)
+    inserted = supabase.probe.rows[0]
+    assert "effective_role" not in inserted
+    assert "role_source" not in inserted
 
 
 def test_can_view_admin_activity_is_limited_to_owner_and_super_admin():

--- a/tests/test_admin_roles.py
+++ b/tests/test_admin_roles.py
@@ -19,6 +19,7 @@ from jupr_app.domain.admin.roles import (
     can_view_audit_log,
     resolve_admin_role,
 )
+from jupr_app.ui.admin_page_permissions import is_admin_page_available_for_role
 
 
 class _Query:
@@ -163,3 +164,7 @@ def test_permission_matrix(role: str, expected: dict[str, bool]):
         "can_enter_scores": can_enter_scores(role),
     }
     assert actual == expected
+
+
+def test_unmapped_admin_only_page_is_denied_by_default():
+    assert is_admin_page_available_for_role("nonexistent_admin_page", ROLE_SUPER_ADMIN, is_admin_only=True) is False

--- a/tests/test_admin_view_as.py
+++ b/tests/test_admin_view_as.py
@@ -1,60 +1,40 @@
 from jupr_app.domain.admin.roles import ROLE_ORGANIZER, ROLE_SUPER_ADMIN
-from jupr_app.domain.admin_activity_log import build_activity_payload
-from jupr_app.ui.admin_page_permissions import is_admin_page_available_for_role
-
-
-def _apply_view_as(real_role: str, view_as_role: str | None) -> tuple[str, str]:
-    if real_role != "super_admin":
-        return real_role, "admin_role_assignments"
-    if view_as_role in {"club_owner", "organizer", "scorekeeper", "read_only"}:
-        return view_as_role, "super_admin_view_as"
-    return real_role, "admin_role_assignments"
+from jupr_app.ui.admin_view_as import (
+    can_use_view_as,
+    resolve_effective_admin_role,
+    sanitize_view_as_role,
+)
 
 
 def test_super_admin_can_select_effective_role():
-    role, source = _apply_view_as("super_admin", "organizer")
+    role, source, view_as_role = resolve_effective_admin_role(
+        "super_admin", "admin_role_assignments", "organizer"
+    )
     assert role == "organizer"
     assert source == "super_admin_view_as"
+    assert view_as_role == "organizer"
 
 
 def test_non_super_admin_cannot_activate_view_as_mode():
-    role, source = _apply_view_as("organizer", "scorekeeper")
+    role, source, view_as_role = resolve_effective_admin_role(
+        "organizer", "admin_role_assignments", "scorekeeper"
+    )
     assert role == "organizer"
-    assert source != "super_admin_view_as"
-
-
-def test_effective_role_controls_navigation_visibility():
-    assert is_admin_page_available_for_role("match_uploader", ROLE_ORGANIZER) is True
-    assert is_admin_page_available_for_role("player_editor", ROLE_ORGANIZER) is False
+    assert source == "admin_role_assignments"
+    assert view_as_role is None
 
 
 def test_real_role_remains_super_admin_while_effective_role_changes():
     real_role = ROLE_SUPER_ADMIN
-    effective_role, source = _apply_view_as(real_role, ROLE_ORGANIZER)
+    effective_role, source, _ = resolve_effective_admin_role(
+        real_role, "admin_role_assignments", ROLE_ORGANIZER
+    )
     assert real_role == ROLE_SUPER_ADMIN
     assert effective_role == ROLE_ORGANIZER
     assert source == "super_admin_view_as"
 
 
-def test_deep_linked_page_blocked_when_role_lacks_permission():
-    assert is_admin_page_available_for_role("player_editor", "scorekeeper") is False
-
-
-def test_view_as_state_is_session_only():
-    session_state = {"admin_view_as_role": "organizer"}
-    session_state.pop("admin_view_as_role", None)
-    assert "admin_view_as_role" not in session_state
-
-
-def test_admin_activity_payload_supports_real_and_effective_roles():
-    payload = build_activity_payload(
-        club_id="club-1",
-        actor_email="admin@example.com",
-        actor_role=ROLE_SUPER_ADMIN,
-        action_type="match_edit",
-        entity_type="match",
-        entity_id="1",
-        after_json={"effective_role": ROLE_ORGANIZER, "source": "super_admin_view_as"},
-    )
-    assert payload["actor_role"] == ROLE_SUPER_ADMIN
-    assert payload["after_json"]["effective_role"] == ROLE_ORGANIZER
+def test_view_as_helpers_enforce_super_admin_only():
+    assert can_use_view_as("super_admin") is True
+    assert can_use_view_as("organizer") is False
+    assert sanitize_view_as_role("organizer", "scorekeeper") is None

--- a/tests/test_page_registry.py
+++ b/tests/test_page_registry.py
@@ -6,6 +6,7 @@ from jupr_app.ui.page_registry import (
     PUBLIC_NAV_KEYS,
     labels_for_keys,
 )
+from jupr_app.ui.admin_page_permissions import ADMIN_PAGE_PERMISSION_MATRIX
 
 
 def test_jupr_live_is_registered_as_public_page():
@@ -79,3 +80,13 @@ def test_player_editor_remains_admin_only():
     assert "player_editor" not in PUBLIC_NAV_KEYS
     assert PAGE_KEY_TO_LABEL["player_editor"] == "👥 Player Editor"
     assert "👥 Player Editor" not in public_labels
+
+
+def test_every_admin_only_page_is_mapped_or_intentionally_blocked():
+    intentionally_blocked = {"admin_login", "reset_password"}
+    missing = sorted(
+        key
+        for key in ADMIN_ONLY_PAGE_KEYS
+        if key not in ADMIN_PAGE_PERMISSION_MATRIX and key not in intentionally_blocked
+    )
+    assert missing == []


### PR DESCRIPTION
### Motivation
- Correct the Super Admin “View As” UX and security gaps introduced earlier so Super Admin Tools render reliably and the effective role is used only for permission preview.  
- Prevent unmapped admin-only pages from being implicitly allowed, which is a security risk.  
- Avoid breaking existing admin activity logging by not sending unknown top-level columns that the current migration does not provide.

### Description
- Resolve real/effective admin roles before sidebar rendering in `streamlit_app.py` and preserve session keys `admin_real_role`, `admin_real_role_source`, `admin_role`, `admin_role_source`, and `admin_view_as_role`, using the effective role for navigation and the real role to gate View As controls.  
- Add a new helper module `jupr_app/ui/admin_view_as.py` with `can_use_view_as`, `sanitize_view_as_role`, and `resolve_effective_admin_role` to centralize session-only View As logic and enforce super-admin-only impersonation.  
- Change admin-page permission checking in `jupr_app/ui/admin_page_permissions.py` to deny-by-default for admin-only pages and add conservative mappings for previously missing admin-only pages (e.g., `league_printout`, `admin_guide`, `challenge_ladder_admin`, `moneyball`, `jupr_live_admin`, `theme_qa`).  
- Make `jupr_app/domain/admin_activity_log.build_activity_payload` schema-compatible by removing top-level `effective_role`/`role_source` keys and nesting view-as metadata under `after_json['_audit_context']` when provided, avoiding any required DB migration and unknown-column insert failures; `write_admin_activity_log` remains unchanged in behavior.

### Testing
- Ran `pytest tests/test_admin_roles.py tests/test_admin_view_as.py tests/test_admin_activity_log.py tests/test_page_registry.py tests/test_streamlit_base_url.py` and all tests succeeded.  
- New/updated tests assert that `View As` helpers enforce super-admin-only behavior, unmapped admin-only pages are denied by default, activity payload nests view-as context under `after_json._audit_context`, and no unknown top-level `effective_role`/`role_source` keys are written.  
- Total: `25 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f625bf9ae88326b47a8ba91ae655c7)