### PR TITLE
Use PostgreSQL 17 client in Supabase schema copy workflow

### DIFF
--- a/.github/workflows/supabase-schema-copy.yml
+++ b/.github/workflows/supabase-schema-copy.yml
@@ -27,6 +27,7 @@ jobs:
       # Secrets are injected at runtime and must never be committed.
       SUPABASE_PROD_DATABASE_URL: ${{ secrets.SUPABASE_PROD_DATABASE_URL }}
       SUPABASE_TEST_DATABASE_URL: ${{ secrets.SUPABASE_TEST_DATABASE_URL }}
+      PG_BIN: /usr/lib/postgresql/17/bin
 
     steps:
       - name: Checkout repository
@@ -35,7 +36,21 @@ jobs:
       - name: Install PostgreSQL client tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y postgresql-client
+          sudo apt-get install -y wget ca-certificates gnupg lsb-release
+
+          sudo install -d /usr/share/postgresql-common/pgdg
+          wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | sudo gpg --dearmor -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg
+
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-17
+
+          echo "$PG_BIN" >> "$GITHUB_PATH"
+          "$PG_BIN/pg_dump" --version
+          "$PG_BIN/psql" --version
 
       - name: Validate required secrets
         run: |
@@ -49,10 +64,18 @@ jobs:
             exit 1
           fi
 
+      - name: Check database connectivity
+        run: |
+          echo "Checking production database connectivity..."
+          "$PG_BIN/psql" "$SUPABASE_PROD_DATABASE_URL" -c "select current_database(), current_user, now();" >/dev/null
+
+          echo "Checking test database connectivity..."
+          "$PG_BIN/psql" "$SUPABASE_TEST_DATABASE_URL" -c "select current_database(), current_user, now();" >/dev/null
+
       - name: Dump production public schema to artifact file
         if: ${{ github.event.inputs.mode == 'dump-prod-schema-artifact' }}
         run: |
-          pg_dump \
+          "$PG_BIN/pg_dump" \
             --schema-only \
             --schema=public \
             --no-owner \
@@ -75,7 +98,7 @@ jobs:
           # This step must target the Supabase Test branch database only.
           # Never set SUPABASE_TEST_DATABASE_URL to a production database.
           # Schema-only copy; this does not copy table data.
-          pg_dump \
+          "$PG_BIN/pg_dump" \
             --schema-only \
             --schema=public \
             --no-owner \
@@ -83,4 +106,4 @@ jobs:
             --clean \
             --if-exists \
             "$SUPABASE_PROD_DATABASE_URL" \
-            | psql "$SUPABASE_TEST_DATABASE_URL"
+            | "$PG_BIN/psql" "$SUPABASE_TEST_DATABASE_URL"


### PR DESCRIPTION
### Motivation
- The workflow previously installed the generic Ubuntu `postgresql-client` package which provided `pg_dump` v16 and failed against Supabase production Postgres v17.6 due to client/server version mismatch. 
- The goal is to pin the workflow to PostgreSQL major version 17 client tools and ensure all `pg_dump`/`psql` usage invokes the explicit v17 binaries. 

### Description
- Added a job-level environment variable `PG_BIN: /usr/lib/postgresql/17/bin` to pin explicit binary paths. 
- Replaced the generic client install with the official PostgreSQL APT repository setup and `postgresql-client-17` installation, and appended `PG_BIN` to `GITHUB_PATH`. 
- Emitted explicit version checks using `"$PG_BIN/pg_dump" --version` and `"$PG_BIN/psql" --version` to confirm v17 tools are used. 
- Added a connectivity diagnostic step that runs `"$PG_BIN/psql"` against both `SUPABASE_PROD_DATABASE_URL` and `SUPABASE_TEST_DATABASE_URL` before dumping/applying, and updated all `pg_dump`/`psql` invocations to use `"$PG_BIN/..."` while preserving both workflow modes and schema-only behavior. 

### Testing
- The modified workflow file was inspected with `sed -n '1,320p' .github/workflows/supabase-schema-copy.yml` and `nl -ba .github/workflows/supabase-schema-copy.yml | sed -n '1,260p'` to verify the edits and they succeeded. 
- The patch was applied via a scripted edit and the install / usage lines were validated by printing the updated sections, which succeeded. 
- PR metadata was created using the repository tooling (`make_pr`) to record the change for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb3b953c48326aead8e47cf7e44fd)