### PR TITLE
Add FastAPI admin audit logging for match-batch writes

### DIFF
--- a/docs/next_admin_auth_design.md
+++ b/docs/next_admin_auth_design.md
@@ -100,3 +100,12 @@ Before enabling Next.js admin score entry for rated workflows, future implementa
 - `read_only` and wrong-club bindings are denied with `403`; missing/invalid auth returns `401`.
 - `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY` is still disabled by default and blocks before auth/write work.
 - Next.js admin score entry remains non-production-active by default.
+
+
+## Audit runtime behavior (Prompt 08)
+
+- `POST /admin/clubs/{club_id}/matches/batch` now attempts audit writes on successful writes and denied authenticated attempts.
+- Denied authenticated attempts are logged with `flagged_for_review=true`.
+- Unauthenticated requests are not audit-logged to avoid token leakage risk.
+- Strict mode: set `JUPR_REQUIRE_API_AUDIT_LOG=1` to fail writes when audit persistence fails.
+- Default mode degrades gracefully if `admin_activity_log` is unavailable in staging.

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -41,13 +41,7 @@ When disabled, the endpoint returns:
 
 To enable in staging experiments only, set `JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=1` (or `true` / `yes`).
 
-When enabled, this route still uses a **server token placeholder guard** and is not production-grade auth.
-
-Required headers:
-- `x-admin-token: <JUPR_ADMIN_API_TOKEN>`
-- `x-admin-permission: enter_scores`
-
-This endpoint is intentionally structured so Supabase JWT and role-based authorization can replace the placeholder guard later without changing the route contract.
+When enabled, this route requires Supabase JWT Bearer auth and role-based authorization for `enter_scores`.
 
 Auth design reference for future replacement of the temporary guard:
 - `docs/next_admin_auth_design.md`
@@ -76,3 +70,11 @@ When running staging API deployments, credentials must come from the staging Sup
   - Secret mode (default): `SUPABASE_JWT_SECRET` (+ optional `SUPABASE_JWT_AUDIENCE`, default `authenticated`).
   - JWKS mode: `JUPR_SUPABASE_JWT_MODE=jwks` + `SUPABASE_JWKS_URL` (+ optional audience).
 - Do not use service-role or JWT secrets in browser/client code.
+
+## Admin audit logging
+
+- Successful admin match-batch writes attempt to write `admin_activity_log` records with actor + club attribution.
+- Denied authenticated writes are flagged for review in audit logs when safe to do so.
+- `JUPR_REQUIRE_API_AUDIT_LOG=1` enables strict mode: write requests fail if audit logging cannot be recorded.
+- Default behavior degrades gracefully when audit table migration is missing (staging-safe).
+- Audit payloads include summary metadata (`source_page`, `source_client`) and do not include raw bearer tokens or secrets.

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -9,6 +9,7 @@ from supabase import Client, create_client
 
 from jupr_app.data.load import load_data
 from jupr_app.domain.admin.roles import PERMISSION_ENTER_SCORES, has_permission, resolve_admin_role
+from jupr_app.domain.admin_activity_log import build_activity_payload, write_admin_activity_log
 from jupr_app.services.context import ServiceContext
 from jupr_app.services.leaderboard_service import get_public_leaderboard
 from jupr_app.services.match_service import submit_match_batch
@@ -25,6 +26,10 @@ def is_staging_env() -> bool:
 
 def is_next_admin_score_entry_enabled() -> bool:
     return os.getenv("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY", "").strip().lower() in {"1", "true", "yes"}
+
+
+def is_api_audit_log_required() -> bool:
+    return os.getenv("JUPR_REQUIRE_API_AUDIT_LOG", "").strip().lower() in {"1", "true", "yes"}
 
 
 def _warn_if_not_staging_configured() -> None:
@@ -232,6 +237,18 @@ def submit_admin_match_batch(
         allowlist=set(),
     )
     if not has_permission(role_resolution.role, PERMISSION_ENTER_SCORES):
+        denied_payload = build_activity_payload(
+            club_id=str(club_id),
+            actor_email=user.email,
+            actor_role=role_resolution.role,
+            action_type="submit_match_batch_denied",
+            entity_type="matches",
+            entity_id="batch",
+            after_json={"source_client": "fastapi/nextjs", "reason": "insufficient_permission"},
+            source_page=payload.source,
+            flagged_for_review=True,
+        )
+        write_admin_activity_log(supabase, denied_payload)
         raise HTTPException(status_code=403, detail="insufficient permission")
     df_players_all, _, df_leagues, _, df_meta, _, _, _, _, name_to_id = load_data(supabase, club_id)
 
@@ -252,6 +269,25 @@ def submit_admin_match_batch(
     )
     if not result.ok:
         raise HTTPException(status_code=400, detail="; ".join(result.errors) or "Unable to submit match batch")
+
+    audit_payload = build_activity_payload(
+        club_id=str(club_id),
+        actor_email=user.email,
+        actor_role=role_resolution.role,
+        action_type="submit_match_batch",
+        entity_type="matches",
+        entity_id="batch",
+        after_json={
+            "source_client": "fastapi/nextjs",
+            "source_page": payload.source,
+            "match_count": len(payload.matches),
+            "result_summary": result.data if isinstance(result.data, dict) else {"ok": True},
+        },
+        source_page=payload.source,
+    )
+    audit_write = write_admin_activity_log(supabase, audit_payload)
+    if not audit_write.ok and is_api_audit_log_required():
+        raise HTTPException(status_code=500, detail="audit log write required but unavailable")
 
     return {
         "ok": True,

--- a/tests/test_api_admin_audit_logging.py
+++ b/tests/test_api_admin_audit_logging.py
@@ -1,0 +1,141 @@
+from tests.conftest import require_api_dependency
+
+require_api_dependency("fastapi")
+require_api_dependency("supabase")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.api.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _enable(monkeypatch):
+    monkeypatch.setenv("JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY", "true")
+
+
+def _mock_common(monkeypatch):
+    monkeypatch.setattr("services.api.main.get_supabase_client", lambda: object())
+    monkeypatch.setattr(
+        "services.api.main.load_data",
+        lambda _supabase, _club_id: (None, None, None, None, None, None, None, None, None, {}),
+    )
+
+
+class _Result:
+    ok = True
+    errors = []
+    data = {"inserted": 1}
+
+
+def test_successful_scorekeeper_write_records_audit_payload(client, monkeypatch):
+    _enable(monkeypatch)
+    _mock_common(monkeypatch)
+    monkeypatch.setattr("services.api.main.authenticate_bearer", lambda *_a, **_k: type("U", (), {"email": "keeper@club.com", "user_id": "u1"})())
+    monkeypatch.setattr("services.api.main.resolve_admin_role", lambda **_kwargs: type("R", (), {"role": "scorekeeper"})())
+    monkeypatch.setattr("services.api.main.submit_match_batch", lambda *_a, **_k: _Result())
+
+    captured = {}
+
+    def _write_audit(_supabase, payload):
+        captured["payload"] = payload
+        return type("W", (), {"ok": True, "warning": None})()
+
+    monkeypatch.setattr("services.api.main.write_admin_activity_log", _write_audit)
+
+    response = client.post(
+        "/admin/clubs/club-1/matches/batch",
+        json={"matches": [{"a": 1}], "source": "next/admin/score-entry"},
+        headers={"Authorization": "Bearer x"},
+    )
+
+    assert response.status_code == 200
+    payload = captured["payload"]
+    assert payload["club_id"] == "club-1"
+    assert payload["actor_email"] == "keeper@club.com"
+    assert payload["actor_role"] == "scorekeeper"
+    assert payload["source_page"] == "next/admin/score-entry"
+    assert payload["after_json"]["source_client"] == "fastapi/nextjs"
+
+
+def test_audit_payload_does_not_include_tokens_or_service_role(client, monkeypatch):
+    _enable(monkeypatch)
+    _mock_common(monkeypatch)
+    monkeypatch.setattr("services.api.main.authenticate_bearer", lambda *_a, **_k: type("U", (), {"email": "keeper@club.com", "user_id": "u1"})())
+    monkeypatch.setattr("services.api.main.resolve_admin_role", lambda **_kwargs: type("R", (), {"role": "scorekeeper"})())
+    monkeypatch.setattr("services.api.main.submit_match_batch", lambda *_a, **_k: _Result())
+
+    captured = {}
+
+    def _write_audit(_supabase, payload):
+        captured["payload"] = payload
+        return type("W", (), {"ok": True, "warning": None})()
+
+    monkeypatch.setattr("services.api.main.write_admin_activity_log", _write_audit)
+    response = client.post(
+        "/admin/clubs/club-1/matches/batch",
+        json={"matches": [{"authorization": "Bearer SECRET_TOKEN", "service_role": "SERVICE_KEY"}]},
+        headers={"Authorization": "Bearer raw-user-token"},
+    )
+
+    assert response.status_code == 200
+    payload_dump = str(captured["payload"])
+    assert "raw-user-token" not in payload_dump
+    assert "SECRET_TOKEN" not in payload_dump
+    assert "SERVICE_KEY" not in payload_dump
+
+
+def test_missing_audit_table_degrades_gracefully_by_default(client, monkeypatch):
+    _enable(monkeypatch)
+    _mock_common(monkeypatch)
+    monkeypatch.delenv("JUPR_REQUIRE_API_AUDIT_LOG", raising=False)
+    monkeypatch.setattr("services.api.main.authenticate_bearer", lambda *_a, **_k: type("U", (), {"email": "keeper@club.com", "user_id": "u1"})())
+    monkeypatch.setattr("services.api.main.resolve_admin_role", lambda **_kwargs: type("R", (), {"role": "scorekeeper"})())
+    monkeypatch.setattr("services.api.main.submit_match_batch", lambda *_a, **_k: _Result())
+    monkeypatch.setattr("services.api.main.write_admin_activity_log", lambda *_a, **_k: type("W", (), {"ok": False, "warning": "missing table"})())
+
+    response = client.post("/admin/clubs/club-1/matches/batch", json={"matches": []}, headers={"Authorization": "Bearer x"})
+    assert response.status_code == 200
+
+
+def test_strict_mode_fails_if_audit_write_fails(client, monkeypatch):
+    _enable(monkeypatch)
+    _mock_common(monkeypatch)
+    monkeypatch.setenv("JUPR_REQUIRE_API_AUDIT_LOG", "1")
+    monkeypatch.setattr("services.api.main.authenticate_bearer", lambda *_a, **_k: type("U", (), {"email": "keeper@club.com", "user_id": "u1"})())
+    monkeypatch.setattr("services.api.main.resolve_admin_role", lambda **_kwargs: type("R", (), {"role": "scorekeeper"})())
+    monkeypatch.setattr("services.api.main.submit_match_batch", lambda *_a, **_k: _Result())
+    monkeypatch.setattr("services.api.main.write_admin_activity_log", lambda *_a, **_k: type("W", (), {"ok": False, "warning": "boom"})())
+
+    response = client.post("/admin/clubs/club-1/matches/batch", json={"matches": []}, headers={"Authorization": "Bearer x"})
+    assert response.status_code == 500
+    assert "audit" in response.json()["detail"]
+
+
+def test_denied_different_club_write_does_not_perform_match_write(client, monkeypatch):
+    _enable(monkeypatch)
+    _mock_common(monkeypatch)
+    monkeypatch.setattr("services.api.main.authenticate_bearer", lambda *_a, **_k: type("U", (), {"email": "viewer@club.com", "user_id": "u2"})())
+    monkeypatch.setattr("services.api.main.resolve_admin_role", lambda **_kwargs: type("R", (), {"role": "read_only"})())
+
+    called = {"match": False, "audit": False}
+
+    def _submit(*_a, **_k):
+        called["match"] = True
+        return _Result()
+
+    def _audit(*_a, **_k):
+        called["audit"] = True
+        return type("W", (), {"ok": True, "warning": None})()
+
+    monkeypatch.setattr("services.api.main.submit_match_batch", _submit)
+    monkeypatch.setattr("services.api.main.write_admin_activity_log", _audit)
+
+    response = client.post("/admin/clubs/other-club/matches/batch", json={"matches": []}, headers={"Authorization": "Bearer x"})
+    assert response.status_code == 403
+    assert called["match"] is False
+    assert called["audit"] is True


### PR DESCRIPTION
### Motivation
- Ensure every future FastAPI admin write is attributed for audit and review so Next.js admin workflows can be trusted for rated operations.
- Provide a safe default that avoids logging secrets and degrades gracefully in staging when the audit table is missing.

### Description
- Add audit integration in `services/api/main.py`: import `build_activity_payload` and `write_admin_activity_log`, add `is_api_audit_log_required()` and call audit writes for both successful and denied authenticated `POST /admin/clubs/{club_id}/matches/batch` flows.
- On denied authenticated attempts create a `submit_match_batch_denied` payload with `flagged_for_review=True` and write it via `write_admin_activity_log`, while avoiding unauthenticated token logging.
- On successful writes create a summary-only `after_json` containing `source_page`, `source_client: fastapi/nextjs`, `match_count` and a `result_summary`, then write the audit payload and enforce strict behavior when `JUPR_REQUIRE_API_AUDIT_LOG=1`.
- Update docs (`docs/next_admin_auth_design.md` and `services/api/README.md`) to document audit runtime behavior and the `JUPR_REQUIRE_API_AUDIT_LOG` strict-mode flag.
- Add tests in `tests/test_api_admin_audit_logging.py` covering successful audit payload content, secret/token non-leakage, graceful degradation when audit persistence fails, strict-mode failure, and denied different-club behavior.

### Testing
- Added and executed `pytest -q tests/test_api_admin_auth.py tests/test_api_admin_audit_logging.py tests/test_api_admin_score_entry_disabled.py` in the environment used for this change, which reported `3 skipped` due to optional API dependency gating (test scaffolding indicates these tests are skipped when API dependencies are not available). 
- The new unit tests in `tests/test_api_admin_audit_logging.py` exercise audit payload creation and behavior via `monkeypatch` and assert expected fields and strict/degrade behavior locally (these tests are included and will run in CI where API dependencies are available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020aea57008326b797a8b1e49b5438)