### PR TITLE
docs: add Next.js→FastAPI admin auth design stub and link from READMEs

### DIFF
--- a/docs/next_admin_auth_design.md
+++ b/docs/next_admin_auth_design.md
@@ -1,0 +1,93 @@
+# Next.js → FastAPI Admin Auth Design (future implementation)
+
+## Purpose
+
+Define the minimum production-grade authentication and authorization contract required before enabling Next.js admin score entry.
+
+This document is a design stub only. **No auth behavior is implemented by this document** and current runtime behavior must remain unchanged.
+
+## Scope
+
+In scope:
+- Next.js admin clients calling FastAPI admin endpoints.
+- Server-side token validation and role/permission checks.
+- Club-scoped authorization for write operations.
+- Audit attribution for admin write actions.
+
+Out of scope:
+- Implementing auth in this PR.
+- Enabling Next.js admin score entry.
+- Changing existing endpoint behavior.
+
+## 1) Authentication source and transport
+
+### Source of truth
+
+- Authentication source is **Supabase Auth JWT**.
+- User identity is represented by Supabase claims (user ID and email).
+
+### Request flow
+
+1. User signs in through approved Next.js auth flow.
+2. Next.js obtains a Supabase Auth access token.
+3. Next.js calls FastAPI admin endpoints with:
+   - `Authorization: Bearer <supabase_access_token>`
+4. FastAPI validates the bearer token before any admin write logic.
+
+### FastAPI validation requirements
+
+FastAPI must reject requests when token is:
+- missing,
+- malformed,
+- invalid signature,
+- expired,
+- otherwise unverifiable.
+
+## 2) Authorization model
+
+After token validation, FastAPI must authorize the request as follows:
+
+1. Resolve authenticated actor identity (`user_id`, `email`) from token claims.
+2. Query `admin_role_assignments` for active role bindings.
+3. Apply permissions using `jupr_app.domain.admin.roles` matrix.
+4. Require `enter_scores` permission for score-entry routes.
+5. Enforce `club_id` scope for all writes.
+
+### Club-scoped write requirement
+
+Every write endpoint must verify actor has permission for the target `club_id`.
+If actor lacks assignment for that club, request must be denied.
+
+## 3) Audit requirements
+
+All admin write actions must write an audit record to `admin_activity_log` with at least:
+
+- `actor_email`
+- `actor_role`
+- `source_page`
+- `source_client`
+
+Audit fields should be captured from request context and resolved role assignment.
+
+## 4) Security requirements (non-negotiable)
+
+- No static admin API token for user-initiated actions.
+- No client-side Supabase service role key usage.
+- No direct browser writes to Supabase rating tables.
+- API must reject missing/invalid/expired tokens.
+- API must reject users without club permission.
+
+## 5) Rollout sequence
+
+Rollout must proceed in this order:
+
+1. **Read-only public Next.js** first.
+2. **Authenticated scorekeeper login** second.
+3. **Score entry enabled in staging only** third.
+4. **Rated production writes** only after:
+   - audit logging is verified, and
+   - rollback path is tested.
+
+## Implementation gate for future PRs
+
+Before enabling Next.js admin score entry for rated workflows, future implementation PRs must satisfy this design contract end-to-end.

--- a/docs/saas_staging_deploy.md
+++ b/docs/saas_staging_deploy.md
@@ -54,6 +54,9 @@ The Next.js admin score-entry flow is **experimental** and intentionally de-risk
 - Disabled by default unless `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY` is exactly `1`, `true`, or `yes`.
 - Even when enabled, current token checks are temporary and **not** production auth.
 
+
+See `docs/next_admin_auth_design.md` for the minimum real-auth contract required before enabling Next.js admin score entry.
+
 Before this flow can be active for rated events, it must implement:
 
 - Supabase JWT validation.

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -45,6 +45,9 @@ Required headers:
 
 This endpoint is intentionally structured so Supabase JWT and role-based authorization can replace the placeholder guard later without changing the route contract.
 
+Auth design reference for future replacement of the temporary guard:
+- `docs/next_admin_auth_design.md`
+
 
 ## Staging deployment guardrails
 


### PR DESCRIPTION
### Motivation
- Define the minimum production-grade auth/authz/audit/security contract required before enabling Next.js admin score entry. 
- Make the design discoverable from the FastAPI README and staging deployment guardrails so future work can replace the temporary placeholder guard against a clear spec. 
- Ensure no insecure admin implementation is added in this PR and runtime behavior remains unchanged.

### Description
- Add `docs/next_admin_auth_design.md` which specifies Supabase Auth JWT as the auth source, bearer-token transport from Next.js to FastAPI, and FastAPI token validation requirements. 
- Specify authorization via resolving `user_id`/`email`, querying `admin_role_assignments`, applying `jupr_app.domain.admin.roles` permissions (including `enter_scores`) and enforcing `club_id`-scoped writes. 
- Define audit requirements to record `actor_email`, `actor_role`, `source_page`, and `source_client` into `admin_activity_log`, and enumerate non-negotiable security constraints (no static admin tokens for user actions, no client-side service role key, no direct browser writes to rating tables). 
- Describe the staged rollout sequence and add links to the new design from `services/api/README.md` and `docs/saas_staging_deploy.md`; no auth libraries or runtime changes were added.

### Testing
- Verified the new file was created and content rendered using file inspection commands (`nl`, `sed`). 
- Verified the README and staging doc updates via `git diff` to ensure the design doc was linked in the intended sections. 
- Committed the changes with `git commit` and created the PR via the repository automation, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d4b5a9188326ab6461c8e266880a)