### PR TITLE
Align club API with public.clubs (slug-first lookup + id fallback)

### DIFF
--- a/services/api/README.md
+++ b/services/api/README.md
@@ -22,6 +22,8 @@ uvicorn services.api.main:app --reload
 - `GET /clubs/{club_slug}`
 - `GET /clubs/{club_slug}/leaderboards?league_name=...`
 
+`GET /clubs/{club_slug}` is backed by `public.clubs` (slug-first lookup with id fallback) and returns a normalized public club contract (`id`, `slug`, `name`, `tagline`, `support_email`, `public_base_url`, `logo_url`, `primary_color`, `is_active`). Tres Palapas default slug is `tres-palapas`.
+
 The leaderboard endpoint delegates to `jupr_app.services.leaderboard_service.get_public_leaderboard` and only returns public-safe fields.
 - `POST /admin/clubs/{club_id}/matches/batch`
 

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -73,14 +73,14 @@ def _normalize_public_leaderboard_rows(rows: list[dict[str, Any]]) -> list[dict[
 
 def _build_leaderboard_response(club_slug: str, league_name: str | None) -> dict[str, Any]:
     club = get_club(club_slug)
-    club_id = str(club.get("club_id") or club_slug)
+    club_id = str(club.get("id") or club.get("club_id") or club_slug)
     supabase = get_supabase_client()
     rows = get_public_leaderboard(supabase=supabase, club_id=club_id, league_name=league_name)
     return {
         "club": {
-            "id": str(club.get("club_id") or club_id),
-            "slug": str(club.get("club_slug") or club_slug),
-            "name": str(club.get("club_name") or club.get("display_name") or club_slug),
+            "id": str(club.get("id") or club.get("club_id") or club_id),
+            "slug": str(club.get("slug") or club.get("club_slug") or club_slug),
+            "name": str(club.get("name") or club.get("club_name") or club.get("display_name") or club_slug),
         },
         "leaderboard": _normalize_public_leaderboard_rows(rows),
     }
@@ -124,38 +124,50 @@ def get_club(club_slug: str) -> dict[str, Any]:
         raise HTTPException(status_code=400, detail="club_slug is required")
 
     supabase = get_supabase_client()
+    club_fields = "id,slug,name,tagline,support_email,public_base_url,logo_url,primary_color,is_active"
 
-    row = (
-        supabase.table("clubs_config")
-        .select("club_id,club_slug,club_name,display_name,is_public")
-        .eq("club_slug", slug)
+    rows = (
+        supabase.table("clubs").select(club_fields).eq("slug", slug).limit(1).execute().data or []
+    )
+    if not rows:
+        rows = supabase.table("clubs").select(club_fields).eq("id", slug).limit(1).execute().data or []
+
+    if rows:
+        row = rows[0] or {}
+        return {
+            "id": row.get("id"),
+            "slug": row.get("slug"),
+            "name": row.get("name"),
+            "tagline": row.get("tagline"),
+            "support_email": row.get("support_email"),
+            "public_base_url": row.get("public_base_url"),
+            "logo_url": row.get("logo_url"),
+            "primary_color": row.get("primary_color"),
+            "is_active": row.get("is_active"),
+        }
+
+    fallback = (
+        supabase.table("players")
+        .select("club_id")
+        .eq("club_id", slug)
         .limit(1)
         .execute()
         .data
         or []
     )
-
-    if not row:
-        fallback = (
-            supabase.table("players")
-            .select("club_id")
-            .eq("club_id", slug)
-            .limit(1)
-            .execute()
-            .data
-            or []
-        )
-        if not fallback:
-            raise HTTPException(status_code=404, detail="club not found")
-        return {
-            "club_id": slug,
-            "club_slug": slug,
-            "club_name": slug,
-            "display_name": slug,
-            "is_public": True,
-        }
-
-    return row[0]
+    if not fallback:
+        raise HTTPException(status_code=404, detail="club not found")
+    return {
+        "id": slug,
+        "slug": slug,
+        "name": slug,
+        "tagline": None,
+        "support_email": None,
+        "public_base_url": None,
+        "logo_url": None,
+        "primary_color": None,
+        "is_active": True,
+    }
 
 
 @app.get("/clubs/{club_slug}/leaderboards")

--- a/tests/test_api_clubs_contract.py
+++ b/tests/test_api_clubs_contract.py
@@ -1,0 +1,126 @@
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("supabase")
+
+from fastapi.testclient import TestClient
+
+from services.api.main import app
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeQuery:
+    def __init__(self, db, table_name):
+        self._db = db
+        self._table_name = table_name
+        self._eq = {}
+
+    def select(self, _fields):
+        return self
+
+    def eq(self, field, value):
+        self._eq[field] = value
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def execute(self):
+        rows = list(self._db.get(self._table_name, []))
+        for key, expected in self._eq.items():
+            rows = [r for r in rows if r.get(key) == expected]
+        return _FakeResponse(rows[:1])
+
+
+class _FakeSupabase:
+    def __init__(self, db):
+        self._db = db
+
+    def table(self, table_name):
+        return _FakeQuery(self._db, table_name)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    db = {
+        "clubs": [
+            {
+                "id": "club-1",
+                "slug": "tres-palapas",
+                "name": "Tres Palapas",
+                "tagline": "Welcome",
+                "support_email": "support@trespalapas.com",
+                "public_base_url": "https://app.example.com",
+                "logo_url": "https://cdn.example.com/logo.png",
+                "primary_color": "#00AA88",
+                "is_active": True,
+            },
+            {
+                "id": "club-2",
+                "slug": "other-club",
+                "name": "Other Club",
+                "tagline": None,
+                "support_email": None,
+                "public_base_url": None,
+                "logo_url": None,
+                "primary_color": None,
+                "is_active": True,
+            },
+        ],
+        "players": [{"club_id": "legacy-club"}],
+    }
+    monkeypatch.setattr("services.api.main.get_supabase_client", lambda: _FakeSupabase(db))
+    return TestClient(app)
+
+
+def test_club_slug_lookup_returns_normalized_fields(client):
+    response = client.get("/clubs/tres-palapas")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": "club-1",
+        "slug": "tres-palapas",
+        "name": "Tres Palapas",
+        "tagline": "Welcome",
+        "support_email": "support@trespalapas.com",
+        "public_base_url": "https://app.example.com",
+        "logo_url": "https://cdn.example.com/logo.png",
+        "primary_color": "#00AA88",
+        "is_active": True,
+    }
+
+
+def test_club_id_fallback_lookup_works(client):
+    response = client.get("/clubs/club-2")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == "club-2"
+    assert payload["slug"] == "other-club"
+
+
+def test_club_legacy_players_fallback_returns_minimal_public_shape(client):
+    response = client.get("/clubs/legacy-club")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": "legacy-club",
+        "slug": "legacy-club",
+        "name": "legacy-club",
+        "tagline": None,
+        "support_email": None,
+        "public_base_url": None,
+        "logo_url": None,
+        "primary_color": None,
+        "is_active": True,
+    }
+
+
+def test_missing_club_returns_404_when_no_fallback_data_exists(client):
+    response = client.get("/clubs/missing-club")
+
+    assert response.status_code == 404


### PR DESCRIPTION
### Motivation
- The API previously queried a non-standard `clubs_config` table which mismatched the migration that creates `public.clubs`, so the FastAPI endpoints must be aligned with the existing `clubs` table contract while preserving legacy fallbacks.
- Ensure public pages do not break if the migration/table is missing by keeping a graceful player-based fallback behavior.

### Description
- Update `GET /clubs/{club_slug}` in `services/api/main.py` to query `public.clubs` (table name `clubs`) and perform a slug-first lookup via `.eq("slug", ...)` with a fallback to `.eq("id", ...)`. 
- Normalize the public response shape to contain `id`, `slug`, `name`, `tagline`, `support_email`, `public_base_url`, `logo_url`, `primary_color`, and `is_active`, and remove direct `clubs_config` references. 
- Preserve a legacy fallback: if no `clubs` row exists but a matching `players.club_id` exists, return a minimal public club shape instead of erroring; otherwise return 404. 
- Update the leaderboard response builder to accept the normalized `id/slug/name` keys while retaining compatibility with older keys, add `tests/test_api_clubs_contract.py` exercising slug lookup, id fallback, legacy fallback, and 404 behavior, and update `services/api/README.md` to document the `public.clubs` backing and the default `tres-palapas` slug.

### Testing
- Ran `pytest -q tests/test_api_clubs_contract.py tests/test_api_leaderboard_contract.py` in this environment. 
- The run resulted in tests being skipped due to optional dependency gating via `pytest.importorskip("fastapi")` / `pytest.importorskip("supabase")` (reported as 2 skipped). 
- The added contract tests exercise slug lookup, id fallback, legacy player fallback minimal response, and missing-club 404 and will execute in environments where `fastapi` and `supabase` test dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ab405b108326816463e5dd4ce4f4)