### PR TITLE
Add second-club staging pilot checklist and test plan

### DIFF
--- a/docs/saas_status.md
+++ b/docs/saas_status.md
@@ -34,7 +34,7 @@ This document is the durable source of truth for JUPR SaaS migration status so J
 
 1. **Milestone 1:** Staging read-only public SaaS demo.
 2. **Milestone 2:** Tenant-safe admin auth and scorekeeper workflow in staging.
-3. **Milestone 3:** Second club pilot in staging.
+3. **Milestone 3:** Second club pilot in staging (see `docs/second_club_staging_pilot.md`).
 4. **Milestone 4:** Production public read-only Next.js/FastAPI cutover.
 5. **Milestone 5:** Production admin migration from Streamlit, only after proven.
 
@@ -52,3 +52,4 @@ This document is the durable source of truth for JUPR SaaS migration status so J
 - `docs/next_admin_auth_design.md`
 - `docs/streamlit_to_saas_migration.md`
 - `docs/migrations.md`
+- `docs/second_club_staging_pilot.md`

--- a/docs/second_club_staging_pilot.md
+++ b/docs/second_club_staging_pilot.md
@@ -1,0 +1,56 @@
+# Second Club Staging Pilot Checklist
+
+## Purpose
+
+Validate JUPR multi-club behavior in staging using a non-production second club before any production multi-club rollout.
+
+## Prerequisites
+
+- Staging Supabase is verified and currently used for `Test` branch validation.
+- `clubs` table migration is applied in staging.
+- Club-scoped admin roles are implemented and enforceable.
+- Public leaderboards are working for club-scoped reads.
+- Staging email safety is enabled (non-production routing/allowlist guardrails).
+- Next admin score entry remains disabled unless explicitly testing auth behavior in staging.
+
+## Setup checklist
+
+- [ ] Create a second club row in staging (non-production tenant only).
+- [ ] Create a small set of staging-only players for the second club.
+- [ ] Create league metadata for the second club.
+- [ ] Assign `club_owner`, `organizer`, and `scorekeeper` roles scoped to the second club.
+- [ ] Confirm Tres Palapas staging data remains separate after setup.
+
+## Validation checklist
+
+### Public
+
+- [ ] Validate `/clubs/{second-club}` resolves correct club public profile in staging.
+- [ ] Validate `/clubs/{second-club}/leaderboards` returns only second-club data.
+- [ ] Confirm no private fields are exposed in public responses.
+
+### Admin
+
+- [ ] Verify second-club scorekeeper cannot access Tres Palapas write operations.
+- [ ] Verify Tres Palapas scorekeeper cannot write second-club matches.
+- [ ] Verify admin activity log records the correct `club_id` for every write attempt.
+- [ ] Verify worker runs are scoped to the selected club.
+
+### Data isolation
+
+- [ ] Confirm matches are club-scoped.
+- [ ] Confirm leaderboards are club-scoped.
+- [ ] Confirm roles are club-scoped.
+- [ ] Confirm email subscriptions/outbox are club-scoped.
+
+## Rollback
+
+- Disable second club in staging.
+- Remove staging-only test data if needed.
+- Do not touch production systems, data, or configuration.
+
+## Non-goals
+
+- No billing.
+- No public signup.
+- No production multi-club launch.


### PR DESCRIPTION
### Motivation

- Provide a staging-only runbook to validate multi-club SaaS behavior using a non-production second club before any production multi-club rollout.
- Make tenant isolation explicit by listing public/admin/data checks and rollback steps so staging validation is repeatable and safe.

### Description

- Add `docs/second_club_staging_pilot.md` containing purpose, prerequisites, setup checklist, validation checks (public, admin, data isolation), rollback, and explicit non-goals.
- Update `docs/saas_status.md` to reference the new checklist from Milestone 3 and add it to the related docs list.
- Ensure all guidance is staging-only and contains no secrets or real private player data.

### Testing

- Verified diffs and file contents with `git diff` and inspected the new file via `nl`/`sed`, confirming the checklist was created as specified and referenced from `docs/saas_status.md`.
- Confirmed repository status with `git status --short` and that the updated `docs/saas_status.md` includes the Milestone 3 cross-reference, with all checks passing.
- No automated runtime or integration tests were added or required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038c5fd7e08326a8b2973255f35b16)