### PR TITLE
Fix View As return loop by syncing selector key with canonical admin role

### DIFF
--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -392,6 +392,13 @@ def render(ctx):
             "jupr_public_mode": bool(st.session_state.get("jupr_public_mode", False)),
             "jupr_admin_entry_active": bool(st.session_state.get("jupr_admin_entry_active", False)),
             "jupr_admin_authenticated": bool(st.session_state.get("jupr_admin_authenticated", False)),
+            "admin_real_role": str(st.session_state.get("admin_real_role", "") or ""),
+            "admin_real_role_source": str(st.session_state.get("admin_real_role_source", "") or ""),
+            "admin_role": str(st.session_state.get("admin_role", "") or ""),
+            "admin_role_source": str(st.session_state.get("admin_role_source", "") or ""),
+            "admin_view_as_role": str(st.session_state.get("admin_view_as_role", "") or ""),
+            "admin_view_as_selector_label": str(st.session_state.get("admin_view_as_selector_label", "") or ""),
+            "view_as_mode_active": bool(st.session_state.get("admin_role_source", "") == "super_admin_view_as"),
             "route_stability_repeat_count": int(st.session_state.get("jupr_route_stability_repeat_count", 0) or 0),
             "route_stability_warning": bool(st.session_state.get("jupr_route_stability_warning", False)),
         }

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -364,6 +364,8 @@ def main():
         st.session_state.setdefault("admin_role", "read_only")
         st.session_state.setdefault("admin_role_source", "not_authenticated")
         st.session_state.setdefault("admin_view_as_role", None)
+        VIEW_AS_ACTUAL_LABEL = "Actual Super Admin"
+        VIEW_AS_SELECTOR_KEY = "admin_view_as_selector_label"
 
         supabase = get_supabase()
         if admin_authenticated:
@@ -418,15 +420,25 @@ def main():
             if admin_authenticated and can_use_view_as(st.session_state.get("admin_real_role", "")):
                 st.sidebar.markdown("### Super Admin Tools")
                 view_as_options = {
-                    "Actual Super Admin": "",
+                    VIEW_AS_ACTUAL_LABEL: "",
                     "View as Club Owner": "club_owner",
                     "View as Organizer": "organizer",
                     "View as Scorekeeper": "scorekeeper",
                     "View as Read Only": "read_only",
                 }
                 current_view_as = str(st.session_state.get("admin_view_as_role", "") or "")
-                selected_label = next((label for label, role in view_as_options.items() if role == current_view_as), "Actual Super Admin")
-                picked_label = st.sidebar.selectbox("View admin as", list(view_as_options.keys()), index=list(view_as_options.keys()).index(selected_label), help="Temporarily preview another role’s permissions. Your real account and audit identity do not change.")
+                selected_label = next((label for label, role in view_as_options.items() if role == current_view_as), VIEW_AS_ACTUAL_LABEL)
+                selector_label = st.session_state.get(VIEW_AS_SELECTOR_KEY)
+                if (selector_label not in view_as_options) or (
+                    current_view_as == "" and selector_label != VIEW_AS_ACTUAL_LABEL
+                ):
+                    st.session_state[VIEW_AS_SELECTOR_KEY] = selected_label
+                picked_label = st.sidebar.selectbox(
+                    "View admin as",
+                    list(view_as_options.keys()),
+                    key=VIEW_AS_SELECTOR_KEY,
+                    help="Temporarily preview another role’s permissions. Your real account and audit identity do not change.",
+                )
                 picked_role = view_as_options[picked_label]
                 current_role = str(st.session_state.get("admin_view_as_role", "") or "")
                 if picked_role != current_role:
@@ -679,6 +691,7 @@ def main():
                 st.sidebar.warning(f"View As mode active: {effective_role}\n\nActions still log under your real super_admin account.")
                 if st.sidebar.button("Return to Super Admin"):
                     st.session_state["admin_view_as_role"] = None
+                    st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL
                     st.rerun()
             visible_labels = [x for x in visible_labels if x not in HIDDEN_PAGE_LABELS]
 

--- a/tests/test_admin_view_as.py
+++ b/tests/test_admin_view_as.py
@@ -4,6 +4,7 @@ from jupr_app.ui.admin_view_as import (
     resolve_effective_admin_role,
     sanitize_view_as_role,
 )
+from pathlib import Path
 
 
 def test_super_admin_can_select_effective_role():
@@ -38,3 +39,30 @@ def test_view_as_helpers_enforce_super_admin_only():
     assert can_use_view_as("super_admin") is True
     assert can_use_view_as("organizer") is False
     assert sanitize_view_as_role("organizer", "scorekeeper") is None
+
+
+def test_view_as_selector_uses_explicit_widget_key():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    assert 'VIEW_AS_SELECTOR_KEY = "admin_view_as_selector_label"' in app
+    assert 'key=VIEW_AS_SELECTOR_KEY' in app
+
+
+def test_return_to_super_admin_clears_role_and_resets_selector_label():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    assert 'if st.sidebar.button("Return to Super Admin"):' in app
+    assert 'st.session_state["admin_view_as_role"] = None' in app
+    assert "st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL" in app
+
+
+def test_stale_selector_value_is_guarded_after_return_to_actual_super_admin():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    assert "current_view_as == \"\" and selector_label != VIEW_AS_ACTUAL_LABEL" in app
+    assert "st.session_state[VIEW_AS_SELECTOR_KEY] = selected_label" in app
+
+
+def test_selectbox_change_paths_still_switch_between_actual_and_organizer():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    assert '"View as Organizer": "organizer"' in app
+    assert "picked_role = view_as_options[picked_label]" in app
+    assert "if picked_role != current_role:" in app
+    assert 'st.session_state["admin_view_as_role"] = picked_role or None' in app


### PR DESCRIPTION
### Motivation
- Prevent a rerun/reload loop that occurs when exiting Super Admin "View As" mode because the Streamlit selectbox widget retained a stale label that re-enabled the previously selected role.
- Ensure a single source of truth for View As state so the UI and canonical session state cannot fight and cause repeated reruns.

### Description
- Introduced constants `VIEW_AS_ACTUAL_LABEL` and `VIEW_AS_SELECTOR_KEY` and gave the View As selectbox an explicit key `admin_view_as_selector_label` so widget state is addressable and controllable. 
- Added initialization/guard logic to sync the selector label with the canonical `st.session_state["admin_view_as_role"]` and to prevent stale selector values from immediately re-enabling a View As role after reset. 
- Updated the "Return to Super Admin" flow to clear both `st.session_state["admin_view_as_role"]` and the selector label (`st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL`) before calling `st.rerun()`. 
- Exposed View As diagnostics in the System Debug Panel by adding `admin_real_role`, `admin_real_role_source`, `admin_role`, `admin_role_source`, `admin_view_as_role`, `admin_view_as_selector_label`, and `view_as_mode_active` to the runtime snapshot. 
- Added tests in `tests/test_admin_view_as.py` to assert explicit widget key usage, reset behavior, stale-selector guarding, and the normal selectbox-driven role change path.

### Testing
- Ran: `pytest tests/test_admin_view_as.py tests/test_page_registry.py tests/test_streamlit_base_url.py tests/test_admin_roles.py tests/test_admin_auth_browser_restore.py`.
- Result: all tests passed (35 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62ea11b848326afa0b01bff6ea6fc)