### PR TITLE
Align public leaderboard API contract between FastAPI and Next.js

### DIFF
--- a/apps/web/app/clubs/[clubSlug]/leaderboards/page.tsx
+++ b/apps/web/app/clubs/[clubSlug]/leaderboards/page.tsx
@@ -7,13 +7,15 @@ type LeaderboardPageProps = {
 export default async function ClubLeaderboardPage({ params }: LeaderboardPageProps) {
   const { clubSlug } = params;
   const { data, error } = await getClubLeaderboard(clubSlug);
+  const entries = data?.leaderboard ?? [];
+  const clubName = data?.club?.name ?? clubSlug;
 
   return (
     <section>
-      <h1>{clubSlug} Leaderboards</h1>
+      <h1>{clubName} Leaderboards</h1>
       {error ? <p style={{ color: "#b91c1c" }}>Could not load leaderboard data. {error}</p> : null}
-      {!error && (!data || data.length === 0) ? <p>No leaderboard data is currently available.</p> : null}
-      {data && data.length > 0 ? (
+      {!error && entries.length === 0 ? <p>No leaderboard data is currently available.</p> : null}
+      {entries.length > 0 ? (
         <div style={{ overflowX: "auto" }}>
           <table style={{ width: "100%", borderCollapse: "collapse", background: "white" }}>
             <thead>
@@ -25,9 +27,11 @@ export default async function ClubLeaderboardPage({ params }: LeaderboardPagePro
               </tr>
             </thead>
             <tbody>
-              {data.map((entry) => (
-                <tr key={`${entry.player_name}-${entry.rank}`}>
-                  <td style={{ borderBottom: "1px solid #e2e8f0", padding: "0.5rem" }}>{entry.rank}</td>
+              {entries.map((entry, index) => (
+                <tr key={`${entry.player_name}-${entry.player_id ?? index}`}>
+                  <td style={{ borderBottom: "1px solid #e2e8f0", padding: "0.5rem" }}>
+                    {entry.rank ?? entry.rank_position ?? index + 1}
+                  </td>
                   <td style={{ borderBottom: "1px solid #e2e8f0", padding: "0.5rem" }}>{entry.player_name}</td>
                   <td style={{ borderBottom: "1px solid #e2e8f0", padding: "0.5rem" }}>{entry.rating ?? "—"}</td>
                   <td style={{ borderBottom: "1px solid #e2e8f0", padding: "0.5rem" }}>{entry.matches_played ?? "—"}</td>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -6,10 +6,28 @@ export type ClubSummary = {
 };
 
 export type LeaderboardEntry = {
-  rank: number;
+  rank?: number | null;
+  rank_position?: number | null;
+  club_id?: string;
+  league_name?: string | null;
+  player_id?: string | number;
   player_name: string;
   rating?: number | null;
+  rating_jupr?: number | null;
+  wins?: number | null;
+  losses?: number | null;
   matches_played?: number | null;
+  is_active?: boolean | null;
+  updated_at?: string | null;
+};
+
+export type LeaderboardResponse = {
+  club: {
+    id: string;
+    slug: string;
+    name: string;
+  };
+  leaderboard: LeaderboardEntry[];
 };
 
 type ApiResult<T> = {
@@ -49,6 +67,6 @@ export async function getClub(clubSlug: string): Promise<ApiResult<ClubSummary>>
   return fetchJson<ClubSummary>(`/clubs/${clubSlug}`);
 }
 
-export async function getClubLeaderboard(clubSlug: string): Promise<ApiResult<LeaderboardEntry[]>> {
-  return fetchJson<LeaderboardEntry[]>(`/clubs/${clubSlug}/leaderboards/public`);
+export async function getClubLeaderboard(clubSlug: string): Promise<ApiResult<LeaderboardResponse>> {
+  return fetchJson<LeaderboardResponse>(`/clubs/${clubSlug}/leaderboards`);
 }

--- a/jupr_app/services/leaderboard_service.py
+++ b/jupr_app/services/leaderboard_service.py
@@ -4,6 +4,7 @@ from typing import Any
 
 
 PUBLIC_LEADERBOARD_FIELDS = {
+    "rank",
     "club_id",
     "league_name",
     "player_id",
@@ -25,6 +26,8 @@ def _normalize_rows(rows: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
         clean = {k: row.get(k) for k in PUBLIC_LEADERBOARD_FIELDS if k in row}
         clean.setdefault("rating_jupr", clean.get("rating"))
         clean.setdefault("matches_played", (clean.get("wins") or 0) + (clean.get("losses") or 0))
+        if clean.get("rank") is None and clean.get("rank_position") is not None:
+            clean["rank"] = clean.get("rank_position")
         normalized.append(clean)
     return normalized
 

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -17,6 +17,23 @@ from jupr_app.services.match_service import submit_match_batch
 app = FastAPI(title="JUPR API", version="0.1.0")
 
 
+PUBLIC_LEADERBOARD_ENTRY_FIELDS = {
+    "rank",
+    "rank_position",
+    "club_id",
+    "league_name",
+    "player_id",
+    "player_name",
+    "rating",
+    "rating_jupr",
+    "wins",
+    "losses",
+    "matches_played",
+    "is_active",
+    "updated_at",
+}
+
+
 class MatchBatchRequest(BaseModel):
     matches: list[dict[str, Any]] = Field(default_factory=list)
     source: str = "next_admin_score_entry"
@@ -39,6 +56,34 @@ def _get_supabase_credentials() -> tuple[str, str]:
 def get_supabase_client() -> Client:
     url, key = _get_supabase_credentials()
     return create_client(url, key)
+
+
+def _normalize_public_leaderboard_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for idx, row in enumerate(rows, start=1):
+        clean = {k: row.get(k) for k in PUBLIC_LEADERBOARD_ENTRY_FIELDS if k in row}
+        if clean.get("rank") is None:
+            if clean.get("rank_position") is not None:
+                clean["rank"] = clean.get("rank_position")
+            else:
+                clean["rank"] = idx
+        normalized.append(clean)
+    return normalized
+
+
+def _build_leaderboard_response(club_slug: str, league_name: str | None) -> dict[str, Any]:
+    club = get_club(club_slug)
+    club_id = str(club.get("club_id") or club_slug)
+    supabase = get_supabase_client()
+    rows = get_public_leaderboard(supabase=supabase, club_id=club_id, league_name=league_name)
+    return {
+        "club": {
+            "id": str(club.get("club_id") or club_id),
+            "slug": str(club.get("club_slug") or club_slug),
+            "name": str(club.get("club_name") or club.get("display_name") or club_slug),
+        },
+        "leaderboard": _normalize_public_leaderboard_rows(rows),
+    }
 
 
 def _authorize_score_entry(*, token: str | None, requested_permission: str) -> str:
@@ -115,18 +160,14 @@ def get_club(club_slug: str) -> dict[str, Any]:
 
 @app.get("/clubs/{club_slug}/leaderboards")
 def get_club_leaderboard(club_slug: str, league_name: str | None = Query(default=None)) -> dict[str, Any]:
-    club = get_club(club_slug)
-    club_id = str(club.get("club_id") or club_slug)
-    supabase = get_supabase_client()
-    rows = get_public_leaderboard(supabase=supabase, club_id=club_id, league_name=league_name)
-    return {
-        "club": {
-            "club_id": club.get("club_id", club_id),
-            "club_slug": club.get("club_slug", club_slug),
-            "club_name": club.get("club_name") or club.get("display_name") or club_slug,
-        },
-        "leaderboard": rows,
-    }
+    return _build_leaderboard_response(club_slug, league_name)
+
+
+@app.get("/clubs/{club_slug}/leaderboards/public")
+def get_club_leaderboard_compat(club_slug: str, league_name: str | None = Query(default=None)) -> dict[str, Any]:
+    # Temporary compatibility alias for Next.js clients still calling /leaderboards/public.
+    # Remove this route after the web app fully migrates to /leaderboards.
+    return _build_leaderboard_response(club_slug, league_name)
 
 
 @app.post("/admin/clubs/{club_id}/matches/batch")

--- a/tests/test_api_leaderboard_contract.py
+++ b/tests/test_api_leaderboard_contract.py
@@ -1,0 +1,78 @@
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("supabase")
+
+from fastapi.testclient import TestClient
+
+from services.api.main import app
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(
+        "services.api.main.get_club",
+        lambda club_slug: {
+            "club_id": "club-1",
+            "club_slug": club_slug,
+            "club_name": "Test Club",
+        },
+    )
+    monkeypatch.setattr("services.api.main.get_supabase_client", lambda: object())
+
+    def fake_get_public_leaderboard(*, supabase, club_id, league_name=None):
+        assert club_id == "club-1"
+        return [
+            {
+                "rank_position": 7,
+                "club_id": "club-1",
+                "league_name": league_name or "Open",
+                "player_id": "p1",
+                "player_name": "Alex",
+                "rating": 1600,
+                "rating_jupr": 1600,
+                "wins": 10,
+                "losses": 2,
+                "matches_played": 12,
+                "is_active": True,
+                "updated_at": "2026-05-04T00:00:00Z",
+                "email": "private@example.com",
+            },
+            {
+                "club_id": "club-1",
+                "league_name": league_name or "Open",
+                "player_id": "p2",
+                "player_name": "Blair",
+                "rating": 1500,
+                "wins": 8,
+                "losses": 4,
+                "matches_played": 12,
+                "is_active": True,
+                "internal_notes": "hidden",
+            },
+        ]
+
+    monkeypatch.setattr("services.api.main.get_public_leaderboard", fake_get_public_leaderboard)
+    return TestClient(app)
+
+
+def test_primary_and_compat_routes_return_same_normalized_contract(client):
+    primary = client.get("/clubs/test-club/leaderboards?league_name=Pro")
+    compat = client.get("/clubs/test-club/leaderboards/public?league_name=Pro")
+
+    assert primary.status_code == 200
+    assert compat.status_code == 200
+    assert primary.json() == compat.json()
+
+    payload = primary.json()
+    assert payload["club"] == {"id": "club-1", "slug": "test-club", "name": "Test Club"}
+    assert isinstance(payload["leaderboard"], list)
+
+    first, second = payload["leaderboard"]
+    assert first["rank"] == 7
+    assert first["rank_position"] == 7
+    assert "email" not in first
+
+    assert second["rank"] == 2
+    assert "rank_position" not in second or second["rank_position"] is None
+    assert "internal_notes" not in second

--- a/tests/test_leaderboard_service.py
+++ b/tests/test_leaderboard_service.py
@@ -123,6 +123,7 @@ def test_missing_view_falls_back_to_tables_and_stays_public_only():
                 "matches_played",
                 "is_active",
                 "rank_position",
+                "rank",
                 "updated_at",
             }
         )


### PR DESCRIPTION
### Motivation
- Fix a contract mismatch where the web client called `/clubs/{clubSlug}/leaderboards/public` but the API exposed `/clubs/{club_slug}/leaderboards` and returned a different shape. 
- Ensure public leaderboard entries always expose a stable `rank` field derived from `rank_position` or list order for predictable client rendering. 
- Provide a temporary compatibility alias so existing Next deployments continue to work during migration. 

### Description
- Normalize API responses in `services/api/main.py` via `_build_leaderboard_response` and `_normalize_public_leaderboard_rows` so the primary route `GET /clubs/{club_slug}/leaderboards` returns `{ "club": { id, slug, name }, "leaderboard": LeaderboardEntry[] }` and strips private/internal fields. 
- Add a temporary alias `GET /clubs/{club_slug}/leaderboards/public` that delegates to the same response builder and includes a comment that it should be removed after migration. 
- Update `jupr_app/services/leaderboard_service.py` to include `rank` in `PUBLIC_LEADERBOARD_FIELDS` and to set `rank = rank_position` when available during normalization. 
- Update the Next client `apps/web/lib/api.ts` to call `/clubs/${clubSlug}/leaderboards`, add a typed `LeaderboardResponse`, and expand `LeaderboardEntry` to the public-safe fields in the contract. 
- Update the Next page `apps/web/app/clubs/[clubSlug]/leaderboards/page.tsx` to consume the normalized response, show the club `name` when available, and render rank using `entry.rank ?? entry.rank_position ?? index + 1`. 
- Add `tests/test_api_leaderboard_contract.py` to assert the primary and compatibility routes return the same normalized, public-safe payload, and adjust `tests/test_leaderboard_service.py` expectations to include `rank`. 

### Testing
- Ran `pytest -q tests/test_api_health.py tests/test_leaderboard_service.py tests/test_api_leaderboard_contract.py` and all tests passed (`6 passed`). 
- Existing leaderboard service unit tests and the new contract test confirm `rank` normalization, exclusion of private fields, and parity between `/leaderboards` and `/leaderboards/public`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a4d222388326a922d131f4215279)