### PR TITLE
Add SaaS observability foundation for API and workers

### DIFF
--- a/jupr_app/workers/badge_queue_worker.py
+++ b/jupr_app/workers/badge_queue_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import json
 import os
 from typing import Any
@@ -18,10 +19,17 @@ def _resolve_supabase_config() -> tuple[str, str, str]:
     if not url:
         raise ValueError("Missing required environment variable: SUPABASE_URL")
     if not key:
-        raise ValueError(
-            "Missing Supabase key. Set SUPABASE_SERVICE_ROLE_KEY (preferred) or SUPABASE_ANON_KEY."
-        )
+        raise ValueError("Missing Supabase key. Set SUPABASE_SERVICE_ROLE_KEY (preferred) or SUPABASE_ANON_KEY.")
     return url, key, key_source
+
+
+def _require_worker_run_log() -> bool:
+    return str(os.getenv("JUPR_REQUIRE_WORKER_RUN_LOG") or "").strip().lower() in {"1", "true", "yes"}
+
+
+def _is_missing_table_error(exc: Exception) -> bool:
+    detail = str(exc).lower()
+    return "worker_run_log" in detail and ("does not exist" in detail or "undefined table" in detail or "relation" in detail)
 
 
 def run_badge_queue_worker(
@@ -35,21 +43,43 @@ def run_badge_queue_worker(
 ) -> dict[str, Any]:
     url, key, key_source = _resolve_supabase_config()
     supabase = make_supabase(url, key)
-    worker_summary = process_badge_eval_queue_until_empty(
-        supabase,
-        club_id,
-        max_total_jobs=max_total_jobs,
-        batch_max_jobs=batch_max_jobs,
-        per_batch_time_budget_seconds=per_batch_time_budget_seconds,
-        max_wall_clock_seconds=max_wall_clock_seconds,
-        max_errors=max_errors,
-    )
-    return {
-        "ok": True,
-        "club_id": club_id,
-        "key_source": key_source,
-        **worker_summary,
-    }
+    run_id: str | None = None
+
+    try:
+        created = supabase.table("worker_run_log").insert(
+            {"worker_name": "badge_queue_worker", "club_id": club_id, "status": "started", "summary_json": {}}
+        ).execute().data or []
+        run_id = str((created[0] or {}).get("id")) if created else None
+    except Exception as exc:  # noqa: BLE001
+        if not (_is_missing_table_error(exc) and not _require_worker_run_log()):
+            raise
+
+    try:
+        worker_summary = process_badge_eval_queue_until_empty(
+            supabase,
+            club_id,
+            max_total_jobs=max_total_jobs,
+            batch_max_jobs=batch_max_jobs,
+            per_batch_time_budget_seconds=per_batch_time_budget_seconds,
+            max_wall_clock_seconds=max_wall_clock_seconds,
+            max_errors=max_errors,
+        )
+        result = {"ok": True, "club_id": club_id, "key_source": key_source, **worker_summary}
+        if run_id:
+            supabase.table("worker_run_log").update(
+                {"status": "success", "finished_at": dt.datetime.now(dt.timezone.utc).isoformat(), "summary_json": result}
+            ).eq("id", run_id).execute()
+        return result
+    except Exception as exc:  # noqa: BLE001
+        if run_id:
+            try:
+                supabase.table("worker_run_log").update(
+                    {"status": "failed", "finished_at": dt.datetime.now(dt.timezone.utc).isoformat(), "error_text": f"{type(exc).__name__}: {exc}"}
+                ).eq("id", run_id).execute()
+            except Exception as log_exc:  # noqa: BLE001
+                if not (_is_missing_table_error(log_exc) and not _require_worker_run_log()):
+                    raise
+        raise
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/jupr_app/workers/player_update_email_worker.py
+++ b/jupr_app/workers/player_update_email_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import json
 import os
 from typing import Any
@@ -20,31 +21,71 @@ def _resolve_supabase_config() -> tuple[str, str, str]:
     if not url:
         raise ValueError("Missing required environment variable: SUPABASE_URL")
     if not key:
-        raise ValueError(
-            "Missing Supabase key. Set SUPABASE_SERVICE_ROLE_KEY (preferred) or SUPABASE_ANON_KEY."
-        )
+        raise ValueError("Missing Supabase key. Set SUPABASE_SERVICE_ROLE_KEY (preferred) or SUPABASE_ANON_KEY.")
     return url, key, key_source
+
+
+def _require_worker_run_log() -> bool:
+    return str(os.getenv("JUPR_REQUIRE_WORKER_RUN_LOG") or "").strip().lower() in {"1", "true", "yes"}
+
+
+def _is_missing_table_error(exc: Exception) -> bool:
+    detail = str(exc).lower()
+    return "worker_run_log" in detail and ("does not exist" in detail or "undefined table" in detail or "relation" in detail)
 
 
 def run_player_update_email_worker(club_id: str, *, limit: int = 250) -> dict[str, Any]:
     url, key, key_source = _resolve_supabase_config()
     supabase = make_supabase(url, key)
+    run_id: str | None = None
+
+    try:
+        created = supabase.table("worker_run_log").insert(
+            {"worker_name": "player_update_email_worker", "club_id": club_id, "status": "started", "summary_json": {}}
+        ).execute().data or []
+        run_id = str((created[0] or {}).get("id")) if created else None
+    except Exception as exc:  # noqa: BLE001
+        if not (_is_missing_table_error(exc) and not _require_worker_run_log()):
+            raise
+
     public_base_url = get_public_base_url()
     ctx = ServiceContext(supabase=supabase, club_id=club_id, public_base_url=public_base_url)
-    summary = send_pending_player_update_emails(
-        ctx,
-        limit=max(1, int(limit)),
-        public_base_url=public_base_url,
-    )
-    return {
-        "ok": True,
-        "club_id": club_id,
-        "key_source": key_source,
-        "attempted": int(summary.get("attempted") or 0),
-        "sent": int(summary.get("sent") or 0),
-        "skipped": int(summary.get("skipped") or 0),
-        "errors": int(summary.get("errors") or 0),
-    }
+
+    try:
+        summary = send_pending_player_update_emails(ctx, limit=max(1, int(limit)), public_base_url=public_base_url)
+        result = {
+            "ok": True,
+            "club_id": club_id,
+            "key_source": key_source,
+            "attempted": int(summary.get("attempted") or 0),
+            "sent": int(summary.get("sent") or 0),
+            "skipped": int(summary.get("skipped") or 0),
+            "errors": int(summary.get("errors") or 0),
+        }
+        if run_id:
+            supabase.table("worker_run_log").update(
+                {
+                    "status": "success",
+                    "finished_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+                    "summary_json": {
+                        "attempted": result["attempted"],
+                        "sent": result["sent"],
+                        "skipped": result["skipped"],
+                        "errors": result["errors"],
+                    },
+                }
+            ).eq("id", run_id).execute()
+        return result
+    except Exception as exc:  # noqa: BLE001
+        if run_id:
+            try:
+                supabase.table("worker_run_log").update(
+                    {"status": "failed", "finished_at": dt.datetime.now(dt.timezone.utc).isoformat(), "error_text": f"{type(exc).__name__}: {exc}"}
+                ).eq("id", run_id).execute()
+            except Exception as log_exc:  # noqa: BLE001
+                if not (_is_missing_table_error(log_exc) and not _require_worker_run_log()):
+                    raise
+        raise
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -14,6 +14,7 @@ from jupr_app.services.context import ServiceContext
 from jupr_app.services.leaderboard_service import get_public_leaderboard
 from jupr_app.services.match_service import submit_match_batch
 from services.api.auth import authenticate_bearer, auth_header
+from services.api.middleware import StructuredRequestLoggingMiddleware
 
 
 def get_jupr_env() -> str:
@@ -45,6 +46,7 @@ def _warn_if_not_staging_configured() -> None:
         )
 
 app = FastAPI(title="JUPR API", version="0.1.0")
+app.add_middleware(StructuredRequestLoggingMiddleware)
 
 
 PUBLIC_LEADERBOARD_ENTRY_FIELDS = {

--- a/services/api/middleware.py
+++ b/services/api/middleware.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = logging.getLogger("jupr.api.request")
+
+
+class StructuredRequestLoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
+        start = time.perf_counter()
+        response = await call_next(request)
+        elapsed_ms = round((time.perf_counter() - start) * 1000, 2)
+        response.headers.setdefault("x-request-id", request_id)
+
+        logger.info(
+            "request.complete",
+            extra={
+                "method": request.method,
+                "path": request.url.path,
+                "status_code": response.status_code,
+                "elapsed_ms": elapsed_ms,
+                "request_id": request_id,
+            },
+        )
+        return response

--- a/supabase/migrations/20260511170000_worker_run_log.sql
+++ b/supabase/migrations/20260511170000_worker_run_log.sql
@@ -1,0 +1,14 @@
+create table if not exists public.worker_run_log (
+  id uuid primary key default gen_random_uuid(),
+  worker_name text not null,
+  club_id text not null,
+  status text not null,
+  started_at timestamptz not null default now(),
+  finished_at timestamptz,
+  summary_json jsonb not null default '{}'::jsonb,
+  error_text text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists worker_run_log_club_created_idx
+  on public.worker_run_log (club_id, created_at desc);

--- a/tests/test_api_logging.py
+++ b/tests/test_api_logging.py
@@ -1,0 +1,19 @@
+import logging
+
+from fastapi.testclient import TestClient
+
+from services.api.main import app
+
+
+def test_request_logging_no_auth_or_secrets(caplog):
+    caplog.set_level(logging.INFO, logger="jupr.api.request")
+    client = TestClient(app)
+    response = client.get("/health", headers={"Authorization": "Bearer secret-token", "x-request-id": "req-1"})
+    assert response.status_code == 200
+    rec = next(r for r in caplog.records if r.name == "jupr.api.request")
+    assert rec.method == "GET"
+    assert rec.path == "/health"
+    assert rec.status_code == 200
+    assert rec.request_id == "req-1"
+    assert "Authorization" not in rec.getMessage()
+    assert "secret" not in rec.getMessage().lower()

--- a/tests/test_worker_run_logging.py
+++ b/tests/test_worker_run_logging.py
@@ -1,0 +1,87 @@
+import pytest
+
+from jupr_app.workers import badge_queue_worker as bqw
+
+
+class _Resp:
+    def __init__(self, data=None):
+        self.data = data
+
+
+class _Query:
+    def __init__(self, table, state):
+        self.table = table
+        self.state = state
+        self.payload = None
+
+    def insert(self, payload):
+        self.payload = payload
+        return self
+
+    def update(self, payload):
+        self.payload = payload
+        return self
+
+    def eq(self, *_args):
+        return self
+
+    def execute(self):
+        if self.state.get("missing"):
+            raise Exception("relation worker_run_log does not exist")
+        if self.table == "worker_run_log" and self.payload and self.payload.get("status") == "started":
+            self.state.setdefault("events", []).append(("start", self.payload))
+            return _Resp([{"id": "run-1"}])
+        if self.table == "worker_run_log" and self.payload:
+            self.state.setdefault("events", []).append((self.payload.get("status"), self.payload))
+        return _Resp([])
+
+
+class _Supabase:
+    def __init__(self, state):
+        self.state = state
+
+    def table(self, name):
+        return _Query(name, self.state)
+
+
+def test_worker_success_logs_summary(monkeypatch):
+    state = {}
+    monkeypatch.setattr(bqw, "make_supabase", lambda *_: _Supabase(state))
+    monkeypatch.setattr(bqw, "process_badge_eval_queue_until_empty", lambda *_, **__: {"total_errored": 0, "processed": 3})
+    monkeypatch.setenv("SUPABASE_URL", "u")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "k")
+    out = bqw.run_badge_queue_worker("club-1")
+    assert out["ok"] is True
+    assert any(evt[0] == "success" for evt in state["events"])
+
+
+def test_worker_failure_logs_error(monkeypatch):
+    state = {}
+    monkeypatch.setattr(bqw, "make_supabase", lambda *_: _Supabase(state))
+    monkeypatch.setattr(bqw, "process_badge_eval_queue_until_empty", lambda *_, **__: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setenv("SUPABASE_URL", "u")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "k")
+    with pytest.raises(RuntimeError):
+        bqw.run_badge_queue_worker("club-1")
+    assert any(evt[0] == "failed" for evt in state["events"])
+
+
+def test_missing_table_degrades_when_not_strict(monkeypatch):
+    state = {"missing": True}
+    monkeypatch.setattr(bqw, "make_supabase", lambda *_: _Supabase(state))
+    monkeypatch.setattr(bqw, "process_badge_eval_queue_until_empty", lambda *_, **__: {"total_errored": 0})
+    monkeypatch.setenv("SUPABASE_URL", "u")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "k")
+    out = bqw.run_badge_queue_worker("club-1")
+    assert out["ok"] is True
+
+
+def test_missing_table_fails_when_strict(monkeypatch):
+    state = {"missing": True}
+    monkeypatch.setattr(bqw, "make_supabase", lambda *_: _Supabase(state))
+    monkeypatch.setattr(bqw, "process_badge_eval_queue_until_empty", lambda *_, **__: {"total_errored": 0})
+    monkeypatch.setenv("SUPABASE_URL", "u")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "k")
+    monkeypatch.setenv("JUPR_REQUIRE_WORKER_RUN_LOG", "1")
+    with pytest.raises(Exception):
+        bqw.run_badge_queue_worker("club-1")


### PR DESCRIPTION
### Motivation
- Improve staging diagnosability and prepare the SaaS path for production operations by adding lightweight observability for the FastAPI API and worker CLIs.

### Description
- Added `StructuredRequestLoggingMiddleware` (`services/api/middleware.py`) and wired it into the FastAPI app with `app.add_middleware(StructuredRequestLoggingMiddleware)`, emitting structured logs with `method`, `path`, `status_code`, `elapsed_ms`, and `request_id` while avoiding authorization and secret exposure.
- Added `supabase/migrations/20260511170000_worker_run_log.sql` to create `public.worker_run_log` and the `worker_run_log_club_created_idx` index for worker run lifecycle records.
- Updated `jupr_app/workers/badge_queue_worker.py` and `jupr_app/workers/player_update_email_worker.py` to record `started` / `success` / `failed` lifecycle events into `worker_run_log`, persist summary JSON or `error_text`, and gracefully degrade when the table is missing unless `JUPR_REQUIRE_WORKER_RUN_LOG=1` is set.
- Added tests `tests/test_api_logging.py` and `tests/test_worker_run_logging.py` to assert log safety (no auth/secrets) and worker run-log behaviors (success, failure, missing-table degrade, strict-mode failure).

### Testing
- Ran `pytest -q tests/test_worker_run_logging.py`, which passed (`4 passed`).
- Attempted `pytest -q tests/test_api_logging.py tests/test_worker_run_logging.py`, but API test collection failed due to the environment missing the `fastapi` package (`ModuleNotFoundError: No module named 'fastapi'`).
- Worker tests use a Supabase shim to validate insertion/update flows and strict-mode behavior for `JUPR_REQUIRE_WORKER_RUN_LOG`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0211dbf06883269f7d29e6a7a7f2cd)