### PR TITLE
Add replay job tracking for admin replay runs

### DIFF
--- a/jupr_app/services/replay_service.py
+++ b/jupr_app/services/replay_service.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from jupr_app.domain.replay_history import replay_history
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def create_replay_job(
+    *,
+    supabase,
+    club_id: str,
+    target_reset: str,
+    actor_email: str | None = None,
+    actor_role: str | None = None,
+) -> dict[str, Any]:
+    row = {
+        "club_id": club_id,
+        "target_reset": str(target_reset),
+        "status": "pending",
+        "actor_email": actor_email,
+        "actor_role": actor_role,
+    }
+    resp = supabase.table("replay_jobs").insert(row).execute()
+    data = (resp.data or [{}])[0]
+    return data
+
+
+def mark_replay_job_running(*, supabase, job_id: str) -> None:
+    supabase.table("replay_jobs").update(
+        {"status": "running", "started_at": _utc_now_iso(), "updated_at": _utc_now_iso()}
+    ).eq("id", job_id).execute()
+
+
+def mark_replay_job_succeeded(*, supabase, job_id: str, result_json: dict[str, Any]) -> None:
+    supabase.table("replay_jobs").update(
+        {
+            "status": "succeeded",
+            "finished_at": _utc_now_iso(),
+            "updated_at": _utc_now_iso(),
+            "result_json": result_json or {},
+            "error_text": None,
+        }
+    ).eq("id", job_id).execute()
+
+
+def mark_replay_job_failed(*, supabase, job_id: str, error_text: str) -> None:
+    supabase.table("replay_jobs").update(
+        {
+            "status": "failed",
+            "finished_at": _utc_now_iso(),
+            "updated_at": _utc_now_iso(),
+            "error_text": str(error_text),
+        }
+    ).eq("id", job_id).execute()
+
+
+def run_replay_with_job_tracking(
+    *,
+    supabase,
+    club_id: str,
+    df_meta,
+    target_reset: str,
+    actor_email: str | None = None,
+    actor_role: str | None = None,
+    progress_cb: Callable[[float], None] | None = None,
+) -> dict[str, Any]:
+    job = create_replay_job(
+        supabase=supabase,
+        club_id=club_id,
+        target_reset=target_reset,
+        actor_email=actor_email,
+        actor_role=actor_role,
+    )
+    job_id = str(job.get("id") or "")
+    try:
+        mark_replay_job_running(supabase=supabase, job_id=job_id)
+        result = replay_history(
+            supabase=supabase,
+            club_id=club_id,
+            df_meta=df_meta,
+            target_reset=target_reset,
+            progress_cb=progress_cb,
+        )
+        mark_replay_job_succeeded(supabase=supabase, job_id=job_id, result_json=result)
+        return {"job_id": job_id, "job_status": "succeeded", "result": result}
+    except Exception as exc:
+        mark_replay_job_failed(supabase=supabase, job_id=job_id, error_text=str(exc))
+        raise

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -4,7 +4,6 @@ import time
 import json
 from datetime import datetime, timezone
 from uuid import uuid4
-from jupr_app.domain.replay_history import replay_history
 from jupr_app.domain.admin.roles import (
     ALL_ROLES,
     ROLE_READ_ONLY,
@@ -36,6 +35,7 @@ from jupr_app.domain.ratings import calculate_hybrid_elo
 from jupr_app.domain.constants import DEFAULT_K_FACTOR
 from jupr_app.domain.tournament_match_payload import build_tournament_match_payload
 from jupr_app.domain.gamification.ensure_badges import ensure_badges
+from jupr_app.services.replay_service import run_replay_with_job_tracking
 from jupr_app.domain.gamification.badge_audit import (
     build_badge_audit_report,
     build_high_roller_diagnostic_report,
@@ -691,14 +691,19 @@ def render(ctx):
     if st.button(f"⚠️ Replay History for: {target_reset}", disabled=not role_can_run_replay):
         bar = st.progress(0.0)
         with st.spinner("Crunching..."):
-            result = replay_history(
+            replay_outcome = run_replay_with_job_tracking(
                 supabase=supabase,
                 club_id=club_id,
                 df_meta=df_meta,
                 target_reset=str(target_reset),
+                actor_email=getattr(ctx, "current_user_email", None),
+                actor_role=admin_role,
                 progress_cb=lambda x: bar.progress(float(x)),
             )
+            result = replay_outcome["result"]
 
+        st.info(f"Replay job id: {replay_outcome['job_id']}")
+        st.info(f"Replay job status: {replay_outcome['job_status']}")
         st.info(f"Skipped incomplete doubles rows: {result['skipped_incomplete']}")
         st.info(f"Matches to rewrite snapshots for: {result['matches_rewritten']}")
         st.info(f"League ratings rows rebuilt: {result['league_ratings_rows']}")

--- a/supabase/migrations/20260502120000_replay_jobs.sql
+++ b/supabase/migrations/20260502120000_replay_jobs.sql
@@ -1,0 +1,14 @@
+create table if not exists public.replay_jobs (
+  id uuid primary key default gen_random_uuid(),
+  club_id text not null,
+  target_reset text not null,
+  status text not null default 'pending',
+  actor_email text,
+  actor_role text,
+  started_at timestamptz,
+  finished_at timestamptz,
+  result_json jsonb not null default '{}'::jsonb,
+  error_text text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);

--- a/tests/test_replay_service.py
+++ b/tests/test_replay_service.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+
+import pytest
+
+from jupr_app.services import replay_service
+
+
+class FakeTable:
+    def __init__(self, name: str, state: dict):
+        self.name = name
+        self.state = state
+        self.pending = None
+
+    def insert(self, row):
+        self.pending = ("insert", row)
+        return self
+
+    def update(self, row):
+        self.pending = ("update", row)
+        return self
+
+    def eq(self, key, value):
+        self.state["eq_calls"].append((self.name, key, value))
+        return self
+
+    def execute(self):
+        kind, payload = self.pending
+        if self.name == "replay_jobs" and kind == "insert":
+            self.state["insert_rows"].append(payload)
+            return SimpleNamespace(data=[{"id": self.state["job_id"], **payload}])
+        if self.name == "replay_jobs" and kind == "update":
+            self.state["updates"].append(payload)
+            return SimpleNamespace(data=[payload])
+        raise AssertionError(f"Unexpected execute for {self.name}/{kind}")
+
+
+class FakeSupabase:
+    def __init__(self):
+        self.state = {"insert_rows": [], "updates": [], "eq_calls": [], "job_id": "job-123"}
+
+    def table(self, name):
+        return FakeTable(name, self.state)
+
+
+def test_run_replay_with_job_tracking_success(monkeypatch):
+    supabase = FakeSupabase()
+    replay_result = {"skipped_incomplete": 0, "matches_rewritten": 4, "league_ratings_rows": 10}
+
+    monkeypatch.setattr(replay_service, "replay_history", lambda **_: replay_result)
+
+    out = replay_service.run_replay_with_job_tracking(
+        supabase=supabase,
+        club_id="club-a",
+        df_meta=None,
+        target_reset="ALL (Full System Reset)",
+        actor_email="admin@example.com",
+        actor_role="owner",
+        progress_cb=None,
+    )
+
+    assert out["job_id"] == "job-123"
+    assert out["job_status"] == "succeeded"
+    assert out["result"] == replay_result
+
+    assert supabase.state["insert_rows"][0]["status"] == "pending"
+    assert supabase.state["updates"][0]["status"] == "running"
+    assert supabase.state["updates"][1]["status"] == "succeeded"
+    assert supabase.state["updates"][1]["result_json"] == replay_result
+
+
+def test_run_replay_with_job_tracking_failure_marks_failed(monkeypatch):
+    supabase = FakeSupabase()
+
+    def _boom(**_):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(replay_service, "replay_history", _boom)
+
+    with pytest.raises(RuntimeError, match="kaboom"):
+        replay_service.run_replay_with_job_tracking(
+            supabase=supabase,
+            club_id="club-a",
+            df_meta=None,
+            target_reset="League A",
+            progress_cb=None,
+        )
+
+    assert supabase.state["updates"][0]["status"] == "running"
+    assert supabase.state["updates"][1]["status"] == "failed"
+    assert supabase.state["updates"][1]["error_text"] == "kaboom"


### PR DESCRIPTION
### Motivation
- Provide durable audit records for destructive/rebuild replay operations so runs can be audited and later moved to a worker.
- Preserve existing synchronous replay behavior and UI while adding job lifecycle metadata for every run.
- Capture success/failure/result/error so replay history is queryable and actionable without changing replay math or permissions.

### Description
- Add migration `supabase/migrations/20260502120000_replay_jobs.sql` to create the `public.replay_jobs` table with the requested columns and defaults.
- Introduce `jupr_app/services/replay_service.py` with `create_replay_job`, `mark_replay_job_running`, `mark_replay_job_succeeded`, `mark_replay_job_failed`, and `run_replay_with_job_tracking` which wraps the existing `replay_history` synchronously and records lifecycle transitions and results/errors.
- Update admin UI in `jupr_app/ui/pages/admin_tools.py` to call `run_replay_with_job_tracking(...)` instead of `replay_history(...)`, preserving the same replay summary output and adding `job_id` and `job_status` display in the UI.
- Add tests in `tests/test_replay_service.py` that mock Supabase interactions and verify the success path (`pending -> running -> succeeded`) and the exception path (`running -> failed` with saved `error_text`).

### Testing
- Ran unit tests `pytest -q tests/test_replay_service.py` which executed the two new tests and both passed (`2 passed`).
- The new tests validate lifecycle updates and result/error persistence via mocked Supabase table calls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6520eca7c83269d67aa763301bf13)