### PR TITLE
Split DB connectivity checks by workflow mode in Supabase schema-copy workflow

### DIFF
--- a/.github/workflows/supabase-schema-copy.yml
+++ b/.github/workflows/supabase-schema-copy.yml
@@ -67,11 +67,14 @@ jobs:
             exit 1
           fi
 
-      - name: Check database connectivity
+      - name: Check production database connectivity
         run: |
           echo "Checking production database connectivity..."
           "$PG_BIN/psql" "$SUPABASE_PROD_DATABASE_URL" -c "select current_database(), current_user, now();" >/dev/null
 
+      - name: Check test database connectivity
+        if: ${{ github.event.inputs.mode == 'apply-prod-schema-to-test' }}
+        run: |
           echo "Checking test database connectivity..."
           "$PG_BIN/psql" "$SUPABASE_TEST_DATABASE_URL" -c "select current_database(), current_user, now();" >/dev/null
 


### PR DESCRIPTION
### Motivation
- Prevent the `dump-prod-schema-artifact` mode from failing due to an unnecessary test DB connectivity check while preserving safety for the `apply-prod-schema-to-test` mode.

### Description
- Split the single connectivity step into `Check production database connectivity` which always runs and `Check test database connectivity` which runs only when `github.event.inputs.mode == 'apply-prod-schema-to-test'` and kept `pg_dump`/`psql` usage unchanged via `"$PG_BIN/..."` paths.
- Left the PostgreSQL client 17 install block and the required secret validation step unchanged, and avoided printing or exposing database URLs/secrets.

### Testing
- Inspected the workflow file with `sed -n '1,260p' .github/workflows/supabase-schema-copy.yml` and `nl -ba .github/workflows/supabase-schema-copy.yml | sed -n '55,110p'` to verify the new conditional step placement (succeeded).
- Verified the patch with `git diff -- .github/workflows/supabase-schema-copy.yml && git status --short` and committed the change with `git add`/`git commit` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb67e62dc832691973da451b22fec)