### PR TITLE
Add standalone badge queue worker CLI entrypoint

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -117,3 +117,23 @@ Never commit:
 - Production DB dumps
 
 If any secret is exposed, rotate it immediately and remove it from history where possible.
+
+## 12) Badge queue worker CLI
+
+You can process badge evaluation queue jobs outside Streamlit Admin Tools with a worker/scheduler process.
+
+Required environment variables:
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY` (preferred)
+- `SUPABASE_ANON_KEY` (fallback only when service role key is unavailable)
+
+Example:
+
+```bash
+python -m jupr_app.workers.badge_queue_worker \
+  --club-id tres_palapas \
+  --max-total-jobs 500 \
+  --max-wall-clock-seconds 90
+```
+
+The command prints a JSON summary and exits nonzero when configuration is missing or queue errors hit the configured safety threshold.

--- a/jupr_app/workers/__init__.py
+++ b/jupr_app/workers/__init__.py
@@ -1,0 +1,5 @@
+"""Background worker entrypoints for JUPr."""
+
+from jupr_app.workers.badge_queue_worker import run_badge_queue_worker
+
+__all__ = ["run_badge_queue_worker"]

--- a/jupr_app/workers/badge_queue_worker.py
+++ b/jupr_app/workers/badge_queue_worker.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+
+from jupr_app.data.client import make_supabase
+from jupr_app.domain.gamification.badge_worker import process_badge_eval_queue_until_empty
+
+
+def _resolve_supabase_config() -> tuple[str, str, str]:
+    url = str(os.getenv("SUPABASE_URL") or "").strip()
+    service_role = str(os.getenv("SUPABASE_SERVICE_ROLE_KEY") or "").strip()
+    anon = str(os.getenv("SUPABASE_ANON_KEY") or "").strip()
+    key = service_role or anon
+    key_source = "SUPABASE_SERVICE_ROLE_KEY" if service_role else "SUPABASE_ANON_KEY"
+    if not url:
+        raise ValueError("Missing required environment variable: SUPABASE_URL")
+    if not key:
+        raise ValueError(
+            "Missing Supabase key. Set SUPABASE_SERVICE_ROLE_KEY (preferred) or SUPABASE_ANON_KEY."
+        )
+    return url, key, key_source
+
+
+def run_badge_queue_worker(
+    club_id: str,
+    *,
+    max_total_jobs: int = 500,
+    batch_max_jobs: int = 10,
+    per_batch_time_budget_seconds: float = 2.0,
+    max_wall_clock_seconds: float = 90.0,
+    max_errors: int = 10,
+) -> dict[str, Any]:
+    url, key, key_source = _resolve_supabase_config()
+    supabase = make_supabase(url, key)
+    worker_summary = process_badge_eval_queue_until_empty(
+        supabase,
+        club_id,
+        max_total_jobs=max_total_jobs,
+        batch_max_jobs=batch_max_jobs,
+        per_batch_time_budget_seconds=per_batch_time_budget_seconds,
+        max_wall_clock_seconds=max_wall_clock_seconds,
+        max_errors=max_errors,
+    )
+    return {
+        "ok": True,
+        "club_id": club_id,
+        "key_source": key_source,
+        **worker_summary,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Process badge evaluation queue jobs.")
+    parser.add_argument("--club-id", required=True, help="Club ID for queue jobs.")
+    parser.add_argument("--max-total-jobs", type=int, default=500)
+    parser.add_argument("--batch-max-jobs", type=int, default=10)
+    parser.add_argument("--per-batch-time-budget-seconds", type=float, default=2.0)
+    parser.add_argument("--max-wall-clock-seconds", type=float, default=90.0)
+    parser.add_argument("--max-errors", type=int, default=10)
+    args = parser.parse_args(argv)
+
+    try:
+        summary = run_badge_queue_worker(
+            args.club_id,
+            max_total_jobs=args.max_total_jobs,
+            batch_max_jobs=args.batch_max_jobs,
+            per_batch_time_budget_seconds=args.per_batch_time_budget_seconds,
+            max_wall_clock_seconds=args.max_wall_clock_seconds,
+            max_errors=args.max_errors,
+        )
+    except ValueError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True))
+        return 2
+    except Exception as exc:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": f"{type(exc).__name__}: {exc}"}, sort_keys=True))
+        return 1
+
+    if int(summary.get("total_errored") or 0) >= int(args.max_errors):
+        summary["ok"] = False
+        print(json.dumps(summary, sort_keys=True, default=str))
+        return 1
+
+    print(json.dumps(summary, sort_keys=True, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_badge_worker_cli.py
+++ b/tests/test_badge_worker_cli.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from jupr_app.workers.badge_queue_worker import main, run_badge_queue_worker
+
+
+def test_run_badge_queue_worker_passes_arguments(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service-role")
+
+    captured = {}
+
+    def fake_make_supabase(url, key):
+        captured["url"] = url
+        captured["key"] = key
+        return "fake-client"
+
+    def fake_process(supabase, club_id, **kwargs):
+        captured["supabase"] = supabase
+        captured["club_id"] = club_id
+        captured["kwargs"] = kwargs
+        return {"total_processed": 3, "total_errored": 0, "loops": 1, "stopped_reason": "empty"}
+
+    monkeypatch.setattr("jupr_app.workers.badge_queue_worker.make_supabase", fake_make_supabase)
+    monkeypatch.setattr(
+        "jupr_app.workers.badge_queue_worker.process_badge_eval_queue_until_empty", fake_process
+    )
+
+    summary = run_badge_queue_worker(
+        "tres_palapas",
+        max_total_jobs=500,
+        batch_max_jobs=11,
+        per_batch_time_budget_seconds=1.5,
+        max_wall_clock_seconds=90,
+        max_errors=7,
+    )
+
+    assert captured["url"] == "https://example.supabase.co"
+    assert captured["key"] == "service-role"
+    assert captured["supabase"] == "fake-client"
+    assert captured["club_id"] == "tres_palapas"
+    assert captured["kwargs"] == {
+        "max_total_jobs": 500,
+        "batch_max_jobs": 11,
+        "per_batch_time_budget_seconds": 1.5,
+        "max_wall_clock_seconds": 90,
+        "max_errors": 7,
+    }
+    assert summary["ok"] is True
+    assert summary["key_source"] == "SUPABASE_SERVICE_ROLE_KEY"
+
+
+def test_main_missing_config_returns_clean_failure(monkeypatch, capsys):
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+    monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    rc = main(["--club-id", "tres_palapas"])
+    out = capsys.readouterr().out
+
+    assert rc == 2
+    assert '"ok": false' in out.lower()
+    assert "SUPABASE_URL" in out
+
+
+def test_main_uses_anon_fallback(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "anon-key")
+
+    monkeypatch.setattr("jupr_app.workers.badge_queue_worker.make_supabase", lambda url, key: object())
+    monkeypatch.setattr(
+        "jupr_app.workers.badge_queue_worker.process_badge_eval_queue_until_empty",
+        lambda *_args, **_kwargs: {
+            "total_processed": 1,
+            "total_errored": 0,
+            "loops": 1,
+            "stopped_reason": "empty",
+        },
+    )
+
+    rc = main(["--club-id", "tres_palapas", "--max-total-jobs", "2"])
+    assert rc == 0


### PR DESCRIPTION
### Motivation
- Provide a simple way to run badge queue processing from a scheduled job or worker process without opening Streamlit Admin Tools.
- Keep existing Admin Tools and badge awarding logic unchanged while enabling off-app workers to drain the badge queue.

### Description
- Add `jupr_app/workers/badge_queue_worker.py` which exposes `run_badge_queue_worker(club_id, ...) -> dict` and a CLI via `python -m jupr_app.workers.badge_queue_worker` with tuning flags (`--max-total-jobs`, `--batch-max-jobs`, `--per-batch-time-budget-seconds`, `--max-wall-clock-seconds`, `--max-errors`).
- Resolve Supabase credentials from environment variables `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` (preferred) with `SUPABASE_ANON_KEY` as a fallback, and build the client with `make_supabase`.
- Delegate processing to the existing `process_badge_eval_queue_until_empty` and print a JSON summary to stdout, returning nonzero on missing config or when error thresholds are exceeded.
- Add `jupr_app/workers/__init__.py` to expose `run_badge_queue_worker`, a test module `tests/test_badge_worker_cli.py`, and documentation in `README.txt` with an example invocation.

### Testing
- Ran `pytest -q tests/test_badge_worker_cli.py`, which passed (3 tests).
- Ran `pytest -q tests/test_admin_tools_badge_controls.py` to ensure Admin Tools were unaffected, which passed (3 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65016a15483268f3b44035dcf3f9e)