### PR TITLE
Fix admin/public mixed-route rerun churn and add route diagnostics

### DIFF
--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -363,6 +363,7 @@ def render(ctx):
 
     with st.expander("🧰 System Debug Panel", expanded=False):
         nav_events = list(st.session_state.get("jupr_nav_debug_events", []))
+        route_sync_events = list(st.session_state.get("jupr_route_sync_debug_events", []))
         auth_events = _format_auth_debug_events(list(st.session_state.get("jupr_auth_debug_events", [])))
         current_query_params = redact_query_params(_query_params_snapshot())
         debug_session_id = str(st.session_state.setdefault("debug_session_id", str(uuid4())))
@@ -374,6 +375,7 @@ def render(ctx):
                 "debug_session_id": debug_session_id,
                 "navigation_events_present": bool(nav_events),
                 "navigation_event_count": len(nav_events),
+                "route_sync_event_count": len(route_sync_events),
                 "auth_event_count": len(auth_events),
             }
         )
@@ -390,17 +392,25 @@ def render(ctx):
             "jupr_public_mode": bool(st.session_state.get("jupr_public_mode", False)),
             "jupr_admin_entry_active": bool(st.session_state.get("jupr_admin_entry_active", False)),
             "jupr_admin_authenticated": bool(st.session_state.get("jupr_admin_authenticated", False)),
+            "route_stability_repeat_count": int(st.session_state.get("jupr_route_stability_repeat_count", 0) or 0),
+            "route_stability_warning": bool(st.session_state.get("jupr_route_stability_warning", False)),
         }
         st.write("Navigation runtime snapshot")
         st.json(nav_runtime)
 
         st.write(f"Recent navigation events ({len(nav_events)})")
         st.json(nav_events)
+        st.write(f"Recent canonical route sync events ({len(route_sync_events)})")
+        st.json(route_sync_events)
+        if bool(st.session_state.get("jupr_route_stability_warning", False)):
+            st.warning("Possible rerun loop detected.")
 
         if st.button("Clear navigation debug events", key="clear_navigation_debug_events"):
             st.session_state["jupr_nav_debug_events"] = []
+            st.session_state["jupr_route_sync_debug_events"] = []
             st.success("Navigation debug events cleared.")
             nav_events = []
+            route_sync_events = []
 
         st.markdown("#### Phase 3 — Auth/session diagnostics")
         auth_debug = {
@@ -436,12 +446,14 @@ def render(ctx):
             "session_continuity": {
                 "navigation_events_present": bool(nav_events),
                 "navigation_event_count": len(nav_events),
+                "route_sync_event_count": len(route_sync_events),
                 "auth_event_count": len(auth_events),
             },
             "navigation": {
                 "query_params": current_query_params,
                 "runtime": nav_runtime,
                 "events": nav_events,
+                "route_sync_events": route_sync_events,
             },
             "auth_session": auth_debug,
         }

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -189,6 +189,27 @@ def _set_query_params_idempotent(
     return changed
 
 
+def _record_route_sync_event(event: dict) -> None:
+    events = st.session_state.setdefault("jupr_route_sync_debug_events", [])
+    events.append(event)
+    if len(events) > 100:
+        del events[:-100]
+
+
+def _track_route_stability(route_fingerprint: str) -> None:
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    history = st.session_state.setdefault("jupr_route_stability_history", [])
+    history.append((now, route_fingerprint))
+    cutoff = now - timedelta(seconds=30)
+    history = [(ts, fp) for ts, fp in history if ts >= cutoff]
+    st.session_state["jupr_route_stability_history"] = history
+    repeats = sum(1 for _ts, fp in history if fp == route_fingerprint)
+    st.session_state["jupr_route_stability_repeat_count"] = repeats
+    st.session_state["jupr_route_stability_warning"] = repeats > 20
+
+
 def main():
     """
     Main Streamlit entrypoint. Keep this deterministic for reloads.
@@ -237,7 +258,7 @@ def main():
         render_admin_browser_session_bridge()
 
         admin_allowlist = load_admin_allowlist()
-        if admin_entry_requested:
+        if admin_entry_requested and not get_current_admin_user():
             maybe_restore_admin_login_from_browser()
 
         current_admin = get_current_admin_user()
@@ -299,7 +320,29 @@ def main():
             if params_changed:
                 st.rerun()
 
-        PUBLIC_MODE = not admin_entry_requested
+        # Route contract:
+        # - Admin mode must only target admin-only pages.
+        # - Mixed route admin=1&page=<public_page> is canonicalized once into public mode.
+        requested_public_page_while_admin = admin_requested and (
+            incoming_page_param in PAGE_KEY_TO_LABEL and incoming_page_param not in ADMIN_ONLY_PAGE_KEYS
+        )
+        if requested_public_page_while_admin:
+            normalized_public_page = incoming_page_param if incoming_page_param and incoming_page_param != "home" else ""
+            params_changed = _set_query_params_idempotent(
+                updates={"page": normalized_public_page} if normalized_public_page else {},
+                removals={
+                    "admin",
+                    "next",
+                    "jupr_admin_access_token",
+                    "jupr_admin_refresh_token",
+                    "jupr_admin_restore_from_storage",
+                },
+            )
+            st.session_state["jupr_public_mode"] = True
+            if params_changed:
+                st.rerun()
+
+        PUBLIC_MODE = not admin_entry_requested or requested_public_page_while_admin
         if public_requested and not admin_entry_requested:
             PUBLIC_MODE = True
         unauthenticated_admin_page_request = requested_admin_page and not admin_authenticated
@@ -566,7 +609,12 @@ def main():
         if not admin_logged_in:
             visible_labels = [x for x in all_labels if x not in ADMIN_ONLY_LABELS]
         else:
-            visible_labels = [x for x in all_labels if x not in ADMIN_ONLY_LABELS or is_admin_page_available_for_role(LABEL_TO_PAGE_KEY.get(x, ""), effective_role)]
+            visible_labels = [
+                x
+                for x in all_labels
+                if x in ADMIN_ONLY_LABELS
+                and is_admin_page_available_for_role(LABEL_TO_PAGE_KEY.get(x, ""), effective_role)
+            ]
 
         public_labels_in_order = labels_for_keys(PUBLIC_NAV_KEYS)
 
@@ -609,6 +657,11 @@ def main():
                 )
 
         else:
+            st.sidebar.page_link(
+                "streamlit_app.py",
+                label="View Public Site",
+                icon="🌐",
+            )
             if (admin_logged_in and st.session_state.get("admin_role_source") == "super_admin_view_as" and st.session_state.get("admin_real_role") == "super_admin"):
                 st.sidebar.warning(f"View As mode active: {effective_role}\n\nActions still log under your real super_admin account.")
                 if st.sidebar.button("Return to Super Admin"):
@@ -636,6 +689,8 @@ def main():
                 "main_nav" not in st.session_state
                 or (current_nav not in visible_labels and current_nav not in HIDDEN_PAGE_LABELS)
             ):
+                st.session_state["main_nav"] = visible_labels[0]
+            if current_nav and LABEL_TO_PAGE_KEY.get(str(current_nav), "") not in ADMIN_ONLY_PAGE_KEYS:
                 st.session_state["main_nav"] = visible_labels[0]
 
             if admin_logged_in and st.sidebar.button("🔄 Refresh data"):
@@ -696,6 +751,18 @@ def main():
                 updates=canonical_updates,
                 removals=canonical_removals,
             )
+            _record_route_sync_event(
+                {
+                    "before": dict(st.query_params),
+                    "updates": canonical_updates,
+                    "removals": sorted(canonical_removals),
+                    "selected_page": target_page,
+                    "public_mode": PUBLIC_MODE,
+                    "admin_mode": not PUBLIC_MODE,
+                    "params_changed": params_changed,
+                    "rerun_triggered": bool(params_changed and current_page != (target_page or "")),
+                }
+            )
 
             st.session_state["_last_rendered_nav"] = sel
 
@@ -726,6 +793,17 @@ def main():
             st.stop()
 
         target_page_key = LABEL_TO_PAGE_KEY.get(sel, "")
+        route_fingerprint = "|".join(
+            [
+                str(target_page_key or ""),
+                f"admin={int(bool(admin_requested))}",
+                f"public={int(bool(PUBLIC_MODE))}",
+                f"main_nav={str(st.session_state.get('main_nav', '') or '')}",
+                f"public_mode={int(bool(st.session_state.get('jupr_public_mode', False)))}",
+                f"admin_entry={int(bool(st.session_state.get('jupr_admin_entry_active', False)))}",
+            ]
+        )
+        _track_route_stability(route_fingerprint)
         if target_page_key in ADMIN_ONLY_PAGE_KEYS and not admin_logged_in:
             st.info("Admin login required to access this page.")
             st.stop()

--- a/tests/test_admin_auth_browser_restore.py
+++ b/tests/test_admin_auth_browser_restore.py
@@ -135,7 +135,8 @@ def test_maybe_restore_success_persists_rotated_tokens(monkeypatch):
 def test_streamlit_app_only_restores_browser_tokens_for_admin_entry():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")
 
-    assert "if admin_entry_requested:\n            maybe_restore_admin_login_from_browser()" in app
+    assert "if admin_entry_requested and not get_current_admin_user():" in app
+    assert "maybe_restore_admin_login_from_browser()" in app
 
 
 def test_append_auth_debug_event_redacts_sensitive_reason_and_query_params(monkeypatch):

--- a/tests/test_page_registry.py
+++ b/tests/test_page_registry.py
@@ -7,6 +7,7 @@ from jupr_app.ui.page_registry import (
     labels_for_keys,
 )
 from jupr_app.ui.admin_page_permissions import ADMIN_PAGE_PERMISSION_MATRIX
+from pathlib import Path
 
 
 def test_jupr_live_is_registered_as_public_page():
@@ -90,3 +91,14 @@ def test_every_admin_only_page_is_mapped_or_intentionally_blocked():
         if key not in ADMIN_PAGE_PERMISSION_MATRIX and key not in intentionally_blocked
     )
     assert missing == []
+
+
+def test_admin_sidebar_excludes_public_pages_and_exposes_public_link():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    assert "if x in ADMIN_ONLY_LABELS" in app
+    assert 'label="View Public Site"' in app
+
+
+def test_mixed_admin_public_route_is_not_kept_canonical():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    assert "requested_public_page_while_admin" in app


### PR DESCRIPTION
### Motivation
- Stop the repeated rerun/reload loop caused by mixed admin/public routes (e.g. `?admin=1&page=home`) that cause nav/query-param churn between public and admin shells.
- Reduce noisy auth-restore debug events when an admin user is already present in session state.
- Provide lightweight diagnostics to detect route instability and make canonical sync behavior observable.

### Description
- Only call `maybe_restore_admin_login_from_browser()` when an admin entry is requested and no current admin user is present by guarding the call with `not get_current_admin_user()` in `streamlit_app.py`.
- Canonicalize mixed routes by detecting `admin=1` + a public `page` and normalizing to public mode once (removing admin-related query params) to avoid admin/public bouncing.
- Restrict the admin sidebar to admin-only pages filtered by effective role, add a `View Public Site` sidebar link, and reset any public `main_nav` when entering admin mode so the admin shell never exposes public pages as primary nav.
- Add route-sync instrumentation (`_record_route_sync_event` / `jupr_route_sync_debug_events`) and a small route-stability detector (`_track_route_stability` / `jupr_route_stability_*`) that tracks recent fingerprints and sets a warning flag when repeated reruns are detected.
- Surface the new route sync events and stability diagnostics in Admin Tools → System Debug Panel and add tests to assert the new restore-guard and mixed-route/admin-sidebar contracts.

### Testing
- Ran: `pytest tests/test_streamlit_base_url.py tests/test_page_registry.py tests/test_admin_view_as.py tests/test_admin_roles.py tests/test_admin_auth_browser_restore.py` and all tests passed.
- Test run summary: 30 passed, 0 failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62bd96f388326b948b7712d6c1183)