### PR TITLE
Add initial Next.js public web shell under apps/web

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,34 @@
+# JUPR Web (Next.js public shell)
+
+This is a minimal, read-only Next.js app for public pages that can eventually serve `juprleagues.com` and club pages.
+
+## Routes
+
+- `/` public JUPR landing page.
+- `/clubs/[clubSlug]` club landing page.
+- `/clubs/[clubSlug]/leaderboards` public leaderboard page.
+
+## Environment variables
+
+Use one of the following:
+
+- `JUPR_API_BASE_URL` (preferred for server-side runtime)
+- `NEXT_PUBLIC_JUPR_API_BASE_URL` (fallback)
+
+Example:
+
+```bash
+export JUPR_API_BASE_URL=http://localhost:8000
+```
+
+## Local development
+
+```bash
+cd apps/web
+npm install
+npm run dev
+```
+
+Then open `http://localhost:3000`.
+
+If the API is unavailable, pages render graceful empty/error states instead of crashing.

--- a/apps/web/app/clubs/[clubSlug]/leaderboards/page.tsx
+++ b/apps/web/app/clubs/[clubSlug]/leaderboards/page.tsx
@@ -1,0 +1,42 @@
+import { getClubLeaderboard } from "@/lib/api";
+
+type LeaderboardPageProps = {
+  params: { clubSlug: string };
+};
+
+export default async function ClubLeaderboardPage({ params }: LeaderboardPageProps) {
+  const { clubSlug } = params;
+  const { data, error } = await getClubLeaderboard(clubSlug);
+
+  return (
+    <section>
+      <h1>{clubSlug} Leaderboards</h1>
+      {error ? <p style={{ color: "#b91c1c" }}>Could not load leaderboard data. {error}</p> : null}
+      {!error && (!data || data.length === 0) ? <p>No leaderboard data is currently available.</p> : null}
+      {data && data.length > 0 ? (
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", background: "white" }}>
+            <thead>
+              <tr>
+                <th style={{ textAlign: "left", borderBottom: "1px solid #cbd5e1", padding: "0.5rem" }}>Rank</th>
+                <th style={{ textAlign: "left", borderBottom: "1px solid #cbd5e1", padding: "0.5rem" }}>Player</th>
+                <th style={{ textAlign: "left", borderBottom: "1px solid #cbd5e1", padding: "0.5rem" }}>Rating</th>
+                <th style={{ textAlign: "left", borderBottom: "1px solid #cbd5e1", padding: "0.5rem" }}>Matches</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((entry) => (
+                <tr key={`${entry.player_name}-${entry.rank}`}>
+                  <td style={{ borderBottom: "1px solid #e2e8f0", padding: "0.5rem" }}>{entry.rank}</td>
+                  <td style={{ borderBottom: "1px solid #e2e8f0", padding: "0.5rem" }}>{entry.player_name}</td>
+                  <td style={{ borderBottom: "1px solid #e2e8f0", padding: "0.5rem" }}>{entry.rating ?? "—"}</td>
+                  <td style={{ borderBottom: "1px solid #e2e8f0", padding: "0.5rem" }}>{entry.matches_played ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/app/clubs/[clubSlug]/page.tsx
+++ b/apps/web/app/clubs/[clubSlug]/page.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { getClub } from "@/lib/api";
+
+type ClubPageProps = {
+  params: { clubSlug: string };
+};
+
+export default async function ClubPage({ params }: ClubPageProps) {
+  const { clubSlug } = params;
+  const { data, error } = await getClub(clubSlug);
+
+  return (
+    <section>
+      <h1>Club: {data?.name ?? clubSlug}</h1>
+      {error ? (
+        <p style={{ color: "#b91c1c" }}>Could not load club data. {error}</p>
+      ) : (
+        <>
+          <p style={{ marginBottom: "0.25rem" }}><strong>Slug:</strong> {data?.slug}</p>
+          {data?.location ? <p style={{ margin: "0.25rem 0" }}><strong>Location:</strong> {data.location}</p> : null}
+          {data?.description ? <p style={{ margin: "0.25rem 0" }}>{data.description}</p> : null}
+        </>
+      )}
+      <p>
+        <Link href={`/clubs/${clubSlug}/leaderboards`}>View public leaderboards</Link>
+      </p>
+    </section>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import type { CSSProperties } from "react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "JUPR Public Web",
+  description: "Public, read-only JUPR pages for clubs and leaderboards"
+};
+
+const shellStyle: CSSProperties = {
+  margin: "0 auto",
+  maxWidth: "860px",
+  padding: "1rem",
+  fontFamily: "Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif",
+  lineHeight: 1.5
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, background: "#f8fafc", color: "#0f172a" }}>
+        <div style={shellStyle}>
+          <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1rem" }}>
+            <Link href="/" style={{ fontWeight: 700, color: "inherit", textDecoration: "none" }}>
+              JUPR
+            </Link>
+            <nav style={{ display: "flex", gap: "1rem", fontSize: "0.95rem" }}>
+              <Link href="/clubs/tres-palapas">Club</Link>
+              <Link href="/clubs/tres-palapas/leaderboards">Leaderboards</Link>
+            </nav>
+          </header>
+          <main>{children}</main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+export default function HomePage() {
+  return (
+    <section>
+      <h1 style={{ marginBottom: "0.5rem" }}>Welcome to JUPR</h1>
+      <p style={{ marginTop: 0 }}>This is the first public web shell for JUPR (read-only pages).</p>
+      <p>
+        Start here: <Link href="/clubs/tres-palapas">Tres Palapas club page</Link>
+      </p>
+    </section>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,0 +1,54 @@
+export type ClubSummary = {
+  slug: string;
+  name: string;
+  location?: string | null;
+  description?: string | null;
+};
+
+export type LeaderboardEntry = {
+  rank: number;
+  player_name: string;
+  rating?: number | null;
+  matches_played?: number | null;
+};
+
+type ApiResult<T> = {
+  data: T | null;
+  error: string | null;
+};
+
+function baseUrl(): string | null {
+  return process.env.JUPR_API_BASE_URL || process.env.NEXT_PUBLIC_JUPR_API_BASE_URL || null;
+}
+
+async function fetchJson<T>(path: string): Promise<ApiResult<T>> {
+  const apiBase = baseUrl();
+  if (!apiBase) {
+    return { data: null, error: "Missing JUPR API base URL environment variable." };
+  }
+
+  const url = `${apiBase.replace(/\/$/, "")}${path}`;
+
+  try {
+    const response = await fetch(url, { next: { revalidate: 60 } });
+    if (!response.ok) {
+      return { data: null, error: `API error (${response.status}).` };
+    }
+
+    const data = (await response.json()) as T;
+    return { data, error: null };
+  } catch (error) {
+    return {
+      data: null,
+      error: `Unable to reach API: ${error instanceof Error ? error.message : "Unknown error"}`
+    };
+  }
+}
+
+export async function getClub(clubSlug: string): Promise<ApiResult<ClubSummary>> {
+  return fetchJson<ClubSummary>(`/clubs/${clubSlug}`);
+}
+
+export async function getClubLeaderboard(clubSlug: string): Promise<ApiResult<LeaderboardEntry[]>> {
+  return fetchJson<LeaderboardEntry[]>(`/clubs/${clubSlug}/leaderboards/public`);
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@jupr/web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "typescript": "5.5.3"
+  }
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a separate, minimal public frontend for JUPR to serve club and leaderboard pages without replacing the existing Streamlit UI. 
- Start with read-only pages that consume the FastAPI service so public sites like `juprleagues.com` can be built out incrementally. 
- Keep client-side code read-only and avoid adding any admin or Supabase write functionality at this stage. 

### Description
- Scaffold a TypeScript Next.js app under `apps/web` with App Router config and basic package/tsconfig files. 
- Add a shared layout and three public routes: `/` (landing), `/clubs/[clubSlug]` (club landing), and `/clubs/[clubSlug]/leaderboards` (public leaderboard table). 
- Implement a small API helper in `apps/web/lib/api.ts` that uses `JUPR_API_BASE_URL` (server-side) with fallback to `NEXT_PUBLIC_JUPR_API_BASE_URL`, and call the API endpoints `/clubs/{slug}` and `/clubs/{slug}/leaderboards/public`. 
- Add `apps/web/README.md` documenting routes, env vars, and local dev commands, and ensure pages render graceful error/empty states when the API is unavailable; do not modify Streamlit files or add any client-side Supabase or write/rating logic. 

### Testing
- Attempted local dependency install with `cd apps/web && npm install`, which failed in this environment due to npm registry access returning `403 Forbidden` when fetching `@types/node`, so build/`next dev` were not executed. 
- No automated unit or integration tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f68ddad3708326ae682183a4aab193)