### PR TITLE
Fix match service passthrough options and validate submit_match_batch call signatures

### DIFF
--- a/jupr_app/services/match_service.py
+++ b/jupr_app/services/match_service.py
@@ -15,6 +15,10 @@ def submit_match_batch(
     df_players_all,
     df_leagues,
     df_meta,
+    sb_retry=None,
+    default_k_factor: float = 32,
+    min_win_delta_elo: float = 1.0,
+    cap_loser_gain_elo: float = 16.0,
 ) -> ServiceResult:
     try:
         result = process_matches(
@@ -25,6 +29,10 @@ def submit_match_batch(
             df_players_all=df_players_all,
             df_leagues=df_leagues,
             df_meta=df_meta,
+            sb_retry=sb_retry,
+            default_k_factor=default_k_factor,
+            min_win_delta_elo=min_win_delta_elo,
+            cap_loser_gain_elo=cap_loser_gain_elo,
         )
     except Exception as exc:
         return ServiceResult.failure(str(exc))

--- a/tests/test_services_match_service_shell.py
+++ b/tests/test_services_match_service_shell.py
@@ -42,6 +42,7 @@ def test_submit_match_batch_wraps_process_matches(monkeypatch):
 
     ctx = ServiceContext(supabase=object(), club_id="club-xyz")
     matches = [{"t1_p1": 1, "t2_p1": 2}]
+    fake_retry = object()
 
     result = submit_match_batch(
         ctx,
@@ -50,6 +51,10 @@ def test_submit_match_batch_wraps_process_matches(monkeypatch):
         df_players_all="players",
         df_leagues="leagues",
         df_meta="meta",
+        sb_retry=fake_retry,
+        default_k_factor=40,
+        min_win_delta_elo=2.5,
+        cap_loser_gain_elo=12.0,
     )
 
     assert result.ok is True
@@ -58,3 +63,7 @@ def test_submit_match_batch_wraps_process_matches(monkeypatch):
     assert captured["match_list"] == matches
     assert captured["kwargs"]["club_id"] == "club-xyz"
     assert captured["kwargs"]["supabase"] is ctx.supabase
+    assert captured["kwargs"]["sb_retry"] is fake_retry
+    assert captured["kwargs"]["default_k_factor"] == 40
+    assert captured["kwargs"]["min_win_delta_elo"] == 2.5
+    assert captured["kwargs"]["cap_loser_gain_elo"] == 12.0

--- a/tests/test_ui_pages_match_submission_boundary.py
+++ b/tests/test_ui_pages_match_submission_boundary.py
@@ -1,4 +1,8 @@
+import ast
+import inspect
 from pathlib import Path
+
+from jupr_app.services.match_service import submit_match_batch
 
 UI_PAGES = Path("jupr_app/ui/pages")
 
@@ -12,3 +16,37 @@ def test_ui_pages_do_not_import_process_matches_directly():
         if "process_matches(" in text:
             offenders.append(str(page))
     assert not offenders, f"UI pages must use match service boundary, offenders: {offenders}"
+
+
+def test_ui_submit_match_batch_kwargs_match_service_signature():
+    accepted_kwargs = {
+        name
+        for name, parameter in inspect.signature(submit_match_batch).parameters.items()
+        if parameter.kind in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    }
+    accepted_kwargs.discard("ctx")
+    accepted_kwargs.discard("matches")
+
+    unexpected_by_file: dict[str, set[str]] = {}
+
+    for page in sorted(UI_PAGES.glob("*.py")):
+        tree = ast.parse(page.read_text(encoding="utf-8"), filename=str(page))
+        used_kwargs: set[str] = set()
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Name) or node.func.id != "submit_match_batch":
+                continue
+            for keyword in node.keywords:
+                if keyword.arg is not None:
+                    used_kwargs.add(keyword.arg)
+
+        unknown = used_kwargs - accepted_kwargs
+        if unknown:
+            unexpected_by_file[str(page)] = unknown
+
+    assert not unexpected_by_file, (
+        "UI submit_match_batch() keyword args must match service signature; "
+        f"found mismatches: {unexpected_by_file}"
+    )


### PR DESCRIPTION
### Motivation
- UI pages routed submissions through the match service but some pages pass passthrough kwargs (e.g. `sb_retry`) that the service signature did not accept, which can raise a `TypeError` at runtime.
- Restore compatibility with existing UI call patterns and add a regression test to prevent future signature drift between UI pages and the service boundary.

### Description
- Extend `submit_match_batch()` signature in `jupr_app/services/match_service.py` to accept `sb_retry=None`, `default_k_factor: float = 32`, `min_win_delta_elo: float = 1.0`, and `cap_loser_gain_elo: float = 16.0` and forward them to `process_matches()`.
- Preserve existing `ServiceResult.success`/`ServiceResult.failure` behavior and do not modify `process_matches()` internals or rating math.
- Update `tests/test_services_match_service_shell.py` to verify forwarded values (including a `fake_retry`) are passed through to the monkeypatched `process_matches()`.
- Add an AST/signature boundary test in `tests/test_ui_pages_match_submission_boundary.py` that scans `jupr_app/ui/pages/*.py` for `submit_match_batch()` calls and asserts UI keyword args are accepted by the service signature while keeping the existing guard that prevents direct `process_matches()` usage from UI pages.

### Testing
- Ran `pytest -q tests/test_services_match_service_shell.py tests/test_ui_pages_match_submission_boundary.py` and all tests passed (5 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6442f2d0c832695189ef1d0472dc7)