### PR TITLE
Add API runtime dependencies and CI contract test runner

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -23,7 +23,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r services/api/requirements.txt
+          python -m pip install pytest
 
       - name: Run API contract tests
         run: |
-          pytest tests/test_api_health.py tests/test_api_contract_clubs.py tests/test_api_contract_leaderboards.py
+          python -m pytest tests/test_api_health.py tests/test_api_contract_clubs.py tests/test_api_contract_leaderboards.py

--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -1,0 +1,29 @@
+name: API Contract Tests
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  api-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r services/api/requirements.txt
+
+      - name: Run API contract tests
+        run: |
+          pytest tests/test_api_health.py tests/test_api_contract_clubs.py tests/test_api_contract_leaderboards.py

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,8 @@ db-migrate: ## Apply pending SQL migrations (requires DATABASE_URL)
 
 check-migration-sources: ## Guard: block undocumented new root migrations
 	@python scripts/check_migration_sources.py
+
+
+.PHONY: api-test
+api-test: ## Run API contract tests
+	@pytest tests/test_api_health.py tests/test_api_contract_clubs.py tests/test_api_contract_leaderboards.py

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -5,8 +5,7 @@ Minimal read-only API scaffold for future service integration.
 ## Run locally
 
 ```bash
-cd services/api
-pip install -r requirements.txt
+pip install -r services/api/requirements.txt
 uvicorn services.api.main:app --reload
 ```
 

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 supabase
+pandas


### PR DESCRIPTION
### Motivation

- Ensure the FastAPI service can import shared JUPR modules in a clean environment by providing the runtime dependencies they require.
- Make it easy to run the API locally with a clear install + start instruction.
- Run API contract tests in CI without requiring secrets and ensure the API tests actually execute rather than being skipped due to missing packages.

### Description

- Added `pandas` to `services/api/requirements.txt` so shared modules that import pandas can load during import.
- Updated `services/api/README.md` to instruct `pip install -r services/api/requirements.txt` and start the app with `uvicorn services.api.main:app --reload`.
- Added a GitHub Actions workflow `.github/workflows/api-contract.yml` named "API Contract Tests" that runs on Python 3.11, installs root and `services/api` requirements, and runs the three API contract tests with `pytest`.
- Added a `make api-test` target to the `Makefile` to run the API contract tests locally with the same `pytest` command.

### Testing

- Ran `pytest tests/test_api_health.py tests/test_api_contract_clubs.py tests/test_api_contract_leaderboards.py` in the local environment and the test run reported 3 skipped tests (tests were skipped because the required API packages were not installed). 
- Attempted `pip install -r services/api/requirements.txt` in this environment but the install failed due to outbound package index/proxy restrictions (network error), not due to repository changes.
- The new CI workflow will install `requirements.txt` and `services/api/requirements.txt` and then run the same `pytest` command in GitHub Actions (expected to run the tests in CI where packages are available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8cc59529c8326a56b56e2c57314ad)