### PR TITLE
Scope admin role assignments by club_id for SaaS tenant safety

### DIFF
--- a/jupr_app/domain/admin/role_assignments.py
+++ b/jupr_app/domain/admin/role_assignments.py
@@ -9,10 +9,11 @@ def normalize_email(email: str | None) -> str:
     return str(email or "").strip().lower()
 
 
-def list_role_assignments(supabase: Any) -> list[dict[str, Any]]:
+def list_role_assignments(supabase: Any, club_id: str) -> list[dict[str, Any]]:
     response = (
         supabase.table("admin_role_assignments")
-        .select("email,role,user_id,created_at,updated_at")
+        .select("club_id,email,role,user_id,created_at,updated_at")
+        .eq("club_id", str(club_id or "").strip())
         .order("email")
         .execute()
     )
@@ -23,17 +24,18 @@ def list_role_assignments(supabase: Any) -> list[dict[str, Any]]:
     return rows
 
 
-def upsert_role_assignment(supabase: Any, email: str, role: str, user_id: str | None = None) -> None:
+def upsert_role_assignment(supabase: Any, club_id: str, email: str, role: str, user_id: str | None = None) -> None:
     payload = {
+        "club_id": str(club_id or "").strip(),
         "email": normalize_email(email),
         "role": normalize_role(role),
         "user_id": str(user_id or "").strip() or None,
     }
-    supabase.table("admin_role_assignments").upsert(payload, on_conflict="email").execute()
+    supabase.table("admin_role_assignments").upsert(payload, on_conflict="club_id,email").execute()
 
 
-def delete_role_assignment(supabase: Any, email: str) -> None:
-    supabase.table("admin_role_assignments").delete().eq("email", normalize_email(email)).execute()
+def delete_role_assignment(supabase: Any, club_id: str, email: str) -> None:
+    supabase.table("admin_role_assignments").delete().eq("club_id", str(club_id or "").strip()).eq("email", normalize_email(email)).execute()
 
 
 def count_super_admin_assignments(rows: list[dict[str, Any]]) -> int:

--- a/jupr_app/domain/admin/roles.py
+++ b/jupr_app/domain/admin/roles.py
@@ -100,6 +100,7 @@ def is_roles_table_missing_error(exc: Exception) -> bool:
 def resolve_admin_role(
     *,
     supabase: Any,
+    club_id: str,
     email: str,
     user_id: str | None,
     allowlist: set[str],
@@ -111,6 +112,7 @@ def resolve_admin_role(
         response = (
             supabase.table("admin_role_assignments")
             .select("role,user_id")
+            .eq("club_id", str(club_id or "").strip())
             .eq("email", normalized_email)
             .execute()
         )
@@ -144,7 +146,8 @@ def resolve_admin_role(
             )
     except Exception as exc:  # noqa: BLE001 - graceful fallback required
         if is_roles_table_missing_error(exc):
-            if normalized_email in allowlist:
+            # Keep legacy allowlist fallback only for Tres Palapas during migration rollout.
+            if str(club_id or "").strip() == "tres_palapas" and normalized_email in allowlist:
                 return AdminRoleResolution(
                     role=ROLE_SUPER_ADMIN,
                     source="allowlist_fallback_missing_table",
@@ -157,7 +160,8 @@ def resolve_admin_role(
             )
         raise
 
-    if normalized_email in allowlist:
+    # Keep legacy allowlist fallback only for Tres Palapas.
+    if str(club_id or "").strip() == "tres_palapas" and normalized_email in allowlist:
         return AdminRoleResolution(
             role=ROLE_SUPER_ADMIN,
             source="allowlist_default",

--- a/jupr_app/ui/pages/admin_tools.py
+++ b/jupr_app/ui/pages/admin_tools.py
@@ -201,11 +201,12 @@ def _render_role_assignment_section(
     st.subheader("🛂 Admin Role Assignments")
     role_source = str(st.session_state.get("admin_role_source", "") or "unknown")
     st.caption(f"Current role: **{current_role}** (source: `{role_source}`).")
+    st.caption(f"Managing roles for club: `{club_id}`")
 
     rows: list[dict] = []
     table_available = True
     try:
-        rows = list_role_assignments(supabase)
+        rows = list_role_assignments(supabase, club_id=str(club_id))
     except Exception as exc:
         table_available = False
         if is_role_table_missing_error(exc):
@@ -268,7 +269,7 @@ def _render_role_assignment_section(
                 if not has_other_super_admin_support(rows=rows, target_email=normalized_email, admin_allowlist=admin_allowlist):
                     st.error("Unsafe change blocked: this would remove the final super_admin access.")
                     return
-            upsert_role_assignment(supabase, normalized_email, selected_role, user_id=str(user_id_input or "").strip() or None)
+            upsert_role_assignment(supabase, str(club_id), normalized_email, selected_role, user_id=str(user_id_input or "").strip() or None)
             log_result = write_admin_activity_log(
                 supabase,
                 build_activity_payload(
@@ -297,7 +298,7 @@ def _render_role_assignment_section(
             if not has_other_super_admin_support(rows=rows, target_email=normalized_email, admin_allowlist=admin_allowlist):
                 st.error("Unsafe revoke blocked: this would remove the final super_admin access.")
                 return
-        delete_role_assignment(supabase, normalized_email)
+        delete_role_assignment(supabase, str(club_id), normalized_email)
         log_result = write_admin_activity_log(
             supabase,
             build_activity_payload(

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -415,6 +415,7 @@ def main():
         if admin_authenticated:
             role_resolution = resolve_admin_role(
                 supabase=supabase,
+                club_id=selected_club_id,
                 email=current_admin_email,
                 user_id=str(getattr(current_admin, "id", "") or "").strip() or None,
                 allowlist=admin_allowlist,

--- a/supabase/migrations/20260511120000_admin_role_assignments_club_scope.sql
+++ b/supabase/migrations/20260511120000_admin_role_assignments_club_scope.sql
@@ -1,0 +1,21 @@
+alter table if exists public.admin_role_assignments
+    add column if not exists club_id text;
+
+update public.admin_role_assignments
+set club_id = 'tres_palapas'
+where club_id is null or btrim(club_id) = '';
+
+alter table public.admin_role_assignments
+    alter column club_id set not null;
+
+alter table public.admin_role_assignments
+    drop constraint if exists admin_role_assignments_email_unique;
+
+alter table public.admin_role_assignments
+    add constraint admin_role_assignments_club_email_unique unique (club_id, email);
+
+create index if not exists admin_role_assignments_club_email_idx
+    on public.admin_role_assignments (club_id, email);
+
+create index if not exists admin_role_assignments_club_user_id_idx
+    on public.admin_role_assignments (club_id, user_id);

--- a/tests/test_admin_role_assignments.py
+++ b/tests/test_admin_role_assignments.py
@@ -4,9 +4,12 @@ from postgrest.exceptions import APIError
 
 from jupr_app.domain.admin.role_assignments import (
     count_super_admin_assignments,
+    delete_role_assignment,
     has_other_super_admin_support,
     is_role_table_missing_error,
+    list_role_assignments,
     normalize_email,
+    upsert_role_assignment,
 )
 from jupr_app.domain.admin.roles import ROLE_CLUB_OWNER, ROLE_SUPER_ADMIN, normalize_role, can_manage_roles
 
@@ -35,3 +38,55 @@ def test_super_admin_count_and_safety_checks():
     assert count_super_admin_assignments(rows) == 1
     assert has_other_super_admin_support(rows=rows, target_email="a@example.com", admin_allowlist=set()) is False
     assert has_other_super_admin_support(rows=rows, target_email="a@example.com", admin_allowlist={"joe@example.com"}) is True
+
+
+class _Query:
+    def __init__(self):
+        self.filters = []
+        self.payload = None
+        self.on_conflict = None
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def order(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, key, val):
+        self.filters.append((key, val))
+        return self
+
+    def upsert(self, payload, on_conflict=None):
+        self.payload = payload
+        self.on_conflict = on_conflict
+        return self
+
+    def delete(self):
+        return self
+
+    def execute(self):
+        return type("Resp", (), {"data": []})()
+
+
+class _Supabase:
+    def __init__(self):
+        self.query = _Query()
+
+    def table(self, _name):
+        return self.query
+
+
+def test_role_assignment_queries_are_club_scoped():
+    sb = _Supabase()
+    list_role_assignments(sb, "club-a")
+    assert ("club_id", "club-a") in sb.query.filters
+
+    sb = _Supabase()
+    upsert_role_assignment(sb, "club-a", "a@example.com", "scorekeeper", user_id="u1")
+    assert sb.query.payload["club_id"] == "club-a"
+    assert sb.query.on_conflict == "club_id,email"
+
+    sb = _Supabase()
+    delete_role_assignment(sb, "club-a", "a@example.com")
+    assert ("club_id", "club-a") in sb.query.filters
+    assert ("email", "a@example.com") in sb.query.filters

--- a/tests/test_admin_roles.py
+++ b/tests/test_admin_roles.py
@@ -59,6 +59,7 @@ def test_resolve_admin_role_uses_assignment_row():
     supabase = _Supabase(_Query(response_data=[{"role": ROLE_CLUB_OWNER}]))
     result = resolve_admin_role(
         supabase=supabase,
+        club_id="club-a",
         email="owner@example.com",
         user_id=None,
         allowlist={"joe@example.com"},
@@ -71,6 +72,7 @@ def test_resolve_admin_role_missing_table_falls_back_to_allowlist_super_admin():
     supabase = _Supabase(_Query(error=_api_error("42P01")))
     result = resolve_admin_role(
         supabase=supabase,
+        club_id="tres_palapas",
         email="joe@example.com",
         user_id=None,
         allowlist={"joe@example.com"},
@@ -83,6 +85,7 @@ def test_resolve_admin_role_defaults_to_read_only_without_assignment():
     supabase = _Supabase(_Query(response_data=[]))
     result = resolve_admin_role(
         supabase=supabase,
+        club_id="club-a",
         email="viewer@example.com",
         user_id=None,
         allowlist={"joe@example.com"},
@@ -98,6 +101,7 @@ def test_resolve_admin_role_prefers_null_user_id_for_email_only_assignment_when_
     ]))
     result = resolve_admin_role(
         supabase=supabase,
+        club_id="club-a",
         email="organizer@example.com",
         user_id="logged-in-user",
         allowlist=set(),
@@ -113,6 +117,7 @@ def test_resolve_admin_role_prefers_exact_user_id_match_over_null_user_id():
     ]))
     result = resolve_admin_role(
         supabase=supabase,
+        club_id="club-a",
         email="multi@example.com",
         user_id="user-123",
         allowlist=set(),
@@ -199,3 +204,23 @@ def test_permission_matrix(role: str, expected: dict[str, bool]):
 
 def test_unmapped_admin_only_page_is_denied_by_default():
     assert is_admin_page_available_for_role("nonexistent_admin_page", ROLE_SUPER_ADMIN, is_admin_only=True) is False
+
+
+def test_resolve_admin_role_allowlist_fallback_only_for_tres_palapas():
+    supabase = _Supabase(_Query(response_data=[]))
+    tres = resolve_admin_role(
+        supabase=supabase,
+        club_id="tres_palapas",
+        email="joe@example.com",
+        user_id=None,
+        allowlist={"joe@example.com"},
+    )
+    other = resolve_admin_role(
+        supabase=supabase,
+        club_id="club-b",
+        email="joe@example.com",
+        user_id=None,
+        allowlist={"joe@example.com"},
+    )
+    assert tres.role == ROLE_SUPER_ADMIN
+    assert other.role == ROLE_READ_ONLY


### PR DESCRIPTION
### Motivation
- Admin role resolution was global by email and allowed a role granted for one club to apply across all clubs, which is unsafe for multi-tenant SaaS hosting. 
- The change introduces explicit club scoping so the same email can hold different roles in different clubs and prevents cross-club privilege leakage. 

### Description
- Added an additive migration `supabase/migrations/20260511120000_admin_role_assignments_club_scope.sql` to add `club_id`, backfill existing rows to `tres_palapas`, enforce `NOT NULL`, replace the `unique(email)` constraint with `unique(club_id, email)`, and add indexes on `(club_id, email)` and `(club_id, user_id)`. 
- Updated role resolution: `resolve_admin_role` now requires `club_id`, queries `admin_role_assignments` by `club_id` + `email`, retains the `user_id` preference logic, and documents/limits the legacy allowlist fallback to `tres_palapas` only during rollout. 
- Converted role-assignment CRUD to be club-scoped with signatures `list_role_assignments(supabase, club_id)`, `upsert_role_assignment(supabase, club_id, email, role, user_id=None)` (now using `on_conflict='club_id,email'`), and `delete_role_assignment(supabase, club_id, email)`. 
- Updated the admin UI to display and operate on the current `club_id` in `jupr_app/ui/pages/admin_tools.py` and updated the Streamlit call site in `streamlit_app.py` to pass `selected_club_id` into `resolve_admin_role`. 

### Testing
- Ran `pytest -q tests/test_admin_roles.py tests/test_admin_role_assignments.py` and the suite passed (`16 passed`).
- Ran `pytest -q tests/test_admin_auth_browser_restore.py` and the suite passed (`8 passed`).
- Added/updated tests to assert club-scoped CRUD filters/`on_conflict` and that the allowlist fallback remains active only for `tres_palapas` during migration rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02044dbcc88326bc92f58ee3946739)