### PR TITLE
Add minimal FastAPI service skeleton for read-only club and leaderboard APIs

### DIFF
--- a/services/api/README.md
+++ b/services/api/README.md
@@ -1,0 +1,25 @@
+# JUPR API (FastAPI skeleton)
+
+Minimal read-only API scaffold for future service integration.
+
+## Run locally
+
+```bash
+cd services/api
+pip install -r requirements.txt
+uvicorn services.api.main:app --reload
+```
+
+## Environment variables
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY` (preferred for server-side API)
+- `SUPABASE_ANON_KEY` (read-only local fallback)
+
+## Endpoints
+
+- `GET /health`
+- `GET /clubs/{club_slug}`
+- `GET /clubs/{club_slug}/leaderboards?league_name=...`
+
+The leaderboard endpoint delegates to `jupr_app.services.leaderboard_service.get_public_leaderboard` and only returns public-safe fields.

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Query
+from supabase import Client, create_client
+
+from jupr_app.services.leaderboard_service import get_public_leaderboard
+
+
+app = FastAPI(title="JUPR API", version="0.1.0")
+
+
+def _get_supabase_credentials() -> tuple[str, str]:
+    url = os.getenv("SUPABASE_URL", "").strip()
+    service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "").strip()
+    anon_key = os.getenv("SUPABASE_ANON_KEY", "").strip()
+    key = service_role_key or anon_key
+
+    if not url or not key:
+        raise RuntimeError(
+            "Supabase config missing. Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY "
+            "(or SUPABASE_ANON_KEY for read-only local development)."
+        )
+    return url, key
+
+
+def get_supabase_client() -> Client:
+    url, key = _get_supabase_credentials()
+    return create_client(url, key)
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    return {"ok": True, "service": "jupr-api"}
+
+
+@app.get("/clubs/{club_slug}")
+def get_club(club_slug: str) -> dict[str, Any]:
+    slug = str(club_slug).strip()
+    if not slug:
+        raise HTTPException(status_code=400, detail="club_slug is required")
+
+    supabase = get_supabase_client()
+
+    row = (
+        supabase.table("clubs_config")
+        .select("club_id,club_slug,club_name,display_name,is_public")
+        .eq("club_slug", slug)
+        .limit(1)
+        .execute()
+        .data
+        or []
+    )
+
+    if not row:
+        fallback = (
+            supabase.table("players")
+            .select("club_id")
+            .eq("club_id", slug)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        if not fallback:
+            raise HTTPException(status_code=404, detail="club not found")
+        return {
+            "club_id": slug,
+            "club_slug": slug,
+            "club_name": slug,
+            "display_name": slug,
+            "is_public": True,
+        }
+
+    return row[0]
+
+
+@app.get("/clubs/{club_slug}/leaderboards")
+def get_club_leaderboard(club_slug: str, league_name: str | None = Query(default=None)) -> dict[str, Any]:
+    club = get_club(club_slug)
+    club_id = str(club.get("club_id") or club_slug)
+    supabase = get_supabase_client()
+    rows = get_public_leaderboard(supabase=supabase, club_id=club_id, league_name=league_name)
+    return {
+        "club": {
+            "club_id": club.get("club_id", club_id),
+            "club_slug": club.get("club_slug", club_slug),
+            "club_name": club.get("club_name") or club.get("display_name") or club_slug,
+        },
+        "leaderboard": rows,
+    }

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+supabase

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,0 +1,19 @@
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("supabase")
+
+from fastapi.testclient import TestClient
+
+from services.api.main import app
+
+
+def test_api_app_imports():
+    assert app is not None
+
+
+def test_api_health_endpoint():
+    client = TestClient(app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "service": "jupr-api"}


### PR DESCRIPTION
### Motivation

- Provide a lightweight API layer to expose read-only health, club, and leaderboard endpoints for future service integration.  
- Avoid duplicating existing leaderboard/rating logic by delegating reads to the current service layer.  
- Keep the existing Streamlit app and deployment untouched while enabling a uvicorn-runnable API service.  

### Description

- Add `services/api/main.py` which creates a `FastAPI` app and implements `GET /health`, `GET /clubs/{club_slug}`, and `GET /clubs/{club_slug}/leaderboards`.  
- Read Supabase configuration from environment with `SUPABASE_SERVICE_ROLE_KEY` preferred and `SUPABASE_ANON_KEY` as a read-only fallback, derived from `SUPABASE_URL`.  
- Delegate leaderboard fetches to `jupr_app.services.leaderboard_service.get_public_leaderboard` and only return public-safe fields.  
- Add `services/api/requirements.txt`, `services/api/README.md` (run instructions and env vars), and `tests/test_api_health.py` (import and `/health` checks using `TestClient` with `importorskip` for runtime deps).  

### Testing

- Ran `pytest -q tests/test_api_health.py` which was skipped in this environment because `fastapi`/`supabase` are not installed, as expected when using `pytest.importorskip`.  
- The test suite includes an app import check and a `GET /health` assertion executed via `fastapi.testclient` when dependencies are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f68d2e431883268ee134a6b5fdc5c9)