### PR TITLE
Make admin login render without full club data load

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -147,6 +147,33 @@ def get_data(club_id: str):
     return load_data(supabase, club_id, match_limit=5000)
 
 
+def _build_minimal_context(
+    *,
+    supabase,
+    club_id: str,
+    public_mode: bool,
+    admin_logged_in: bool,
+) -> AppContext:
+    empty_df = pd.DataFrame()
+    return AppContext(
+        supabase=supabase,
+        club_id=club_id,
+        df_players_all=empty_df,
+        df_players_active=empty_df,
+        df_leagues=empty_df,
+        df_matches=empty_df,
+        df_meta=empty_df,
+        df_badges=empty_df,
+        df_player_badges=empty_df,
+        name_to_id={},
+        id_to_name={},
+        public_mode=public_mode,
+        admin_logged_in=admin_logged_in,
+        schema_degraded=False,
+        schema_degraded_reason=None,
+    )
+
+
 # -------------------------
 # UI helpers
 # -------------------------
@@ -471,6 +498,23 @@ def main():
             except Exception:
                 pass
             st.session_state["force_data_refresh"] = False
+
+        # ---- Early auth-route render without full data load ----
+        auth_route_requested = admin_login_requested or recovery_flow or incoming_page_param == "reset_password"
+        if auth_route_requested:
+            from jupr_app.ui.pages import admin_login, reset_password
+
+            auth_ctx = _build_minimal_context(
+                supabase=supabase,
+                club_id=selected_club_id,
+                public_mode=PUBLIC_MODE,
+                admin_logged_in=admin_logged_in,
+            )
+            if admin_login_requested:
+                admin_login.render(auth_ctx)
+            else:
+                reset_password.render(auth_ctx)
+            return
 
         # ---- Load data + ctx ----
         

--- a/tests/test_admin_login_lightweight_route.py
+++ b/tests/test_admin_login_lightweight_route.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+def test_streamlit_app_has_minimal_auth_context_helper():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+
+    assert "def _build_minimal_context(" in app
+    assert "schema_degraded=False" in app
+    assert "schema_degraded_reason=None" in app
+
+
+def test_streamlit_app_handles_auth_routes_before_get_data():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+
+    early_branch = app.index("auth_route_requested =")
+    get_data_call = app.index(") = get_data(selected_club_id)")
+
+    assert early_branch < get_data_call
+    assert "if auth_route_requested:" in app
+    assert "from jupr_app.ui.pages import admin_login, reset_password" in app
+
+
+def test_streamlit_app_early_auth_route_renders_without_full_data_load():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+
+    assert "auth_ctx = _build_minimal_context(" in app
+    assert "admin_login.render(auth_ctx)" in app
+    assert "reset_password.render(auth_ctx)" in app
+    assert "return" in app[app.index("if auth_route_requested:"): app.index("# ---- Load data + ctx ----")]


### PR DESCRIPTION
### Motivation
- Admin auth pages could fail to render because the app waited for the full `get_data(...)` load which can break during schema/migration issues. 
- Provide a minimal, resilient context so `admin_login` and `reset_password` (including recovery flow) can render even when optional data loads are degraded.

### Description
- Add `_build_minimal_context(...)` in `streamlit_app.py` which returns an `AppContext` with `supabase`, `club_id`, empty pandas `DataFrame`s for players/leagues/matches/meta/badges/player_badges, empty `name_to_id`/`id_to_name`, `public_mode`, `admin_logged_in`, and `schema_degraded=False`/`schema_degraded_reason=None`.
- Add an early auth-route branch placed before the `get_data(selected_club_id)` call that checks `admin_login`, recovery flow, or `reset_password`, imports only `admin_login` and `reset_password`, builds the minimal context, renders the appropriate page, and returns before performing the full data load.
- Preserve the existing admin auth bootstrap/bridge/allowlist/token-restore flow (these still run earlier in `main()`), and preserve post-login redirect behavior and full-data requirements for non-auth pages.

### Testing
- Added `tests/test_admin_login_lightweight_route.py` which asserts the presence of the helper and that the early auth branch precedes the `get_data(...)` call and invokes `admin_login.reset_password` rendering with the minimal context.
- Ran `pytest -q tests/test_admin_login_lightweight_route.py tests/test_admin_auth_browser_restore.py::test_streamlit_app_only_restores_browser_tokens_for_admin_entry` and all tests passed (4 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f68c3b50208326a155faf581bae7f8)