### PR TITLE
ci: fix Supabase schema copy pg_dump server/client mismatch

### DIFF
--- a/.github/workflows/supabase-schema-copy.yml
+++ b/.github/workflows/supabase-schema-copy.yml
@@ -23,10 +23,23 @@ jobs:
       # SAFETY: This workflow is for staging/Test operations only.
       # SAFETY: Never point SUPABASE_TEST_DATABASE_URL at production.
       # SAFETY: Do not use this workflow to copy production data.
-      - name: Install PostgreSQL client
+      - name: Install PostgreSQL client tools (v17)
         run: |
           sudo apt-get update
-          sudo apt-get install -y postgresql-client
+          sudo apt-get install -y wget ca-certificates gnupg lsb-release
+
+          sudo install -d /usr/share/postgresql-common/pgdg
+          wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | sudo gpg --dearmor -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg
+
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-17
+
+          pg_dump --version
+          psql --version
 
       - name: Validate required secrets
         run: |


### PR DESCRIPTION
### Motivation
- The Supabase schema copy workflow was failing with `pg_dump` server/client version mismatch because the default Ubuntu `postgresql-client` package provided `pg_dump` 16 while production runs Postgres 17.6. 
- The goal is to ensure the workflow uses `pg_dump`/`psql` v17 so schema-only operations succeed without changing behavior or exposing secrets.

### Description
- Replaced the old `Install PostgreSQL client` step with an explicit install that adds the official PostgreSQL APT repo and installs `postgresql-client-17`. 
- Added required utilities (`wget`, `ca-certificates`, `gnupg`, `lsb-release`) and imported the PostgreSQL signing key to `/usr/share/postgresql-common/pgdg`. 
- After install the workflow prints `pg_dump --version` and `psql --version` to confirm client v17 is present. 
- Kept `runs-on: ubuntu-latest`, preserved both `workflow_dispatch` modes (`dump-prod-schema-artifact` and `apply-prod-schema-to-test`), and left schema-only dump/apply behavior unchanged.

### Testing
- Verified the patch diff shows the install step replacement using `git diff` and validated the updated file contents with `nl -ba` to confirm the new install block and version checks. 
- Ensured the new install block matches the suggested APT repo and `postgresql-client-17` installation commands. 
- Created PR metadata for review and the change is ready to run in CI where the `dump-prod-schema-artifact` mode should no longer fail due to `pg_dump` 16 vs server 17 mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcafae0b1883268693d0afe60b45fd)