### PR TITLE
Add production readiness report command

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -347,3 +347,17 @@ If any secret is exposed, rotate it immediately and remove it from history where
 ## Manual staging smoke workflow
 
 Run GitHub Actions workflow `Staging Smoke` via `workflow_dispatch` to perform read-only API/web checks against staging. Configure `STAGING_JUPR_API_BASE_URL` secret (required) and `STAGING_WEB_BASE_URL` (optional).
+
+## 10) Production promotion readiness report
+
+Before promoting `Test` to `rollback-feb8`, generate a readiness summary:
+
+```bash
+python scripts/production_readiness_report.py --base rollback-feb8 --head Test
+```
+
+Optional JSON output:
+
+```bash
+python scripts/production_readiness_report.py --base rollback-feb8 --head Test --json
+```

--- a/scripts/production_readiness_report.py
+++ b/scripts/production_readiness_report.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Generate a branch promotion readiness report for JUPR."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+AREAS = [
+    "Streamlit UI",
+    "domain/services",
+    "Supabase migrations",
+    "FastAPI",
+    "Next.js",
+    "workers",
+    "docs",
+    "tests/CI",
+    "other",
+]
+
+
+@dataclass
+class CommandResult:
+    command: str
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def run_command(*args: str) -> CommandResult:
+    result = subprocess.run(args, cwd=ROOT, capture_output=True, text=True)
+    return CommandResult(" ".join(args), result.returncode, result.stdout.strip(), result.stderr.strip())
+
+
+def ahead_behind(base: str, head: str) -> str:
+    result = run_command("git", "rev-list", "--left-right", "--count", f"{base}...{head}")
+    if result.returncode != 0 or not result.stdout:
+        return "unavailable"
+    parts = result.stdout.split()
+    if len(parts) != 2:
+        return "unavailable"
+    behind, ahead = parts
+    return f"{head} is ahead by {ahead}, behind by {behind} versus {base}"
+
+
+def changed_files(base: str, head: str) -> list[str]:
+    result = run_command("git", "diff", "--name-only", f"{base}...{head}")
+    if result.returncode != 0 or not result.stdout:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def added_files(base: str, head: str) -> list[str]:
+    result = run_command("git", "diff", "--name-status", "--diff-filter=A", f"{base}...{head}")
+    if result.returncode != 0 or not result.stdout:
+        return []
+    added: list[str] = []
+    for line in result.stdout.splitlines():
+        parts = line.split(maxsplit=1)
+        if len(parts) == 2 and parts[0] == "A":
+            added.append(parts[1].strip())
+    return added
+
+
+def classify_path(path: str) -> str:
+    if path.startswith(("app.py", "streamlit_app.py", "jupr_court_board/", "jupr_app/ui/")):
+        return "Streamlit UI"
+    if path.startswith("services/api/"):
+        return "FastAPI"
+    if path.startswith(("jupr_app/services/", "services/", "jupr_app/domain/")):
+        return "domain/services"
+    if path.startswith(("supabase/migrations/", "migrations/")):
+        return "Supabase migrations"
+    if path.startswith("apps/web/"):
+        return "Next.js"
+    if "/workers/" in path or path.startswith("workers/"):
+        return "workers"
+    if path.startswith("docs/") or path == "README.txt":
+        return "docs"
+    if path.startswith("tests/") or path.startswith((".github/workflows/", "Makefile")):
+        return "tests/CI"
+    return "other"
+
+
+def build_risk_flags(files: list[str]) -> list[str]:
+    risk_flags: list[str] = []
+    joined = "\n".join(files)
+
+    if any(p.startswith(("services/api/", "apps/web/")) and "admin" in p and "score" in p for p in files):
+        risk_flags.append("FastAPI/Next.js admin score entry related files touched")
+    if any(p.startswith(("apps/web/", "services/api/", "README.txt", "docs/")) for p in files):
+        tracked = run_command("git", "diff", "-U0", "rollback-feb8...HEAD", "--", "apps/web", "services/api", "README.txt", "docs")
+        if "JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY" in tracked.stdout or "NEXT_PUBLIC_JUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY" in tracked.stdout:
+            risk_flags.append("Admin score entry feature flag defaults changed")
+    if any(p.startswith("apps/web/") for p in files):
+        web_diff = run_command("git", "diff", "-U0", "rollback-feb8...HEAD", "--", "apps/web")
+        if "SERVICE_ROLE" in web_diff.stdout.upper() or "SUPABASE_SERVICE_ROLE_KEY" in web_diff.stdout:
+            risk_flags.append("Potential service-role key reference in apps/web changes")
+    if "process_matches" in joined and not any("services" in p for p in files if "process_matches" in p):
+        risk_flags.append("process_matches import/use touched outside service layer")
+    if any("match_processing.py" in p for p in files):
+        risk_flags.append("match_processing.py changed")
+    if any("admin_auth" in p.lower() and "streamlit" in p.lower() or "admin_auth" in p.lower() and p.startswith("jupr_app/") for p in files):
+        risk_flags.append("Streamlit admin auth related changes detected")
+    if any(p.startswith(("supabase/migrations/", "migrations/")) for p in files):
+        risk_flags.append("Supabase migration files changed")
+
+    return risk_flags
+
+
+def build_report(base: str, head: str) -> dict:
+    files = changed_files(base, head)
+    added = added_files(base, head)
+
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for path in files:
+        grouped[classify_path(path)].append(path)
+
+    supabase_added = [p for p in added if p.startswith("supabase/migrations/")]
+    root_added = [p for p in added if p.startswith("migrations/")]
+
+    checks = {
+        "check_supabase_migration_versions": run_command("python", "scripts/check_supabase_migration_versions.py").__dict__,
+        "check_migration_sources": run_command("python", "scripts/check_migration_sources.py", "--base-ref", base).__dict__,
+    }
+
+    return {
+        "base": base,
+        "head": head,
+        "ahead_behind": ahead_behind(base, head),
+        "changed_files_count": len(files),
+        "changed_files_grouped": {k: grouped.get(k, []) for k in AREAS},
+        "migration_summary": {
+            "supabase_migrations_added": supabase_added,
+            "root_migrations_added": root_added,
+            "root_migration_warning": bool(root_added),
+            "checks": checks,
+        },
+        "risk_flags": build_risk_flags(files),
+        "recommended_checklist": [
+            "staging env verified",
+            "staging smoke passed",
+            "production SQL reviewed",
+            "Next admin score entry disabled",
+            "Streamlit smoke passed",
+            "rollback plan ready",
+        ],
+    }
+
+
+def format_text(report: dict) -> str:
+    lines = [
+        "# Production Promotion Readiness Report",
+        f"Base: {report['base']}",
+        f"Head: {report['head']}",
+        "",
+        "## 1) Branch diff summary",
+        f"- Ahead/behind: {report['ahead_behind']}",
+        f"- Changed files: {report['changed_files_count']}",
+    ]
+    for area, paths in report["changed_files_grouped"].items():
+        lines.append(f"- {area}: {len(paths)}")
+        for path in paths:
+            lines.append(f"  - {path}")
+
+    m = report["migration_summary"]
+    lines.extend([
+        "",
+        "## 2) Migration summary",
+        "- Supabase migrations added:",
+    ])
+    lines.extend([f"  - {p}" for p in m["supabase_migrations_added"]] or ["  - (none)"])
+    lines.append("- Root migrations added:")
+    lines.extend([f"  - {p}" for p in m["root_migrations_added"]] or ["  - (none)"])
+    if m["root_migration_warning"]:
+        lines.append("- WARNING: root migrations under migrations/ were added")
+    for name, result in m["checks"].items():
+        status = "PASS" if result["returncode"] == 0 else "FAIL"
+        lines.append(f"- {name}: {status}")
+        if result["stdout"]:
+            lines.append(f"  stdout: {result['stdout']}")
+        if result["stderr"]:
+            lines.append(f"  stderr: {result['stderr']}")
+
+    lines.extend(["", "## 3) Risk flags"])
+    if report["risk_flags"]:
+        lines.extend([f"- {x}" for x in report["risk_flags"]])
+    else:
+        lines.append("- No explicit risk flags detected.")
+
+    lines.extend(["", "## 4) Recommended checklist"])
+    lines.extend([f"- [ ] {x}" for x in report["recommended_checklist"]])
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", default="rollback-feb8")
+    parser.add_argument("--head", default="Test")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    report = build_report(args.base, args.head)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(format_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_production_readiness_report.py
+++ b/tests/test_production_readiness_report.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import scripts.production_readiness_report as prr
+
+
+def test_classify_changed_files_correctly() -> None:
+    assert prr.classify_path("streamlit_app.py") == "Streamlit UI"
+    assert prr.classify_path("jupr_app/services/match_service.py") == "domain/services"
+    assert prr.classify_path("supabase/migrations/20260101010101_x.sql") == "Supabase migrations"
+    assert prr.classify_path("services/api/main.py") == "FastAPI"
+    assert prr.classify_path("apps/web/app/page.tsx") == "Next.js"
+    assert prr.classify_path("jupr_app/workers/badge_worker.py") == "workers"
+    assert prr.classify_path("docs/saas_staging_deploy.md") == "docs"
+    assert prr.classify_path("tests/test_api_health.py") == "tests/CI"
+
+
+def test_detect_migration_additions(monkeypatch) -> None:
+    def fake_run(*args: str):
+        cmd = " ".join(args)
+        if "--name-status" in cmd:
+            return prr.CommandResult(cmd, 0, "A supabase/migrations/202601.sql\nA migrations/202602.sql", "")
+        if "--name-only" in cmd:
+            return prr.CommandResult(cmd, 0, "supabase/migrations/202601.sql\nmigrations/202602.sql", "")
+        if "rev-list" in cmd:
+            return prr.CommandResult(cmd, 0, "0 2", "")
+        return prr.CommandResult(cmd, 0, "ok", "")
+
+    monkeypatch.setattr(prr, "run_command", fake_run)
+    report = prr.build_report("rollback-feb8", "Test")
+    assert report["migration_summary"]["supabase_migrations_added"] == ["supabase/migrations/202601.sql"]
+    assert report["migration_summary"]["root_migrations_added"] == ["migrations/202602.sql"]
+    assert report["migration_summary"]["root_migration_warning"] is True
+
+
+def test_detect_high_risk_and_service_role(monkeypatch) -> None:
+    changed = ["apps/web/admin/score/page.tsx", "jupr_app/match_processing.py", "supabase/migrations/a.sql"]
+
+    def fake_run(*args: str):
+        cmd = " ".join(args)
+        if "apps/web" in cmd and "diff" in cmd:
+            return prr.CommandResult(cmd, 0, "SUPABASE_SERVICE_ROLE_KEY\nJUPR_ENABLE_NEXT_ADMIN_SCORE_ENTRY=1", "")
+        return prr.CommandResult(cmd, 0, "", "")
+
+    monkeypatch.setattr(prr, "run_command", fake_run)
+    flags = prr.build_risk_flags(changed)
+    assert any("admin score entry" in x for x in flags)
+    assert any("service-role" in x for x in flags)
+    assert any("match_processing.py" in x for x in flags)
+    assert any("Supabase migration files changed" in x for x in flags)
+
+
+def test_json_output_valid(monkeypatch, capsys) -> None:
+    fake_report = {
+        "base": "rollback-feb8",
+        "head": "Test",
+        "ahead_behind": "ok",
+        "changed_files_count": 0,
+        "changed_files_grouped": {k: [] for k in prr.AREAS},
+        "migration_summary": {"supabase_migrations_added": [], "root_migrations_added": [], "root_migration_warning": False, "checks": {}},
+        "risk_flags": [],
+        "recommended_checklist": ["a"],
+    }
+
+    monkeypatch.setattr(prr, "build_report", lambda base, head: fake_report)
+    monkeypatch.setattr("sys.argv", ["production_readiness_report.py", "--json"])
+    prr.main()
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed["base"] == "rollback-feb8"


### PR DESCRIPTION
### Motivation
- Provide a local, non-destructive check to decide whether the `Test` branch is safe to promote to `rollback-feb8` by summarizing diffs, migrations, and high-risk changes. 
- Codify operator guardrails into a single command that can be used interactively or in automation without requiring GitHub API or production secrets. 

### Description
- Add `scripts/production_readiness_report.py` which compares `--base` and `--head`, reports ahead/behind, groups changed files into areas (Streamlit UI, domain/services, Supabase migrations, FastAPI, Next.js, workers, docs, tests/CI, other), summarizes migration additions, runs migration guardrail scripts, detects a set of risk flags, and prints human-readable or `--json` output. 
- The report runs `python scripts/check_supabase_migration_versions.py` and `python scripts/check_migration_sources.py` as part of the migration summary and inspects diffs via `git` subprocess calls (no external APIs or secrets required). 
- Add unit tests in `tests/test_production_readiness_report.py` covering path classification, migration-addition detection, high-risk/service-role detection, and JSON output validity. 
- Update `README.txt` with a short operator reference showing how to run the readiness report (text and `--json` forms). 

### Testing
- Ran `pytest -q tests/test_production_readiness_report.py` which executed the new test suite and all tests passed (`4 passed`). 
- The added tests mock `run_command` to validate classification, migration detection, risk-flag logic, and JSON output formatting without touching external state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0386d3a15c8326ae9cb5d9a156bf88)