### PR TITLE
Add DB-backed club configuration with Tres Palapas fallback

### DIFF
--- a/jupr_app/domain/clubs.py
+++ b/jupr_app/domain/clubs.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from jupr_app.ui import branding
+
+
+def get_default_club_id() -> str:
+    """Resolve default club id from env, preserving Tres Palapas fallback."""
+    return str(os.getenv("JUPR_DEFAULT_CLUB_ID") or branding.CLUB_ID).strip() or branding.CLUB_ID
+
+
+def _fallback_config(club_id: str) -> dict[str, Any]:
+    return {
+        "id": club_id or branding.CLUB_ID,
+        "slug": "tres-palapas",
+        "name": branding.CLUB_NAME,
+        "tagline": branding.TAGLINE,
+        "support_email": branding.SUPPORT_EMAIL,
+        "public_base_url": branding.PUBLIC_BASE_URL_FALLBACK,
+        "logo_url": None,
+        "primary_color": None,
+        "is_active": True,
+    }
+
+
+def get_club_config(supabase: Any, club_id: str) -> dict[str, Any]:
+    """Load club config from DB, falling back for legacy deployments/missing table."""
+    requested_club_id = str(club_id or "").strip() or get_default_club_id()
+    fallback = _fallback_config(requested_club_id)
+
+    if supabase is None:
+        return fallback
+
+    try:
+        response = (
+            supabase.table("clubs")
+            .select("id,slug,name,tagline,support_email,public_base_url,logo_url,primary_color,is_active")
+            .eq("id", requested_club_id)
+            .limit(1)
+            .execute()
+        )
+    except Exception:
+        return fallback
+
+    rows = getattr(response, "data", None) or []
+    if not rows:
+        return fallback
+
+    row = rows[0] or {}
+    merged = {**fallback, **row}
+    return merged
+
+
+__all__ = ["get_default_club_id", "get_club_config"]

--- a/jupr_app/ui/branding.py
+++ b/jupr_app/ui/branding.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 PRODUCT_NAME = "JUPR"
+# Fallback defaults retained for backward compatibility while DB club config rollout is in progress.
 CLUB_NAME = "Tres Palapas"
 CLUB_ID = "tres_palapas"
 TAGLINE = "Official player ratings and events for Tres Palapas"

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -35,6 +35,7 @@ from jupr_app.ui.page_registry import (
     labels_for_keys,
 )
 from jupr_app.ui.branding import CLUB_ID, PUBLIC_BASE_URL_FALLBACK
+from jupr_app.domain.clubs import get_default_club_id
 from jupr_app.ui.public_nav import render_public_app_header, render_public_footer
 from jupr_app.ui.theme_clean import apply_clean_theme
 from jupr_app.ui.url import qp_get
@@ -246,6 +247,9 @@ def main():
         debug_exceptions = _debug_exceptions_enabled()
 
         # Make base_url available to all pages (leaderboards uses this for share links)
+
+        selected_club_id = get_default_club_id() or CLUB_ID
+
         # Use session_state because ctx is a frozen-ish dataclass and you don't want to refactor it mid-stream.
         st.session_state["base_url"] = PUBLIC_BASE_URL
 
@@ -482,11 +486,11 @@ def main():
             id_to_name,
             schema_degraded,
             schema_degraded_reason,
-        ) = get_data(CLUB_ID)
+        ) = get_data(selected_club_id)
 
         ctx = AppContext(
             supabase=supabase,
-            club_id=CLUB_ID,
+            club_id=selected_club_id,
             df_players_all=df_players_all,
             df_players_active=df_players_active,
             df_leagues=df_leagues,
@@ -520,10 +524,10 @@ def main():
                 player_ids = df_players_all["id"].dropna().astype(int).tolist()
             enqueue_result = enqueue_badge_eval(
                 supabase,
-                club_id=CLUB_ID,
+                club_id=selected_club_id,
                 event_type="match_recorded",
                 player_ids=player_ids,
-                match_id=f"initial_load:{CLUB_ID}",
+                match_id=f"initial_load:{selected_club_id}",
                 payload={"initial_load": True},
             )
             if enqueue_result.get("queued"):

--- a/supabase/migrations/20260502121500_clubs_config.sql
+++ b/supabase/migrations/20260502121500_clubs_config.sql
@@ -1,0 +1,41 @@
+create table if not exists public.clubs (
+  id text primary key,
+  slug text unique not null,
+  name text not null,
+  tagline text,
+  support_email text,
+  public_base_url text,
+  logo_url text,
+  primary_color text,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+insert into public.clubs (
+  id,
+  slug,
+  name,
+  tagline,
+  support_email,
+  public_base_url,
+  is_active
+)
+values (
+  'tres_palapas',
+  'tres-palapas',
+  'Tres Palapas',
+  'Official player ratings and events for Tres Palapas',
+  'joe@juprleagues.com',
+  'https://juprtrespalapas.streamlit.app',
+  true
+)
+on conflict (id) do update
+set
+  slug = excluded.slug,
+  name = excluded.name,
+  tagline = excluded.tagline,
+  support_email = excluded.support_email,
+  public_base_url = excluded.public_base_url,
+  is_active = excluded.is_active,
+  updated_at = now();

--- a/tests/test_club_config.py
+++ b/tests/test_club_config.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from jupr_app.domain.clubs import get_club_config, get_default_club_id
+
+
+class _FakeQuery:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, _key, _value):
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=self._rows)
+
+
+class _FakeSupabase:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def table(self, _name):
+        return _FakeQuery(self._rows)
+
+
+class _MissingTableSupabase:
+    def table(self, _name):
+        raise RuntimeError("relation \"clubs\" does not exist")
+
+
+def test_default_club_id_can_come_from_env(monkeypatch):
+    monkeypatch.setenv("JUPR_DEFAULT_CLUB_ID", "demo_club")
+    assert get_default_club_id() == "demo_club"
+
+
+def test_get_club_config_falls_back_when_table_missing():
+    config = get_club_config(_MissingTableSupabase(), "tres_palapas")
+
+    assert config["id"] == "tres_palapas"
+    assert config["name"] == "Tres Palapas"
+    assert config["tagline"] == "Official player ratings and events for Tres Palapas"
+
+
+def test_get_club_config_uses_database_row():
+    supabase = _FakeSupabase(
+        [
+            {
+                "id": "tres_palapas",
+                "slug": "tres-palapas",
+                "name": "Tres Palapas Custom",
+                "tagline": "DB tagline",
+                "support_email": "support@example.org",
+                "public_base_url": "https://example.org",
+                "is_active": True,
+            }
+        ]
+    )
+
+    config = get_club_config(supabase, "tres_palapas")
+
+    assert config["name"] == "Tres Palapas Custom"
+    assert config["tagline"] == "DB tagline"
+    assert config["support_email"] == "support@example.org"


### PR DESCRIPTION
### Motivation
- Prepare the app for multi-club SaaS by adding a database-backed club configuration while preserving the current single-club behavior. 
- Ensure Tres Palapas remains the default club and public URLs continue to work during rollout. 
- Provide a graceful compatibility path for deployments where the new `clubs` table is not yet present. 

### Description
- Add a Supabase migration `supabase/migrations/20260502121500_clubs_config.sql` that creates `public.clubs` with the requested schema and upserts the `tres_palapas` seed row. 
- Add `jupr_app.domain.clubs` implementing `get_default_club_id()` (env `JUPR_DEFAULT_CLUB_ID` or `tres_palapas`) and `get_club_config(supabase, club_id)` which reads from `clubs` and falls back to existing branding constants when the table is missing or inaccessible. 
- Mark existing branding constants in `jupr_app/ui/branding.py` as fallback defaults for backward compatibility. 
- Make minimal changes to `streamlit_app.py` to resolve `selected_club_id = get_default_club_id() or CLUB_ID` and use `selected_club_id` for data/context loading and initial badge enqueueing without changing public URL behavior or global routing. 
- Add `tests/test_club_config.py` to verify env-driven default, missing-table fallback, and DB-row override behavior. 

### Testing
- Ran `pytest -q tests/test_club_config.py tests/test_streamlit_base_url.py` and the suite succeeded. 
- The new tests verifying fallback and DB-read behavior passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6565b74c0832695350f8973013b43)