### PR TITLE
Add Supabase JWT auth scaffold for FastAPI admin score-entry writes

### DIFF
--- a/docs/next_admin_auth_design.md
+++ b/docs/next_admin_auth_design.md
@@ -91,3 +91,12 @@ Rollout must proceed in this order:
 ## Implementation gate for future PRs
 
 Before enabling Next.js admin score entry for rated workflows, future implementation PRs must satisfy this design contract end-to-end.
+
+
+## Implementation status (Prompt 07)
+
+- FastAPI admin score entry route now uses Bearer JWT auth scaffolding for Supabase tokens.
+- Authorization resolves role from `admin_role_assignments` by `club_id` + `email/user_id` and enforces `enter_scores`.
+- `read_only` and wrong-club bindings are denied with `403`; missing/invalid auth returns `401`.
+- `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY` is still disabled by default and blocks before auth/write work.
+- Next.js admin score entry remains non-production-active by default.

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -65,3 +65,14 @@ This API path is currently **staging-only** for the new SaaS rollout.
 See `docs/saas_staging_deploy.md` for the full checklist and rollout constraints.
 
 When running staging API deployments, credentials must come from the staging Supabase project only.
+
+
+## Admin JWT auth (Supabase)
+
+- `POST /admin/clubs/{club_id}/matches/batch` requires `Authorization: Bearer <access_token>`.
+- Feature flag `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY` remains disabled by default.
+- When disabled, endpoint returns `403` before auth and writes.
+- JWT verification config (server-side only):
+  - Secret mode (default): `SUPABASE_JWT_SECRET` (+ optional `SUPABASE_JWT_AUDIENCE`, default `authenticated`).
+  - JWKS mode: `JUPR_SUPABASE_JWT_MODE=jwks` + `SUPABASE_JWKS_URL` (+ optional audience).
+- Do not use service-role or JWT secrets in browser/client code.

--- a/services/api/auth.py
+++ b/services/api/auth.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import jwt
+from fastapi import Header, HTTPException
+from jwt import InvalidTokenError
+
+
+@dataclass(frozen=True)
+class AuthenticatedUser:
+    user_id: str
+    email: str
+    claims: dict[str, Any]
+
+
+def _unauthorized(detail: str = "invalid bearer token") -> HTTPException:
+    return HTTPException(status_code=401, detail=detail)
+
+
+def parse_bearer_token(authorization: str | None) -> str:
+    value = str(authorization or "").strip()
+    if not value:
+        raise _unauthorized("missing bearer token")
+    scheme, _, token = value.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        raise _unauthorized("malformed bearer token")
+    return token.strip()
+
+
+def _decode_with_secret(token: str, *, secret: str, audience: str | None) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "algorithms": ["HS256"],
+        "options": {"require": ["exp", "sub"]},
+    }
+    if audience:
+        kwargs["audience"] = audience
+    return jwt.decode(token, secret, **kwargs)
+
+
+def _decode_with_jwks(token: str, *, jwks_url: str, audience: str | None) -> dict[str, Any]:
+    signing_key = jwt.PyJWKClient(jwks_url).get_signing_key_from_jwt(token)
+    kwargs: dict[str, Any] = {"algorithms": ["RS256"], "options": {"require": ["exp", "sub"]}}
+    if audience:
+        kwargs["audience"] = audience
+    return jwt.decode(token, signing_key.key, **kwargs)
+
+
+def get_token_decoder() -> Callable[[str], dict[str, Any]]:
+    mode = os.getenv("JUPR_SUPABASE_JWT_MODE", "").strip().lower()
+    secret = os.getenv("SUPABASE_JWT_SECRET", "").strip()
+    audience = os.getenv("SUPABASE_JWT_AUDIENCE", "authenticated").strip() or None
+    jwks_url = os.getenv("SUPABASE_JWKS_URL", "").strip()
+
+    if mode in {"", "secret"} and secret:
+        return lambda token: _decode_with_secret(token, secret=secret, audience=audience)
+    if mode in {"jwks", ""} and jwks_url:
+        return lambda token: _decode_with_jwks(token, jwks_url=jwks_url, audience=audience)
+
+    raise RuntimeError(
+        "Supabase JWT verification is not configured. Set SUPABASE_JWT_SECRET for secret mode "
+        "or SUPABASE_JWKS_URL with JUPR_SUPABASE_JWT_MODE=jwks."
+    )
+
+
+def authenticate_bearer(
+    authorization: str | None,
+    *,
+    decode_token: Callable[[str], dict[str, Any]] | None = None,
+) -> AuthenticatedUser:
+    token = parse_bearer_token(authorization)
+    decoder = decode_token or get_token_decoder()
+    try:
+        claims = decoder(token)
+    except InvalidTokenError:
+        raise _unauthorized("invalid bearer token")
+    except Exception:
+        raise _unauthorized("invalid bearer token")
+
+    user_id = str(claims.get("sub") or "").strip()
+    email = str(claims.get("email") or "").strip().lower()
+    if not user_id or not email:
+        raise _unauthorized("invalid bearer token")
+    return AuthenticatedUser(user_id=user_id, email=email, claims=claims)
+
+
+def auth_header(authorization: str | None = Header(default=None)) -> str | None:
+    return authorization

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from fastapi import FastAPI, Header, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel, Field
 from supabase import Client, create_client
 
 from jupr_app.data.load import load_data
-from jupr_app.domain.admin.roles import PERMISSION_ENTER_SCORES
+from jupr_app.domain.admin.roles import PERMISSION_ENTER_SCORES, has_permission, resolve_admin_role
 from jupr_app.services.context import ServiceContext
 from jupr_app.services.leaderboard_service import get_public_leaderboard
 from jupr_app.services.match_service import submit_match_batch
+from services.api.auth import authenticate_bearer, auth_header
 
 
 def get_jupr_env() -> str:
@@ -124,32 +125,6 @@ def _build_leaderboard_response(club_slug: str, league_name: str | None) -> dict
     }
 
 
-def _authorize_score_entry(*, token: str | None, requested_permission: str) -> str:
-    """Temporary guard for v1 admin workflow.
-
-    This is intentionally a placeholder and NOT production auth. It verifies an
-    environment token and leaves room for future Supabase JWT + role validation.
-    """
-
-    if requested_permission != PERMISSION_ENTER_SCORES:
-        raise HTTPException(status_code=403, detail="insufficient permission")
-
-    expected = os.getenv("JUPR_ADMIN_API_TOKEN", "").strip()
-    provided = str(token or "").strip()
-    if not expected:
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                "Admin score-entry token is not configured. Set JUPR_ADMIN_API_TOKEN. "
-                "This endpoint currently uses a placeholder token guard."
-            ),
-        )
-    if provided != expected:
-        raise HTTPException(status_code=401, detail="invalid admin token")
-
-    return "token_guard_placeholder"
-
-
 @app.on_event("startup")
 def startup_checks() -> None:
     _warn_if_not_staging_configured()
@@ -236,8 +211,7 @@ def get_club_leaderboard_compat(club_slug: str, league_name: str | None = Query(
 def submit_admin_match_batch(
     club_id: str,
     payload: MatchBatchRequest,
-    x_admin_token: str | None = Header(default=None),
-    x_admin_permission: str | None = Header(default=None),
+    authorization: str | None = auth_header(),
 ) -> dict[str, Any]:
     if not is_next_admin_score_entry_enabled():
         raise HTTPException(
@@ -247,18 +221,26 @@ def submit_admin_match_batch(
             ),
         )
 
-    # Temporary guard only: this path must migrate to Supabase JWT + admin role checks
-    # before it can be considered production-grade authorization.
-    auth_mode = _authorize_score_entry(token=x_admin_token, requested_permission=str(x_admin_permission or ""))
+    user = authenticate_bearer(authorization)
 
     supabase = get_supabase_client()
+    role_resolution = resolve_admin_role(
+        supabase=supabase,
+        club_id=str(club_id),
+        email=user.email,
+        user_id=user.user_id,
+        allowlist=set(),
+    )
+    if not has_permission(role_resolution.role, PERMISSION_ENTER_SCORES):
+        raise HTTPException(status_code=403, detail="insufficient permission")
     df_players_all, _, df_leagues, _, df_meta, _, _, _, _, name_to_id = load_data(supabase, club_id)
 
     service_ctx = ServiceContext(
         supabase=supabase,
         club_id=str(club_id),
         source=payload.source,
-        actor_role="scorekeeper",
+        actor_email=user.email,
+        actor_role=role_resolution.role,
     )
     result = submit_match_batch(
         service_ctx,
@@ -273,7 +255,7 @@ def submit_admin_match_batch(
 
     return {
         "ok": True,
-        "auth_mode": auth_mode,
+        "auth_mode": "supabase_jwt",
         "required_permission": PERMISSION_ENTER_SCORES,
         "result": result.data,
     }

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 supabase
 pandas
+PyJWT

--- a/tests/test_api_admin_auth.py
+++ b/tests/test_api_admin_auth.py
@@ -1,0 +1,102 @@
+from tests.conftest import require_api_dependency
+
+require_api_dependency("fastapi")
+require_api_dependency("supabase")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.api.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _enable(monkeypatch):
+    monkeypatch.setenv("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY", "true")
+
+
+def _mock_common(monkeypatch):
+    monkeypatch.setattr("services.api.main.get_supabase_client", lambda: object())
+    monkeypatch.setattr(
+        "services.api.main.load_data",
+        lambda _supabase, _club_id: (None, None, None, None, None, None, None, None, None, {}),
+    )
+
+
+class _Result:
+    ok = True
+    errors = []
+    data = {"inserted": 1}
+
+
+def test_missing_bearer_token_returns_401(client, monkeypatch):
+    _enable(monkeypatch)
+    response = client.post("/admin/clubs/club-1/matches/batch", json={"matches": []})
+    assert response.status_code == 401
+    assert "token" in response.json()["detail"]
+
+
+def test_invalid_token_returns_401(client, monkeypatch):
+    _enable(monkeypatch)
+    monkeypatch.setattr("services.api.main.authenticate_bearer", lambda *_args, **_kwargs: (_ for _ in ()).throw(Exception("bad")))
+    response = client.post(
+        "/admin/clubs/club-1/matches/batch",
+        json={"matches": []},
+        headers={"Authorization": "Bearer invalid"},
+    )
+    assert response.status_code == 401
+
+
+def test_valid_token_no_role_returns_403(client, monkeypatch):
+    _enable(monkeypatch)
+    _mock_common(monkeypatch)
+    monkeypatch.setattr("services.api.main.authenticate_bearer", lambda *_a, **_k: type("U", (), {"email": "a@b.com", "user_id": "u1"})())
+    monkeypatch.setattr("services.api.main.resolve_admin_role", lambda **_k: type("R", (), {"role": "read_only"})())
+
+    response = client.post("/admin/clubs/club-1/matches/batch", json={"matches": []}, headers={"Authorization": "Bearer x"})
+    assert response.status_code == 403
+
+
+def test_scorekeeper_for_requested_club_reaches_submit(client, monkeypatch):
+    _enable(monkeypatch)
+    _mock_common(monkeypatch)
+    monkeypatch.setattr("services.api.main.authenticate_bearer", lambda *_a, **_k: type("U", (), {"email": "keeper@club.com", "user_id": "u1"})())
+    monkeypatch.setattr("services.api.main.resolve_admin_role", lambda **kwargs: type("R", (), {"role": "scorekeeper"})())
+    called = {"ok": False}
+    def _submit(*_a, **_k):
+        called["ok"] = True
+        return _Result()
+    monkeypatch.setattr("services.api.main.submit_match_batch", _submit)
+    response = client.post("/admin/clubs/club-1/matches/batch", json={"matches": [{"a":1}]}, headers={"Authorization": "Bearer x"})
+    assert response.status_code == 200
+    assert called["ok"] is True
+
+
+def test_role_for_different_club_returns_403(client, monkeypatch):
+    _enable(monkeypatch)
+    _mock_common(monkeypatch)
+    monkeypatch.setattr("services.api.main.authenticate_bearer", lambda *_a, **_k: type("U", (), {"email": "keeper@club.com", "user_id": "u1"})())
+    monkeypatch.setattr("services.api.main.resolve_admin_role", lambda **kwargs: type("R", (), {"role": "read_only"})())
+    response = client.post("/admin/clubs/club-2/matches/batch", json={"matches": []}, headers={"Authorization": "Bearer x"})
+    assert response.status_code == 403
+
+
+def test_read_only_returns_403(client, monkeypatch):
+    _enable(monkeypatch)
+    _mock_common(monkeypatch)
+    monkeypatch.setattr("services.api.main.authenticate_bearer", lambda *_a, **_k: type("U", (), {"email": "viewer@club.com", "user_id": "u9"})())
+    monkeypatch.setattr("services.api.main.resolve_admin_role", lambda **kwargs: type("R", (), {"role": "read_only"})())
+    response = client.post("/admin/clubs/club-1/matches/batch", json={"matches": []}, headers={"Authorization": "Bearer x"})
+    assert response.status_code == 403
+
+
+def test_no_secret_in_error_response(client, monkeypatch):
+    _enable(monkeypatch)
+    secret = "super-secret-value"
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", secret)
+    response = client.post("/admin/clubs/club-1/matches/batch", json={"matches": []}, headers={"Authorization": "Bearer invalid"})
+    body = response.text
+    assert secret not in body

--- a/tests/test_api_admin_score_entry_disabled.py
+++ b/tests/test_api_admin_score_entry_disabled.py
@@ -15,60 +15,23 @@ def client():
     return TestClient(app)
 
 
-def test_admin_batch_endpoint_disabled_by_default(client, monkeypatch):
+def test_admin_batch_endpoint_disabled_by_default_returns_403_before_auth_or_writes(client, monkeypatch):
     monkeypatch.delenv("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY", raising=False)
+
+    called = {"auth": False, "write": False}
+
+    def _auth(*_args, **_kwargs):
+        called["auth"] = True
+        raise AssertionError("auth should not run")
+
+    def _write(*_args, **_kwargs):
+        called["write"] = True
+        raise AssertionError("writes should not run")
+
+    monkeypatch.setattr("services.api.main.authenticate_bearer", _auth)
+    monkeypatch.setattr("services.api.main.submit_match_batch", _write)
 
     response = client.post("/admin/clubs/club-1/matches/batch", json={"matches": []})
 
     assert response.status_code == 403
-    assert (
-        response.json()["detail"]
-        == "Next admin score entry is disabled. Use Streamlit admin until Supabase JWT role auth is implemented."
-    )
-
-
-def test_admin_batch_endpoint_enabled_still_requires_token_guard(client, monkeypatch):
-    monkeypatch.setenv("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY", "true")
-    monkeypatch.setenv("JUPR_ADMIN_API_TOKEN", "expected-token")
-
-    response = client.post(
-        "/admin/clubs/club-1/matches/batch",
-        json={"matches": []},
-        headers={"x-admin-permission": "enter_scores", "x-admin-token": "wrong-token"},
-    )
-
-    assert response.status_code == 401
-    assert response.json()["detail"] == "invalid admin token"
-
-
-def test_admin_batch_endpoint_enabled_with_valid_token_reaches_service(client, monkeypatch):
-    monkeypatch.setenv("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY", "yes")
-    monkeypatch.setenv("JUPR_ADMIN_API_TOKEN", "expected-token")
-
-    monkeypatch.setattr(
-        "services.api.main.get_supabase_client",
-        lambda: object(),
-    )
-    monkeypatch.setattr(
-        "services.api.main.load_data",
-        lambda _supabase, _club_id: (None, None, None, None, None, None, None, None, None, {}),
-    )
-
-    class _Result:
-        ok = True
-        errors = []
-        data = {"inserted": 1, "skipped_incomplete": 0}
-
-    monkeypatch.setattr("services.api.main.submit_match_batch", lambda *_args, **_kwargs: _Result())
-
-    response = client.post(
-        "/admin/clubs/club-1/matches/batch",
-        json={"matches": [{"league": "A"}], "source": "next_admin_score_entry"},
-        headers={"x-admin-permission": "enter_scores", "x-admin-token": "expected-token"},
-    )
-
-    assert response.status_code == 200
-    payload = response.json()
-    assert payload["ok"] is True
-    assert payload["auth_mode"] == "token_guard_placeholder"
-    assert payload["result"]["inserted"] == 1
+    assert called == {"auth": False, "write": False}


### PR DESCRIPTION
### Motivation

- Replace the temporary static `JUPR_ADMIN_API_TOKEN` guard with a production-shaped Bearer JWT auth path for admin score-entry while keeping the Next.js score entry disabled by default. 
- Provide the authentication / authorization plumbing (token parsing, validation, role resolution, and audit context) so future Next.js admin workflows can integrate safely without enabling production writes.

### Description

- Added `services/api/auth.py` which parses `Authorization: Bearer <token>`, validates Supabase JWTs via secret mode (`SUPABASE_JWT_SECRET`) or JWKS mode (`SUPABASE_JWKS_URL` + `JUPR_SUPABASE_JWT_MODE`), extracts `sub`/`email`/claims, and exposes `authenticate_bearer` with an injectable `decode_token` for tests. 
- Replaced the placeholder `_authorize_score_entry` guard in `services/api/main.py` with `authenticate_bearer`, then resolved role via `resolve_admin_role` and enforced `enter_scores` using `has_permission`, while still short-circuiting when `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY` is disabled. 
- Populate `ServiceContext` with `actor_email`, `actor_role`, `club_id`, and `source` to prepare for audit attribution; response now indicates `auth_mode:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0209ca303883268a0142c4a6eb87dc)