### PR TITLE
Add internal clubs SaaS onboarding foundation for staging pilots

### DIFF
--- a/jupr_app/domain/clubs.py
+++ b/jupr_app/domain/clubs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from typing import Any
 
 from jupr_app.ui import branding
@@ -53,4 +54,70 @@ def get_club_config(supabase: Any, club_id: str) -> dict[str, Any]:
     return merged
 
 
-__all__ = ["get_default_club_id", "get_club_config"]
+_SLUG_RE = re.compile(r"^[a-z0-9-]+$")
+
+
+def validate_club_slug(slug: str) -> str:
+    normalized = str(slug or "").strip().lower()
+    if not normalized:
+        raise ValueError("Club slug is required.")
+    if not _SLUG_RE.fullmatch(normalized):
+        raise ValueError("Club slug must contain only lowercase letters, numbers, or hyphens.")
+    return normalized
+
+
+def get_club_by_slug(supabase: Any, slug: str, include_inactive: bool = False) -> dict[str, Any] | None:
+    normalized = validate_club_slug(slug)
+    query = supabase.table("clubs").select("*").eq("slug", normalized)
+    if not include_inactive:
+        query = query.eq("is_active", True)
+    response = query.limit(1).execute()
+    rows = getattr(response, "data", None) or []
+    return rows[0] if rows else None
+
+
+def create_club_config(
+    supabase: Any,
+    *,
+    club_id: str,
+    slug: str,
+    name: str,
+    tagline: str | None = None,
+    support_email: str | None = None,
+    public_base_url: str | None = None,
+    created_by_email: str | None = None,
+    features_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    normalized_slug = validate_club_slug(slug)
+    if get_club_by_slug(supabase, normalized_slug, include_inactive=True):
+        raise ValueError(f"Club slug '{normalized_slug}' already exists.")
+
+    payload: dict[str, Any] = {
+        "id": str(club_id or "").strip(),
+        "slug": normalized_slug,
+        "name": str(name or "").strip(),
+        "tagline": tagline,
+        "support_email": support_email,
+        "public_base_url": public_base_url,
+        "created_by_email": created_by_email,
+        "features_json": features_json or {},
+    }
+    if not payload["id"]:
+        raise ValueError("club_id is required.")
+    if not payload["name"]:
+        raise ValueError("name is required.")
+
+    response = supabase.table("clubs").insert(payload).execute()
+    rows = getattr(response, "data", None) or []
+    return rows[0] if rows else payload
+
+
+def list_clubs(supabase: Any, include_inactive: bool = False) -> list[dict[str, Any]]:
+    query = supabase.table("clubs").select("*")
+    if not include_inactive:
+        query = query.eq("is_active", True)
+    response = query.execute()
+    return list(getattr(response, "data", None) or [])
+
+
+__all__ = ["get_default_club_id", "get_club_config", "validate_club_slug", "get_club_by_slug", "create_club_config", "list_clubs"]

--- a/supabase/migrations/20260511143000_clubs_saas_onboarding_fields.sql
+++ b/supabase/migrations/20260511143000_clubs_saas_onboarding_fields.sql
@@ -1,0 +1,8 @@
+alter table if exists public.clubs
+  add column if not exists plan_status text not null default 'pilot',
+  add column if not exists features_json jsonb not null default '{}'::jsonb,
+  add column if not exists created_by_email text,
+  add column if not exists onboarding_status text not null default 'draft';
+
+create index if not exists clubs_slug_idx on public.clubs (slug);
+create index if not exists clubs_active_idx on public.clubs (is_active);

--- a/tests/test_club_onboarding.py
+++ b/tests/test_club_onboarding.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from jupr_app.domain.clubs import (
+    create_club_config,
+    get_club_by_slug,
+    get_club_config,
+    list_clubs,
+    validate_club_slug,
+)
+
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = list(rows)
+        self._filters = []
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, key, value):
+        self._filters.append((key, value))
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def insert(self, payload):
+        self._insert_payload = payload
+        self._rows.append(payload)
+        return self
+
+    def execute(self):
+        rows = self._rows
+        for key, value in self._filters:
+            rows = [r for r in rows if r.get(key) == value]
+        return SimpleNamespace(data=rows)
+
+
+class _Supabase:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def table(self, _name):
+        return _Query(self._rows)
+
+
+class _MissingTableSupabase:
+    def table(self, _name):
+        raise RuntimeError('relation "clubs" does not exist')
+
+
+def test_validate_slug_accepts_valid_value():
+    assert validate_club_slug("  New-Club-01 ") == "new-club-01"
+
+
+def test_validate_slug_rejects_invalid_value():
+    with pytest.raises(ValueError, match="only lowercase letters"):
+        validate_club_slug("Bad Slug!")
+
+
+def test_duplicate_slug_is_rejected():
+    supabase = _Supabase([{"id": "c1", "slug": "pilot-club", "name": "Pilot", "is_active": True}])
+    with pytest.raises(ValueError, match="already exists"):
+        create_club_config(supabase, club_id="c2", slug="pilot-club", name="Another")
+
+
+def test_inactive_club_is_hidden_by_default():
+    supabase = _Supabase(
+        [
+            {"id": "a", "slug": "active", "name": "Active", "is_active": True},
+            {"id": "i", "slug": "inactive", "name": "Inactive", "is_active": False},
+        ]
+    )
+    visible = list_clubs(supabase)
+    all_rows = list_clubs(supabase, include_inactive=True)
+    assert [r["slug"] for r in visible] == ["active"]
+    assert len(all_rows) == 2
+
+
+def test_get_club_by_slug_honors_include_inactive():
+    supabase = _Supabase([{"id": "i", "slug": "inactive", "name": "Inactive", "is_active": False}])
+    assert get_club_by_slug(supabase, "inactive") is None
+    assert get_club_by_slug(supabase, "inactive", include_inactive=True)["id"] == "i"
+
+
+def test_tres_palapas_fallback_when_table_missing():
+    config = get_club_config(_MissingTableSupabase(), "tres_palapas")
+    assert config["slug"] == "tres-palapas"
+    assert config["name"] == "Tres Palapas"
+
+
+def test_create_club_config_without_production_only_fields():
+    supabase = _Supabase([])
+    created = create_club_config(
+        supabase,
+        club_id="staging-club-2",
+        slug="staging-club-2",
+        name="Staging Club 2",
+    )
+    assert created["id"] == "staging-club-2"
+    assert created["slug"] == "staging-club-2"
+    assert created["features_json"] == {}


### PR DESCRIPTION
### Motivation
- Prepare the codebase for multi-club SaaS pilots by adding internal onboarding metadata to the `clubs` table and helper APIs for managing a second (staging) club. 
- Keep the existing Tres Palapas fallback behavior intact so legacy or single-club deployments continue to work without schema changes. 
- Provide safe, internal-only onboarding tooling without introducing billing, public signup, or production data migrations. 

### Description
- Add a Supabase migration `supabase/migrations/20260511143000_clubs_saas_onboarding_fields.sql` that adds `plan_status`, `features_json`, `created_by_email`, and `onboarding_status` to `public.clubs` and creates `clubs_slug_idx` and `clubs_active_idx` using `IF NOT EXISTS`. 
- Extend `jupr_app.domain.clubs` with onboarding helpers: `validate_club_slug`, `get_club_by_slug`, `create_club_config`, and `list_clubs`, and preserve `get_club_config` and `get_default_club_id` behavior. 
- Enforce slug normalization to lowercase and validation to allow only letters, numbers, and hyphens; reject duplicate slugs with a clear `ValueError`. 
- Ensure public reads exclude inactive clubs by default and allow returning inactive clubs only when `include_inactive=True`. 

### Testing
- Added unit tests in `tests/test_club_onboarding.py` covering slug validation, duplicate slug rejection, inactive-club filtering, include-inactive behavior, Tres Palapas fallback when the `clubs` table is missing, and minimal staging club creation. 
- Ran the focused test suite with `pytest -q tests/test_club_config.py tests/test_club_onboarding.py` and all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020e43a1c48326945def8099bf00b8)