### PR TITLE
Fix Supabase schema copy workflow GPG key import for non-interactive CI

### DIFF
--- a/.github/workflows/supabase-schema-copy.yml
+++ b/.github/workflows/supabase-schema-copy.yml
@@ -39,8 +39,11 @@ jobs:
           sudo apt-get install -y wget ca-certificates gnupg lsb-release
 
           sudo install -d /usr/share/postgresql-common/pgdg
-          wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            | sudo gpg --dearmor -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg
+          wget -qO /tmp/postgresql.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          sudo rm -f /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg
+          sudo gpg --batch --yes --dearmor \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg \
+            /tmp/postgresql.asc
 
           echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list


### PR DESCRIPTION
### Motivation
- The PostgreSQL APT key import used a piped `gpg --dearmor` which can require a TTY and fails in GitHub Actions with `gpg: cannot open '/dev/tty'`, so the import must run non-interactively.

### Description
- Replace the piped key import with a non-interactive flow that downloads the key to `/tmp/postgresql.asc`, removes any previous keyring file, and runs `sudo gpg --batch --yes --dearmor -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg /tmp/postgresql.asc`.
- Preserve the rest of the PostgreSQL 17 install logic including installing `wget ca-certificates gnupg lsb-release`, creating `/usr/share/postgresql-common/pgdg`, adding the `apt.postgresql.org` repo, installing `postgresql-client-17`, appending `"$PG_BIN"` to `GITHUB_PATH`, and printing `"$PG_BIN/pg_dump" --version` and `"$PG_BIN/psql" --version`.
- Do not change schema dump/apply behavior, do not expose secrets, and continue to use explicit binaries `"$PG_BIN/pg_dump"` and `"$PG_BIN/psql"`.

### Testing
- Locally verified the workflow file now contains the non-interactive key import block and no unrelated modifications; the file diff validation succeeded.
- Changes were saved to branch `Test` and a PR was created for CI verification on GitHub Actions.
- No GitHub Actions run was executed as part of this update; please run the workflow to confirm the install step no longer fails and the logs show `pg_dump 17.x` and `psql 17.x`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb52cd06c83268a77eab86d5e64d2)