### PR TITLE
Fix Super Admin View As rerun loop and sync role reconciliation

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -399,6 +399,14 @@ def main():
         VIEW_AS_SELECTOR_KEY = "admin_view_as_selector_label"
         VIEW_AS_RESET_PENDING_KEY = "admin_view_as_reset_pending"
 
+        def _apply_effective_admin_role_from_view_as(mapped_role: str | None) -> None:
+            if mapped_role:
+                st.session_state["admin_role"] = mapped_role
+                st.session_state["admin_role_source"] = "super_admin_view_as"
+            else:
+                st.session_state["admin_role"] = st.session_state.get("admin_real_role", "read_only")
+                st.session_state["admin_role_source"] = st.session_state.get("admin_real_role_source", "not_authenticated")
+
         if st.session_state.pop(VIEW_AS_RESET_PENDING_KEY, False):
             st.session_state["admin_view_as_role"] = None
             st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL
@@ -485,7 +493,7 @@ def main():
                 current_role = st.session_state.get("admin_view_as_role")
                 if mapped_role != current_role:
                     st.session_state["admin_view_as_role"] = mapped_role
-                    st.rerun()
+                    _apply_effective_admin_role_from_view_as(mapped_role)
 
         # Optional: allow pages to request a refresh of cached data
         if bool(st.session_state.get("force_data_refresh", False)):
@@ -751,8 +759,8 @@ def main():
                 if st.sidebar.button("Return to Super Admin"):
                     st.session_state["admin_view_as_role"] = None
                     st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL
-                    st.session_state[VIEW_AS_RESET_PENDING_KEY] = True
-                    st.rerun()
+                    st.session_state["admin_role"] = st.session_state.get("admin_real_role", "read_only")
+                    st.session_state["admin_role_source"] = st.session_state.get("admin_real_role_source", "not_authenticated")
             visible_labels = [x for x in visible_labels if x not in HIDDEN_PAGE_LABELS]
 
             valid_admin_deep_label = ""

--- a/tests/test_admin_view_as.py
+++ b/tests/test_admin_view_as.py
@@ -47,19 +47,24 @@ def test_view_as_selector_uses_explicit_widget_key():
     assert 'key=VIEW_AS_SELECTOR_KEY' in app
 
 
-def test_return_to_super_admin_sets_actual_label_and_reruns():
+def test_return_to_super_admin_restores_real_role_without_explicit_rerun():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")
     assert 'if st.sidebar.button("Return to Super Admin"):' in app
     assert 'st.session_state["admin_view_as_role"] = None' in app
     assert 'st.session_state[VIEW_AS_SELECTOR_KEY] = VIEW_AS_ACTUAL_LABEL' in app
-    assert "st.session_state[VIEW_AS_RESET_PENDING_KEY] = True" in app
+    assert 'st.session_state["admin_role"] = st.session_state.get("admin_real_role", "read_only")' in app
+    assert 'st.session_state["admin_role_source"] = st.session_state.get("admin_real_role_source", "not_authenticated")' in app
+    return_block = app.split('if st.sidebar.button("Return to Super Admin"):', 1)[1].split("visible_labels =", 1)[0]
+    assert "st.rerun()" not in return_block
 
 
-def test_selected_label_is_source_of_truth_for_view_as_role_every_run():
+def test_selected_label_reconciles_view_as_role_without_explicit_rerun():
     app = Path("streamlit_app.py").read_text(encoding="utf-8")
     assert "mapped_role = picked_role or None" in app
     assert "if mapped_role != current_role:" in app
     assert 'st.session_state["admin_view_as_role"] = mapped_role' in app
+    selectbox_block = app.split("picked_label = st.sidebar.selectbox", 1)[1].split("# Optional: allow pages to request a refresh", 1)[0]
+    assert "st.rerun()" not in selectbox_block
 
 
 def test_pending_reset_applies_before_selectbox_render():
@@ -76,6 +81,20 @@ def test_selectbox_change_paths_still_switch_between_actual_and_organizer():
     assert "mapped_role = picked_role or None" in app
     assert "if mapped_role != current_role:" in app
     assert 'st.session_state["admin_view_as_role"] = mapped_role' in app
+    assert "_apply_effective_admin_role_from_view_as(mapped_role)" in app
+
+
+def test_view_as_helper_restores_super_admin_when_actual_selected():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    assert "def _apply_effective_admin_role_from_view_as(mapped_role: str | None) -> None:" in app
+    assert 'st.session_state["admin_role"] = st.session_state.get("admin_real_role", "read_only")' in app
+    assert 'st.session_state["admin_role_source"] = st.session_state.get("admin_real_role_source", "not_authenticated")' in app
+
+
+def test_view_as_helper_sets_read_only_source_for_super_admin_view_as():
+    app = Path("streamlit_app.py").read_text(encoding="utf-8")
+    assert 'st.session_state["admin_role"] = mapped_role' in app
+    assert 'st.session_state["admin_role_source"] = "super_admin_view_as"' in app
 
 
 def test_pending_reset_handled_before_effective_role_resolution():


### PR DESCRIPTION
### Motivation
- The View As selector was calling `st.rerun()` when the mapped role differed from the current role, which could trap the app in a continuous reload loop.
- Role changes from the selector should be applied synchronously in the same run so the UI and permission state remain stable without forcing reruns.
- Preserve the prior role-assignment/guard logic introduced earlier so effective role resolution continues to behave correctly.

### Description
- Removed explicit `st.rerun()` from the View As selector reconciliation path in `streamlit_app.py` and instead apply role changes inline. 
- Added helper `def _apply_effective_admin_role_from_view_as(mapped_role: str | None) -> None:` that sets `st.session_state["admin_role"]` and `st.session_state["admin_role_source"]` immediately based on `mapped_role`.
- Updated the "Return to Super Admin" button to clear `admin_view_as_role`, set `admin_view_as_selector_label` to `"Actual Super Admin"`, and restore `admin_role`/`admin_role_source` synchronously without calling `st.rerun()`.
- Updated `tests/test_admin_view_as.py` to reflect the new reconciliation behavior and to assert there is no reliance on `st.rerun()` for View As reconciliation and return paths.

### Testing
- Ran `pytest -q tests/test_admin_view_as.py` and all tests passed: `16 passed`.
- Tests were updated to check that selecting Actual Super Admin restores the real role, selecting View as Read Only sets the effective role and source to `super_admin_view_as`, and neither path asserts that `st.rerun()` is called.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c4af9d8c83269606d5f51fb22088)