### PR TITLE
Add CLI worker for sending pending player update emails

### DIFF
--- a/jupr_app/workers/player_update_email_worker.py
+++ b/jupr_app/workers/player_update_email_worker.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+
+from jupr_app.config import get_public_base_url
+from jupr_app.data.client import make_supabase
+from jupr_app.domain.notifications.player_update_sender import send_pending_player_update_emails
+from jupr_app.services.context import ServiceContext
+
+
+def _resolve_supabase_config() -> tuple[str, str, str]:
+    url = str(os.getenv("SUPABASE_URL") or "").strip()
+    service_role = str(os.getenv("SUPABASE_SERVICE_ROLE_KEY") or "").strip()
+    anon = str(os.getenv("SUPABASE_ANON_KEY") or "").strip()
+    key = service_role or anon
+    key_source = "SUPABASE_SERVICE_ROLE_KEY" if service_role else "SUPABASE_ANON_KEY"
+    if not url:
+        raise ValueError("Missing required environment variable: SUPABASE_URL")
+    if not key:
+        raise ValueError(
+            "Missing Supabase key. Set SUPABASE_SERVICE_ROLE_KEY (preferred) or SUPABASE_ANON_KEY."
+        )
+    return url, key, key_source
+
+
+def run_player_update_email_worker(club_id: str, *, limit: int = 250) -> dict[str, Any]:
+    url, key, key_source = _resolve_supabase_config()
+    supabase = make_supabase(url, key)
+    public_base_url = get_public_base_url()
+    ctx = ServiceContext(supabase=supabase, club_id=club_id, public_base_url=public_base_url)
+    summary = send_pending_player_update_emails(
+        ctx,
+        limit=max(1, int(limit)),
+        public_base_url=public_base_url,
+    )
+    return {
+        "ok": True,
+        "club_id": club_id,
+        "key_source": key_source,
+        "attempted": int(summary.get("attempted") or 0),
+        "sent": int(summary.get("sent") or 0),
+        "skipped": int(summary.get("skipped") or 0),
+        "errors": int(summary.get("errors") or 0),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Send pending player update emails from the outbox.")
+    parser.add_argument("--club-id", required=True, help="Club ID for player update outbox sends.")
+    parser.add_argument("--limit", type=int, default=250)
+    args = parser.parse_args(argv)
+
+    try:
+        summary = run_player_update_email_worker(args.club_id, limit=args.limit)
+    except ValueError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True))
+        return 2
+    except Exception as exc:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": f"{type(exc).__name__}: {exc}"}, sort_keys=True))
+        return 1
+
+    print(json.dumps(summary, sort_keys=True, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_player_update_email_worker.py
+++ b/tests/test_player_update_email_worker.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from jupr_app.workers.player_update_email_worker import main, run_player_update_email_worker
+
+
+def test_run_player_update_email_worker_passes_club_and_limit(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service-role")
+    monkeypatch.setenv("JUPR_PUBLIC_BASE_URL", "https://jupr.example.com")
+
+    captured = {}
+
+    def fake_make_supabase(url, key):
+        captured["url"] = url
+        captured["key"] = key
+        return "fake-client"
+
+    def fake_send_pending(ctx, *, limit, public_base_url=None, smtp_config=None):
+        captured["club_id"] = ctx.club_id
+        captured["supabase"] = ctx.supabase
+        captured["limit"] = limit
+        captured["public_base_url"] = public_base_url
+        return {"attempted": 8, "sent": 5, "skipped": 2, "errors": 1}
+
+    monkeypatch.setattr("jupr_app.workers.player_update_email_worker.make_supabase", fake_make_supabase)
+    monkeypatch.setattr(
+        "jupr_app.workers.player_update_email_worker.send_pending_player_update_emails",
+        fake_send_pending,
+    )
+
+    summary = run_player_update_email_worker("tres_palapas", limit=250)
+
+    assert captured == {
+        "url": "https://example.supabase.co",
+        "key": "service-role",
+        "club_id": "tres_palapas",
+        "supabase": "fake-client",
+        "limit": 250,
+        "public_base_url": "https://jupr.example.com",
+    }
+    assert summary == {
+        "ok": True,
+        "club_id": "tres_palapas",
+        "key_source": "SUPABASE_SERVICE_ROLE_KEY",
+        "attempted": 8,
+        "sent": 5,
+        "skipped": 2,
+        "errors": 1,
+    }
+
+
+def test_main_prints_json_summary(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "jupr_app.workers.player_update_email_worker.run_player_update_email_worker",
+        lambda club_id, limit: {
+            "ok": True,
+            "club_id": club_id,
+            "key_source": "SUPABASE_SERVICE_ROLE_KEY",
+            "attempted": 3,
+            "sent": 2,
+            "skipped": 1,
+            "errors": 0,
+        },
+    )
+
+    rc = main(["--club-id", "tres_palapas", "--limit", "250"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert '"club_id": "tres_palapas"' in out
+    assert '"attempted": 3' in out
+    assert '"sent": 2' in out
+    assert '"skipped": 1' in out
+    assert '"errors": 0' in out


### PR DESCRIPTION
### Motivation

- Allow pending player update outbox emails to be sent from a scheduled/CLI process rather than only from the Streamlit admin UI. 
- Provide a worker-safe adapter so existing sender logic can be reused outside the full Streamlit `AppContext`.
- Keep digest generation and email template/subscription behavior unchanged while enabling automation.

### Description

- Add `jupr_app/workers/player_update_email_worker.py` which resolves Supabase credentials from env, creates a Supabase client via `make_supabase`, builds a lightweight `ServiceContext`, invokes `send_pending_player_update_emails`, and returns a JSON-like summary. 
- Use existing public base URL resolution via `get_public_base_url` and reuse the domain sender logic without duplicating digest generation. 
- Follow the same Supabase env fallback pattern as existing workers (`SUPABASE_SERVICE_ROLE_KEY` or `SUPABASE_ANON_KEY`) and expose a `main` entrypoint supporting `--club-id` and `--limit`. 
- Add tests in `tests/test_player_update_email_worker.py` to assert env/argument wiring and that the CLI prints the expected JSON summary.

### Testing

- Ran `pytest -q tests/test_player_update_email_worker.py tests/test_badge_worker_cli.py` which exercised the new CLI wiring and existing worker patterns, and the suite passed (`5 passed`).
- Tests use `monkeypatch` to stub `make_supabase` and `send_pending_player_update_emails` and verify that `club_id`, `limit`, and `public_base_url` are passed through and that the JSON summary contains `attempted`, `sent`, `skipped`, and `errors` fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6513ff19c8326a874b68512548a87)