### PR TITLE
Align staging-first SaaS docs and guardrails

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -336,3 +336,9 @@ Never commit:
 - GitHub Actions logs containing secrets
 
 If any secret is exposed, rotate it immediately and remove it from history where possible.
+
+## 13) Docs consistency check
+
+- `README.txt` = operator source of truth.
+- `docs/saas_staging_deploy.md` = staging deployment guardrails for FastAPI + Next.js.
+- `docs/next_admin_auth_design.md` = future admin auth contract before Next admin score entry can be enabled for rated workflows.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,6 +1,6 @@
 # JUPR Web (Next.js public shell)
 
-This is a minimal, read-only Next.js app for public pages that can eventually serve `juprleagues.com` and club pages.
+This is a minimal, read-only-first Next.js app for public pages that can eventually serve `juprleagues.com` and club pages.
 
 ## Routes
 
@@ -13,7 +13,7 @@ This is a minimal, read-only Next.js app for public pages that can eventually se
 Use one of the following:
 
 - `JUPR_API_BASE_URL` (preferred for server-side runtime)
-- `NEXT_PUBLIC_JUPR_API_BASE_URL` (fallback)
+- `NEXT_PUBLIC_JUPR_API_BASE_URL` (fallback for browser-visible configuration)
 
 Example:
 
@@ -39,7 +39,9 @@ If the API is unavailable, pages render graceful empty/error states instead of c
 This Next.js path is currently **staging-only** for the SaaS migration.
 
 - Point `JUPR_API_BASE_URL` / `NEXT_PUBLIC_JUPR_API_BASE_URL` to the staging API.
-- Keep `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=0`.
+- Keep `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=0` and `NEXT_PUBLIC_JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=0`.
+- Next admin score-entry UI remains disabled unless explicitly enabled for staging experiments.
 - Do **not** migrate production traffic to Next.js yet.
+- Never expose `SUPABASE_SERVICE_ROLE_KEY` (or any service-role key) in browser/client env vars.
 
 See `docs/saas_staging_deploy.md` for required environment variables and warnings.

--- a/docs/saas_staging_deploy.md
+++ b/docs/saas_staging_deploy.md
@@ -2,6 +2,8 @@
 
 This document defines deployment guardrails for the new SaaS stack.
 
+Operator source of truth: `README.txt`. If any conflict exists, follow `README.txt`.
+
 ## Status: staging only
 
 The **Next.js + FastAPI** path is currently approved for **staging only**.
@@ -28,7 +30,9 @@ Set these when deploying the staging stack:
 ## Guardrails and explicit warnings
 
 - **Do not point staging API at production Supabase.**
-- **Do not deploy Next admin score entry for rated matches.** Keep `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=0`.
+- **Do not point `SUPABASE_TEST_DATABASE_URL` at production.**
+- **Do not deploy Next admin score entry for rated matches.**
+- **Keep `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=0`.**
 - **Do not migrate production traffic to Next yet.**
 - **Streamlit remains the active admin console for rated events.**
 

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -5,16 +5,18 @@ Minimal read-only API scaffold for future service integration.
 ## Run locally
 
 ```bash
+pip install -r requirements.txt
 pip install -r services/api/requirements.txt
 uvicorn services.api.main:app --reload
 ```
 
 ## Environment variables
 
-- `SUPABASE_URL`
-- `SUPABASE_SERVICE_ROLE_KEY` (preferred for server-side API)
+- `JUPR_ENV=staging`
+- `SUPABASE_URL` (must be the staging Supabase project URL for staging runtime)
+- `SUPABASE_SERVICE_ROLE_KEY` (preferred for server-side API; use staging credentials in staging)
 - `SUPABASE_ANON_KEY` (read-only local fallback)
-- `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY` (`1` / `true` / `yes` to enable, disabled by default)
+- `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=0` (leave disabled by default)
 
 ## Endpoints
 
@@ -28,6 +30,8 @@ The leaderboard endpoint delegates to `jupr_app.services.leaderboard_service.get
 - `POST /admin/clubs/{club_id}/matches/batch`
 
 ## Admin score-entry guard (experimental + temporary)
+
+Admin score-entry is **experimental and disabled by default**. Keep it disabled unless running explicit staging-only experiments.
 
 `POST /admin/clubs/{club_id}/matches/batch` is **disabled by default**.
 
@@ -59,3 +63,5 @@ This API path is currently **staging-only** for the new SaaS rollout.
 - Do **not** point this staging API at production Supabase.
 
 See `docs/saas_staging_deploy.md` for the full checklist and rollout constraints.
+
+When running staging API deployments, credentials must come from the staging Supabase project only.


### PR DESCRIPTION
### Motivation

- Ensure all staging and SaaS documentation consistently reflect the staging-first rollout and avoid conflicting guidance about production vs staging Supabase usage.
- Reinforce guardrails preventing accidental production writes from staging (including `SUPABASE_TEST_DATABASE_URL`) and prevent premature enabling of Next.js admin score-entry for rated matches.
- Keep operator guidance centralized and explicit so Streamlit remains the trusted production admin path until secure auth/authorization is implemented.

### Description

- Updated `docs/saas_staging_deploy.md` to reference `README.txt` as the operator source of truth, add a warning to never point `SUPABASE_TEST_DATABASE_URL` at production, and explicitly keep `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=0` while marking Next.js + FastAPI as staging-only.
- Updated `services/api/README.md` to include `JUPR_ENV=staging` in env documentation, require staging Supabase credentials for staging runtime, add the `SUPABASE_ANON_KEY` fallback note, clarify the local run steps, and state that admin score-entry is experimental and disabled by default.
- Updated `apps/web/README.md` to emphasize the read-only-first posture, clarify `JUPR_API_BASE_URL` vs `NEXT_PUBLIC_JUPR_API_BASE_URL`, assert the admin score-entry UI remains disabled unless explicitly enabled for staging experiments, and warn that service-role keys must never be exposed in browser/client env.
- Added a short "Docs consistency check" section to `README.txt` mapping `README.txt` as the operator source of truth and pointing to `docs/saas_staging_deploy.md` and `docs/next_admin_auth_design.md` for guardrails and future auth contract.
- Verified `.env.example` files keep all secret values blank and maintain safe defaults (`JUPR_ENV=staging`, `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=0`, `NEXT_PUBLIC_JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=0`) and did not add any secrets.

### Testing

- Inspected updated files with file-read commands (`sed`, `nl`) to confirm the new guidance appears in `README.txt`, `docs/saas_staging_deploy.md`, `services/api/README.md`, and `apps/web/README.md`, and these reads succeeded.
- Ran a repository diff and file-diff checks to confirm only the intended documentation files were modified and the changes match the described guardrails, and the checks succeeded.
- Verified `services/api/.env.example` and `apps/web/.env.example` contain blank secret placeholders and the expected staging defaults, and those inspections succeeded.
- Performed basic repository status and local validation commands to ensure no unintended runtime code changes were introduced, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fa952f7c8326954904cdf8ed69d8)