### PR TITLE
Make notification modules worker-safe by removing Streamlit deps

### DIFF
--- a/jupr_app/config.py
+++ b/jupr_app/config.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SMTPConfig:
+    host: str
+    port: int
+    username: str
+    password: str
+    from_email: str
+    from_name: str
+    reply_to: str
+    use_tls: bool
+
+
+def get_env_or_default(name: str, default: str = "") -> str:
+    value = str(os.getenv(name, "")).strip()
+    if value:
+        return value
+    return str(default).strip()
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = get_env_or_default(name).lower()
+    if not value:
+        return default
+    return value in {"1", "true", "yes", "y", "on"}
+
+
+def get_public_base_url(default: str = "http://localhost:8501") -> str:
+    for env_name in ("JUPR_PUBLIC_BASE_URL", "PUBLIC_BASE_URL"):
+        value = get_env_or_default(env_name)
+        if value:
+            return value.rstrip("/")
+    return str(default).strip().rstrip("/")
+
+
+def get_smtp_config() -> SMTPConfig:
+    host = get_env_or_default("SMTP_HOST")
+    port_raw = get_env_or_default("SMTP_PORT")
+    username = get_env_or_default("SMTP_USERNAME")
+    password = get_env_or_default("SMTP_PASSWORD")
+    from_email = get_env_or_default("SMTP_FROM_EMAIL")
+    from_name = get_env_or_default("SMTP_FROM_NAME", "JUPR Notifications")
+    reply_to = get_env_or_default("SMTP_REPLY_TO", "joe@juprleagues.com")
+    use_tls = _env_bool("SMTP_USE_TLS", default=True)
+
+    missing = [
+        key
+        for key, value in [
+            ("SMTP_HOST", host),
+            ("SMTP_PORT", port_raw),
+            ("SMTP_USERNAME", username),
+            ("SMTP_PASSWORD", password),
+            ("SMTP_FROM_EMAIL", from_email),
+        ]
+        if not value
+    ]
+    if missing:
+        raise ValueError(f"Missing SMTP configuration: {', '.join(missing)}")
+
+    try:
+        port = int(port_raw)
+    except Exception as exc:
+        raise ValueError("SMTP_PORT must be an integer") from exc
+
+    return SMTPConfig(
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        from_email=from_email,
+        from_name=from_name,
+        reply_to=reply_to,
+        use_tls=use_tls,
+    )

--- a/jupr_app/domain/notifications/player_update_sender.py
+++ b/jupr_app/domain/notifications/player_update_sender.py
@@ -4,8 +4,6 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import urlencode
 
-import streamlit as st
-
 from jupr_app.domain.notifications.player_profile_update_repo import (
     DEFAULT_PREFERENCES,
     REQUEST_STATUS_ACTIVE,
@@ -25,6 +23,7 @@ from jupr_app.domain.notifications.player_update_email_template import (
     build_player_update_email_subject,
     build_player_update_email_text,
 )
+from jupr_app.config import get_public_base_url
 from jupr_app.domain.notifications.smtp_mailer import send_email_with_inline_chart
 from jupr_app.domain.recaps.player_weekly_digest import compute_player_weekly_digest
 
@@ -68,24 +67,15 @@ def _safe_digest_for_week(
         return None
 
 
-def _public_base_url() -> str:
-    base = str(st.session_state.get("base_url", "") or "").strip().rstrip("/")
-    if base:
-        return base
-    try:
-        base = str(st.secrets.get("PUBLIC_BASE_URL", "") or "").strip().rstrip("/")
-        if base:
-            return base
-    except Exception:
-        pass
-    return "http://localhost:8501"
+def _normalize_public_base_url(public_base_url: str | None = None) -> str:
+    return str(public_base_url or get_public_base_url()).strip().rstrip("/")
 
 
-def _build_public_players_url(params: dict[str, str]) -> str:
+def _build_public_players_url(params: dict[str, str], *, public_base_url: str | None = None) -> str:
     query = {"page": "players", "public": "1"}
     for key, value in (params or {}).items():
         query[str(key)] = str(value)
-    return f"{_public_base_url()}/?{urlencode(query)}"
+    return f"{_normalize_public_base_url(public_base_url)}/?{urlencode(query)}"
 
 
 def _merge_links_for_send(
@@ -94,15 +84,16 @@ def _merge_links_for_send(
     player_id: int,
     subscription_id: str,
     unsubscribe_token: str | None = None,
+    public_base_url: str | None = None,
 ) -> dict[str, Any]:
     links = dict((digest or {}).get("links") or {})
-    links["player_profile"] = _build_public_players_url({"pid": str(int(player_id))})
+    links["player_profile"] = _build_public_players_url({"pid": str(int(player_id))}, public_base_url=public_base_url)
     unsubscribe_params = {"page": "email_preferences"}
     if str(unsubscribe_token or "").strip():
         unsubscribe_params["token"] = str(unsubscribe_token).strip()
     else:
         unsubscribe_params["sid"] = str(subscription_id)
-    links["unsubscribe"] = f"{_public_base_url()}/?{urlencode(unsubscribe_params)}"
+    links["unsubscribe"] = f"{_normalize_public_base_url(public_base_url)}/?{urlencode(unsubscribe_params)}"
     merged = dict(digest or {})
     merged["links"] = links
     return merged
@@ -393,7 +384,7 @@ def queue_saved_digest_rows(ctx, *, digest_rows: list[dict[str, Any]]) -> dict[s
     }
 
 
-def send_pending_player_update_emails(ctx, *, limit: int = 100) -> dict[str, int]:
+def send_pending_player_update_emails(ctx, *, limit: int = 100, public_base_url: str | None = None) -> dict[str, int]:
     supabase = ctx.supabase
     club_id = str(ctx.club_id)
     pending_rows = list_outbox_rows(supabase, club_id, status="pending", limit=max(1, int(limit)))
@@ -444,6 +435,7 @@ def send_pending_player_update_emails(ctx, *, limit: int = 100) -> dict[str, int
                     supabase,
                     str(subscription.get("id") or ""),
                 ),
+                public_base_url=public_base_url,
             )
 
             if _is_send_only_if_changed_and_unchanged(subscription, digest):
@@ -510,15 +502,14 @@ def send_test_player_update_email(
     end_date: date,
     player_id: int | None = None,
     to_email: str | None = None,
+    public_base_url: str | None = None,
 ) -> dict[str, str]:
     supabase = ctx.supabase
     club_id = str(ctx.club_id)
     admin_email = str(
         to_email
         or getattr(ctx, "admin_email", "")
-        or st.session_state.get("admin_email", "")
         or getattr(ctx, "user_email", "")
-        or st.session_state.get("user_email", "")
     ).strip()
     if not admin_email:
         raise ValueError("No admin email available for test send.")
@@ -544,6 +535,7 @@ def send_test_player_update_email(
         player_id=int(selected_player_id),
         subscription_id=selected_subscription_id,
         unsubscribe_token=ensure_unsubscribe_token(supabase, selected_subscription_id),
+        public_base_url=public_base_url,
     )
 
     chart_cid = "player-digest-chart"

--- a/jupr_app/domain/notifications/player_update_sender.py
+++ b/jupr_app/domain/notifications/player_update_sender.py
@@ -23,7 +23,7 @@ from jupr_app.domain.notifications.player_update_email_template import (
     build_player_update_email_subject,
     build_player_update_email_text,
 )
-from jupr_app.config import get_public_base_url
+from jupr_app.config import SMTPConfig, get_public_base_url
 from jupr_app.domain.notifications.smtp_mailer import send_email_with_inline_chart
 from jupr_app.domain.recaps.player_weekly_digest import compute_player_weekly_digest
 
@@ -384,7 +384,13 @@ def queue_saved_digest_rows(ctx, *, digest_rows: list[dict[str, Any]]) -> dict[s
     }
 
 
-def send_pending_player_update_emails(ctx, *, limit: int = 100, public_base_url: str | None = None) -> dict[str, int]:
+def send_pending_player_update_emails(
+    ctx,
+    *,
+    limit: int = 100,
+    public_base_url: str | None = None,
+    smtp_config: SMTPConfig | None = None,
+) -> dict[str, int]:
     supabase = ctx.supabase
     club_id = str(ctx.club_id)
     pending_rows = list_outbox_rows(supabase, club_id, status="pending", limit=max(1, int(limit)))
@@ -462,6 +468,7 @@ def send_pending_player_update_emails(ctx, *, limit: int = 100, public_base_url:
                 chart_png_bytes=chart_png,
                 chart_cid=chart_cid if chart_png else None,
                 unsubscribe_url=str(((digest.get("links") or {}).get("unsubscribe")) or "").strip() or None,
+                smtp_config=smtp_config,
             )
 
             update_outbox_status(
@@ -503,6 +510,7 @@ def send_test_player_update_email(
     player_id: int | None = None,
     to_email: str | None = None,
     public_base_url: str | None = None,
+    smtp_config: SMTPConfig | None = None,
 ) -> dict[str, str]:
     supabase = ctx.supabase
     club_id = str(ctx.club_id)
@@ -553,5 +561,6 @@ def send_test_player_update_email(
         chart_png_bytes=chart_png,
         chart_cid=chart_cid if chart_png else None,
         unsubscribe_url=unsubscribe_url,
+        smtp_config=smtp_config,
     )
     return {"to_email": admin_email, "provider_message_id": provider_message_id}

--- a/jupr_app/domain/notifications/smtp_mailer.py
+++ b/jupr_app/domain/notifications/smtp_mailer.py
@@ -5,8 +5,14 @@ from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
+from jupr_app.config import SMTPConfig, get_env_or_default, get_smtp_config
 
-from jupr_app.config import get_env_or_default, get_smtp_config
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = get_env_or_default(name).lower()
+    if not value:
+        return default
+    return value in {"1", "true", "yes", "y", "on"}
 
 
 def get_smtp_config_status() -> dict:
@@ -18,25 +24,52 @@ def get_smtp_config_status() -> dict:
     from_email = get_env_or_default("SMTP_FROM_EMAIL")
     from_name = get_env_or_default("SMTP_FROM_NAME", "JUPR Notifications")
     reply_to = get_env_or_default("SMTP_REPLY_TO", "joe@juprleagues.com")
+    use_tls = _env_bool("SMTP_USE_TLS", default=True)
 
-    for key, value in (("SMTP_HOST", host),("SMTP_PORT", port_raw),("SMTP_USERNAME", username),("SMTP_PASSWORD", password),("SMTP_FROM_EMAIL", from_email)):
+    for key, value in (
+        ("SMTP_HOST", host),
+        ("SMTP_PORT", port_raw),
+        ("SMTP_USERNAME", username),
+        ("SMTP_PASSWORD", password),
+        ("SMTP_FROM_EMAIL", from_email),
+    ):
         if not value:
             missing.append(key)
 
-    port=None
-    port_error=None
+    port: int | None = None
+    port_error: str | None = None
     if port_raw:
         try:
-            port=int(port_raw)
+            port = int(port_raw)
         except Exception:
             port_error = "SMTP_PORT must be an integer"
 
-    return {"ok": len(missing)==0 and port_error is None, "missing": missing, "host": host, "port": port, "from_email": from_email, "from_name": from_name, "reply_to": reply_to, "reply_to_configured": bool(reply_to), "use_tls": get_smtp_config().use_tls if len(missing)==0 and port_error is None else True, "port_error": port_error}
+    return {
+        "ok": len(missing) == 0 and port_error is None,
+        "missing": missing,
+        "host": host,
+        "port": port,
+        "from_email": from_email,
+        "from_name": from_name,
+        "reply_to": reply_to,
+        "reply_to_configured": bool(reply_to),
+        "use_tls": use_tls,
+        "port_error": port_error,
+    }
 
 
-def _smtp_config_from_env() -> dict:
-    cfg = get_smtp_config()
-    return {"host": cfg.host, "port": cfg.port, "username": cfg.username, "password": cfg.password, "from_email": cfg.from_email, "from_name": cfg.from_name, "reply_to": cfg.reply_to, "use_tls": cfg.use_tls}
+def _smtp_config_dict(smtp_config: SMTPConfig | None = None) -> dict:
+    cfg = smtp_config or get_smtp_config()
+    return {
+        "host": cfg.host,
+        "port": cfg.port,
+        "username": cfg.username,
+        "password": cfg.password,
+        "from_email": cfg.from_email,
+        "from_name": cfg.from_name,
+        "reply_to": cfg.reply_to,
+        "use_tls": cfg.use_tls,
+    }
 
 
 def send_email_with_inline_chart(
@@ -48,8 +81,9 @@ def send_email_with_inline_chart(
     chart_png_bytes: bytes | None = None,
     chart_cid: str | None = None,
     unsubscribe_url: str | None = None,
+    smtp_config: SMTPConfig | None = None,
 ) -> str:
-    cfg = _smtp_config_from_env()
+    cfg = _smtp_config_dict(smtp_config)
 
     msg = MIMEMultipart("related")
     msg["Subject"] = str(subject)

--- a/jupr_app/domain/notifications/smtp_mailer.py
+++ b/jupr_app/domain/notifications/smtp_mailer.py
@@ -1,112 +1,42 @@
 from __future__ import annotations
 
-import os
 import smtplib
 from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
-import streamlit as st
 
-
-def _secret_or_env(name: str, default: str = "") -> str:
-    env_val = str(os.getenv(name, "")).strip()
-    if env_val:
-        return env_val
-
-    try:
-        secret_val = st.secrets.get(name, default)
-    except Exception:
-        return str(default).strip()
-
-    if secret_val is None:
-        return str(default).strip()
-    return str(secret_val).strip()
-
-
-def _env_bool(name: str, default: bool = False) -> bool:
-    val = _secret_or_env(name).lower()
-    if not val:
-        return default
-    return val in {"1", "true", "yes", "y", "on"}
-
-
-def _read_smtp_config_raw() -> dict:
-    host = _secret_or_env("SMTP_HOST")
-    port_raw = _secret_or_env("SMTP_PORT")
-    username = _secret_or_env("SMTP_USERNAME")
-    password = _secret_or_env("SMTP_PASSWORD")
-    from_email = _secret_or_env("SMTP_FROM_EMAIL")
-    from_name = _secret_or_env("SMTP_FROM_NAME") or "JUPR Notifications"
-    reply_to = _secret_or_env("SMTP_REPLY_TO") or "joe@juprleagues.com"
-    use_tls = _env_bool("SMTP_USE_TLS", default=True)
-
-    return {
-        "host": host,
-        "port_raw": port_raw,
-        "username": username,
-        "password": password,
-        "from_email": from_email,
-        "from_name": from_name,
-        "reply_to": reply_to,
-        "use_tls": use_tls,
-    }
+from jupr_app.config import get_env_or_default, get_smtp_config
 
 
 def get_smtp_config_status() -> dict:
-    raw = _read_smtp_config_raw()
-    missing = [
-        key
-        for key, value in [
-            ("SMTP_HOST", raw.get("host")),
-            ("SMTP_PORT", raw.get("port_raw")),
-            ("SMTP_USERNAME", raw.get("username")),
-            ("SMTP_PASSWORD", raw.get("password")),
-            ("SMTP_FROM_EMAIL", raw.get("from_email")),
-        ]
-        if not value
-    ]
+    missing: list[str] = []
+    host = get_env_or_default("SMTP_HOST")
+    port_raw = get_env_or_default("SMTP_PORT")
+    username = get_env_or_default("SMTP_USERNAME")
+    password = get_env_or_default("SMTP_PASSWORD")
+    from_email = get_env_or_default("SMTP_FROM_EMAIL")
+    from_name = get_env_or_default("SMTP_FROM_NAME", "JUPR Notifications")
+    reply_to = get_env_or_default("SMTP_REPLY_TO", "joe@juprleagues.com")
 
-    port: int | None = None
-    port_error: str | None = None
-    if raw.get("port_raw"):
+    for key, value in (("SMTP_HOST", host),("SMTP_PORT", port_raw),("SMTP_USERNAME", username),("SMTP_PASSWORD", password),("SMTP_FROM_EMAIL", from_email)):
+        if not value:
+            missing.append(key)
+
+    port=None
+    port_error=None
+    if port_raw:
         try:
-            port = int(raw["port_raw"])
+            port=int(port_raw)
         except Exception:
             port_error = "SMTP_PORT must be an integer"
 
-    return {
-        "ok": len(missing) == 0 and port_error is None,
-        "missing": missing,
-        "host": raw.get("host"),
-        "port": port,
-        "from_email": raw.get("from_email"),
-        "from_name": raw.get("from_name"),
-        "reply_to": raw.get("reply_to"),
-        "reply_to_configured": bool(raw.get("reply_to")),
-        "use_tls": bool(raw.get("use_tls", True)),
-        "port_error": port_error,
-    }
+    return {"ok": len(missing)==0 and port_error is None, "missing": missing, "host": host, "port": port, "from_email": from_email, "from_name": from_name, "reply_to": reply_to, "reply_to_configured": bool(reply_to), "use_tls": get_smtp_config().use_tls if len(missing)==0 and port_error is None else True, "port_error": port_error}
 
 
 def _smtp_config_from_env() -> dict:
-    status = get_smtp_config_status()
-    if status["missing"]:
-        raise ValueError(f"Missing SMTP configuration: {', '.join(status['missing'])}")
-    if status.get("port_error"):
-        raise ValueError(str(status["port_error"]))
-
-    raw = _read_smtp_config_raw()
-    return {
-        "host": status["host"],
-        "port": int(status["port"]),
-        "username": raw["username"],
-        "password": raw["password"],
-        "from_email": status["from_email"],
-        "from_name": status["from_name"],
-        "reply_to": raw["reply_to"],
-        "use_tls": status["use_tls"],
-    }
+    cfg = get_smtp_config()
+    return {"host": cfg.host, "port": cfg.port, "username": cfg.username, "password": cfg.password, "from_email": cfg.from_email, "from_name": cfg.from_name, "reply_to": cfg.reply_to, "use_tls": cfg.use_tls}
 
 
 def send_email_with_inline_chart(

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -5,6 +5,7 @@ from datetime import date, timedelta
 import pandas as pd
 import streamlit as st
 
+from jupr_app.config import get_public_base_url
 from jupr_app.domain.notifications.player_profile_update_repo import (
     REQUEST_STATUS_UNSUBSCRIBED,
     approve_request,
@@ -179,6 +180,12 @@ def _render_digest_preview(digest: dict) -> None:
         else:
             st.caption("No chart points available in selected date range.")
 
+
+
+
+def _resolve_public_base_url() -> str:
+    base = str(st.session_state.get("base_url", "") or "").strip().rstrip("/")
+    return base or get_public_base_url()
 
 def _friendly_error(exc: Exception) -> str:
     text = str(exc or "").strip()
@@ -606,7 +613,7 @@ def render(ctx) -> None:
         with c1:
             if st.button("Send Pending", use_container_width=True):
                 try:
-                    result = send_pending_player_update_emails(ctx, limit=500)
+                    result = send_pending_player_update_emails(ctx, limit=500, public_base_url=_resolve_public_base_url())
                     st.success(
                         f"Attempted: {result['attempted']} · Sent: {result['sent']} · "
                         f"Skipped: {result['skipped']} · Errors: {result['errors']}"

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 import pandas as pd
 import streamlit as st
 
-from jupr_app.config import get_public_base_url
+from jupr_app.config import SMTPConfig, get_env_or_default, get_public_base_url
 from jupr_app.domain.notifications.player_profile_update_repo import (
     REQUEST_STATUS_UNSUBSCRIBED,
     approve_request,
@@ -182,6 +182,53 @@ def _render_digest_preview(digest: dict) -> None:
 
 
 
+
+
+
+def _ui_env_or_secret(name: str, default: str = "") -> str:
+    value = get_env_or_default(name).strip()
+    if value:
+        return value
+    try:
+        secret_val = st.secrets.get(name, default)
+    except Exception:
+        return str(default).strip()
+    if secret_val is None:
+        return str(default).strip()
+    return str(secret_val).strip()
+
+
+def _ui_env_or_secret_bool(name: str, default: bool = False) -> bool:
+    value = _ui_env_or_secret(name).lower()
+    if not value:
+        return default
+    return value in {"1", "true", "yes", "y", "on"}
+
+
+def _resolve_smtp_config_from_ui() -> SMTPConfig | None:
+    host = _ui_env_or_secret("SMTP_HOST")
+    port_raw = _ui_env_or_secret("SMTP_PORT")
+    username = _ui_env_or_secret("SMTP_USERNAME")
+    password = _ui_env_or_secret("SMTP_PASSWORD")
+    from_email = _ui_env_or_secret("SMTP_FROM_EMAIL")
+    if not all([host, port_raw, username, password, from_email]):
+        return None
+
+    try:
+        port = int(port_raw)
+    except Exception:
+        return None
+
+    return SMTPConfig(
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        from_email=from_email,
+        from_name=_ui_env_or_secret("SMTP_FROM_NAME", "JUPR Notifications"),
+        reply_to=_ui_env_or_secret("SMTP_REPLY_TO", "joe@juprleagues.com"),
+        use_tls=_ui_env_or_secret_bool("SMTP_USE_TLS", default=True),
+    )
 
 def _resolve_public_base_url() -> str:
     base = str(st.session_state.get("base_url", "") or "").strip().rstrip("/")
@@ -613,7 +660,12 @@ def render(ctx) -> None:
         with c1:
             if st.button("Send Pending", use_container_width=True):
                 try:
-                    result = send_pending_player_update_emails(ctx, limit=500, public_base_url=_resolve_public_base_url())
+                    result = send_pending_player_update_emails(
+                        ctx,
+                        limit=500,
+                        public_base_url=_resolve_public_base_url(),
+                        smtp_config=_resolve_smtp_config_from_ui(),
+                    )
                     st.success(
                         f"Attempted: {result['attempted']} · Sent: {result['sent']} · "
                         f"Skipped: {result['skipped']} · Errors: {result['errors']}"

--- a/tests/test_notification_config.py
+++ b/tests/test_notification_config.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from jupr_app.config import get_public_base_url, get_smtp_config
+from jupr_app.config import SMTPConfig, get_public_base_url, get_smtp_config
 
 
 def test_smtp_mailer_imports_without_streamlit(monkeypatch):
@@ -29,3 +29,67 @@ def test_get_public_base_url_from_env(monkeypatch):
     monkeypatch.setenv("JUPR_PUBLIC_BASE_URL", "https://example.org")
     monkeypatch.setenv("PUBLIC_BASE_URL", "https://fallback.example.org")
     assert get_public_base_url() == "https://example.org"
+
+
+def test_player_update_sender_imports_without_streamlit(monkeypatch):
+    monkeypatch.setitem(sys.modules, "streamlit", None)
+    module = importlib.import_module("jupr_app.domain.notifications.player_update_sender")
+    assert module is not None
+
+
+def test_send_email_uses_provided_smtp_config(monkeypatch):
+    from jupr_app.domain.notifications import smtp_mailer
+
+    class FakeSMTP:
+        def __init__(self, host, port, timeout=30):
+            self.host = host
+            self.port = port
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def ehlo(self):
+            return None
+
+        def starttls(self):
+            return None
+
+        def login(self, username, password):
+            self.username = username
+            self.password = password
+
+        def sendmail(self, from_email, to_emails, payload):
+            self.from_email = from_email
+            self.to_emails = to_emails
+            self.payload = payload
+
+    monkeypatch.setattr(smtp_mailer.smtplib, "SMTP", FakeSMTP)
+
+    def _raise_if_called():
+        raise AssertionError("get_smtp_config should not be called when smtp_config is provided")
+
+    monkeypatch.setattr(smtp_mailer, "get_smtp_config", _raise_if_called)
+
+    cfg = SMTPConfig(
+        host="smtp.example.org",
+        port=2525,
+        username="user",
+        password="pass",
+        from_email="noreply@example.org",
+        from_name="JUPR Notifications",
+        reply_to="reply@example.org",
+        use_tls=True,
+    )
+
+    provider = smtp_mailer.send_email_with_inline_chart(
+        to_email="to@example.org",
+        subject="Subject",
+        html_body="<p>hi</p>",
+        text_body="hi",
+        smtp_config=cfg,
+    )
+    assert provider == "smtp"

--- a/tests/test_notification_config.py
+++ b/tests/test_notification_config.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+from jupr_app.config import get_public_base_url, get_smtp_config
+
+
+def test_smtp_mailer_imports_without_streamlit(monkeypatch):
+    monkeypatch.setitem(sys.modules, "streamlit", None)
+    module = importlib.import_module("jupr_app.domain.notifications.smtp_mailer")
+    assert module is not None
+
+
+def test_get_smtp_config_missing_is_clear(monkeypatch):
+    for key in ["SMTP_HOST", "SMTP_PORT", "SMTP_USERNAME", "SMTP_PASSWORD", "SMTP_FROM_EMAIL"]:
+        monkeypatch.delenv(key, raising=False)
+
+    with pytest.raises(ValueError) as exc:
+        get_smtp_config()
+
+    assert "Missing SMTP configuration" in str(exc.value)
+    assert "SMTP_HOST" in str(exc.value)
+
+
+def test_get_public_base_url_from_env(monkeypatch):
+    monkeypatch.setenv("JUPR_PUBLIC_BASE_URL", "https://example.org")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://fallback.example.org")
+    assert get_public_base_url() == "https://example.org"


### PR DESCRIPTION
### Motivation

- Make notification sending code safe to run in background workers by removing direct `streamlit` imports from domain notification modules. 
- Centralize environment/config resolution into a Streamlit-free module so domain code can read settings without UI runtime. 
- Preserve existing SMTP-based sending path and existing email content/links while enabling non-UI execution.

### Description

- Add `jupr_app/config.py` with `get_env_or_default`, `get_public_base_url`, and typed `get_smtp_config()` (`SMTPConfig` dataclass) supporting the existing SMTP env names and `JUPR_PUBLIC_BASE_URL`/`PUBLIC_BASE_URL` lookups. 
- Refactor `jupr_app/domain/notifications/smtp_mailer.py` to remove `streamlit` usage and read SMTP configuration via `jupr_app.config.get_smtp_config()` while preserving the SMTP env var names and SMTP send behavior. 
- Refactor `jupr_app/domain/notifications/player_update_sender.py` to remove `streamlit` imports and replace implicit base-URL resolution with explicit `public_base_url` parameters and a `get_public_base_url` fallback, keeping link generation and email templates unchanged. 
- Update `jupr_app/ui/pages/player_updates_admin.py` to resolve the public base URL in the UI (using `st.session_state` or `get_public_base_url()`) and pass it into sender calls, and add `tests/test_notification_config.py` to validate import/no-Streamlit, missing-SMTP error messaging, and public URL resolution from env.

### Testing

- Ran `python -m py_compile` on the modified modules to ensure syntax correctness and it completed successfully. 
- Ran `pytest -q tests/test_notification_config.py` and the three tests passed (`3 passed`). 
- Tests verify that `smtp_mailer` imports without `streamlit`, missing SMTP config raises a clear `ValueError`, and `get_public_base_url()` prefers `JUPR_PUBLIC_BASE_URL` when present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64aca065483269ad8271f15dbf42d)