### PR TITLE
Add Supabase Schema Copy (Prod -> Test) workflow to default branch

### DIFF
--- a/.github/workflows/supabase-schema-copy.yml
+++ b/.github/workflows/supabase-schema-copy.yml
@@ -1,0 +1,73 @@
+name: Supabase Schema Copy (Prod -> Test)
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Operation mode"
+        required: true
+        type: choice
+        options:
+          - dump-prod-schema-artifact
+          - apply-prod-schema-to-test
+
+jobs:
+  supabase-schema-copy:
+    name: Supabase Schema Copy (Prod -> Test)
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_PROD_DATABASE_URL: ${{ secrets.SUPABASE_PROD_DATABASE_URL }}
+      SUPABASE_TEST_DATABASE_URL: ${{ secrets.SUPABASE_TEST_DATABASE_URL }}
+
+    steps:
+      # SAFETY: This workflow is for staging/Test operations only.
+      # SAFETY: Never point SUPABASE_TEST_DATABASE_URL at production.
+      # SAFETY: Do not use this workflow to copy production data.
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Validate required secrets
+        run: |
+          set -euo pipefail
+          if [ -z "${SUPABASE_PROD_DATABASE_URL:-}" ]; then
+            echo "Missing SUPABASE_PROD_DATABASE_URL secret"
+            exit 1
+          fi
+          if [ -z "${SUPABASE_TEST_DATABASE_URL:-}" ]; then
+            echo "Missing SUPABASE_TEST_DATABASE_URL secret"
+            exit 1
+          fi
+
+      - name: Dump production public schema to artifact file
+        if: ${{ inputs.mode == 'dump-prod-schema-artifact' }}
+        run: |
+          set -euo pipefail
+          pg_dump "$SUPABASE_PROD_DATABASE_URL" \
+            --schema-only \
+            --schema=public \
+            --no-owner \
+            --no-privileges \
+            --file=prod_public_schema.sql
+
+      - name: Upload production public schema artifact
+        if: ${{ inputs.mode == 'dump-prod-schema-artifact' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-public-schema
+          path: prod_public_schema.sql
+          if-no-files-found: error
+
+      - name: Apply production public schema to test
+        if: ${{ inputs.mode == 'apply-prod-schema-to-test' }}
+        run: |
+          set -euo pipefail
+          pg_dump "$SUPABASE_PROD_DATABASE_URL" \
+            --schema-only \
+            --schema=public \
+            --no-owner \
+            --no-privileges \
+            --clean \
+            --if-exists \
+          | psql "$SUPABASE_TEST_DATABASE_URL"


### PR DESCRIPTION
### Motivation
- Ensure the manual schema-copy workflow appears in the GitHub Actions UI by adding it to the repository default branch so `workflow_dispatch` can be run from the UI.
- Provide a safe, manual-only mechanism to either export a production public schema artifact or apply a production schema to the Test database while enforcing safety checks and using repository secrets.

### Description
- Add a single workflow file at ` .github/workflows/supabase-schema-copy.yml` that defines the `Supabase Schema Copy (Prod -> Test)` workflow and uses `workflow_dispatch` with a required `mode` choice input. 
- The workflow runs on `ubuntu-latest`, sets `SUPABASE_PROD_DATABASE_URL` and `SUPABASE_TEST_DATABASE_URL` from repository secrets, installs `postgresql-client`, and validates both secrets are present before proceeding. 
- Implements `dump-prod-schema-artifact` to `pg_dump` the production `public` schema with `--schema-only --no-owner --no-privileges` to `prod_public_schema.sql` and uploads it as artifact `prod-public-schema`, and implements `apply-prod-schema-to-test` to run `pg_dump` with `--clean --if-exists` and pipe into `psql "$SUPABASE_TEST_DATABASE_URL"`. 
- Adds explicit safety comments in the workflow warning that it is for staging/Test only and to never point `SUPABASE_TEST_DATABASE_URL` at production.

### Testing
- Ran `test -f .github/workflows/supabase-schema-copy.yml; echo $?` to verify the file was created and the check succeeded. 
- Verified the file contents with `nl -ba .github/workflows/supabase-schema-copy.yml` and confirmed the new workflow file is the only change. 
- Committed the change with `git -C /workspace/JUPR commit -m "Add manual Supabase schema copy workflow"` and confirmed the commit includes only ` .github/workflows/supabase-schema-copy.yml`.
- All automated verification commands executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e6bedeb08326a0d084de15439a35)