### PR TITLE
Fix Super Admin View As reset ordering and stale effective-role state

### DIFF
--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -398,6 +398,8 @@ def render(ctx):
             "admin_role_source": str(st.session_state.get("admin_role_source", "") or ""),
             "admin_view_as_role": str(st.session_state.get("admin_view_as_role", "") or ""),
             "admin_view_as_selector_label": str(st.session_state.get("admin_view_as_selector_label", "") or ""),
+            "admin_view_as_reset_pending": bool(st.session_state.get("admin_view_as_reset_pending", False)),
+            "admin_view_as_last_selector_label": str(st.session_state.get("admin_view_as_last_selector_label", "") or ""),
             "view_as_mode_active": bool(st.session_state.get("admin_role_source", "") == "super_admin_view_as"),
             "route_stability_repeat_count": int(st.session_state.get("jupr_route_stability_repeat_count", 0) or 0),
             "route_stability_warning": bool(st.session_state.get("jupr_route_stability_warning", False)),

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -369,6 +369,11 @@ def main():
         VIEW_AS_RESET_PENDING_KEY = "admin_view_as_reset_pending"
         VIEW_AS_LAST_SELECTOR_KEY = "admin_view_as_last_selector_label"
 
+        if st.session_state.pop(VIEW_AS_RESET_PENDING_KEY, False):
+            st.session_state["admin_view_as_role"] = None
+            st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL
+            st.session_state[VIEW_AS_LAST_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL
+
         supabase = get_supabase()
         if admin_authenticated:
             role_resolution = resolve_admin_role(
@@ -387,6 +392,12 @@ def main():
             st.session_state["admin_role"] = effective_role
             st.session_state["admin_role_source"] = effective_role_source
             st.session_state["admin_view_as_role"] = sanitized_view_as_role
+            if (
+                st.session_state.get("admin_view_as_role") is None
+                and st.session_state.get("admin_role_source") == "super_admin_view_as"
+            ):
+                st.session_state["admin_role"] = st.session_state.get("admin_real_role", "read_only")
+                st.session_state["admin_role_source"] = st.session_state.get("admin_real_role_source", "not_authenticated")
         else:
             st.session_state["admin_real_role"] = "read_only"
             st.session_state["admin_real_role_source"] = "not_authenticated"
@@ -428,9 +439,6 @@ def main():
                     "View as Scorekeeper": "scorekeeper",
                     "View as Read Only": "read_only",
                 }
-                if st.session_state.pop(VIEW_AS_RESET_PENDING_KEY, False):
-                    st.session_state["admin_view_as_role"] = None
-                    st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL
                 current_view_as = str(st.session_state.get("admin_view_as_role", "") or "")
                 selected_label = next((label for label, role in view_as_options.items() if role == current_view_as), VIEW_AS_ACTUAL_LABEL)
                 selector_label = st.session_state.get(VIEW_AS_SELECTOR_KEY)

--- a/tests/test_admin_view_as.py
+++ b/tests/test_admin_view_as.py
@@ -75,3 +75,37 @@ def test_selectbox_change_paths_still_switch_between_actual_and_organizer():
     assert "picked_role = view_as_options[picked_label]" in app
     assert "if selector_changed and picked_role != current_role:" in app
     assert 'st.session_state["admin_view_as_role"] = picked_role or None' in app
+
+
+def test_pending_reset_handled_before_effective_role_resolution():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    reset_idx = app.index("if st.session_state.pop(VIEW_AS_RESET_PENDING_KEY, False):")
+    resolve_idx = app.index("resolve_effective_admin_role(")
+    assert reset_idx < resolve_idx
+
+
+def test_pending_reset_clears_view_as_before_role_resolution():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    pre_resolve = app.split("resolve_effective_admin_role(", 1)[0]
+    assert 'st.session_state["admin_view_as_role"] = None' in pre_resolve
+
+
+def test_pending_reset_sets_selector_and_last_selector_before_selectbox():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    pre_selectbox = app.split("picked_label = st.sidebar.selectbox", 1)[0]
+    assert "st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL" in pre_selectbox
+    assert "st.session_state[VIEW_AS_LAST_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL" in pre_selectbox
+
+
+def test_impossible_state_guard_present_after_effective_role_resolution():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    assert 'st.session_state.get("admin_view_as_role") is None' in app
+    assert 'st.session_state.get("admin_role_source") == "super_admin_view_as"' in app
+    assert 'st.session_state["admin_role"] = st.session_state.get("admin_real_role", "read_only")' in app
+    assert 'st.session_state["admin_role_source"] = st.session_state.get("admin_real_role_source", "not_authenticated")' in app
+
+
+def test_read_only_super_admin_view_as_caption_not_possible_with_actual_super_admin_label():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    assert "Actual Super Admin" in app
+    assert "Current role: **read_only** (source: `super_admin_view_as`)." not in Path("jupr_app/ui/pages/admin_tools.py").read_text(encoding="utf-8")


### PR DESCRIPTION
### Motivation
- The sidebar selector could reset to `Actual Super Admin` while the app still resolved the effective admin role as `read_only` with source `super_admin_view_as`, leaving the UI and effective role inconsistent.  
- The root cause was the pending reset being processed after effective-role resolution, so the resolved role/state for the render remained stale.  
- The change ensures the pending reset is applied before any role resolution and guards against an impossible state where `admin_view_as_role` is `None` but `admin_role_source` remains `super_admin_view_as`.

### Description
- Introduced the `VIEW_AS_*` constants near the top of `main()` and moved pending reset handling to execute before any effective-role resolution in `streamlit_app.py`.  
- Removed the later-in-sidebar pending reset logic and instead set `admin_view_as_role`, `admin_view_as_selector_label`, and `admin_view_as_last_selector_label` during the early pending-reset processing.  
- Added a safety guard after effective-role resolution in `streamlit_app.py` to force `admin_role`/`admin_role_source` back to the real role/source if `admin_view_as_role` is `None` but `admin_role_source` is `super_admin_view_as`.  
- Kept the Return to Super Admin handler minimal and safe by only clearing `admin_view_as_role`, setting the pending reset flag, and calling `st.rerun()` without directly mutating widget-backed session state after selectbox creation.  
- Expanded the Admin Tools diagnostics snapshot in `jupr_app/ui/pages/admin_tools.py` to include `admin_view_as_reset_pending` and `admin_view_as_last_selector_label`.  
- Added and extended tests in `tests/test_admin_view_as.py` to assert reset ordering, selector behavior, pending-reset clearing, the impossible-state guard, and that the return button does not directly set the widget key after selectbox instantiation.

### Testing
- Ran `pytest tests/test_admin_view_as.py tests/test_page_registry.py tests/test_streamlit_base_url.py tests/test_admin_roles.py tests/test_admin_auth_browser_restore.py`.  
- Test run result: all tests passed (`41 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63b51d434832684ce09dfb09a30ec)