### PR TITLE
Add public SaaS API contract tests for clubs and leaderboards

### DIFF
--- a/tests/test_api_contract_clubs.py
+++ b/tests/test_api_contract_clubs.py
@@ -1,0 +1,89 @@
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("supabase")
+
+from fastapi.testclient import TestClient
+
+from services.api.main import app
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeQuery:
+    def __init__(self, db, table_name):
+        self._db = db
+        self._table_name = table_name
+        self._eq = {}
+
+    def select(self, _fields):
+        return self
+
+    def eq(self, field, value):
+        self._eq[field] = value
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def execute(self):
+        rows = list(self._db.get(self._table_name, []))
+        for key, expected in self._eq.items():
+            rows = [row for row in rows if row.get(key) == expected]
+        return _FakeResponse(rows[:1])
+
+
+class _FakeSupabase:
+    def __init__(self, db):
+        self._db = db
+
+    def table(self, table_name):
+        return _FakeQuery(self._db, table_name)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    db = {
+        "clubs": [
+            {
+                "id": "club-1",
+                "slug": "tres-palapas",
+                "name": "Tres Palapas",
+                "tagline": "Welcome",
+                "support_email": "support@trespalapas.com",
+                "public_base_url": "https://app.example.com",
+                "logo_url": "https://cdn.example.com/logo.png",
+                "primary_color": "#00AA88",
+                "is_active": True,
+                "admin_notes": "private",
+                "subscription_token": "secret-token",
+            }
+        ]
+    }
+    monkeypatch.setattr("services.api.main.get_supabase_client", lambda: _FakeSupabase(db))
+    return TestClient(app)
+
+
+def test_health_contract(client):
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "service": "jupr-api"}
+
+
+def test_public_club_contract_filters_private_fields(client):
+    response = client.get("/clubs/tres-palapas")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["id"] == "club-1"
+    assert payload["slug"] == "tres-palapas"
+    assert payload["name"] == "Tres Palapas"
+    assert payload["is_active"] is True
+
+    assert "admin_notes" not in payload
+    assert "subscription_token" not in payload

--- a/tests/test_api_contract_leaderboards.py
+++ b/tests/test_api_contract_leaderboards.py
@@ -1,0 +1,92 @@
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("supabase")
+
+from fastapi.testclient import TestClient
+
+from services.api.main import app
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(
+        "services.api.main.get_club",
+        lambda club_slug: {
+            "id": "club-1",
+            "slug": club_slug,
+            "name": "Tres Palapas",
+        },
+    )
+    monkeypatch.setattr("services.api.main.get_supabase_client", lambda: object())
+
+    def fake_get_public_leaderboard(*, supabase, club_id, league_name=None):
+        assert club_id == "club-1"
+        return [
+            {
+                "rank_position": 1,
+                "club_id": "club-1",
+                "league_name": league_name or "Open",
+                "player_id": "p1",
+                "player_name": "Alex",
+                "rating": 1600,
+                "rating_jupr": 1600,
+                "wins": 10,
+                "losses": 2,
+                "matches_played": 12,
+                "is_active": True,
+                "updated_at": "2026-05-04T00:00:00Z",
+                "email": "private@example.com",
+                "admin_flag": "secret",
+            },
+            {
+                "club_id": "club-1",
+                "league_name": league_name or "Open",
+                "player_id": "p2",
+                "player_name": "Blair",
+                "rating_jupr": 1500,
+                "wins": 8,
+                "losses": 4,
+                "matches_played": 12,
+                "is_active": True,
+                "subscription_token": "nope",
+            },
+        ]
+
+    monkeypatch.setattr("services.api.main.get_public_leaderboard", fake_get_public_leaderboard)
+    return TestClient(app)
+
+
+def test_public_leaderboards_contract_shape(client):
+    response = client.get("/clubs/tres-palapas/leaderboards?league_name=Pro")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["club"] == {"id": "club-1", "slug": "tres-palapas", "name": "Tres Palapas"}
+    assert isinstance(payload["leaderboard"], list)
+
+    first_row = payload["leaderboard"][0]
+    assert first_row["rank"] == 1
+    assert first_row["player_name"] == "Alex"
+    assert "rating" in first_row or "rating_jupr" in first_row
+    assert first_row["matches_played"] == 12
+    assert "email" not in first_row
+    assert "admin_flag" not in first_row
+
+    second_row = payload["leaderboard"][1]
+    assert second_row["rank"] == 2
+    assert second_row["player_name"] == "Blair"
+    assert "rating" in second_row or "rating_jupr" in second_row
+    assert second_row["matches_played"] == 12
+    assert "subscription_token" not in second_row
+
+
+def test_public_leaderboards_compat_alias_matches_primary_contract(client):
+    # Temporary compatibility alias only; this should match /leaderboards exactly.
+    primary = client.get("/clubs/tres-palapas/leaderboards?league_name=Pro")
+    compat = client.get("/clubs/tres-palapas/leaderboards/public?league_name=Pro")
+
+    assert primary.status_code == 200
+    assert compat.status_code == 200
+    assert compat.json() == primary.json()


### PR DESCRIPTION
### Motivation
- Lock the public FastAPI SaaS contract for clubs and leaderboards so future mismatches between the web client and API break CI.  
- Ensure the public endpoints can be tested deterministically without requiring a live Supabase instance or external services.  
- Provide a test for the temporary compatibility alias `/clubs/{club_slug}/leaderboards/public` to guarantee parity while clients migrate.

### Description
- Add `tests/test_api_contract_clubs.py` which tests `GET /health` and `GET /clubs/tres-palapas` using `TestClient` and a small in-memory fake Supabase implementation.  
- Add `tests/test_api_contract_leaderboards.py` which tests `GET /clubs/tres-palapas/leaderboards` and the compatibility alias `GET /clubs/tres-palapas/leaderboards/public` by monkeypatching `services.api.main.get_public_leaderboard` and `get_club`.  
- The fake Supabase helpers implement the minimal query chain used by the service (`table(...).select(...).eq(...).limit(...).execute()`) so tests do not require real credentials or network access.  
- Tests assert required public fields (IDs, `slug`, `name`, `is_active`, `club` + `leaderboard` shape, `rank`/`player_name`/`rating` or `rating_jupr`/`matches_played`) and explicitly verify private/admin/secret-like fields are excluded from responses.

### Testing
- Ran the focused command `pytest -q tests/test_api_contract_clubs.py tests/test_api_contract_leaderboards.py tests/test_api_health.py`.  
- In this environment the tests were gated by optional dependency checks (`pytest.importorskip`) and reported as skipped (no assertion failures).  
- Tests are deterministic, fast, and designed to pass in a normal development environment with `fastapi` and `supabase` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b15ae1b883268806d5be212be325)