### PR TITLE
Add initial services shell for Streamlit-to-SaaS migration

### DIFF
--- a/jupr_app/services/__init__.py
+++ b/jupr_app/services/__init__.py
@@ -1,0 +1,7 @@
+"""Service layer interfaces for app, workers, and APIs."""
+
+from jupr_app.services.context import ServiceContext
+from jupr_app.services.match_service import submit_match_batch
+from jupr_app.services.result_types import ServiceResult
+
+__all__ = ["ServiceContext", "ServiceResult", "submit_match_batch"]

--- a/jupr_app/services/context.py
+++ b/jupr_app/services/context.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class ServiceContext:
+    supabase: object
+    club_id: str
+    actor_email: str | None = None
+    actor_role: str | None = None
+    source: str | None = None
+    public_base_url: str | None = None

--- a/jupr_app/services/match_service.py
+++ b/jupr_app/services/match_service.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+from jupr_app.domain.match_processing import process_matches
+from jupr_app.services.context import ServiceContext
+from jupr_app.services.result_types import ServiceResult
+
+
+def submit_match_batch(
+    ctx: ServiceContext,
+    matches: list[dict[str, Any]],
+    *,
+    name_to_id: dict[str, int],
+    df_players_all,
+    df_leagues,
+    df_meta,
+) -> ServiceResult:
+    try:
+        result = process_matches(
+            matches,
+            supabase=ctx.supabase,
+            club_id=ctx.club_id,
+            name_to_id=name_to_id,
+            df_players_all=df_players_all,
+            df_leagues=df_leagues,
+            df_meta=df_meta,
+        )
+    except Exception as exc:
+        return ServiceResult.failure(str(exc))
+
+    return ServiceResult.success(data=result)

--- a/jupr_app/services/result_types.py
+++ b/jupr_app/services/result_types.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class ServiceResult:
+    ok: bool
+    data: dict[str, Any]
+    warnings: list[str]
+    errors: list[str]
+
+    @classmethod
+    def success(
+        cls,
+        data: dict[str, Any] | None = None,
+        warnings: list[str] | None = None,
+    ) -> "ServiceResult":
+        return cls(ok=True, data=data or {}, warnings=warnings or [], errors=[])
+
+    @classmethod
+    def failure(
+        cls,
+        errors: list[str] | str,
+        data: dict[str, Any] | None = None,
+        warnings: list[str] | None = None,
+    ) -> "ServiceResult":
+        error_list = [errors] if isinstance(errors, str) else errors
+        return cls(ok=False, data=data or {}, warnings=warnings or [], errors=error_list)

--- a/tests/test_services_match_service_shell.py
+++ b/tests/test_services_match_service_shell.py
@@ -1,0 +1,60 @@
+from jupr_app.services.context import ServiceContext
+from jupr_app.services.match_service import submit_match_batch
+from jupr_app.services.result_types import ServiceResult
+
+
+def test_service_context_creation_is_worker_safe():
+    ctx = ServiceContext(supabase=object(), club_id="club-123", source="streamlit")
+
+    assert ctx.club_id == "club-123"
+    assert ctx.source == "streamlit"
+    assert ctx.actor_email is None
+
+
+def test_service_result_helpers():
+    ok = ServiceResult.success(data={"count": 1}, warnings=["heads-up"])
+    assert ok.ok is True
+    assert ok.data == {"count": 1}
+    assert ok.warnings == ["heads-up"]
+    assert ok.errors == []
+
+    failed = ServiceResult.failure("boom")
+    assert failed.ok is False
+    assert failed.data == {}
+    assert failed.warnings == []
+    assert failed.errors == ["boom"]
+
+    failed_many = ServiceResult.failure(["a", "b"], data={"step": 2}, warnings=["warn"])
+    assert failed_many.errors == ["a", "b"]
+    assert failed_many.data == {"step": 2}
+    assert failed_many.warnings == ["warn"]
+
+
+def test_submit_match_batch_wraps_process_matches(monkeypatch):
+    captured = {}
+
+    def fake_process_matches(match_list, **kwargs):
+        captured["match_list"] = match_list
+        captured["kwargs"] = kwargs
+        return {"processed": len(match_list), "club": kwargs["club_id"]}
+
+    monkeypatch.setattr("jupr_app.services.match_service.process_matches", fake_process_matches)
+
+    ctx = ServiceContext(supabase=object(), club_id="club-xyz")
+    matches = [{"t1_p1": 1, "t2_p1": 2}]
+
+    result = submit_match_batch(
+        ctx,
+        matches,
+        name_to_id={"A": 1},
+        df_players_all="players",
+        df_leagues="leagues",
+        df_meta="meta",
+    )
+
+    assert result.ok is True
+    assert result.errors == []
+    assert result.data == {"processed": 1, "club": "club-xyz"}
+    assert captured["match_list"] == matches
+    assert captured["kwargs"]["club_id"] == "club-xyz"
+    assert captured["kwargs"]["supabase"] is ctx.supabase


### PR DESCRIPTION
### Motivation
- Introduce a reusable, worker-safe `jupr_app/services/` layer to be used by Streamlit pages, background workers, and a future FastAPI surface. 
- Provide a minimal, non-behavioral scaffold that centralizes context and result envelope types for service entrypoints. 
- Ensure this layer has no `streamlit` dependency so it is safe to import in workers and server processes. 

### Description
- Add `jupr_app/services/__init__.py` to publicly export `ServiceContext`, `ServiceResult`, and `submit_match_batch`.
- Add `jupr_app/services/context.py` implementing a lightweight `ServiceContext` dataclass with `supabase`, `club_id`, and optional actor/source metadata, with no Streamlit imports.
- Add `jupr_app/services/result_types.py` implementing `ServiceResult` dataclass and `success(...)` / `failure(...)` classmethods that produce predictable envelope shapes.
- Add `jupr_app/services/match_service.py` with `submit_match_batch(...)` that forwards to the existing `jupr_app.domain.match_processing.process_matches(...)`, wraps results in `ServiceResult.success(...)`, and returns `ServiceResult.failure(...)` on exceptions.

### Testing
- Ran `pytest -q tests/test_services_match_service_shell.py` and the suite passed with `3 passed`.
- Tests verify `ServiceContext` creation without Streamlit, `ServiceResult` helpers, and that `submit_match_batch(...)` forwards `club_id`/`supabase` to `process_matches` and wraps the returned data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f640d0afa88326a319246330b52418)