### PR TITLE
Enforce single match write path with service-layer boundary tests

### DIFF
--- a/tests/test_match_write_boundaries.py
+++ b/tests/test_match_write_boundaries.py
@@ -1,0 +1,130 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+from jupr_app.services.context import ServiceContext
+from jupr_app.services.match_service import submit_match_batch
+from jupr_app.services.result_types import ServiceResult
+
+
+ALLOWED_PROCESS_MATCHES_IMPORTERS = {
+    Path("jupr_app/services/match_service.py"),
+}
+
+
+
+def _find_process_matches_importers() -> list[Path]:
+    offenders: list[Path] = []
+    targets = list(Path("jupr_app/ui/pages").glob("*.py")) + list(Path("services/api").glob("*.py"))
+    for file_path in sorted(targets):
+        tree = ast.parse(file_path.read_text(encoding="utf-8"), filename=str(file_path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if node.module != "jupr_app.domain.match_processing":
+                continue
+            if any(alias.name == "process_matches" for alias in node.names):
+                offenders.append(file_path)
+                break
+    return offenders
+
+
+
+def test_ui_and_api_do_not_import_process_matches_directly():
+    offenders = [p for p in _find_process_matches_importers() if p not in ALLOWED_PROCESS_MATCHES_IMPORTERS]
+    assert not offenders, (
+        "UI/API must submit scores via submit_match_batch; direct process_matches imports are forbidden. "
+        f"offenders={offenders}"
+    )
+
+
+
+def test_submit_match_batch_delegates_to_process_matches(monkeypatch):
+    captured = {}
+
+    def fake_process_matches(match_list, **kwargs):
+        captured["match_list"] = match_list
+        captured["kwargs"] = kwargs
+        return {"ok": True, "processed": len(match_list)}
+
+    monkeypatch.setattr("jupr_app.services.match_service.process_matches", fake_process_matches)
+
+    ctx = ServiceContext(supabase=object(), club_id="club-123")
+    result = submit_match_batch(
+        ctx,
+        [{"winner": "A"}],
+        name_to_id={"A": 1},
+        df_players_all="players_df",
+        df_leagues="leagues_df",
+        df_meta="meta_df",
+    )
+
+    assert result.ok is True
+    assert result.data == {"ok": True, "processed": 1}
+    assert captured["kwargs"]["supabase"] is ctx.supabase
+    assert captured["kwargs"]["club_id"] == ctx.club_id
+    assert captured["kwargs"]["name_to_id"] == {"A": 1}
+    assert captured["kwargs"]["df_players_all"] == "players_df"
+    assert captured["kwargs"]["df_leagues"] == "leagues_df"
+    assert captured["kwargs"]["df_meta"] == "meta_df"
+
+
+
+def test_submit_match_batch_wraps_errors_as_failure(monkeypatch):
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr("jupr_app.services.match_service.process_matches", boom)
+
+    ctx = ServiceContext(supabase=object(), club_id="club-123")
+    result = submit_match_batch(
+        ctx,
+        [{"winner": "A"}],
+        name_to_id={"A": 1},
+        df_players_all="players_df",
+        df_leagues="leagues_df",
+        df_meta="meta_df",
+    )
+
+    assert result == ServiceResult.failure("kaboom")
+
+
+
+def test_fastapi_admin_batch_uses_submit_match_batch(monkeypatch):
+    pytest.importorskip("fastapi")
+    from services.api import main as api_main
+
+    submit_calls = {}
+
+    class FakeUser:
+        email = "admin@example.com"
+        user_id = "uid-1"
+
+    class FakeRole:
+        role = "admin"
+
+    def fake_submit(ctx, matches, **kwargs):
+        submit_calls["ctx"] = ctx
+        submit_calls["matches"] = matches
+        submit_calls["kwargs"] = kwargs
+        return ServiceResult.success(data={"processed": len(matches)})
+
+    monkeypatch.setattr(api_main, "is_next_admin_score_entry_enabled", lambda: True)
+    monkeypatch.setattr(api_main, "authenticate_bearer", lambda _auth: FakeUser())
+    monkeypatch.setattr(api_main, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(api_main, "resolve_admin_role", lambda **_kwargs: FakeRole())
+    monkeypatch.setattr(api_main, "has_permission", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(api_main, "load_data", lambda *_args, **_kwargs: ("players", None, "leagues", None, "meta", None, None, None, None, {"A": 1}))
+    monkeypatch.setattr(api_main, "write_admin_activity_log", lambda *_args, **_kwargs: ServiceResult.success(data={}))
+    monkeypatch.setattr(api_main, "submit_match_batch", fake_submit)
+
+    payload = api_main.MatchBatchRequest(matches=[{"winner": "A"}], source="test")
+    out = api_main.submit_admin_match_batch("club-123", payload, authorization="Bearer token")
+
+    assert out["ok"] is True
+    assert submit_calls["matches"] == [{"winner": "A"}]
+    assert submit_calls["kwargs"]["name_to_id"] == {"A": 1}
+
+    api_source = Path("services/api/main.py").read_text(encoding="utf-8")
+    assert "from jupr_app.domain.match_processing import process_matches" not in api_source


### PR DESCRIPTION
### Motivation

- Ensure all UI and API score submissions go through the canonical service boundary and prevent any UI/API from calling the domain `process_matches` write path directly.
- Make the service boundary explicit so rating math and writes remain in the Python domain/service layer and avoid duplicate/JS write paths.

### Description

- Add `tests/test_match_write_boundaries.py` which statically scans `jupr_app/ui/pages/*.py` and `services/api/*.py` and fails if those files directly import `jupr_app.domain.match_processing.process_matches` (allowing the import only in `jupr_app/services/match_service.py`).
- Add behavioral tests that monkeypatch `jupr_app.services.match_service.process_matches` and assert `submit_match_batch()` forwards `ctx.supabase`, `ctx.club_id`, `name_to_id`, `df_players_all`, `df_leagues`, and `df_meta` to the domain engine.
- Add tests that verify errors raised by `process_matches` are returned as `ServiceResult.failure(...)` and successful returns are wrapped with `ServiceResult.success(...)`.
- Add a FastAPI boundary test that monkeypatches `submit_match_batch` in `services.api.main` and asserts the admin batch endpoint routes writes via the service boundary and does not import `process_matches` directly.

### Testing

- Ran `pytest` for the new and related service/UI tests and the final run reported `8 passed, 1 skipped`.
- Tests include a FastAPI-boundary check which is skipped when `fastapi` is not installed via `pytest.importorskip("fastapi")`, addressing environments without FastAPI and allowing the suite to pass.
- The new tests enforce the static and behavioral boundaries without changing domain rating behavior or production code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020bf4b2188326bb5b80c38ba92e27)