### PR TITLE
Harden clubs API fallback and align web club contract

### DIFF
--- a/apps/web/app/clubs/[clubSlug]/page.tsx
+++ b/apps/web/app/clubs/[clubSlug]/page.tsx
@@ -17,8 +17,7 @@ export default async function ClubPage({ params }: ClubPageProps) {
       ) : (
         <>
           <p style={{ marginBottom: "0.25rem" }}><strong>Slug:</strong> {data?.slug}</p>
-          {data?.location ? <p style={{ margin: "0.25rem 0" }}><strong>Location:</strong> {data.location}</p> : null}
-          {data?.description ? <p style={{ margin: "0.25rem 0" }}>{data.description}</p> : null}
+          {data?.tagline ? <p style={{ margin: "0.25rem 0" }}>{data.tagline}</p> : null}
         </>
       )}
       <p>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,8 +1,13 @@
 export type ClubSummary = {
+  id: string;
   slug: string;
   name: string;
-  location?: string | null;
-  description?: string | null;
+  tagline?: string | null;
+  support_email?: string | null;
+  public_base_url?: string | null;
+  logo_url?: string | null;
+  primary_color?: string | null;
+  is_active?: boolean | null;
 };
 
 export type LeaderboardEntry = {

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -58,6 +58,20 @@ def get_supabase_client() -> Client:
     return create_client(url, key)
 
 
+def _is_missing_table_error(exc: Exception, table_name: str) -> bool:
+    detail = str(exc).lower()
+    table = table_name.lower()
+    return (
+        table in detail
+        and (
+            "does not exist" in detail
+            or "undefined table" in detail
+            or "relation" in detail
+            or "not found" in detail
+        )
+    )
+
+
 def _normalize_public_leaderboard_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     normalized: list[dict[str, Any]] = []
     for idx, row in enumerate(rows, start=1):
@@ -126,11 +140,18 @@ def get_club(club_slug: str) -> dict[str, Any]:
     supabase = get_supabase_client()
     club_fields = "id,slug,name,tagline,support_email,public_base_url,logo_url,primary_color,is_active"
 
-    rows = (
-        supabase.table("clubs").select(club_fields).eq("slug", slug).limit(1).execute().data or []
-    )
-    if not rows:
-        rows = supabase.table("clubs").select(club_fields).eq("id", slug).limit(1).execute().data or []
+    rows: list[dict[str, Any]] = []
+    try:
+        rows = (
+            supabase.table("clubs").select(club_fields).eq("slug", slug).limit(1).execute().data or []
+        )
+        if not rows:
+            rows = supabase.table("clubs").select(club_fields).eq("id", slug).limit(1).execute().data or []
+    except Exception as exc:
+        if _is_missing_table_error(exc, "clubs"):
+            rows = []
+        else:
+            raise
 
     if rows:
         row = rows[0] or {}

--- a/tests/test_api_clubs_contract.py
+++ b/tests/test_api_clubs_contract.py
@@ -30,6 +30,9 @@ class _FakeQuery:
         return self
 
     def execute(self):
+        execute_error = self._db.get(f"{self._table_name}__execute_error")
+        if execute_error is not None:
+            raise execute_error
         rows = list(self._db.get(self._table_name, []))
         for key, expected in self._eq.items():
             rows = [r for r in rows if r.get(key) == expected]
@@ -124,3 +127,29 @@ def test_missing_club_returns_404_when_no_fallback_data_exists(client):
     response = client.get("/clubs/missing-club")
 
     assert response.status_code == 404
+
+
+def test_club_players_fallback_works_when_clubs_table_is_missing(monkeypatch):
+    db = {
+        "clubs__execute_error": RuntimeError('relation "clubs" does not exist'),
+        "players": [{"club_id": "legacy-club"}],
+    }
+    monkeypatch.setattr("services.api.main.get_supabase_client", lambda: _FakeSupabase(db))
+    client = TestClient(app)
+
+    legacy_response = client.get("/clubs/legacy-club")
+    assert legacy_response.status_code == 200
+    assert legacy_response.json() == {
+        "id": "legacy-club",
+        "slug": "legacy-club",
+        "name": "legacy-club",
+        "tagline": None,
+        "support_email": None,
+        "public_base_url": None,
+        "logo_url": None,
+        "primary_color": None,
+        "is_active": True,
+    }
+
+    missing_response = client.get("/clubs/missing-club")
+    assert missing_response.status_code == 404


### PR DESCRIPTION
### Motivation
- Ensure the public clubs API remains resilient when the `clubs` table is missing or unavailable while preserving the existing lookup order (slug → id → players → 404). 
- Align the Next.js web app types and club page with the actual API response so the UI shows fields the API returns.

### Description
- Added `_is_missing_table_error(exc, "clubs")` and wrapped the `clubs` table lookups in `get_club()` with a targeted `try/except` so missing-table errors fall back to the legacy `players` lookup without swallowing unrelated exceptions (`services/api/main.py`).
- Preserved behavior: slug lookup first, id lookup second, players fallback third, and 404 if neither returns data (`services/api/main.py`).
- Added test harness support for simulating table execution errors and a regression test that verifies `/clubs/legacy-club` returns the minimal fallback when `clubs` lookups fail and that a missing club still returns 404 (`tests/test_api_clubs_contract.py`).
- Updated `ClubSummary` TypeScript type to include `id`, `slug`, `name`, `tagline`, `support_email`, `public_base_url`, `logo_url`, `primary_color`, and `is_active` to match the API payload (`apps/web/lib/api.ts`).
- Simplified the club page to display `tagline` when present instead of legacy `location`/`description` fields (`apps/web/app/clubs/[clubSlug]/page.tsx`).

### Testing
- Ran `pytest -q tests/test_api_clubs_contract.py` in this environment which reported `1 skipped` due to `pytest.importorskip("supabase")`, and there were no test failures for the exercised cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8afb4b9a08326b74a60efda04d8ee)