### PR TITLE
Fix admin sidebar public-site navigation crash by removing Streamlit page_link

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -657,11 +657,24 @@ def main():
                 )
 
         else:
-            st.sidebar.page_link(
-                "streamlit_app.py",
-                label="View Public Site",
-                icon="🌐",
-            )
+            if st.sidebar.button("🌐 View Public Site", key="admin_view_public_site_btn"):
+                st.session_state.pop("main_nav", None)
+                st.session_state.pop("public_nav", None)
+                st.session_state["jupr_public_mode"] = True
+                st.session_state["jupr_admin_entry_active"] = False
+                _set_query_params_idempotent(
+                    updates={},
+                    removals={
+                        "admin",
+                        "next",
+                        "jupr_admin_access_token",
+                        "jupr_admin_refresh_token",
+                        "jupr_admin_restore_from_storage",
+                        "logout",
+                        "page",
+                    },
+                )
+                st.rerun()
             if (admin_logged_in and st.session_state.get("admin_role_source") == "super_admin_view_as" and st.session_state.get("admin_real_role") == "super_admin"):
                 st.sidebar.warning(f"View As mode active: {effective_role}\n\nActions still log under your real super_admin account.")
                 if st.sidebar.button("Return to Super Admin"):

--- a/tests/test_page_registry.py
+++ b/tests/test_page_registry.py
@@ -93,11 +93,27 @@ def test_every_admin_only_page_is_mapped_or_intentionally_blocked():
     assert missing == []
 
 
-def test_admin_sidebar_excludes_public_pages_and_exposes_public_link():
+def test_admin_sidebar_excludes_public_pages_and_uses_safe_public_link_control():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")
     assert "if x in ADMIN_ONLY_LABELS" in app
-    assert 'label="View Public Site"' in app
+    assert "st.sidebar.page_link(" not in app
+    assert 'st.sidebar.button("🌐 View Public Site", key="admin_view_public_site_btn")' in app
 
+
+
+
+def test_view_public_site_clears_admin_query_params_and_enters_public_mode():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    assert '"admin_view_public_site_btn"' in app
+    assert 'st.session_state["jupr_public_mode"] = True' in app
+    assert 'st.session_state["jupr_admin_entry_active"] = False' in app
+    assert '"admin",' in app
+    assert '"next",' in app
+    assert '"jupr_admin_access_token",' in app
+    assert '"jupr_admin_refresh_token",' in app
+    assert '"jupr_admin_restore_from_storage",' in app
+    assert '"logout",' in app
+    assert '"page",' in app
 
 def test_mixed_admin_public_route_is_not_kept_canonical():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")


### PR DESCRIPTION
### Motivation
- The app is a single-file custom-router and using `st.sidebar.page_link(...)` caused a production `KeyError: 'url_pathname'` because Streamlit multipage metadata is not present.
- Replace the unsafe `page_link` usage with a router-safe control that cleanly exits admin mode without relying on Streamlit multipage internals.

### Description
- Removed the `st.sidebar.page_link("streamlit_app.py", ...)` call and replaced it with `st.sidebar.button("🌐 View Public Site", key="admin_view_public_site_btn")` to navigate to the public site.
- The button handler clears navigation/session state and query params via `_set_query_params_idempotent(...)`, pops `main_nav` and `public_nav`, sets `st.session_state["jupr_public_mode"] = True` and `st.session_state["jupr_admin_entry_active"] = False`, and calls `st.rerun()` for a clean render.
- Updated tests in `tests/test_page_registry.py` to assert the absence of `st.sidebar.page_link(`, the presence of the safe button control, and that the button-based implementation includes clearing admin/auth/query params and setting public-mode flags.
- Preserved existing admin-sidebar behavior including admin-only page visibility, Super Admin View As handling, route sync logic, and auth restore gating.

### Testing
- Ran `pytest tests/test_streamlit_base_url.py tests/test_page_registry.py tests/test_admin_view_as.py tests/test_admin_roles.py tests/test_admin_auth_browser_restore.py` and all tests passed.
- Test run summary: `31 passed`.
- New/modified assertions in `tests/test_page_registry.py` verify that `st.sidebar.page_link(` is not present and that the safe `View Public Site` button and its query-param-clearing behavior are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62d3318a4832697130d4e37b075ad)