### PR TITLE
Add manual GitHub Actions workflow to copy Supabase prod public schema to Test

### DIFF
--- a/.github/workflows/supabase-schema-copy.yml
+++ b/.github/workflows/supabase-schema-copy.yml
@@ -1,0 +1,86 @@
+name: Supabase Schema Copy (Prod -> Test)
+
+# WARNING:
+# - This workflow is for staging/Test operations only.
+# - Never point SUPABASE_TEST_DATABASE_URL at production.
+# - Do not use this workflow to copy production data.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Choose operation mode"
+        required: true
+        type: choice
+        options:
+          - dump-prod-schema-artifact
+          - apply-prod-schema-to-test
+
+jobs:
+  schema-copy:
+    name: Run schema copy mode
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      # Secrets are injected at runtime and must never be committed.
+      SUPABASE_PROD_DATABASE_URL: ${{ secrets.SUPABASE_PROD_DATABASE_URL }}
+      SUPABASE_TEST_DATABASE_URL: ${{ secrets.SUPABASE_TEST_DATABASE_URL }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install PostgreSQL client tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Validate required secrets
+        run: |
+          if [ -z "$SUPABASE_PROD_DATABASE_URL" ]; then
+            echo "SUPABASE_PROD_DATABASE_URL is not set."
+            exit 1
+          fi
+
+          if [ -z "$SUPABASE_TEST_DATABASE_URL" ]; then
+            echo "SUPABASE_TEST_DATABASE_URL is not set."
+            exit 1
+          fi
+
+      - name: Dump production public schema to artifact file
+        if: ${{ github.event.inputs.mode == 'dump-prod-schema-artifact' }}
+        run: |
+          pg_dump \
+            --schema-only \
+            --schema=public \
+            --no-owner \
+            --no-privileges \
+            "$SUPABASE_PROD_DATABASE_URL" \
+            > prod_public_schema.sql
+
+      - name: Upload production public schema artifact
+        if: ${{ github.event.inputs.mode == 'dump-prod-schema-artifact' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-public-schema
+          path: prod_public_schema.sql
+          if-no-files-found: error
+
+      - name: Apply production public schema to Supabase Test branch
+        if: ${{ github.event.inputs.mode == 'apply-prod-schema-to-test' }}
+        run: |
+          # SAFETY WARNING:
+          # This step must target the Supabase Test branch database only.
+          # Never set SUPABASE_TEST_DATABASE_URL to a production database.
+          # Schema-only copy; this does not copy table data.
+          pg_dump \
+            --schema-only \
+            --schema=public \
+            --no-owner \
+            --no-privileges \
+            --clean \
+            --if-exists \
+            "$SUPABASE_PROD_DATABASE_URL" \
+            | psql "$SUPABASE_TEST_DATABASE_URL"


### PR DESCRIPTION
### Motivation
- Provide a safe remote mechanism to copy the production `public` schema into the Supabase Test branch without using a local terminal. 
- Ensure the operation is manual, secrets are never committed, and this is explicitly marked for staging/Test only.

### Description
- Add `.github/workflows/supabase-schema-copy.yml` with a manual `workflow_dispatch` input `mode` offering `dump-prod-schema-artifact` and `apply-prod-schema-to-test` choices. 
- Install `postgresql-client` on the runner and validate `SUPABASE_PROD_DATABASE_URL` and `SUPABASE_TEST_DATABASE_URL` are present via repository secrets injected at runtime. 
- Implement `dump-prod-schema-artifact` to run `pg_dump` (schema-only, `public`, `--no-owner`, `--no-privileges`) to `prod_public_schema.sql` and upload it as a workflow artifact without committing it. 
- Implement `apply-prod-schema-to-test` to run a production `pg_dump` (schema-only, `public`, `--no-owner`, `--no-privileges`, `--clean`, `--if-exists`) piped directly into `psql` connected to `SUPABASE_TEST_DATABASE_URL`, and include clear safety warnings that the Test URL must never point to production.

### Testing
- Ran `git status --short` and observed the new workflow file was present. 
- Performed `git add` and `git commit` for the new workflow file and the commit completed successfully. 
- Printed the workflow file with `nl -ba .github/workflows/supabase-schema-copy.yml` to validate the contents and confirmed the intended steps were present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e0be7f448326b2bccded7386e9ec)