### PR TITLE
Disable Next admin score-entry by default until real auth is implemented

### DIFF
--- a/apps/web/app/admin/clubs/[clubId]/score-entry/page.tsx
+++ b/apps/web/app/admin/clubs/[clubId]/score-entry/page.tsx
@@ -13,6 +13,10 @@ type MatchPayload = {
 };
 
 export default function ScoreEntryPage({ params }: { params: { clubId: string } }) {
+  const isEnabled = (() => {
+    const value = (process.env.NEXT_PUBLIC_JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY || "").trim().toLowerCase();
+    return value === "1" || value === "true" || value === "yes";
+  })();
   const [match, setMatch] = useState<MatchPayload>({
     league: "",
     t1_p1: "",
@@ -54,6 +58,12 @@ export default function ScoreEntryPage({ params }: { params: { clubId: string } 
     <main style={{ maxWidth: 700, margin: "2rem auto", padding: "0 1rem" }}>
       <h1>Score Entry</h1>
       <p>Club: {params.clubId}</p>
+      {!isEnabled ? (
+        <p>
+          Score entry is not enabled in the Next.js admin yet. Use the Streamlit admin console for rated events.
+        </p>
+      ) : null}
+      {!isEnabled ? null : (
       <form onSubmit={onSubmit} style={{ display: "grid", gap: "0.75rem" }}>
         <label>
           League
@@ -85,6 +95,7 @@ export default function ScoreEntryPage({ params }: { params: { clubId: string } 
         </label>
         <button type="submit" disabled={busy}>{busy ? "Submitting..." : "Submit"}</button>
       </form>
+      )}
       {status ? <p>{status}</p> : null}
     </main>
   );

--- a/apps/web/app/api/admin/clubs/[clubId]/matches/batch/route.ts
+++ b/apps/web/app/api/admin/clubs/[clubId]/matches/batch/route.ts
@@ -4,7 +4,22 @@ function getApiBaseUrl(): string | null {
   return process.env.JUPR_API_BASE_URL || process.env.NEXT_PUBLIC_JUPR_API_BASE_URL || null;
 }
 
+function isNextAdminScoreEntryEnabled(): boolean {
+  const value = (process.env.JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY || "").trim().toLowerCase();
+  return value === "1" || value === "true" || value === "yes";
+}
+
 export async function POST(request: NextRequest, { params }: { params: { clubId: string } }) {
+  if (!isNextAdminScoreEntryEnabled()) {
+    return NextResponse.json(
+      {
+        error:
+          "Next admin score entry is disabled. Use Streamlit admin until Supabase JWT role auth is implemented.",
+      },
+      { status: 403 }
+    );
+  }
+
   const apiBase = getApiBaseUrl();
   const adminToken = process.env.JUPR_ADMIN_API_TOKEN;
 

--- a/docs/saas_staging_deploy.md
+++ b/docs/saas_staging_deploy.md
@@ -30,6 +30,7 @@ Set these when deploying the staging stack:
 - **Do not point staging API at production Supabase.**
 - **Do not deploy Next admin score entry for rated matches.** Keep `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=0`.
 - **Do not migrate production traffic to Next yet.**
+- **Streamlit remains the active admin console for rated events.**
 
 ## Staging deployment checklist
 
@@ -45,3 +46,18 @@ Set these when deploying the staging stack:
 - Production deployment config for FastAPI.
 - Production Vercel/custom-domain cutover for Next.js.
 - Production traffic migration from Streamlit.
+
+## Next admin score entry status
+
+The Next.js admin score-entry flow is **experimental** and intentionally de-risked:
+
+- Disabled by default unless `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY` is exactly `1`, `true`, or `yes`.
+- Even when enabled, current token checks are temporary and **not** production auth.
+
+Before this flow can be active for rated events, it must implement:
+
+- Supabase JWT validation.
+- Admin role lookup.
+- Club-scoped authorization.
+- Audit identity attribution.
+- CSRF/session strategy for the chosen auth model (if applicable).

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -14,6 +14,7 @@ uvicorn services.api.main:app --reload
 - `SUPABASE_URL`
 - `SUPABASE_SERVICE_ROLE_KEY` (preferred for server-side API)
 - `SUPABASE_ANON_KEY` (read-only local fallback)
+- `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY` (`1` / `true` / `yes` to enable, disabled by default)
 
 ## Endpoints
 
@@ -26,9 +27,17 @@ uvicorn services.api.main:app --reload
 The leaderboard endpoint delegates to `jupr_app.services.leaderboard_service.get_public_leaderboard` and only returns public-safe fields.
 - `POST /admin/clubs/{club_id}/matches/batch`
 
-## Admin score-entry guard (v1 placeholder)
+## Admin score-entry guard (experimental + temporary)
 
-`POST /admin/clubs/{club_id}/matches/batch` currently uses a **server token placeholder guard** and is not production-grade auth.
+`POST /admin/clubs/{club_id}/matches/batch` is **disabled by default**.
+
+When disabled, the endpoint returns:
+
+`Next admin score entry is disabled. Use Streamlit admin until Supabase JWT role auth is implemented.`
+
+To enable in staging experiments only, set `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=1` (or `true` / `yes`).
+
+When enabled, this route still uses a **server token placeholder guard** and is not production-grade auth.
 
 Required headers:
 - `x-admin-token: <JUPR_ADMIN_API_TOKEN>`

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -22,6 +22,10 @@ def is_staging_env() -> bool:
     return get_jupr_env() == "staging"
 
 
+def is_next_admin_score_entry_enabled() -> bool:
+    return os.getenv("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY", "").strip().lower() in {"1", "true", "yes"}
+
+
 def _warn_if_not_staging_configured() -> None:
     env = get_jupr_env()
     if not env:
@@ -235,6 +239,16 @@ def submit_admin_match_batch(
     x_admin_token: str | None = Header(default=None),
     x_admin_permission: str | None = Header(default=None),
 ) -> dict[str, Any]:
+    if not is_next_admin_score_entry_enabled():
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Next admin score entry is disabled. Use Streamlit admin until Supabase JWT role auth is implemented."
+            ),
+        )
+
+    # Temporary guard only: this path must migrate to Supabase JWT + admin role checks
+    # before it can be considered production-grade authorization.
     auth_mode = _authorize_score_entry(token=x_admin_token, requested_permission=str(x_admin_permission or ""))
 
     supabase = get_supabase_client()

--- a/tests/test_api_admin_score_entry_disabled.py
+++ b/tests/test_api_admin_score_entry_disabled.py
@@ -1,0 +1,72 @@
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("supabase")
+
+from fastapi.testclient import TestClient
+
+from services.api.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_admin_batch_endpoint_disabled_by_default(client, monkeypatch):
+    monkeypatch.delenv("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY", raising=False)
+
+    response = client.post("/admin/clubs/club-1/matches/batch", json={"matches": []})
+
+    assert response.status_code == 403
+    assert (
+        response.json()["detail"]
+        == "Next admin score entry is disabled. Use Streamlit admin until Supabase JWT role auth is implemented."
+    )
+
+
+def test_admin_batch_endpoint_enabled_still_requires_token_guard(client, monkeypatch):
+    monkeypatch.setenv("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY", "true")
+    monkeypatch.setenv("JUPR_ADMIN_API_TOKEN", "expected-token")
+
+    response = client.post(
+        "/admin/clubs/club-1/matches/batch",
+        json={"matches": []},
+        headers={"x-admin-permission": "enter_scores", "x-admin-token": "wrong-token"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "invalid admin token"
+
+
+def test_admin_batch_endpoint_enabled_with_valid_token_reaches_service(client, monkeypatch):
+    monkeypatch.setenv("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY", "yes")
+    monkeypatch.setenv("JUPR_ADMIN_API_TOKEN", "expected-token")
+
+    monkeypatch.setattr(
+        "services.api.main.get_supabase_client",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        "services.api.main.load_data",
+        lambda _supabase, _club_id: (None, None, None, None, None, None, None, None, None, {}),
+    )
+
+    class _Result:
+        ok = True
+        errors = []
+        data = {"inserted": 1, "skipped_incomplete": 0}
+
+    monkeypatch.setattr("services.api.main.submit_match_batch", lambda *_args, **_kwargs: _Result())
+
+    response = client.post(
+        "/admin/clubs/club-1/matches/batch",
+        json={"matches": [{"league": "A"}], "source": "next_admin_score_entry"},
+        headers={"x-admin-permission": "enter_scores", "x-admin-token": "expected-token"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["auth_mode"] == "token_guard_placeholder"
+    assert payload["result"]["inserted"] == 1


### PR DESCRIPTION
### Motivation
- De-risk the experimental Next.js admin score-entry workflow so rated matches cannot be submitted accidentally without proper auth.
- Preserve the code for future development while making clear this is not production auth until Supabase JWT + role authorization is implemented.

### Description
- Add an environment flag check function `is_next_admin_score_entry_enabled()` and gate `POST /admin/clubs/{club_id}/matches/batch` to return 403 with a clear message when `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY` is not exactly `1`, `true`, or `yes` in `services/api/main.py`.
- Add the same environment gate to the Next.js proxy route in `apps/web/app/api/admin/clubs/[clubId]/matches/batch/route.ts` so the proxy returns 403 before forwarding and does not expose server token details.
- Update the Next score-entry page `apps/web/app/admin/clubs/[clubId]/score-entry/page.tsx` to render a clear notice and hide the active score-entry form unless `NEXT_PUBLIC_JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY` enables it.
- Keep the placeholder token guard in place when the flow is enabled and add comments/docs that it is temporary and not production-grade auth.
- Update docs: `services/api/README.md` and `docs/saas_staging_deploy.md` to mark the flow experimental, document `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY`, and state that Streamlit remains the active admin console until proper auth (Supabase JWT, role lookup, club-scoped authorization, audit identity, CSRF/session strategy) is implemented.
- Add tests in `tests/test_api_admin_score_entry_disabled.py` covering default-disabled rejection, enabled-but-invalid-token rejection, and enabled+valid-token path reaching the service via monkeypatching.

### Testing
- Ran `pytest -q tests/test_api_admin_score_entry_disabled.py`, which was executed in this environment but skipped due to optional dependency gating via `pytest.importorskip("fastapi")` / `pytest.importorskip("supabase")` (result: skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d1d8e010832691337de5f63a014d)