### PR TITLE
Route Streamlit match submissions through match service

### DIFF
--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -34,7 +34,6 @@ from postgrest.exceptions import APIError
 
 from jupr_app.domain.ratings import calculate_hybrid_elo
 from jupr_app.domain.constants import DEFAULT_K_FACTOR
-from jupr_app.domain.match_processing import process_matches
 from jupr_app.domain.tournament_match_payload import build_tournament_match_payload
 from jupr_app.domain.gamification.ensure_badges import ensure_badges
 from jupr_app.domain.gamification.badge_audit import (
@@ -55,6 +54,7 @@ from jupr_app.domain.live_social import (
 )
 from jupr_app.ui.layout import page_shell
 from jupr_app.ui.public_links import redact_query_params
+from jupr_app.services import ServiceContext, submit_match_batch
 
 
 def _query_params_snapshot() -> dict[str, str]:
@@ -1249,15 +1249,25 @@ def _run_tournament_match_backfill(ctx):
             continue
 
         try:
-            result = process_matches(
-                [payload],
+            service_ctx = ServiceContext(
                 supabase=supabase,
                 club_id=club_id,
+                actor_email=st.session_state.get("admin_email"),
+                actor_role=st.session_state.get("admin_role"),
+                source="admin_tools",
+                public_base_url=st.session_state.get("public_base_url"),
+            )
+            service_result = submit_match_batch(
+                service_ctx,
+                [payload],
                 name_to_id=name_to_id,
                 df_players_all=df_players_all,
                 df_leagues=df_leagues,
                 df_meta=df_meta,
             )
+            if not service_result.ok:
+                raise RuntimeError("; ".join(service_result.errors) or "Unknown backfill error")
+            result = service_result.data
         except Exception as exc:
             errors += 1
             st.error(f"Backfill failed for tournament game {game.get('id')}: {exc}")

--- a/jupr_app/ui/pages/challenge_ladder_admin.py
+++ b/jupr_app/ui/pages/challenge_ladder_admin.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, Tuple
 import pandas as pd
 import streamlit as st
 from jupr_app.domain.tier_movement import compute_out_of_tier_streak
-from jupr_app.domain.match_processing import process_matches
+from jupr_app.services import ServiceContext, submit_match_batch
 
 from jupr_app.domain.challenge_ladder import (
     TIER_ORDER,
@@ -818,16 +818,26 @@ def render(ctx):
                             }
 
                             try:
-                                pm_result = process_matches(
-                                    [match_a, match_b],
+                                service_ctx = ServiceContext(
                                     supabase=ctx.supabase,
                                     club_id=str(ctx.club_id),
+                                    actor_email=getattr(ctx, "admin_email", None),
+                                    actor_role=st.session_state.get("admin_role"),
+                                    source="challenge_ladder_admin",
+                                    public_base_url=st.session_state.get("public_base_url"),
+                                )
+                                result = submit_match_batch(
+                                    service_ctx,
+                                    [match_a, match_b],
                                     name_to_id=ctx.name_to_id,
                                     df_players_all=ctx.df_players_all,
                                     df_leagues=ctx.df_leagues,
                                     df_meta=ctx.df_meta,
                                     sb_retry=sb_retry,
                                 )
+                                if not result.ok:
+                                    raise ValueError("; ".join(result.errors) or "Could not process challenge matches")
+                                pm_result = result.data
                             except Exception as e:
                                 st.error(f"Could not process challenge matches: {e}")
                                 st.stop()

--- a/jupr_app/ui/pages/jupr_live_admin.py
+++ b/jupr_app/ui/pages/jupr_live_admin.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import streamlit as st
 
-from jupr_app.domain.match_processing import process_matches
 from jupr_app.domain.live_beta_engine import clear_expired_substitutions
+from jupr_app.services import ServiceContext, submit_match_batch
 from jupr_app.ui.layout import page_shell
 from jupr_app.ui.live.shared import (
     LivePageConfig,
@@ -32,15 +32,25 @@ ADMIN_CONFIG = LivePageConfig(
 
 
 def _process_payloads(ctx, payloads: list[dict]) -> dict:
-    return process_matches(
-        payloads,
+    service_ctx = ServiceContext(
         supabase=ctx.supabase,
         club_id=str(ctx.club_id),
+        actor_email=getattr(ctx, "admin_email", None),
+        actor_role=st.session_state.get("admin_role"),
+        source="jupr_live_admin",
+        public_base_url=st.session_state.get("public_base_url"),
+    )
+    result = submit_match_batch(
+        service_ctx,
+        payloads,
         name_to_id=ctx.name_to_id,
         df_players_all=ctx.df_players_all,
         df_leagues=ctx.df_leagues,
         df_meta=ctx.df_meta,
     )
+    if not result.ok:
+        raise ValueError("; ".join(result.errors) or "Unable to save matches.")
+    return result.data
 
 
 def _save_rr_official(ctx, state: dict, event: dict) -> None:

--- a/jupr_app/ui/pages/league_manager.py
+++ b/jupr_app/ui/pages/league_manager.py
@@ -27,7 +27,7 @@ from jupr_app.domain.leagues import (
     normalize_league_status,
 )
 from jupr_app.domain.player_ratings_source import build_seed_rating_maps, current_seed_rating
-from jupr_app.domain.match_processing import process_matches
+from jupr_app.services import ServiceContext, submit_match_batch
 from jupr_app.domain.roster import (
     compress_courts,
     courts_to_roster_df,
@@ -1040,15 +1040,26 @@ def render(ctx):
                             st.warning("No scores entered (all matches 0–0).")
                             st.stop()
 
-                        res = process_matches(
-                            valid_matches,
+                        service_ctx = ServiceContext(
                             supabase=ctx.supabase,
                             club_id=str(ctx.club_id),
+                            actor_email=getattr(ctx, "admin_email", None),
+                            actor_role=st.session_state.get("admin_role"),
+                            source="league_manager",
+                            public_base_url=st.session_state.get("public_base_url"),
+                        )
+                        result = submit_match_batch(
+                            service_ctx,
+                            valid_matches,
                             name_to_id=name_to_id,
                             df_players_all=ctx.df_players_all,
                             df_leagues=ctx.df_leagues,
                             df_meta=ctx.df_meta,
                         )
+                        if not result.ok:
+                            st.error("; ".join(result.errors) or "Unable to save matches.")
+                            st.stop()
+                        res = result.data
                         st.success(f"Matches saved ({res['inserted']}). Skipped incomplete: {res['skipped_incomplete']}.")
 
                         roster_pids = st.session_state.ladder_live_roster["player_id"].astype(int).tolist()

--- a/jupr_app/ui/pages/moneyball.py
+++ b/jupr_app/ui/pages/moneyball.py
@@ -9,7 +9,7 @@ import pandas as pd
 import streamlit as st
 
 from jupr_app.domain.schedule import get_match_schedule
-from jupr_app.domain.match_processing import process_matches
+from jupr_app.services import ServiceContext, submit_match_batch
 from jupr_app.data.load import load_data
 from jupr_app.ui.layout import page_shell
 
@@ -516,15 +516,25 @@ def render(ctx):
                         }
                     )
 
-                process_matches(
-                    payload,
+                service_ctx = ServiceContext(
                     supabase=supabase,
                     club_id=club_id,
+                    actor_email=st.session_state.get("admin_email"),
+                    actor_role=st.session_state.get("admin_role"),
+                    source="moneyball",
+                    public_base_url=st.session_state.get("public_base_url"),
+                )
+                result = submit_match_batch(
+                    service_ctx,
+                    payload,
                     name_to_id=name_to_id,
                     df_players_all=df_players_all,
                     df_leagues=df_leagues,
                     df_meta=df_meta,
                 )
+                if not result.ok:
+                    st.error("; ".join(result.errors) or "Unable to save matches.")
+                    return
                 st.session_state["mb_saved"] = True
                 st.session_state["mb_event_id"] = st.session_state.get("mb_event_id") or str(uuid4())
                 load_data(supabase, club_id, match_limit=5000)

--- a/jupr_app/ui/pages/tournament_live.py
+++ b/jupr_app/ui/pages/tournament_live.py
@@ -8,7 +8,6 @@ import pandas as pd
 import streamlit as st
 
 from jupr_app.domain.event_tags import derive_default_date_tags, normalize_event_tags
-from jupr_app.domain.match_processing import process_matches
 from jupr_app.domain.player_ops import safe_add_player
 from jupr_app.domain.tournament_match_payload import build_tournament_match_payload
 from jupr_app.domain.tournament_results_import import (

--- a/jupr_app/ui/pages/tournament_ops.py
+++ b/jupr_app/ui/pages/tournament_ops.py
@@ -8,7 +8,7 @@ import pandas as pd
 import streamlit as st
 
 from jupr_app.domain.event_tags import derive_default_date_tags, normalize_event_tags
-from jupr_app.domain.match_processing import process_matches
+from jupr_app.services import ServiceContext, submit_match_batch
 from jupr_app.domain.player_ops import safe_add_player
 from jupr_app.domain.tournament_match_payload import build_tournament_match_payload
 from jupr_app.domain.tournament_results_import import (
@@ -1301,15 +1301,25 @@ def _save_games(ctx, tournament: dict[str, Any], teams_by_id: dict[str, dict], g
         except ValueError:
             continue
         match_payload = build_tournament_match_payload(tournament, game, teams_by_id, score_a=score_a, score_b=score_b)
-        process_matches(
-            [match_payload],
+        service_ctx = ServiceContext(
             supabase=supabase,
             club_id=str(ctx.club_id),
+            actor_email=getattr(ctx, "admin_email", None),
+            actor_role=st.session_state.get("admin_role"),
+            source="tournament_ops",
+            public_base_url=st.session_state.get("public_base_url"),
+        )
+        result = submit_match_batch(
+            service_ctx,
+            [match_payload],
             name_to_id=ctx.name_to_id,
             df_players_all=ctx.df_players_all,
             df_leagues=ctx.df_leagues,
             df_meta=ctx.df_meta,
         )
+        if not result.ok:
+            st.error("; ".join(result.errors) or "Could not save tournament match.")
+            continue
         supabase.table("tournament_games").update(finalize_payload).eq("id", game_id).execute()
 
         if stage == "PLAYOFF":

--- a/tests/test_ui_pages_match_submission_boundary.py
+++ b/tests/test_ui_pages_match_submission_boundary.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+UI_PAGES = Path("jupr_app/ui/pages")
+
+
+def test_ui_pages_do_not_import_process_matches_directly():
+    offenders: list[str] = []
+    for page in sorted(UI_PAGES.glob("*.py")):
+        text = page.read_text(encoding="utf-8")
+        if "from jupr_app.domain.match_processing import process_matches" in text:
+            offenders.append(str(page))
+        if "process_matches(" in text:
+            offenders.append(str(page))
+    assert not offenders, f"UI pages must use match service boundary, offenders: {offenders}"


### PR DESCRIPTION
### Motivation
- Consolidate all Streamlit UI match-write flows behind a single service boundary so pages do not call the domain `process_matches` function directly.
- Ensure UI pages provide consistent actor/context metadata when invoking match writes and centralize error/result handling in the service layer.

### Description
- Replaced direct `process_matches(...)` usages with `submit_match_batch(...)` and built a `ServiceContext` (including `supabase`, `club_id`, `actor_email`, `actor_role`, `source`, and `public_base_url`) in `jupr_app/ui/pages/jupr_live_admin.py`, `league_manager.py`, `moneyball.py`, `tournament_ops.py`, `challenge_ladder_admin.py`, and `admin_tools.py`.
- Preserved each page's existing payload construction and user-facing success/error messaging while surfacing service failures (checking `result.ok` and displaying/raising appropriate errors) and returning `result.data` for inserted/skipped counts.
- Removed the direct import of `process_matches` from `tournament_live.py` so no UI page imports the domain function directly.
- Added a static/import test `tests/test_ui_pages_match_submission_boundary.py` to assert UI pages do not import or call `process_matches` directly.

### Testing
- Added `tests/test_ui_pages_match_submission_boundary.py` which scans `jupr_app/ui/pages/*.py` for forbidden imports/calls to `process_matches` and fails if any are present.
- Ran `pytest -q tests/test_ui_pages_match_submission_boundary.py tests/test_services_match_service_shell.py` and all tests passed (`4 passed in 1.27s`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6423bc9a48326a2eac50898d100cb)