### PR TITLE
Add staging-safe email modes for player update sends

### DIFF
--- a/jupr_app/config.py
+++ b/jupr_app/config.py
@@ -16,6 +16,12 @@ class SMTPConfig:
     use_tls: bool
 
 
+EMAIL_MODE_LIVE = "live"
+EMAIL_MODE_DRY_RUN = "dry_run"
+EMAIL_MODE_STAGING_REDIRECT = "staging_redirect"
+SUPPORTED_EMAIL_MODES = {EMAIL_MODE_LIVE, EMAIL_MODE_DRY_RUN, EMAIL_MODE_STAGING_REDIRECT}
+
+
 def get_env_or_default(name: str, default: str = "") -> str:
     value = str(os.getenv(name, "")).strip()
     if value:
@@ -77,3 +83,25 @@ def get_smtp_config() -> SMTPConfig:
         reply_to=reply_to,
         use_tls=use_tls,
     )
+
+
+def get_jupr_env() -> str:
+    return get_env_or_default("JUPR_ENV", "production").lower()
+
+
+def get_email_mode() -> str:
+    env = get_jupr_env()
+    configured = get_env_or_default("JUPR_EMAIL_MODE").lower()
+    if configured:
+        if configured not in SUPPORTED_EMAIL_MODES:
+            raise ValueError(f"Invalid JUPR_EMAIL_MODE: {configured}")
+        if (
+            env == "staging"
+            and configured == EMAIL_MODE_LIVE
+            and get_env_or_default("JUPR_ALLOW_STAGING_LIVE_EMAIL") != "1"
+        ):
+            raise ValueError("Staging live email blocked. Set JUPR_ALLOW_STAGING_LIVE_EMAIL=1 to allow live sends.")
+        return configured
+    if env == "staging":
+        return EMAIL_MODE_DRY_RUN
+    return EMAIL_MODE_LIVE

--- a/jupr_app/domain/notifications/player_update_sender.py
+++ b/jupr_app/domain/notifications/player_update_sender.py
@@ -23,7 +23,14 @@ from jupr_app.domain.notifications.player_update_email_template import (
     build_player_update_email_subject,
     build_player_update_email_text,
 )
-from jupr_app.config import SMTPConfig, get_public_base_url
+from jupr_app.config import (
+    EMAIL_MODE_DRY_RUN,
+    EMAIL_MODE_STAGING_REDIRECT,
+    SMTPConfig,
+    get_email_mode,
+    get_env_or_default,
+    get_public_base_url,
+)
 from jupr_app.domain.notifications.smtp_mailer import send_email_with_inline_chart
 from jupr_app.domain.recaps.player_weekly_digest import compute_player_weekly_digest
 
@@ -250,7 +257,7 @@ def generate_and_queue_digests_for_active_subscriptions(
     start_date: date,
     end_date: date,
     only_players_with_matches: bool = False,
-) -> dict[str, int]:
+) -> dict[str, Any]:
     supabase = ctx.supabase
     club_id = str(ctx.club_id)
 
@@ -395,6 +402,7 @@ def send_pending_player_update_emails(
     club_id = str(ctx.club_id)
     pending_rows = list_outbox_rows(supabase, club_id, status="pending", limit=max(1, int(limit)))
 
+    email_mode = get_email_mode()
     sent = 0
     skipped = 0
     errors = 0
@@ -460,8 +468,20 @@ def send_pending_player_update_emails(
             html_body = build_player_update_email_html(digest, chart_cid if chart_png else None)
             text_body = build_player_update_email_text(digest)
 
-            provider_message_id = send_email_with_inline_chart(
-                to_email=str(outbox.get("email") or ""),
+            original_to_email = str(outbox.get("email") or "").strip()
+            effective_to_email = original_to_email
+            if email_mode == EMAIL_MODE_STAGING_REDIRECT:
+                redirect_to = get_env_or_default("JUPR_STAGING_EMAIL_REDIRECT_TO").strip()
+                if not redirect_to:
+                    raise ValueError("JUPR_STAGING_EMAIL_REDIRECT_TO is required when JUPR_EMAIL_MODE=staging_redirect.")
+                effective_to_email = redirect_to
+                subject = f"[STAGING→{original_to_email}] {subject}"
+
+            if email_mode == EMAIL_MODE_DRY_RUN:
+                provider_message_id = "dry_run"
+            else:
+                provider_message_id = send_email_with_inline_chart(
+                    to_email=effective_to_email,
                 subject=subject,
                 html_body=html_body,
                 text_body=text_body,
@@ -469,7 +489,7 @@ def send_pending_player_update_emails(
                 chart_cid=chart_cid if chart_png else None,
                 unsubscribe_url=str(((digest.get("links") or {}).get("unsubscribe")) or "").strip() or None,
                 smtp_config=smtp_config,
-            )
+                )
 
             update_outbox_status(
                 supabase,
@@ -499,6 +519,7 @@ def send_pending_player_update_emails(
         "sent": sent,
         "skipped": skipped,
         "errors": errors,
+        "email_mode": email_mode,
     }
 
 

--- a/jupr_app/ui/pages/player_updates_admin.py
+++ b/jupr_app/ui/pages/player_updates_admin.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 import pandas as pd
 import streamlit as st
 
-from jupr_app.config import SMTPConfig, get_env_or_default, get_public_base_url
+from jupr_app.config import SMTPConfig, get_email_mode, get_env_or_default, get_public_base_url
 from jupr_app.domain.notifications.player_profile_update_repo import (
     REQUEST_STATUS_UNSUBSCRIBED,
     approve_request,
@@ -638,6 +638,11 @@ def render(ctx) -> None:
     with queue_tab:
         st.subheader("Send Queue")
         st.caption("Digests generated on Player Digests are queued automatically. Just hit send here.")
+        try:
+            current_email_mode = get_email_mode()
+        except Exception as exc:
+            current_email_mode = f"invalid ({_friendly_error(exc)})"
+        st.info(f"Email mode: {current_email_mode}")
 
         try:
             outbox_rows = list_outbox_rows(supabase, club_id, limit=1000)
@@ -668,7 +673,8 @@ def render(ctx) -> None:
                     )
                     st.success(
                         f"Attempted: {result['attempted']} · Sent: {result['sent']} · "
-                        f"Skipped: {result['skipped']} · Errors: {result['errors']}"
+                        f"Skipped: {result['skipped']} · Errors: {result['errors']} · "
+                        f"Mode: {result.get('email_mode', 'unknown')}"
                     )
                     st.rerun()
                 except Exception as exc:

--- a/jupr_app/workers/player_update_email_worker.py
+++ b/jupr_app/workers/player_update_email_worker.py
@@ -61,6 +61,7 @@ def run_player_update_email_worker(club_id: str, *, limit: int = 250) -> dict[st
             "sent": int(summary.get("sent") or 0),
             "skipped": int(summary.get("skipped") or 0),
             "errors": int(summary.get("errors") or 0),
+            "email_mode": str(summary.get("email_mode") or "unknown"),
         }
         if run_id:
             supabase.table("worker_run_log").update(
@@ -72,6 +73,7 @@ def run_player_update_email_worker(club_id: str, *, limit: int = 250) -> dict[st
                         "sent": result["sent"],
                         "skipped": result["skipped"],
                         "errors": result["errors"],
+                        "email_mode": result["email_mode"],
                     },
                 }
             ).eq("id", run_id).execute()

--- a/tests/test_player_update_email_worker.py
+++ b/tests/test_player_update_email_worker.py
@@ -10,17 +10,32 @@ def test_run_player_update_email_worker_passes_club_and_limit(monkeypatch):
 
     captured = {}
 
+    class _FakeTable:
+        def insert(self, *_args, **_kwargs):
+            return self
+        def update(self, *_args, **_kwargs):
+            return self
+        def eq(self, *_args, **_kwargs):
+            return self
+        def execute(self):
+            class R: data = []
+            return R()
+
+    class _FakeSupabase:
+        def table(self, _name):
+            return _FakeTable()
+
     def fake_make_supabase(url, key):
         captured["url"] = url
         captured["key"] = key
-        return "fake-client"
+        return _FakeSupabase()
 
     def fake_send_pending(ctx, *, limit, public_base_url=None, smtp_config=None):
         captured["club_id"] = ctx.club_id
         captured["supabase"] = ctx.supabase
         captured["limit"] = limit
         captured["public_base_url"] = public_base_url
-        return {"attempted": 8, "sent": 5, "skipped": 2, "errors": 1}
+        return {"attempted": 8, "sent": 5, "skipped": 2, "errors": 1, "email_mode": "dry_run"}
 
     monkeypatch.setattr("jupr_app.workers.player_update_email_worker.make_supabase", fake_make_supabase)
     monkeypatch.setattr(
@@ -34,7 +49,7 @@ def test_run_player_update_email_worker_passes_club_and_limit(monkeypatch):
         "url": "https://example.supabase.co",
         "key": "service-role",
         "club_id": "tres_palapas",
-        "supabase": "fake-client",
+        "supabase": captured["supabase"],
         "limit": 250,
         "public_base_url": "https://jupr.example.com",
     }
@@ -46,6 +61,7 @@ def test_run_player_update_email_worker_passes_club_and_limit(monkeypatch):
         "sent": 5,
         "skipped": 2,
         "errors": 1,
+        "email_mode": "dry_run",
     }
 
 
@@ -60,6 +76,7 @@ def test_main_prints_json_summary(monkeypatch, capsys):
             "sent": 2,
             "skipped": 1,
             "errors": 0,
+            "email_mode": "live",
         },
     )
 
@@ -85,6 +102,7 @@ def test_main_errors_do_not_fail_without_flag(monkeypatch):
             "sent": 1,
             "skipped": 0,
             "errors": 1,
+            "email_mode": "live",
         },
     )
 
@@ -104,6 +122,7 @@ def test_main_fail_on_errors_sets_nonzero_and_ok_false(monkeypatch, capsys):
             "sent": 1,
             "skipped": 0,
             "errors": 1,
+            "email_mode": "live",
         },
     )
 

--- a/tests/test_staging_email_safety.py
+++ b/tests/test_staging_email_safety.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from jupr_app import config
+from jupr_app.domain.notifications import player_update_sender as sender
+
+
+class _FakeTable:
+    def update(self, *_args, **_kwargs):
+        return self
+    def eq(self, *_args, **_kwargs):
+        return self
+    def insert(self, *_args, **_kwargs):
+        return self
+    def execute(self):
+        class R: data = []
+        return R()
+
+
+class _FakeSupabase:
+    def table(self, _name):
+        return _FakeTable()
+
+
+def test_staging_defaults_to_dry_run(monkeypatch):
+    monkeypatch.setenv("JUPR_ENV", "staging")
+    monkeypatch.delenv("JUPR_EMAIL_MODE", raising=False)
+    assert config.get_email_mode() == "dry_run"
+
+
+def test_production_defaults_to_live(monkeypatch):
+    monkeypatch.setenv("JUPR_ENV", "production")
+    monkeypatch.delenv("JUPR_EMAIL_MODE", raising=False)
+    assert config.get_email_mode() == "live"
+
+
+def test_staging_live_requires_explicit_allow(monkeypatch):
+    monkeypatch.setenv("JUPR_ENV", "staging")
+    monkeypatch.setenv("JUPR_EMAIL_MODE", "live")
+    monkeypatch.delenv("JUPR_ALLOW_STAGING_LIVE_EMAIL", raising=False)
+    try:
+        config.get_email_mode()
+        assert False, "Expected ValueError"
+    except ValueError as exc:
+        assert "blocked" in str(exc).lower()
+
+
+def test_dry_run_does_not_call_smtp_send(monkeypatch):
+    monkeypatch.setenv("JUPR_ENV", "staging")
+    monkeypatch.delenv("JUPR_EMAIL_MODE", raising=False)
+
+    calls = {"smtp": 0, "status": []}
+
+    monkeypatch.setattr(sender, "list_outbox_rows", lambda *a, **k: [{"id": "o1", "subscription_id": "s1", "week_start": "2026-05-01", "week_end": "2026-05-07", "player_id": 9, "email": "real@example.com"}])
+    monkeypatch.setattr(sender, "_safe_subscription", lambda *a, **k: {"id": "s1", "request_status": "active", "preferences_json": {"send_only_if_changed": False}})
+    monkeypatch.setattr(sender, "_safe_digest_for_week", lambda *a, **k: {"final_json": {"summary": {"matches_played": 1}, "links": {}}})
+    monkeypatch.setattr(sender, "_merge_links_for_send", lambda **k: {"summary": {"matches_played": 1}, "links": {"unsubscribe": "https://x/u"}})
+    monkeypatch.setattr(sender, "ensure_unsubscribe_token", lambda *a, **k: "tok")
+    monkeypatch.setattr(sender, "render_player_digest_chart_png", lambda *a, **k: None)
+    monkeypatch.setattr(sender, "build_player_update_email_subject", lambda *a, **k: "Subject")
+    monkeypatch.setattr(sender, "build_player_update_email_html", lambda *a, **k: "<p>Hi</p>")
+    monkeypatch.setattr(sender, "build_player_update_email_text", lambda *a, **k: "Hi")
+    monkeypatch.setattr(sender, "update_outbox_status", lambda *a, **k: calls["status"].append(k))
+
+    def _smtp_should_not_be_called(**kwargs):
+        calls["smtp"] += 1
+        return "smtp"
+
+    monkeypatch.setattr(sender, "send_email_with_inline_chart", _smtp_should_not_be_called)
+
+    class Ctx:
+        supabase = _FakeSupabase()
+        club_id = "club"
+
+    result = sender.send_pending_player_update_emails(Ctx(), limit=10)
+    assert result["sent"] == 1
+    assert result["email_mode"] == "dry_run"
+    assert calls["smtp"] == 0
+
+
+def test_staging_redirect_sends_to_redirect_only(monkeypatch):
+    monkeypatch.setenv("JUPR_ENV", "staging")
+    monkeypatch.setenv("JUPR_EMAIL_MODE", "staging_redirect")
+    monkeypatch.setenv("JUPR_STAGING_EMAIL_REDIRECT_TO", "safe@example.com")
+
+    captured = {"to": None}
+    monkeypatch.setattr(sender, "list_outbox_rows", lambda *a, **k: [{"id": "o1", "subscription_id": "s1", "week_start": "2026-05-01", "week_end": "2026-05-07", "player_id": 9, "email": "real@example.com"}])
+    monkeypatch.setattr(sender, "_safe_subscription", lambda *a, **k: {"id": "s1", "request_status": "active", "preferences_json": {"send_only_if_changed": False}})
+    monkeypatch.setattr(sender, "_safe_digest_for_week", lambda *a, **k: {"final_json": {"summary": {"matches_played": 1}, "links": {}}})
+    monkeypatch.setattr(sender, "_merge_links_for_send", lambda **k: {"summary": {"matches_played": 1}, "links": {"unsubscribe": "https://x/u"}})
+    monkeypatch.setattr(sender, "ensure_unsubscribe_token", lambda *a, **k: "tok")
+    monkeypatch.setattr(sender, "render_player_digest_chart_png", lambda *a, **k: None)
+    monkeypatch.setattr(sender, "build_player_update_email_subject", lambda *a, **k: "Subject")
+    monkeypatch.setattr(sender, "build_player_update_email_html", lambda *a, **k: "<p>Hi</p>")
+    monkeypatch.setattr(sender, "build_player_update_email_text", lambda *a, **k: "Hi")
+    monkeypatch.setattr(sender, "update_outbox_status", lambda *a, **k: None)
+
+    def _smtp(**kwargs):
+        captured["to"] = kwargs["to_email"]
+        return "smtp"
+
+    monkeypatch.setattr(sender, "send_email_with_inline_chart", _smtp)
+
+    class Ctx:
+        supabase = _FakeSupabase()
+        club_id = "club"
+
+    sender.send_pending_player_update_emails(Ctx(), limit=10)
+    assert captured["to"] == "safe@example.com"
+
+
+def test_summaries_do_not_print_secrets(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service-role")
+    monkeypatch.setenv("SMTP_PASSWORD", "super-secret")
+
+    from jupr_app.workers import player_update_email_worker as worker
+
+    monkeypatch.setattr(worker, "make_supabase", lambda u, k: _FakeSupabase())
+    monkeypatch.setattr(worker, "send_pending_player_update_emails", lambda *a, **k: {"attempted": 0, "sent": 0, "skipped": 0, "errors": 0, "email_mode": "dry_run"})
+
+    summary = worker.run_player_update_email_worker("club")
+    assert "super-secret" not in str(summary)


### PR DESCRIPTION
### Motivation
- Prevent accidental live emails being sent to real players during staging tests by adding configurable email modes and explicit guards.
- Provide a safe `dry_run` mode to exercise the send pipeline without performing SMTP sends while still recording outcomes.
- Provide a `staging_redirect` mode to route staging emails to a safe address while preserving origin metadata.
- Surface the active email mode to operators and the worker run log so staging behavior is visible and auditable.

### Description
- Added email mode constants and resolution helpers to `jupr_app/config.py` with `get_email_mode()`, supporting `live`, `dry_run`, and `staging_redirect`, plus staging guard requiring `JUPR_ALLOW_STAGING_LIVE_EMAIL=1` for explicit live sends in staging.
- Updated `jupr_app/domain/notifications/player_update_sender.py` to read `email_mode`, to skip SMTP calls in `dry_run` (marking rows as sent), to redirect recipients in `staging_redirect` to `JUPR_STAGING_EMAIL_REDIRECT_TO` and prefix the subject with the original recipient, and to include `email_mode` in send summaries.
- Updated `jupr_app/workers/player_update_email_worker.py` to include `email_mode` in the worker result payload and persisted `worker_run_log.summary_json`. 
- Updated Streamlit admin page `jupr_app/ui/pages/player_updates_admin.py` to display the current email mode and to include the mode in the send result message. 
- Added `tests/test_staging_email_safety.py` exercising staging defaults, production defaults, staging live-block behavior, `dry_run` suppression of SMTP, `staging_redirect` recipient behavior, and summary secret-safety; and updated `tests/test_player_update_email_worker.py` to account for `email_mode` and worker-run logging behavior.

### Testing
- Ran targeted pytest: `pytest -q tests/test_staging_email_safety.py tests/test_player_update_email_worker.py tests/test_notification_config.py`, and the suite passed with all tests green. 
- Verified the full modified test set including worker tests and new staging tests completed successfully (all assertions passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02421d20388326997420c79574eb36)