### PR TITLE
Harden worker exports, player update worker exits, and replay job UX

### DIFF
--- a/jupr_app/services/replay_service.py
+++ b/jupr_app/services/replay_service.py
@@ -59,6 +59,33 @@ def mark_replay_job_failed(*, supabase, job_id: str, error_text: str) -> None:
     ).eq("id", job_id).execute()
 
 
+
+def is_replay_jobs_table_missing_error(exc: Exception) -> bool:
+    code = str(getattr(exc, "code", "") or "").upper()
+    args0 = exc.args[0] if getattr(exc, "args", None) else None
+    payload_code = ""
+    payload_text = ""
+    if isinstance(args0, dict):
+        payload_code = str(args0.get("code") or "").upper()
+        payload_text = " ".join(
+            str(args0.get(k) or "") for k in ("message", "details", "hint")
+        )
+
+    if code == "42P01" or payload_code == "42P01":
+        return True
+    if code == "PGRST205" or payload_code == "PGRST205":
+        return True
+
+    text = f"{exc} {payload_text}".lower()
+    return (
+        "replay_jobs" in text
+        and (
+            "does not exist" in text
+            or "could not find" in text
+            or "schema cache" in text
+        )
+    )
+
 def run_replay_with_job_tracking(
     *,
     supabase,

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -35,7 +35,10 @@ from jupr_app.domain.ratings import calculate_hybrid_elo
 from jupr_app.domain.constants import DEFAULT_K_FACTOR
 from jupr_app.domain.tournament_match_payload import build_tournament_match_payload
 from jupr_app.domain.gamification.ensure_badges import ensure_badges
-from jupr_app.services.replay_service import run_replay_with_job_tracking
+from jupr_app.services.replay_service import (
+    is_replay_jobs_table_missing_error,
+    run_replay_with_job_tracking,
+)
 from jupr_app.domain.gamification.badge_audit import (
     build_badge_audit_report,
     build_high_roller_diagnostic_report,
@@ -141,6 +144,21 @@ def _format_auth_debug_events(events: list[dict[str, object]]) -> list[dict[str,
         formatted.append(normalized)
     return formatted
 
+
+
+def _admin_actor_email(ctx) -> str:
+    values = [
+        getattr(ctx, "admin_email", None),
+        getattr(ctx, "user_email", None),
+        st.session_state.get("admin_email"),
+        st.session_state.get("user_email"),
+        getattr(st.session_state.get("admin_auth_user"), "email", ""),
+    ]
+    for value in values:
+        text = str(value or "").strip()
+        if text:
+            return text
+    return "admin"
 
 def _admin_role_context() -> tuple[str, bool, bool, bool]:
     role = normalize_role(str(st.session_state.get("admin_role", ROLE_READ_ONLY) or ROLE_READ_ONLY))
@@ -691,16 +709,24 @@ def render(ctx):
     if st.button(f"⚠️ Replay History for: {target_reset}", disabled=not role_can_run_replay):
         bar = st.progress(0.0)
         with st.spinner("Crunching..."):
-            replay_outcome = run_replay_with_job_tracking(
-                supabase=supabase,
-                club_id=club_id,
-                df_meta=df_meta,
-                target_reset=str(target_reset),
-                actor_email=getattr(ctx, "current_user_email", None),
-                actor_role=admin_role,
-                progress_cb=lambda x: bar.progress(float(x)),
-            )
-            result = replay_outcome["result"]
+            try:
+                replay_outcome = run_replay_with_job_tracking(
+                    supabase=supabase,
+                    club_id=club_id,
+                    df_meta=df_meta,
+                    target_reset=str(target_reset),
+                    actor_email=_admin_actor_email(ctx),
+                    actor_role=admin_role,
+                    progress_cb=lambda x: bar.progress(float(x)),
+                )
+                result = replay_outcome["result"]
+            except Exception as exc:  # noqa: BLE001
+                if is_replay_jobs_table_missing_error(exc):
+                    st.error("Replay job tracking table is not installed yet.")
+                    st.caption("Apply migration: `supabase/migrations/20260502120000_replay_jobs.sql`")
+                    st.code("NOTIFY pgrst, 'reload schema';", language="sql")
+                    return
+                raise
 
         st.info(f"Replay job id: {replay_outcome['job_id']}")
         st.info(f"Replay job status: {replay_outcome['job_status']}")

--- a/jupr_app/workers/__init__.py
+++ b/jupr_app/workers/__init__.py
@@ -1,5 +1,6 @@
 """Background worker entrypoints for JUPr."""
 
 from jupr_app.workers.badge_queue_worker import run_badge_queue_worker
+from jupr_app.workers.player_update_email_worker import run_player_update_email_worker
 
-__all__ = ["run_badge_queue_worker"]
+__all__ = ["run_badge_queue_worker", "run_player_update_email_worker"]

--- a/jupr_app/workers/player_update_email_worker.py
+++ b/jupr_app/workers/player_update_email_worker.py
@@ -51,6 +51,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Send pending player update emails from the outbox.")
     parser.add_argument("--club-id", required=True, help="Club ID for player update outbox sends.")
     parser.add_argument("--limit", type=int, default=250)
+    parser.add_argument("--fail-on-errors", action="store_true")
     args = parser.parse_args(argv)
 
     try:
@@ -60,6 +61,11 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     except Exception as exc:  # noqa: BLE001
         print(json.dumps({"ok": False, "error": f"{type(exc).__name__}: {exc}"}, sort_keys=True))
+        return 1
+
+    if args.fail_on_errors and int(summary.get("errors") or 0) > 0:
+        summary["ok"] = False
+        print(json.dumps(summary, sort_keys=True, default=str))
         return 1
 
     print(json.dumps(summary, sort_keys=True, default=str))

--- a/tests/test_admin_tools_replay_jobs.py
+++ b/tests/test_admin_tools_replay_jobs.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_admin_tools_has_replay_jobs_migration_guidance():
+    source = Path("jupr_app/ui/pages/admin_tools.py").read_text()
+    assert "20260502120000_replay_jobs.sql" in source
+    assert "NOTIFY pgrst, 'reload schema';" in source

--- a/tests/test_player_update_email_worker.py
+++ b/tests/test_player_update_email_worker.py
@@ -72,3 +72,43 @@ def test_main_prints_json_summary(monkeypatch, capsys):
     assert '"sent": 2' in out
     assert '"skipped": 1' in out
     assert '"errors": 0' in out
+
+
+def test_main_errors_do_not_fail_without_flag(monkeypatch):
+    monkeypatch.setattr(
+        "jupr_app.workers.player_update_email_worker.run_player_update_email_worker",
+        lambda club_id, limit: {
+            "ok": True,
+            "club_id": club_id,
+            "key_source": "SUPABASE_SERVICE_ROLE_KEY",
+            "attempted": 2,
+            "sent": 1,
+            "skipped": 0,
+            "errors": 1,
+        },
+    )
+
+    rc = main(["--club-id", "tres_palapas", "--limit", "250"])
+
+    assert rc == 0
+
+
+def test_main_fail_on_errors_sets_nonzero_and_ok_false(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "jupr_app.workers.player_update_email_worker.run_player_update_email_worker",
+        lambda club_id, limit: {
+            "ok": True,
+            "club_id": club_id,
+            "key_source": "SUPABASE_SERVICE_ROLE_KEY",
+            "attempted": 2,
+            "sent": 1,
+            "skipped": 0,
+            "errors": 1,
+        },
+    )
+
+    rc = main(["--club-id", "tres_palapas", "--limit", "250", "--fail-on-errors"])
+    out = capsys.readouterr().out
+
+    assert rc == 1
+    assert '"ok": false' in out.lower()

--- a/tests/test_replay_service.py
+++ b/tests/test_replay_service.py
@@ -88,3 +88,18 @@ def test_run_replay_with_job_tracking_failure_marks_failed(monkeypatch):
     assert supabase.state["updates"][0]["status"] == "running"
     assert supabase.state["updates"][1]["status"] == "failed"
     assert supabase.state["updates"][1]["error_text"] == "kaboom"
+
+
+def test_is_replay_jobs_table_missing_error_code_42p01():
+    exc = Exception({"code": "42P01", "message": "relation replay_jobs does not exist"})
+    assert replay_service.is_replay_jobs_table_missing_error(exc)
+
+
+def test_is_replay_jobs_table_missing_error_code_pgrst205():
+    exc = Exception({"code": "PGRST205", "message": "Could not find table replay_jobs in schema cache"})
+    assert replay_service.is_replay_jobs_table_missing_error(exc)
+
+
+def test_is_replay_jobs_table_missing_error_text_only():
+    exc = Exception("replay_jobs does not exist")
+    assert replay_service.is_replay_jobs_table_missing_error(exc)

--- a/tests/test_workers_exports.py
+++ b/tests/test_workers_exports.py
@@ -1,0 +1,6 @@
+from jupr_app.workers import run_badge_queue_worker, run_player_update_email_worker
+
+
+def test_workers_exports_available():
+    assert callable(run_badge_queue_worker)
+    assert callable(run_player_update_email_worker)


### PR DESCRIPTION
### Motivation
- Make the new player update worker importable from the `jupr_app.workers` package root for consistency with other workers.
- Provide an opt-in nonzero CLI exit when player update sends report errors to aid CI/ops detection without changing default behavior.
- Ensure Admin Tools records a meaningful actor email for replay jobs instead of frequently storing `None`.
- Replace confusing raw DB errors in Admin Tools with clear migration guidance when the `replay_jobs` table is not installed.

### Description
- Exported `run_player_update_email_worker` from `jupr_app.workers` and kept `__all__` accurate by updating `jupr_app/workers/__init__.py`.
- Added a `--fail-on-errors` `argparse` flag to `jupr_app/workers/player_update_email_worker.py` and implemented logic to return exit code `1` and set `summary["ok"] = False` when the flag is passed and `summary["errors"] > 0`, while preserving existing `2` (missing config) and `1` (unexpected exception) exits and existing summary keys.
- Added `is_replay_jobs_table_missing_error(exc: Exception) -> bool` to `jupr_app/services/replay_service.py` to detect missing-table cases via SQLSTATE `42P01`, PostgREST `PGRST205`, and text heuristics referencing `replay_jobs` + missing/schema-cache phrases.
- Introduced `_admin_actor_email(ctx) -> str` in `jupr_app/ui/pages/admin_tools.py` that resolves actor email using the requested fallback order and wired it into `run_replay_with_job_tracking(...)`.
- Wrapped the Admin Tools replay call in a `try/except` that uses `is_replay_jobs_table_missing_error(...)` to display friendly guidance (`supabase/migrations/20260502120000_replay_jobs.sql` and `NOTIFY pgrst, 'reload schema';`) and abort the action rather than surfacing the raw DB exception.
- Added and updated tests to cover the new CLI behavior, package exports, replay missing-table detection, and presence of the Admin Tools migration guidance strings.

### Testing
- Ran targeted tests: `pytest -q tests/test_player_update_email_worker.py tests/test_workers_exports.py tests/test_replay_service.py tests/test_admin_tools_replay_jobs.py` and observed `11 passed`.
- Added `tests/test_workers_exports.py` to assert both `run_badge_queue_worker` and `run_player_update_email_worker` are importable from `jupr_app.workers`.
- Extended `tests/test_player_update_email_worker.py` to verify default CLI exit remains `0` when `errors > 0` and that `--fail-on-errors` yields exit `1` and a printed summary with `"ok": false`.
- Extended `tests/test_replay_service.py` to validate `is_replay_jobs_table_missing_error(...)` recognizes `42P01`, `PGRST205`, and a text-only `replay_jobs` missing error, and added `tests/test_admin_tools_replay_jobs.py` to assert migration guidance strings are present in Admin Tools source.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f654da8a2483268094731551f96213)