### PR TITLE
Add read-only staging environment verification command

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -168,6 +168,7 @@ Guardrail commands:
 ```bash
 make check-migration-sources
 python scripts/check_supabase_migration_versions.py
+python scripts/check_staging_environment.py --require-supabase --require-api --club-slug tres-palapas --club-id tres_palapas
 ```
 
 API/web checks:

--- a/scripts/check_staging_environment.py
+++ b/scripts/check_staging_environment.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib import error, parse, request
+
+from jupr_app.data.client import make_supabase
+
+PROD_MARKERS = ("prod", "production", "live")
+SUPABASE_OBJECTS = (
+    "clubs",
+    "public_leaderboards",
+    "admin_role_assignments",
+    "admin_activity_log",
+    "replay_jobs",
+)
+
+
+@dataclass
+class CheckResult:
+    status: str
+    detail: str
+
+
+
+def _truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+
+def _mask_url(raw: str | None) -> str | None:
+    if not raw:
+        return None
+    try:
+        parts = parse.urlsplit(raw)
+        host = parts.hostname or ""
+        if parts.port:
+            host = f"{host}:{parts.port}"
+        path = parts.path if parts.path else ""
+        return parse.urlunsplit((parts.scheme, host, path, "", ""))
+    except Exception:
+        return "<unparseable-url>"
+
+
+
+def _looks_production(value: str | None) -> bool:
+    if not value:
+        return False
+    lower = value.lower()
+    return any(marker in lower for marker in PROD_MARKERS)
+
+
+
+def _check_supabase_objects(summary: dict[str, Any], require_supabase: bool) -> None:
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_ANON_KEY")
+    if not (url and key):
+        if require_supabase:
+            summary["errors"].append("Supabase checks requested but SUPABASE_URL/key is missing.")
+        return
+
+    try:
+        supabase = make_supabase(url, key)
+    except Exception as exc:
+        summary["errors"].append(f"Failed to initialize Supabase client: {exc}")
+        return
+
+    checked: dict[str, dict[str, str]] = {}
+    for obj in SUPABASE_OBJECTS:
+        try:
+            supabase.table(obj).select("*").limit(1).execute()
+            checked[obj] = {"status": "ok", "detail": "readable"}
+        except Exception as exc:
+            checked[obj] = {"status": "error", "detail": str(exc)}
+            summary["errors"].append(f"Supabase object check failed: {obj}")
+    summary["checked_tables"] = checked
+
+
+
+def _http_get_json(url: str) -> tuple[int, Any, str | None]:
+    try:
+        req = request.Request(url, method="GET")
+        with request.urlopen(req, timeout=10) as resp:
+            body = resp.read().decode("utf-8")
+            return resp.status, json.loads(body), None
+    except error.HTTPError as exc:
+        return exc.code, None, f"HTTP {exc.code}"
+    except Exception as exc:
+        return 0, None, str(exc)
+
+
+
+def _check_api(summary: dict[str, Any], base_url: str, club_slug: str) -> None:
+    base = base_url.rstrip("/")
+    endpoints = {
+        "/health": f"{base}/health",
+        f"/clubs/{club_slug}": f"{base}/clubs/{club_slug}",
+        f"/clubs/{club_slug}/leaderboards": f"{base}/clubs/{club_slug}/leaderboards",
+    }
+    results: dict[str, dict[str, Any]] = {}
+
+    for path, url in endpoints.items():
+        status, payload, err = _http_get_json(url)
+        if err:
+            results[path] = {"status": "error", "http_status": status, "detail": err}
+            summary["errors"].append(f"API check failed: {path}")
+            continue
+        results[path] = {"status": "ok", "http_status": status}
+        if path == "/health" and payload.get("ok") is not True:
+            results[path]["status"] = "warning"
+            summary["warnings"].append("/health reachable but ok=true not present.")
+        if path.startswith("/clubs/") and path.endswith("/leaderboards"):
+            if not isinstance(payload, dict) or "club" not in payload or "leaderboard" not in payload:
+                results[path]["status"] = "warning"
+                summary["warnings"].append("Leaderboard response missing expected keys.")
+        if path.startswith("/clubs/") and not path.endswith("/leaderboards"):
+            if not isinstance(payload, dict) or not {"id", "slug", "name"}.issubset(payload.keys()):
+                results[path]["status"] = "warning"
+                summary["warnings"].append("Club response missing one or more of id/slug/name.")
+
+    summary["checked_endpoints"] = results
+
+
+
+def run_checks(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    env = os.getenv("JUPR_ENV")
+    summary: dict[str, Any] = {
+        "ok": True,
+        "warnings": [],
+        "errors": [],
+        "environment": {
+            "JUPR_ENV": env,
+            "SUPABASE_URL": _mask_url(os.getenv("SUPABASE_URL")),
+            "DATABASE_URL": _mask_url(os.getenv("DATABASE_URL")),
+            "SUPABASE_TEST_DATABASE_URL": _mask_url(os.getenv("SUPABASE_TEST_DATABASE_URL")),
+            "JUPR_API_BASE_URL": _mask_url(args.api_base_url or os.getenv("JUPR_API_BASE_URL")),
+        },
+        "checked_tables": {},
+        "checked_endpoints": {},
+    }
+
+    if env == "production":
+        summary["errors"].append("Refusing to run: JUPR_ENV=production")
+        summary["ok"] = False
+        return 2, summary
+
+    if env != "staging":
+        summary["errors"].append("JUPR_ENV must be set to staging.")
+
+    if args.require_supabase:
+        if not os.getenv("SUPABASE_URL"):
+            summary["errors"].append("SUPABASE_URL is required when --require-supabase is passed.")
+        if not (os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_ANON_KEY")):
+            summary["errors"].append(
+                "SUPABASE_SERVICE_ROLE_KEY or SUPABASE_ANON_KEY is required when --require-supabase is passed."
+            )
+
+    if not args.allow_next_admin_score_entry:
+        if _truthy(os.getenv("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY")):
+            summary["errors"].append("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY must be disabled for staging verification.")
+        if _truthy(os.getenv("NEXT_PUBLIC_JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY")):
+            summary["errors"].append(
+                "NEXT_PUBLIC_JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY must be disabled for staging verification."
+            )
+
+    for var_name in ("SUPABASE_URL", "DATABASE_URL", "SUPABASE_TEST_DATABASE_URL"):
+        value = os.getenv(var_name)
+        if _looks_production(value):
+            summary["warnings"].append(f"{var_name} appears to include production markers.")
+    api_base = args.api_base_url or os.getenv("JUPR_API_BASE_URL")
+    if _looks_production(api_base):
+        summary["warnings"].append("JUPR_API_BASE_URL appears to include production markers.")
+
+    _check_supabase_objects(summary, require_supabase=args.require_supabase)
+
+    if api_base:
+        _check_api(summary, api_base, args.club_slug)
+    elif args.require_api:
+        summary["errors"].append("API checks required but no API base URL provided.")
+
+    summary["ok"] = not summary["errors"]
+    return (0 if summary["ok"] else 1), summary
+
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read-only staging environment verification.")
+    parser.add_argument("--allow-next-admin-score-entry", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--api-base-url")
+    parser.add_argument("--require-api", action="store_true")
+    parser.add_argument("--require-supabase", action="store_true")
+    parser.add_argument("--club-slug", default="tres-palapas")
+    parser.add_argument("--club-id", default="tres_palapas")
+    return parser
+
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    rc, summary = run_checks(args)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return rc
+
+    print("[staging-check] Verification summary")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_staging_environment.py
+++ b/tests/test_check_staging_environment.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from scripts import check_staging_environment as cse
+
+
+class _FakeQuery:
+    def __init__(self, table_name: str, fail_tables: set[str]):
+        self.table_name = table_name
+        self.fail_tables = fail_tables
+
+    def select(self, _cols: str):
+        return self
+
+    def limit(self, _n: int):
+        return self
+
+    def execute(self):
+        if self.table_name in self.fail_tables:
+            raise RuntimeError("boom")
+        return {"data": []}
+
+
+class _FakeSupabase:
+    def __init__(self, fail_tables: set[str] | None = None):
+        self.fail_tables = fail_tables or set()
+
+    def table(self, table_name: str):
+        return _FakeQuery(table_name, self.fail_tables)
+
+
+def _args(**kwargs):
+    base = {
+        "allow_next_admin_score_entry": False,
+        "json": False,
+        "api_base_url": None,
+        "require_api": False,
+        "require_supabase": False,
+        "club_slug": "tres-palapas",
+        "club_id": "tres_palapas",
+    }
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+def test_missing_jupr_env_fails(monkeypatch):
+    monkeypatch.delenv("JUPR_ENV", raising=False)
+    rc, summary = cse.run_checks(_args())
+    assert rc == 1
+    assert summary["ok"] is False
+    assert any("JUPR_ENV" in e for e in summary["errors"])
+
+
+def test_production_is_rejected(monkeypatch):
+    monkeypatch.setenv("JUPR_ENV", "production")
+    rc, summary = cse.run_checks(_args())
+    assert rc == 2
+    assert summary["ok"] is False
+
+
+def test_next_admin_entry_guard(monkeypatch):
+    monkeypatch.setenv("JUPR_ENV", "staging")
+    monkeypatch.setenv("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY", "true")
+    rc, summary = cse.run_checks(_args())
+    assert rc == 1
+    assert any("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY" in e for e in summary["errors"])
+
+    rc2, summary2 = cse.run_checks(_args(allow_next_admin_score_entry=True))
+    assert rc2 == 0
+    assert summary2["ok"] is True
+
+
+def test_secret_values_are_not_printed(monkeypatch, capsys):
+    monkeypatch.setenv("JUPR_ENV", "staging")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "super-secret-value")
+    monkeypatch.setenv("SUPABASE_URL", "https://user:pass@example.supabase.co/path")
+
+    monkeypatch.setattr(cse, "make_supabase", lambda _u, _k: _FakeSupabase())
+    rc = cse.main([])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "super-secret-value" not in out
+    assert "user:pass" not in out
+
+
+def test_mocked_supabase_table_checks(monkeypatch):
+    monkeypatch.setenv("JUPR_ENV", "staging")
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "anon")
+    monkeypatch.setattr(cse, "make_supabase", lambda _u, _k: _FakeSupabase())
+
+    rc, summary = cse.run_checks(_args(require_supabase=True))
+    assert rc == 0
+    assert summary["checked_tables"]["clubs"]["status"] == "ok"
+
+    monkeypatch.setattr(cse, "make_supabase", lambda _u, _k: _FakeSupabase({"replay_jobs"}))
+    rc2, summary2 = cse.run_checks(_args(require_supabase=True))
+    assert rc2 == 1
+    assert summary2["checked_tables"]["replay_jobs"]["status"] == "error"
+
+
+def test_mocked_api_checks(monkeypatch):
+    monkeypatch.setenv("JUPR_ENV", "staging")
+
+    def fake_get(url: str):
+        if url.endswith("/health"):
+            return 200, {"ok": True}, None
+        if url.endswith("/clubs/tres-palapas"):
+            return 200, {"id": "1", "slug": "tres-palapas", "name": "Tres"}, None
+        return 200, {"club": {}, "leaderboard": []}, None
+
+    monkeypatch.setattr(cse, "_http_get_json", fake_get)
+    rc, summary = cse.run_checks(_args(api_base_url="https://api.example.com", require_api=True))
+    assert rc == 0
+    assert summary["checked_endpoints"]["/health"]["status"] == "ok"
+
+    monkeypatch.setattr(cse, "_http_get_json", lambda _url: (500, None, "HTTP 500"))
+    rc2, summary2 = cse.run_checks(_args(api_base_url="https://api.example.com", require_api=True))
+    assert rc2 == 1
+    assert summary2["checked_endpoints"]["/health"]["status"] == "error"
+
+
+def test_json_output_is_valid(monkeypatch, capsys):
+    monkeypatch.setenv("JUPR_ENV", "staging")
+    rc = cse.main(["--json"])
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert rc == 0
+    assert isinstance(parsed, dict)
+    assert "ok" in parsed


### PR DESCRIPTION
### Motivation
- Provide a repeatable pre-flight command to validate the staging data environment before running API, web, worker, migration, or SaaS tests.
- Enforce guardrails that prevent accidental testing against production and surface obvious misconfigurations early.

### Description
- Add `scripts/check_staging_environment.py`, a CLI that enforces `JUPR_ENV=staging` (hard-fails on `production`), masks URLs, warns on production-like markers, and never prints secret keys.
- Implement optional read-only Supabase object checks using the existing `make_supabase` client and `select(...).limit(1).execute()` for `clubs`, `public_leaderboards`, `admin_role_assignments`, `admin_activity_log`, and `replay_jobs`.
- Add optional API checks for `GET /health`, `GET /clubs/{club_slug}`, and `GET /clubs/{club_slug}/leaderboards`, a `--json` output mode, and flags `--allow-next-admin-score-entry`, `--api-base-url`, `--require-api`, `--require-supabase`, `--club-slug`, and `--club-id`.
- Update `README.txt` staging guardrail commands to include the new verification script.

### Testing
- Unit tests added in `tests/test_check_staging_environment.py` mock Supabase and API interactions and validate behavior for missing `JUPR_ENV`, production rejection, next-admin-score-entry guard, secret redaction, Supabase table pass/fail, API pass/fail, and `--json` output.
- Ran `python -m pytest tests/test_check_staging_environment.py -q` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02007314908326901cc1f5060d49c4)