### PR TITLE
Fix super-admin View As state reconciliation and email-only role assignment resolution

### DIFF
--- a/jupr_app/domain/admin/roles.py
+++ b/jupr_app/domain/admin/roles.py
@@ -108,19 +108,37 @@ def resolve_admin_role(
     normalized_user_id = str(user_id or "").strip() or None
 
     try:
-        query = (
+        response = (
             supabase.table("admin_role_assignments")
-            .select("role")
+            .select("role,user_id")
             .eq("email", normalized_email)
-            .limit(1)
+            .execute()
         )
-        if normalized_user_id:
-            query = query.eq("user_id", normalized_user_id)
-        response = query.execute()
         rows = response.data or []
         if rows:
+            preferred_row = None
+            if normalized_user_id:
+                preferred_row = next(
+                    (
+                        row
+                        for row in rows
+                        if str(row.get("user_id") or "").strip() == normalized_user_id
+                    ),
+                    None,
+                )
+            if preferred_row is None:
+                preferred_row = next(
+                    (
+                        row
+                        for row in rows
+                        if str(row.get("user_id") or "").strip() == ""
+                    ),
+                    None,
+                )
+            if preferred_row is None:
+                preferred_row = rows[0]
             return AdminRoleResolution(
-                role=normalize_role(rows[0].get("role")),
+                role=normalize_role(preferred_row.get("role")),
                 source="admin_role_assignments",
                 table_available=True,
             )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -398,12 +398,10 @@ def main():
         VIEW_AS_ACTUAL_LABEL = "Actual Super Admin"
         VIEW_AS_SELECTOR_KEY = "admin_view_as_selector_label"
         VIEW_AS_RESET_PENDING_KEY = "admin_view_as_reset_pending"
-        VIEW_AS_LAST_SELECTOR_KEY = "admin_view_as_last_selector_label"
 
         if st.session_state.pop(VIEW_AS_RESET_PENDING_KEY, False):
             st.session_state["admin_view_as_role"] = None
             st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL
-            st.session_state[VIEW_AS_LAST_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL
 
         supabase = get_supabase()
         if admin_authenticated:
@@ -483,12 +481,10 @@ def main():
                     help="Temporarily preview another role’s permissions. Your real account and audit identity do not change.",
                 )
                 picked_role = view_as_options[picked_label]
-                current_role = str(st.session_state.get("admin_view_as_role", "") or "")
-                last_selector_label = st.session_state.get(VIEW_AS_LAST_SELECTOR_KEY)
-                selector_changed = picked_label != last_selector_label
-                st.session_state[VIEW_AS_LAST_SELECTOR_KEY] = picked_label
-                if selector_changed and picked_role != current_role:
-                    st.session_state["admin_view_as_role"] = picked_role or None
+                mapped_role = picked_role or None
+                current_role = st.session_state.get("admin_view_as_role")
+                if mapped_role != current_role:
+                    st.session_state["admin_view_as_role"] = mapped_role
                     st.rerun()
 
         # Optional: allow pages to request a refresh of cached data
@@ -754,6 +750,7 @@ def main():
                 st.sidebar.warning(f"View As mode active: {effective_role}\n\nActions still log under your real super_admin account.")
                 if st.sidebar.button("Return to Super Admin"):
                     st.session_state["admin_view_as_role"] = None
+                    st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL
                     st.session_state[VIEW_AS_RESET_PENDING_KEY] = True
                     st.rerun()
             visible_labels = [x for x in visible_labels if x not in HIDDEN_PAGE_LABELS]

--- a/tests/test_admin_roles.py
+++ b/tests/test_admin_roles.py
@@ -8,6 +8,7 @@ from jupr_app.domain.admin.roles import (
     ROLE_READ_ONLY,
     ROLE_SCOREKEEPER,
     ROLE_SUPER_ADMIN,
+    ROLE_ORGANIZER,
     can_delete_matches,
     can_enter_scores,
     can_manage_matches,
@@ -88,6 +89,36 @@ def test_resolve_admin_role_defaults_to_read_only_without_assignment():
     )
     assert result.role == ROLE_READ_ONLY
     assert result.source == "default"
+
+
+def test_resolve_admin_role_prefers_null_user_id_for_email_only_assignment_when_user_id_present():
+    supabase = _Supabase(_Query(response_data=[
+        {"role": ROLE_ORGANIZER, "user_id": None},
+        {"role": ROLE_READ_ONLY, "user_id": "other-user"},
+    ]))
+    result = resolve_admin_role(
+        supabase=supabase,
+        email="organizer@example.com",
+        user_id="logged-in-user",
+        allowlist=set(),
+    )
+    assert result.role == ROLE_ORGANIZER
+    assert result.source == "admin_role_assignments"
+
+
+def test_resolve_admin_role_prefers_exact_user_id_match_over_null_user_id():
+    supabase = _Supabase(_Query(response_data=[
+        {"role": ROLE_ORGANIZER, "user_id": None},
+        {"role": ROLE_SCOREKEEPER, "user_id": "user-123"},
+    ]))
+    result = resolve_admin_role(
+        supabase=supabase,
+        email="multi@example.com",
+        user_id="user-123",
+        allowlist=set(),
+    )
+    assert result.role == ROLE_SCOREKEEPER
+    assert result.source == "admin_role_assignments"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_admin_view_as.py
+++ b/tests/test_admin_view_as.py
@@ -47,19 +47,19 @@ def test_view_as_selector_uses_explicit_widget_key():
     assert 'key=VIEW_AS_SELECTOR_KEY' in app
 
 
-def test_return_to_super_admin_sets_pending_reset_and_reruns():
+def test_return_to_super_admin_sets_actual_label_and_reruns():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")
     assert 'if st.sidebar.button("Return to Super Admin"):' in app
     assert 'st.session_state["admin_view_as_role"] = None' in app
+    assert 'st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL' in app
     assert "st.session_state[VIEW_AS_RESET_PENDING_KEY] = True" in app
-    assert "st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL" not in app.split('if st.sidebar.button("Return to Super Admin"):', 1)[1].split('st.rerun()', 1)[0]
 
 
-def test_stale_selector_value_is_guarded_after_return_to_actual_super_admin():
+def test_selected_label_is_source_of_truth_for_view_as_role_every_run():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")
-    assert "last_selector_label = st.session_state.get(VIEW_AS_LAST_SELECTOR_KEY)" in app
-    assert "selector_changed = picked_label != last_selector_label" in app
-    assert "if selector_changed and picked_role != current_role:" in app
+    assert "mapped_role = picked_role or None" in app
+    assert "if mapped_role != current_role:" in app
+    assert 'st.session_state["admin_view_as_role"] = mapped_role' in app
 
 
 def test_pending_reset_applies_before_selectbox_render():
@@ -73,8 +73,9 @@ def test_selectbox_change_paths_still_switch_between_actual_and_organizer():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")
     assert '"View as Organizer": "organizer"' in app
     assert "picked_role = view_as_options[picked_label]" in app
-    assert "if selector_changed and picked_role != current_role:" in app
-    assert 'st.session_state["admin_view_as_role"] = picked_role or None' in app
+    assert "mapped_role = picked_role or None" in app
+    assert "if mapped_role != current_role:" in app
+    assert 'st.session_state["admin_view_as_role"] = mapped_role' in app
 
 
 def test_pending_reset_handled_before_effective_role_resolution():
@@ -90,11 +91,10 @@ def test_pending_reset_clears_view_as_before_role_resolution():
     assert 'st.session_state["admin_view_as_role"] = None' in pre_resolve
 
 
-def test_pending_reset_sets_selector_and_last_selector_before_selectbox():
+def test_pending_reset_sets_selector_before_selectbox():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")
     pre_selectbox = app.split("picked_label = st.sidebar.selectbox", 1)[0]
     assert "st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL" in pre_selectbox
-    assert "st.session_state[VIEW_AS_LAST_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL" in pre_selectbox
 
 
 def test_impossible_state_guard_present_after_effective_role_resolution():


### PR DESCRIPTION
### Motivation
- Fix a bug where the sidebar could display “Actual Super Admin” while the internal `st.session_state["admin_view_as_role"]` remained `"read_only"`, preventing the real super admin from regaining full permissions. 
- Ensure the View As selector always reconciles the visible dropdown label with the session state on every run and that returning to Super Admin reliably restores selector state. 
- Ensure email-only role assignments (rows with `user_id` null) are honored for users who have not stored a `user_id` in the assignments table while preserving allowlist fallback behavior.

### Description
- Treat the selected dropdown label as the source of truth in `streamlit_app.py` by mapping the picked label to `admin_view_as_role` every run and calling `st.rerun()` when the mapped value differs from the stored value. 
- Implement mapping so `"Actual Super Admin"` maps to `None` and other labels map to the explicit role (e.g., `"View as Organizer"` -> `"organizer"`).
- Update the Return to Super Admin flow to clear `admin_view_as_role`, set the selector back to `Actual Super Admin`, and rerun to avoid stale selector/state mismatches while keeping the existing impossible-state guard. 
- Change `resolve_admin_role()` in `jupr_app/domain/admin/roles.py` to query assignments by email first (selecting `role,user_id`) and prefer rows in this order: exact `user_id` match, null/blank `user_id`, then the first row; allowlist fallback remains unchanged. 
- Add and update unit tests to cover the View As reconciliation/reset behavior and email-only assignment resolution precedence.

### Testing
- Ran: `pytest -q tests/test_admin_view_as.py tests/test_admin_roles.py`.
- Result: all tests passed (24 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c21f582c832686b726bf4436e5a1)