### PR TITLE
Fix Return to Super Admin crash by deferring View As selector reset

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -366,6 +366,8 @@ def main():
         st.session_state.setdefault("admin_view_as_role", None)
         VIEW_AS_ACTUAL_LABEL = "Actual Super Admin"
         VIEW_AS_SELECTOR_KEY = "admin_view_as_selector_label"
+        VIEW_AS_RESET_PENDING_KEY = "admin_view_as_reset_pending"
+        VIEW_AS_LAST_SELECTOR_KEY = "admin_view_as_last_selector_label"
 
         supabase = get_supabase()
         if admin_authenticated:
@@ -426,13 +428,15 @@ def main():
                     "View as Scorekeeper": "scorekeeper",
                     "View as Read Only": "read_only",
                 }
+                if st.session_state.pop(VIEW_AS_RESET_PENDING_KEY, False):
+                    st.session_state["admin_view_as_role"] = None
+                    st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL
                 current_view_as = str(st.session_state.get("admin_view_as_role", "") or "")
                 selected_label = next((label for label, role in view_as_options.items() if role == current_view_as), VIEW_AS_ACTUAL_LABEL)
                 selector_label = st.session_state.get(VIEW_AS_SELECTOR_KEY)
-                if (selector_label not in view_as_options) or (
-                    current_view_as == "" and selector_label != VIEW_AS_ACTUAL_LABEL
-                ):
+                if selector_label not in view_as_options:
                     st.session_state[VIEW_AS_SELECTOR_KEY] = selected_label
+                    selector_label = selected_label
                 picked_label = st.sidebar.selectbox(
                     "View admin as",
                     list(view_as_options.keys()),
@@ -441,7 +445,10 @@ def main():
                 )
                 picked_role = view_as_options[picked_label]
                 current_role = str(st.session_state.get("admin_view_as_role", "") or "")
-                if picked_role != current_role:
+                last_selector_label = st.session_state.get(VIEW_AS_LAST_SELECTOR_KEY)
+                selector_changed = picked_label != last_selector_label
+                st.session_state[VIEW_AS_LAST_SELECTOR_KEY] = picked_label
+                if selector_changed and picked_role != current_role:
                     st.session_state["admin_view_as_role"] = picked_role or None
                     st.rerun()
 
@@ -691,7 +698,7 @@ def main():
                 st.sidebar.warning(f"View As mode active: {effective_role}\n\nActions still log under your real super_admin account.")
                 if st.sidebar.button("Return to Super Admin"):
                     st.session_state["admin_view_as_role"] = None
-                    st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL
+                    st.session_state[VIEW_AS_RESET_PENDING_KEY] = True
                     st.rerun()
             visible_labels = [x for x in visible_labels if x not in HIDDEN_PAGE_LABELS]
 

--- a/tests/test_admin_view_as.py
+++ b/tests/test_admin_view_as.py
@@ -47,22 +47,31 @@ def test_view_as_selector_uses_explicit_widget_key():
     assert 'key=VIEW_AS_SELECTOR_KEY' in app
 
 
-def test_return_to_super_admin_clears_role_and_resets_selector_label():
+def test_return_to_super_admin_sets_pending_reset_and_reruns():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")
     assert 'if st.sidebar.button("Return to Super Admin"):' in app
     assert 'st.session_state["admin_view_as_role"] = None' in app
-    assert "st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL" in app
+    assert "st.session_state[VIEW_AS_RESET_PENDING_KEY] = True" in app
+    assert "st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL" not in app.split('if st.sidebar.button("Return to Super Admin"):', 1)[1].split('st.rerun()', 1)[0]
 
 
 def test_stale_selector_value_is_guarded_after_return_to_actual_super_admin():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")
-    assert "current_view_as == \"\" and selector_label != VIEW_AS_ACTUAL_LABEL" in app
-    assert "st.session_state[VIEW_AS_SELECTOR_KEY] = selected_label" in app
+    assert "last_selector_label = st.session_state.get(VIEW_AS_LAST_SELECTOR_KEY)" in app
+    assert "selector_changed = picked_label != last_selector_label" in app
+    assert "if selector_changed and picked_role != current_role:" in app
+
+
+def test_pending_reset_applies_before_selectbox_render():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    pre_selectbox = app.split("picked_label = st.sidebar.selectbox", 1)[0]
+    assert "if st.session_state.pop(VIEW_AS_RESET_PENDING_KEY, False):" in pre_selectbox
+    assert "st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL" in pre_selectbox
 
 
 def test_selectbox_change_paths_still_switch_between_actual_and_organizer():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")
     assert '"View as Organizer": "organizer"' in app
     assert "picked_role = view_as_options[picked_label]" in app
-    assert "if picked_role != current_role:" in app
+    assert "if selector_changed and picked_role != current_role:" in app
     assert 'st.session_state["admin_view_as_role"] = picked_role or None' in app


### PR DESCRIPTION
### Motivation
- Prevent a `StreamlitAPIException` caused by writing to a widget-backed `st.session_state` key after the corresponding widget has been instantiated in the same run. 
- Ensure the View As selector reliably returns to `Actual Super Admin` and does not immediately flip back into an impersonation role or cause reload loops.

### Description
- Added constants `VIEW_AS_RESET_PENDING_KEY = "admin_view_as_reset_pending"` and `VIEW_AS_LAST_SELECTOR_KEY = "admin_view_as_last_selector_label"` and kept `admin_view_as_role` as the canonical role source. 
- Changed the "Return to Super Admin" handler to set `st.session_state["admin_view_as_role"] = None`, set `st.session_state[VIEW_AS_RESET_PENDING_KEY] = True`, and call `st.rerun()` without directly assigning `st.session_state[VIEW_AS_SELECTOR_KEY]` in that handler. 
- Before instantiating the selectbox, consume the pending reset with `st.session_state.pop(VIEW_AS_RESET_PENDING_KEY, False)` and, if set, mirror the selector label to `VIEW_AS_ACTUAL_LABEL` so the assignment occurs before the widget is rendered. 
- Added stale-selector protection by tracking `VIEW_AS_LAST_SELECTOR_KEY` and only applying role changes when `picked_label` truly changed in the current run (guarded with `selector_changed`). 
- Updated `tests/test_admin_view_as.py` to assert the new pending-reset flow, pre-selectbox reset, stale-value guard, and that normal selection behavior still works.

### Testing
- Ran `pytest tests/test_admin_view_as.py tests/test_page_registry.py tests/test_streamlit_base_url.py tests/test_admin_roles.py tests/test_admin_auth_browser_restore.py`.
- Result: all tests passed (`36 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62fa76370832682f27e1b173504ab)